### PR TITLE
Nested rule contexts in parse_atn_rule + lexer mode scoping fix

### DIFF
--- a/.github/workflows/kotlin-parity.yml
+++ b/.github/workflows/kotlin-parity.yml
@@ -1,0 +1,70 @@
+name: Kotlin Parse-Tree Parity
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  ANTLR_VERSION: 4.13.2
+  ANTLR4_JAR: /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar
+  GRAMMARS_V4: /tmp/grammars-v4
+  # Pin grammars-v4 to a known commit so unrelated upstream grammar tweaks
+  # cannot turn the parity check into a flake.
+  GRAMMARS_V4_SHA: 284602b3f23ca54dc30778204ab7ae9e969145e9
+  CARGO_TERM_COLOR: always
+
+jobs:
+  kotlin-parity:
+    name: Kotlin Parser Parity
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Install stable Rust
+        run: |
+          rustup toolchain install stable --profile minimal --no-self-update
+          rustup default stable
+
+      - name: Install Java
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install antlr4-python3-runtime
+        run: pip install "antlr4-python3-runtime==${ANTLR_VERSION}"
+
+      - name: Download ANTLR jar
+        run: |
+          set -euxo pipefail
+          mkdir -p /tmp/antlr-cleanroom/tools
+          curl --fail --location --output "${ANTLR4_JAR}" \
+            "https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar"
+
+      - name: Fetch antlr/grammars-v4 Kotlin grammar
+        run: |
+          set -euxo pipefail
+          git clone --filter=blob:none --no-checkout \
+            https://github.com/antlr/grammars-v4.git "${GRAMMARS_V4}"
+          git -C "${GRAMMARS_V4}" sparse-checkout init --cone
+          git -C "${GRAMMARS_V4}" sparse-checkout set kotlin/kotlin
+          git -C "${GRAMMARS_V4}" checkout "${GRAMMARS_V4_SHA}"
+
+      - name: Run Kotlin parity smoke
+        run: tests/kotlin-parity/run.sh

--- a/.github/workflows/kotlin-parity.yml
+++ b/.github/workflows/kotlin-parity.yml
@@ -12,10 +12,12 @@ permissions:
 
 env:
   ANTLR_VERSION: 4.13.2
+  # Pin both upstream artifacts to known checksums so a compromised mirror
+  # or unrelated grammar tweak cannot turn the parity check into a flake or
+  # silently introduce malicious code into the runner.
+  ANTLR_JAR_SHA256: eae2dfa119a64327444672aff63e9ec35a20180dc5b8090b7a6ab85125df4d76
   ANTLR4_JAR: /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar
   GRAMMARS_V4: /tmp/grammars-v4
-  # Pin grammars-v4 to a known commit so unrelated upstream grammar tweaks
-  # cannot turn the parity check into a flake.
   GRAMMARS_V4_SHA: 284602b3f23ca54dc30778204ab7ae9e969145e9
   CARGO_TERM_COLOR: always
 
@@ -56,6 +58,7 @@ jobs:
           mkdir -p /tmp/antlr-cleanroom/tools
           curl --fail --location --output "${ANTLR4_JAR}" \
             "https://www.antlr.org/download/antlr-${ANTLR_VERSION}-complete.jar"
+          echo "${ANTLR_JAR_SHA256}  ${ANTLR4_JAR}" | sha256sum -c -
 
       - name: Fetch antlr/grammars-v4 Kotlin grammar
         run: |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -37,4 +37,4 @@ Generated code should avoid global mutable state except for immutable metadata a
 
 The runtime keeps generated-code shape stable by putting grammar execution behind metadata-backed ATN simulators. Generated lexers/parsers provide static names, vocabulary, and serialized ATN data; the runtime owns deserialization, token recognition, parser rule recognition, and shared stream/tree behavior.
 
-Current parser recognition is intentionally separate from final parse-tree shaping. It validates token sequences through the parser ATN and returns a rule node over the consumed token interval; nested rule contexts, listener callbacks during parsing, adaptive prediction caches, and ANTLR-compatible error recovery are the next compatibility layers.
+Parser recognition emits a parse tree whose shape mirrors ANTLR's generated targets: each grammar rule invocation produces a nested rule context, with tokens, error tokens, and missing tokens attached at their grammar position. Listener callbacks during parsing, adaptive prediction caches, and the broader ANTLR error-recovery surface are the next compatibility layers.

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -26,6 +26,11 @@ struct LexerConfig {
 struct LexerActionTrace {
     action_index: usize,
     position: usize,
+    /// Lexer rule that the action transition belonged to. ANTLR suppresses
+    /// commands of nested non-fragment rule references, so the dispatcher
+    /// must compare this against the accepted rule before applying side
+    /// effects like `pushMode` / `popMode`.
+    rule_index: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -241,18 +246,20 @@ where
             .unwrap_or(INVALID_TOKEN_TYPE);
         let mut result = LexerActionResult::new(token_type, DEFAULT_CHANNEL);
         for trace in accept.actions {
+            if !lexer_action_belongs_to_accept(atn, accept.rule_index, trace.rule_index) {
+                continue;
+            }
             if let Some(action) = atn.lexer_actions().get(trace.action_index) {
                 match action {
                     LexerAction::Custom {
                         rule_index,
                         action_index,
-                    } if lexer_action_belongs_to_accept(atn, accept.rule_index, *rule_index) => {
+                    } => {
                         custom_action(
                             lexer,
                             LexerCustomAction::new(*rule_index, *action_index, trace.position),
                         );
                     }
-                    LexerAction::Custom { .. } => {}
                     other => result.apply(other, lexer),
                 }
             }
@@ -286,10 +293,7 @@ where
 /// text, but its embedded action does not run unless that rule itself accepts
 /// the token. Fragment-rule actions remain eligible because fragments have no
 /// token type of their own.
-fn lexer_action_belongs_to_accept(atn: &Atn, accept_rule: usize, action_rule: i32) -> bool {
-    let Ok(action_rule) = usize::try_from(action_rule) else {
-        return false;
-    };
+fn lexer_action_belongs_to_accept(atn: &Atn, accept_rule: usize, action_rule: usize) -> bool {
     action_rule == accept_rule
         || atn
             .rule_to_token_type()
@@ -519,6 +523,7 @@ fn close_config<I, F, P>(
             Transition::Action {
                 target,
                 action_index,
+                rule_index,
                 ..
             } => {
                 let mut next = config.clone();
@@ -528,6 +533,7 @@ fn close_config<I, F, P>(
                     next.actions.push(LexerActionTrace {
                         action_index: *action_index,
                         position: config.position,
+                        rule_index: *rule_index,
                     });
                 }
                 close_config(lexer, atn, next, closure, semantic_predicate);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -305,6 +305,38 @@ struct FastRecognizeOutcome {
     index: usize,
     consumed_eof: bool,
     diagnostics: Vec<ParserDiagnostic>,
+    nodes: Vec<FastRecognizedNode>,
+}
+
+/// Minimal parse-tree fragment retained by the fast recognizer so the public
+/// rule entry can build nested rule contexts without paying for
+/// action/decision bookkeeping.
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+enum FastRecognizedNode {
+    Token {
+        index: usize,
+    },
+    ErrorToken {
+        index: usize,
+    },
+    MissingToken {
+        token_type: i32,
+        at_index: usize,
+        text: String,
+    },
+    Rule {
+        rule_index: usize,
+        invoking_state: isize,
+        start_index: usize,
+        stop_index: Option<usize>,
+        children: Vec<Self>,
+    },
+    /// Marker emitted at a precedence-rule loop entry where ANTLR would call
+    /// `pushNewRecursionContext`. Folded into a wrapper rule node before the
+    /// public rule entry hands the tree to the caller.
+    LeftRecursiveBoundary {
+        rule_index: usize,
+    },
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -414,6 +446,84 @@ fn state_expected_symbols(atn: &Atn, state_number: usize) -> BTreeSet<i32> {
         }
     }
     symbols
+}
+
+/// FIRST set for a rule entry plus whether the rule is nullable.
+///
+/// Walks epsilon, predicate, action, and rule-call transitions until it finds
+/// a consuming transition or reaches the rule's stop state. Used by the fast
+/// recognizer to skip rule alternatives whose first-consumed token cannot
+/// possibly match the current lookahead.
+#[derive(Clone, Debug, Default)]
+struct FirstSet {
+    symbols: BTreeSet<i32>,
+    nullable: bool,
+}
+
+fn rule_first_set(atn: &Atn, target: usize, rule_stop_state: usize) -> FirstSet {
+    let mut first = FirstSet::default();
+    rule_first_set_inner(atn, target, rule_stop_state, &mut BTreeSet::new(), &mut first);
+    first
+}
+
+fn rule_first_set_inner(
+    atn: &Atn,
+    state_number: usize,
+    rule_stop_state: usize,
+    visited: &mut BTreeSet<usize>,
+    first: &mut FirstSet,
+) {
+    if !visited.insert(state_number) {
+        return;
+    }
+    if state_number == rule_stop_state {
+        first.nullable = true;
+        return;
+    }
+    let Some(state) = atn.state(state_number) else {
+        return;
+    };
+    for transition in &state.transitions {
+        let transition_symbols = transition_expected_symbols(transition, atn.max_token_type());
+        if !transition_symbols.is_empty() {
+            first.symbols.extend(transition_symbols);
+            continue;
+        }
+        match transition {
+            Transition::Epsilon { target }
+            | Transition::Action { target, .. }
+            | Transition::Predicate { target, .. }
+            | Transition::Precedence { target, .. } => {
+                rule_first_set_inner(atn, *target, rule_stop_state, visited, first);
+            }
+            Transition::Rule {
+                target,
+                rule_index,
+                follow_state,
+                ..
+            } => {
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                    continue;
+                };
+                let child = rule_first_set(atn, *target, child_stop);
+                first.symbols.extend(child.symbols);
+                if child.nullable {
+                    rule_first_set_inner(
+                        atn,
+                        *follow_state,
+                        rule_stop_state,
+                        visited,
+                        first,
+                    );
+                }
+            }
+            Transition::Atom { .. }
+            | Transition::Range { .. }
+            | Transition::Set { .. }
+            | Transition::NotSet { .. }
+            | Transition::Wildcard { .. } => {}
+        }
+    }
 }
 
 /// Returns token types that can resume parsing from `state_number` after a
@@ -846,10 +956,10 @@ where
     ///
     /// The recognizer backtracks across alternatives and loop exits using token
     /// stream indices instead of committing to input consumption immediately.
-    /// Once a viable ATN path is found, the parser consumes the accepted token
-    /// interval and returns a rule node. The initial tree is intentionally flat;
-    /// nested rule-node construction will be layered on top of the same
-    /// recognition routine.
+    /// Once a viable ATN path is found, the parser commits the accepted token
+    /// interval and returns a rule node whose children mirror every grammar
+    /// rule invocation reached on that path, matching ANTLR's parse-tree
+    /// shape.
     pub fn parse_atn_rule(
         &mut self,
         atn: &Atn,
@@ -910,19 +1020,86 @@ where
         if let Some(token) = self.rule_stop_token(outcome.index, outcome.consumed_eof) {
             context.set_stop(token);
         }
-        self.input.seek(start_index);
-        while self.input.index() < outcome.index {
-            let token_type = self.la(1);
-            let child = self.match_token(token_type)?;
-            if self.build_parse_trees {
-                context.add_child(child);
+        if self.build_parse_trees {
+            let folded = fold_fast_left_recursive_boundaries(outcome.nodes);
+            for node in &folded {
+                context.add_child(self.fast_recognized_node_tree(node)?);
             }
         }
-        if outcome.consumed_eof && self.la(1) == TOKEN_EOF && self.build_parse_trees {
-            context.add_child(self.match_eof()?);
-        }
+        self.input.seek(outcome.index);
 
         Ok(self.rule_node(context))
+    }
+
+    /// Converts a recognized fast-recognizer node into a public parse-tree
+    /// node, mirroring [`Self::recognized_node_tree`] for the slow path.
+    fn fast_recognized_node_tree(
+        &mut self,
+        node: &FastRecognizedNode,
+    ) -> Result<ParseTree, AntlrError> {
+        match node {
+            FastRecognizedNode::Token { index } => {
+                let token =
+                    self.input
+                        .get(*index)
+                        .cloned()
+                        .ok_or_else(|| AntlrError::ParserError {
+                            line: 0,
+                            column: 0,
+                            message: format!("missing token at index {index}"),
+                        })?;
+                Ok(ParseTree::Terminal(TerminalNode::new(token)))
+            }
+            FastRecognizedNode::ErrorToken { index } => {
+                let token =
+                    self.input
+                        .get(*index)
+                        .cloned()
+                        .ok_or_else(|| AntlrError::ParserError {
+                            line: 0,
+                            column: 0,
+                            message: format!("missing error token at index {index}"),
+                        })?;
+                Ok(ParseTree::Error(ErrorNode::new(token)))
+            }
+            FastRecognizedNode::MissingToken {
+                token_type,
+                at_index,
+                text,
+            } => {
+                let current = self.token_at(*at_index);
+                let token = CommonToken::new(*token_type)
+                    .with_text(text)
+                    .with_span(usize::MAX, usize::MAX)
+                    .with_position(
+                        current.as_ref().map(Token::line).unwrap_or_default(),
+                        current.as_ref().map(Token::column).unwrap_or_default(),
+                    );
+                Ok(ParseTree::Error(ErrorNode::new(token)))
+            }
+            FastRecognizedNode::Rule {
+                rule_index,
+                invoking_state,
+                start_index,
+                stop_index,
+                children,
+            } => {
+                let mut context = ParserRuleContext::new(*rule_index, *invoking_state);
+                if let Some(token) = self.token_at(*start_index) {
+                    context.set_start(token);
+                }
+                if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
+                    context.set_stop(token);
+                }
+                for child in children {
+                    context.add_child(self.fast_recognized_node_tree(child)?);
+                }
+                Ok(self.rule_node(context))
+            }
+            FastRecognizedNode::LeftRecursiveBoundary { rule_index } => Err(AntlrError::Unsupported(
+                format!("unfolded left-recursive boundary for rule {rule_index}"),
+            )),
+        }
     }
 
     /// Parses a generated rule and returns semantic actions reached on the
@@ -1431,6 +1608,12 @@ where
             outcome.consumed_eof |= next_symbol == TOKEN_EOF;
             outcome.diagnostics.insert(0, diagnostic.clone());
             outcome
+                .nodes
+                .insert(0, FastRecognizedNode::Token { index: next_index });
+            outcome
+                .nodes
+                .insert(0, FastRecognizedNode::ErrorToken { index });
+            outcome
         })
         .collect()
     }
@@ -1462,7 +1645,7 @@ where
             ..
         } = request;
         let follow_symbols = state_expected_symbols(atn, transition.target());
-        let Some((diagnostic, _token_type, _text)) = self.single_token_insertion(
+        let Some((diagnostic, token_type, text)) = self.single_token_insertion(
             transition,
             index,
             atn.max_token_type(),
@@ -1491,6 +1674,14 @@ where
         .into_iter()
         .map(|mut outcome| {
             outcome.diagnostics.insert(0, diagnostic.clone());
+            outcome.nodes.insert(
+                0,
+                FastRecognizedNode::MissingToken {
+                    token_type,
+                    at_index: index,
+                    text: text.clone(),
+                },
+            );
             outcome
         })
         .collect()
@@ -1513,7 +1704,7 @@ where
         if request.index == request.rule_start_index {
             return Vec::new();
         }
-        let Some((diagnostic, next_index, _skipped)) =
+        let Some((diagnostic, next_index, skipped)) =
             self.current_token_deletion(request.index, &expected_symbols)
         else {
             return Vec::new();
@@ -1526,6 +1717,11 @@ where
             .into_iter()
             .map(|mut outcome| {
                 outcome.diagnostics.insert(0, diagnostic.clone());
+                for index in skipped.iter().rev() {
+                    outcome
+                        .nodes
+                        .insert(0, FastRecognizedNode::ErrorToken { index: *index });
+                }
                 outcome
             })
             .collect()
@@ -1560,6 +1756,7 @@ where
                 index,
                 consumed_eof: false,
                 diagnostics: Vec::new(),
+                nodes: Vec::new(),
             }];
         }
         let key = FastRecognizeKey {
@@ -1598,30 +1795,9 @@ where
                 Transition::Epsilon { target }
                 | Transition::Predicate { target, .. }
                 | Transition::Action { target, .. } => {
-                    outcomes.extend(self.recognize_state_fast(
-                        atn,
-                        FastRecognizeRequest {
-                            state_number: *target,
-                            stop_state,
-                            index,
-                            rule_start_index,
-                            decision_start_index: next_decision_start_index,
-                            precedence,
-                            depth: depth + 1,
-                            recovery_symbols: epsilon_recovery_symbols.clone(),
-                            recovery_state: epsilon_recovery_state,
-                        },
-                        visiting,
-                        memo,
-                        expected,
-                    ));
-                }
-                Transition::Precedence {
-                    target,
-                    precedence: transition_precedence,
-                } => {
-                    if *transition_precedence >= precedence {
-                        outcomes.extend(self.recognize_state_fast(
+                    let boundary = left_recursive_boundary(atn, state, *target);
+                    outcomes.extend(
+                        self.recognize_state_fast(
                             atn,
                             FastRecognizeRequest {
                                 state_number: *target,
@@ -1637,7 +1813,53 @@ where
                             visiting,
                             memo,
                             expected,
-                        ));
+                        )
+                        .into_iter()
+                        .map(|mut outcome| {
+                            if let Some(rule_index) = boundary {
+                                outcome
+                                    .nodes
+                                    .insert(0, FastRecognizedNode::LeftRecursiveBoundary { rule_index });
+                            }
+                            outcome
+                        }),
+                    );
+                }
+                Transition::Precedence {
+                    target,
+                    precedence: transition_precedence,
+                } => {
+                    if *transition_precedence >= precedence {
+                        let boundary = left_recursive_boundary(atn, state, *target);
+                        outcomes.extend(
+                            self.recognize_state_fast(
+                                atn,
+                                FastRecognizeRequest {
+                                    state_number: *target,
+                                    stop_state,
+                                    index,
+                                    rule_start_index,
+                                    decision_start_index: next_decision_start_index,
+                                    precedence,
+                                    depth: depth + 1,
+                                    recovery_symbols: epsilon_recovery_symbols.clone(),
+                                    recovery_state: epsilon_recovery_state,
+                                },
+                                visiting,
+                                memo,
+                                expected,
+                            )
+                            .into_iter()
+                            .map(|mut outcome| {
+                                if let Some(rule_index) = boundary {
+                                    outcome.nodes.insert(
+                                        0,
+                                        FastRecognizedNode::LeftRecursiveBoundary { rule_index },
+                                    );
+                                }
+                                outcome
+                            }),
+                        );
                     }
                 }
                 Transition::Rule {
@@ -1651,6 +1873,31 @@ where
                     else {
                         continue;
                     };
+                    // Lookahead-based pruning. The recognizer would otherwise
+                    // explore every speculative rule call, producing exponential
+                    // work on grammars with many epsilon-reachable rules. When
+                    // the rule is non-nullable and its FIRST set excludes the
+                    // current lookahead, recursion can't find a clean path —
+                    // skip it but contribute its FIRST set to the diagnostic
+                    // expected-token accumulator so the rendered error keeps
+                    // matching ANTLR's reference behavior.
+                    let symbol = self.token_type_at(index);
+                    let first = rule_first_set(atn, *target, child_stop);
+                    if !first.nullable && !first.symbols.contains(&symbol) {
+                        if !first.symbols.is_empty() {
+                            match expected.index {
+                                Some(current) if index < current => {}
+                                Some(current) if index == current => {
+                                    expected.symbols.extend(first.symbols);
+                                }
+                                _ => {
+                                    expected.index = Some(index);
+                                    expected.symbols = first.symbols;
+                                }
+                            }
+                        }
+                        continue;
+                    }
                     let expected_before_child = expected.clone();
                     let children = self.recognize_state_fast(
                         atn,
@@ -1676,6 +1923,13 @@ where
                         *expected = expected_before_child;
                     }
                     for child in children {
+                        let child_node = FastRecognizedNode::Rule {
+                            rule_index: *rule_index,
+                            invoking_state: invoking_state_number(state_number),
+                            start_index: index,
+                            stop_index: self.rule_stop_token_index(child.index, child.consumed_eof),
+                            children: fold_fast_left_recursive_boundaries(child.nodes.clone()),
+                        };
                         outcomes.extend(
                             self.recognize_state_fast(
                                 atn,
@@ -1700,6 +1954,7 @@ where
                                 let mut diagnostics = child.diagnostics.clone();
                                 diagnostics.append(&mut outcome.diagnostics);
                                 outcome.diagnostics = diagnostics;
+                                outcome.nodes.insert(0, child_node.clone());
                                 outcome
                             }),
                         );
@@ -1734,6 +1989,7 @@ where
                             .into_iter()
                             .map(|mut outcome| {
                                 outcome.consumed_eof |= symbol == TOKEN_EOF;
+                                outcome.nodes.insert(0, FastRecognizedNode::Token { index });
                                 outcome
                             }),
                         );
@@ -3266,6 +3522,62 @@ fn fold_left_recursive_boundaries(nodes: Vec<RecognizedNode>) -> Vec<RecognizedN
     folded
 }
 
+/// Mirrors [`fold_left_recursive_boundaries`] for [`FastRecognizedNode`].
+fn fold_fast_left_recursive_boundaries(nodes: Vec<FastRecognizedNode>) -> Vec<FastRecognizedNode> {
+    let mut folded = Vec::new();
+    for node in nodes {
+        match node {
+            FastRecognizedNode::LeftRecursiveBoundary { rule_index } => {
+                if !folded.is_empty() {
+                    let children = std::mem::take(&mut folded);
+                    let start_index =
+                        fast_recognized_nodes_start_index(&children).unwrap_or_default();
+                    let stop_index = fast_recognized_nodes_stop_index(&children);
+                    folded.push(FastRecognizedNode::Rule {
+                        rule_index,
+                        invoking_state: -1,
+                        start_index,
+                        stop_index,
+                        children,
+                    });
+                }
+            }
+            node => folded.push(node),
+        }
+    }
+    folded
+}
+
+fn fast_recognized_nodes_start_index(nodes: &[FastRecognizedNode]) -> Option<usize> {
+    nodes.iter().find_map(fast_recognized_node_start_index)
+}
+
+const fn fast_recognized_node_start_index(node: &FastRecognizedNode) -> Option<usize> {
+    match node {
+        FastRecognizedNode::Token { index } | FastRecognizedNode::ErrorToken { index } => {
+            Some(*index)
+        }
+        FastRecognizedNode::MissingToken { at_index, .. } => Some(*at_index),
+        FastRecognizedNode::Rule { start_index, .. } => Some(*start_index),
+        FastRecognizedNode::LeftRecursiveBoundary { .. } => None,
+    }
+}
+
+fn fast_recognized_nodes_stop_index(nodes: &[FastRecognizedNode]) -> Option<usize> {
+    nodes.iter().rev().find_map(fast_recognized_node_stop_index)
+}
+
+const fn fast_recognized_node_stop_index(node: &FastRecognizedNode) -> Option<usize> {
+    match node {
+        FastRecognizedNode::Token { index } | FastRecognizedNode::ErrorToken { index } => {
+            Some(*index)
+        }
+        FastRecognizedNode::MissingToken { at_index, .. } => at_index.checked_sub(1),
+        FastRecognizedNode::Rule { stop_index, .. } => *stop_index,
+        FastRecognizedNode::LeftRecursiveBoundary { .. } => None,
+    }
+}
+
 fn recognized_nodes_start_index(nodes: &[RecognizedNode]) -> Option<usize> {
     nodes.iter().find_map(recognized_node_start_index)
 }
@@ -3691,10 +4003,28 @@ fn node_needs_stable_tie(node: &RecognizedNode) -> bool {
     }
 }
 
-/// Sorts and removes equivalent endpoints before memoizing a state result.
+/// Removes equivalent endpoints before memoizing a state result while
+/// preserving ATN transition-discovery order.
+///
+/// Outcomes are compared on observable recognition state — the input index,
+/// EOF consumption, and diagnostics — without descending into the parse-tree
+/// fragment carried by `nodes`. Two paths reaching the same point with
+/// different node trees would otherwise prevent memoization from collapsing
+/// equivalent suffixes and explode the speculative-path cache.
+///
+/// The first occurrence per recognition key wins, which matches ANTLR's
+/// greedy alternative selection: serialized ATNs put greedy `*`/`+` loop-back
+/// transitions before loop-exit, so the first-discovered outcome carries the
+/// greedy parse-tree fragment.
 fn dedupe_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
-    outcomes.sort_unstable();
-    outcomes.dedup();
+    let mut seen: BTreeSet<(usize, bool, Vec<ParserDiagnostic>)> = BTreeSet::new();
+    outcomes.retain(|outcome| {
+        seen.insert((
+            outcome.index,
+            outcome.consumed_eof,
+            outcome.diagnostics.clone(),
+        ))
+    });
 }
 
 /// Sorts and removes equivalent endpoints, including their action traces.
@@ -3944,11 +4274,13 @@ mod tests {
                 column: 0,
                 message: "mismatched input 'x'".to_owned(),
             }],
+            nodes: Vec::new(),
         };
         let second = FastRecognizeOutcome {
             index: first.index,
             consumed_eof: first.consumed_eof,
             diagnostics: Vec::new(),
+            nodes: Vec::new(),
         };
 
         let selected = select_best_fast_outcome(
@@ -3961,6 +4293,7 @@ mod tests {
             index: second.index,
             consumed_eof: true,
             diagnostics: Vec::new(),
+            nodes: Vec::new(),
         };
         let selected =
             select_best_fast_outcome([first.clone(), eof_second].into_iter(), PredictionMode::Sll)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -258,6 +258,11 @@ pub struct BaseParser<S> {
     /// speculative recognition may revisit the same coordinate, so replay it
     /// once per parser instance.
     invoked_predicates: Vec<(usize, usize)>,
+    /// FIRST-set cache shared across all speculative rule-call lookups in a
+    /// single parser instance. The fast recognizer consults FIRST sets on
+    /// every rule transition; without caching the same DFS would repeat for
+    /// every speculative path that visits the same rule.
+    first_set_cache: FirstSetCache,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -454,15 +459,72 @@ fn state_expected_symbols(atn: &Atn, state_number: usize) -> BTreeSet<i32> {
 /// a consuming transition or reaches the rule's stop state. Used by the fast
 /// recognizer to skip rule alternatives whose first-consumed token cannot
 /// possibly match the current lookahead.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct FirstSet {
     symbols: BTreeSet<i32>,
     nullable: bool,
 }
 
-fn rule_first_set(atn: &Atn, target: usize, rule_stop_state: usize) -> FirstSet {
+/// Per-parser cache of FIRST sets computed during recognition. The fast path
+/// consults this on every speculative `Transition::Rule` encounter, so the
+/// computation must amortize across all of those calls — the FIRST set is a
+/// pure function of the ATN, not of the input position.
+type FirstSetCache = BTreeMap<(usize, usize), FirstSet>;
+
+/// Mutable bookkeeping shared across one FIRST-set computation. Bundling the
+/// rarely-touched fields keeps the recursive helpers below the function-arity
+/// lint and lets every nested call thread the same cache and cycle guards.
+struct FirstSetCtx<'a> {
+    cache: &'a mut FirstSetCache,
+    in_progress: BTreeSet<(usize, usize)>,
+    hit_cycle: bool,
+}
+
+/// Returns the FIRST set for the (rule entry, rule stop) pair, populating the
+/// shared cache and tolerating recursive nullable rule chains. Mutually
+/// recursive rules cannot stack-overflow because callers in flight are tracked
+/// in `ctx.in_progress`; revisits return without recursing, and the partial
+/// result is cached only when no cycle was detected during its computation.
+fn rule_first_set(
+    atn: &Atn,
+    target: usize,
+    rule_stop_state: usize,
+    cache: &mut FirstSetCache,
+) -> FirstSet {
+    let mut ctx = FirstSetCtx {
+        cache,
+        in_progress: BTreeSet::new(),
+        hit_cycle: false,
+    };
+    rule_first_set_cached(atn, target, rule_stop_state, &mut ctx)
+}
+
+fn rule_first_set_cached(
+    atn: &Atn,
+    target: usize,
+    rule_stop_state: usize,
+    ctx: &mut FirstSetCtx<'_>,
+) -> FirstSet {
+    let key = (target, rule_stop_state);
+    if let Some(cached) = ctx.cache.get(&key) {
+        return cached.clone();
+    }
+    if !ctx.in_progress.insert(key) {
+        // Cycle: a caller above is already computing this entry. Return an
+        // empty FIRST set; that caller's traversal supplies the contributions
+        // from the rule's other alternatives.
+        return FirstSet::default();
+    }
+    let saved_hit_cycle = ctx.hit_cycle;
+    ctx.hit_cycle = false;
     let mut first = FirstSet::default();
-    rule_first_set_inner(atn, target, rule_stop_state, &mut BTreeSet::new(), &mut first);
+    let mut visited = BTreeSet::new();
+    rule_first_set_inner(atn, target, rule_stop_state, ctx, &mut visited, &mut first);
+    ctx.in_progress.remove(&key);
+    if !ctx.hit_cycle {
+        ctx.cache.insert(key, first.clone());
+    }
+    ctx.hit_cycle = saved_hit_cycle || ctx.hit_cycle;
     first
 }
 
@@ -470,6 +532,7 @@ fn rule_first_set_inner(
     atn: &Atn,
     state_number: usize,
     rule_stop_state: usize,
+    ctx: &mut FirstSetCtx<'_>,
     visited: &mut BTreeSet<usize>,
     first: &mut FirstSet,
 ) {
@@ -494,7 +557,7 @@ fn rule_first_set_inner(
             | Transition::Action { target, .. }
             | Transition::Predicate { target, .. }
             | Transition::Precedence { target, .. } => {
-                rule_first_set_inner(atn, *target, rule_stop_state, visited, first);
+                rule_first_set_inner(atn, *target, rule_stop_state, ctx, visited, first);
             }
             Transition::Rule {
                 target,
@@ -505,16 +568,14 @@ fn rule_first_set_inner(
                 let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
                     continue;
                 };
-                let child = rule_first_set(atn, *target, child_stop);
+                let child_key = (*target, child_stop);
+                if ctx.in_progress.contains(&child_key) && !ctx.cache.contains_key(&child_key) {
+                    ctx.hit_cycle = true;
+                }
+                let child = rule_first_set_cached(atn, *target, child_stop, ctx);
                 first.symbols.extend(child.symbols);
                 if child.nullable {
-                    rule_first_set_inner(
-                        atn,
-                        *follow_state,
-                        rule_stop_state,
-                        visited,
-                        first,
-                    );
+                    rule_first_set_inner(atn, *follow_state, rule_stop_state, ctx, visited, first);
                 }
             }
             Transition::Atom { .. }
@@ -884,6 +945,7 @@ where
             reported_prediction_diagnostics: BTreeSet::new(),
             int_members: BTreeMap::new(),
             invoked_predicates: Vec::new(),
+            first_set_cache: BTreeMap::new(),
         }
     }
 
@@ -1882,7 +1944,8 @@ where
                     // expected-token accumulator so the rendered error keeps
                     // matching ANTLR's reference behavior.
                     let symbol = self.token_type_at(index);
-                    let first = rule_first_set(atn, *target, child_stop);
+                    let first =
+                        rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
                     if !first.nullable && !first.symbols.contains(&symbol) {
                         if !first.symbols.is_empty() {
                             match expected.index {
@@ -4017,13 +4080,36 @@ fn node_needs_stable_tie(node: &RecognizedNode) -> bool {
 /// transitions before loop-exit, so the first-discovered outcome carries the
 /// greedy parse-tree fragment.
 fn dedupe_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
-    let mut seen: BTreeSet<(usize, bool, Vec<ParserDiagnostic>)> = BTreeSet::new();
-    outcomes.retain(|outcome| {
-        seen.insert((
-            outcome.index,
-            outcome.consumed_eof,
-            outcome.diagnostics.clone(),
-        ))
+    if outcomes.len() < 2 {
+        return;
+    }
+    let mut keep = Vec::with_capacity(outcomes.len());
+    let mut seen: BTreeMap<(usize, bool), Vec<usize>> = BTreeMap::new();
+    'outcomes: for (index, outcome) in outcomes.iter().enumerate() {
+        let bucket = seen
+            .entry((outcome.index, outcome.consumed_eof))
+            .or_default();
+        for &previous in bucket.iter() {
+            if outcomes[previous].diagnostics == outcome.diagnostics {
+                continue 'outcomes;
+            }
+        }
+        bucket.push(index);
+        keep.push(index);
+    }
+    if keep.len() == outcomes.len() {
+        return;
+    }
+    let mut iter = keep.into_iter();
+    let mut next_keep = iter.next();
+    let mut current = 0_usize;
+    outcomes.retain(|_| {
+        let result = next_keep == Some(current);
+        if result {
+            next_keep = iter.next();
+        }
+        current += 1;
+        result
     });
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 
 use crate::atn::{Atn, AtnState, AtnStateKind, Transition};
 use crate::errors::AntlrError;
@@ -310,7 +311,66 @@ struct FastRecognizeOutcome {
     index: usize,
     consumed_eof: bool,
     diagnostics: Vec<ParserDiagnostic>,
-    nodes: Vec<FastRecognizedNode>,
+    /// Speculative parse-tree fragment built up as the recognizer climbs.
+    /// The list is held as a persistent cons-list of `Rc`-wrapped nodes so
+    /// prepending while chaining recognition outcomes is `O(1)` and cloning
+    /// an outcome (memo lookup, dedup, or when fanning a child's tree out
+    /// to every follow outcome) only bumps a reference count rather than
+    /// deep-copying. On left-recursive grammars the unfolded list can carry
+    /// thousands of nodes per speculative path; without the persistent-list
+    /// shape recognition becomes super-linear in path length.
+    nodes: NodeList,
+}
+
+/// Persistent cons-list of fast-recognizer nodes. The list keeps nodes in the
+/// same head-first order as the original `Vec<FastRecognizedNode>` they
+/// replaced. Shared tails across speculative outcomes amortize the cost of
+/// chaining a child rule's nodes onto every follow outcome.
+#[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+enum NodeList {
+    #[default]
+    Empty,
+    Cons {
+        head: Rc<FastRecognizedNode>,
+        tail: Rc<Self>,
+    },
+}
+
+impl NodeList {
+    /// Creates an empty list.
+    const fn new() -> Self {
+        Self::Empty
+    }
+
+    /// Prepends `node` and returns the new list. Both shared tails and the
+    /// new head are reference-counted so this is `O(1)`.
+    fn cons(self, node: Rc<FastRecognizedNode>) -> Self {
+        Self::Cons {
+            head: node,
+            tail: Rc::new(self),
+        }
+    }
+
+    /// In-place prepend that takes ownership of `self` via [`std::mem::take`]
+    /// so existing call sites can keep using `&mut` access.
+    fn prepend(&mut self, node: Rc<FastRecognizedNode>) {
+        let owned = std::mem::take(self);
+        *self = owned.cons(node);
+    }
+
+    /// Materializes the list into a `Vec` in head-first order. Used at the
+    /// boundaries that need random-access traversal (the public rule entry
+    /// when building the final parse tree, and
+    /// `fold_fast_left_recursive_boundaries`).
+    fn to_vec(&self) -> Vec<Rc<FastRecognizedNode>> {
+        let mut out = Vec::new();
+        let mut cursor = self;
+        while let Self::Cons { head, tail } = cursor {
+            out.push(Rc::clone(head));
+            cursor = tail.as_ref();
+        }
+        out
+    }
 }
 
 /// Minimal parse-tree fragment retained by the fast recognizer so the public
@@ -334,7 +394,7 @@ enum FastRecognizedNode {
         invoking_state: isize,
         start_index: usize,
         stop_index: Option<usize>,
-        children: Vec<Self>,
+        children: Vec<Rc<Self>>,
     },
     /// Marker emitted at a precedence-rule loop entry where ANTLR would call
     /// `pushNewRecursionContext`. Folded into a wrapper rule node before the
@@ -1083,9 +1143,9 @@ where
             context.set_stop(token);
         }
         if self.build_parse_trees {
-            let folded = fold_fast_left_recursive_boundaries(outcome.nodes);
+            let folded = fold_fast_left_recursive_boundaries(outcome.nodes.to_vec());
             for node in &folded {
-                context.add_child(self.fast_recognized_node_tree(node)?);
+                context.add_child(self.fast_recognized_node_tree(node.as_ref())?);
             }
         }
         self.input.seek(outcome.index);
@@ -1154,7 +1214,7 @@ where
                     context.set_stop(token);
                 }
                 for child in children {
-                    context.add_child(self.fast_recognized_node_tree(child)?);
+                    context.add_child(self.fast_recognized_node_tree(child.as_ref())?);
                 }
                 Ok(self.rule_node(context))
             }
@@ -1671,10 +1731,10 @@ where
             outcome.diagnostics.insert(0, diagnostic.clone());
             outcome
                 .nodes
-                .insert(0, FastRecognizedNode::Token { index: next_index });
+                .prepend(Rc::new(FastRecognizedNode::Token { index: next_index }));
             outcome
                 .nodes
-                .insert(0, FastRecognizedNode::ErrorToken { index });
+                .prepend(Rc::new(FastRecognizedNode::ErrorToken { index }));
             outcome
         })
         .collect()
@@ -1736,14 +1796,11 @@ where
         .into_iter()
         .map(|mut outcome| {
             outcome.diagnostics.insert(0, diagnostic.clone());
-            outcome.nodes.insert(
-                0,
-                FastRecognizedNode::MissingToken {
-                    token_type,
-                    at_index: index,
-                    text: text.clone(),
-                },
-            );
+            outcome.nodes.prepend(Rc::new(FastRecognizedNode::MissingToken {
+                token_type,
+                at_index: index,
+                text: text.clone(),
+            }));
             outcome
         })
         .collect()
@@ -1782,7 +1839,7 @@ where
                 for index in skipped.iter().rev() {
                     outcome
                         .nodes
-                        .insert(0, FastRecognizedNode::ErrorToken { index: *index });
+                        .prepend(Rc::new(FastRecognizedNode::ErrorToken { index: *index }));
                 }
                 outcome
             })
@@ -1818,7 +1875,7 @@ where
                 index,
                 consumed_eof: false,
                 diagnostics: Vec::new(),
-                nodes: Vec::new(),
+                nodes: NodeList::new(),
             }];
         }
         let key = FastRecognizeKey {
@@ -1879,9 +1936,9 @@ where
                         .into_iter()
                         .map(|mut outcome| {
                             if let Some(rule_index) = boundary {
-                                outcome
-                                    .nodes
-                                    .insert(0, FastRecognizedNode::LeftRecursiveBoundary { rule_index });
+                                outcome.nodes.prepend(Rc::new(
+                                    FastRecognizedNode::LeftRecursiveBoundary { rule_index },
+                                ));
                             }
                             outcome
                         }),
@@ -1914,10 +1971,11 @@ where
                             .into_iter()
                             .map(|mut outcome| {
                                 if let Some(rule_index) = boundary {
-                                    outcome.nodes.insert(
-                                        0,
-                                        FastRecognizedNode::LeftRecursiveBoundary { rule_index },
-                                    );
+                                    outcome.nodes.prepend(Rc::new(
+                                        FastRecognizedNode::LeftRecursiveBoundary {
+                                            rule_index,
+                                        },
+                                    ));
                                 }
                                 outcome
                             }),
@@ -1986,20 +2044,23 @@ where
                         *expected = expected_before_child;
                     }
                     for child in children {
-                        let child_node = FastRecognizedNode::Rule {
+                        let child_index = child.index;
+                        let child_consumed_eof = child.consumed_eof;
+                        let child_diagnostics = child.diagnostics;
+                        let child_node = Rc::new(FastRecognizedNode::Rule {
                             rule_index: *rule_index,
                             invoking_state: invoking_state_number(state_number),
                             start_index: index,
-                            stop_index: self.rule_stop_token_index(child.index, child.consumed_eof),
-                            children: fold_fast_left_recursive_boundaries(child.nodes.clone()),
-                        };
+                            stop_index: self.rule_stop_token_index(child_index, child_consumed_eof),
+                            children: fold_fast_left_recursive_boundaries(child.nodes.to_vec()),
+                        });
                         outcomes.extend(
                             self.recognize_state_fast(
                                 atn,
                                 FastRecognizeRequest {
                                     state_number: *follow_state,
                                     stop_state,
-                                    index: child.index,
+                                    index: child_index,
                                     rule_start_index,
                                     decision_start_index: next_decision_start_index,
                                     precedence,
@@ -2013,11 +2074,11 @@ where
                             )
                             .into_iter()
                             .map(|mut outcome| {
-                                outcome.consumed_eof |= child.consumed_eof;
-                                let mut diagnostics = child.diagnostics.clone();
+                                outcome.consumed_eof |= child_consumed_eof;
+                                let mut diagnostics = child_diagnostics.clone();
                                 diagnostics.append(&mut outcome.diagnostics);
                                 outcome.diagnostics = diagnostics;
-                                outcome.nodes.insert(0, child_node.clone());
+                                outcome.nodes.prepend(Rc::clone(&child_node));
                                 outcome
                             }),
                         );
@@ -2052,7 +2113,9 @@ where
                             .into_iter()
                             .map(|mut outcome| {
                                 outcome.consumed_eof |= symbol == TOKEN_EOF;
-                                outcome.nodes.insert(0, FastRecognizedNode::Token { index });
+                                outcome
+                                    .nodes
+                                    .prepend(Rc::new(FastRecognizedNode::Token { index }));
                                 outcome
                             }),
                         );
@@ -3586,33 +3649,37 @@ fn fold_left_recursive_boundaries(nodes: Vec<RecognizedNode>) -> Vec<RecognizedN
 }
 
 /// Mirrors [`fold_left_recursive_boundaries`] for [`FastRecognizedNode`].
-fn fold_fast_left_recursive_boundaries(nodes: Vec<FastRecognizedNode>) -> Vec<FastRecognizedNode> {
-    let mut folded = Vec::new();
+fn fold_fast_left_recursive_boundaries(
+    nodes: Vec<Rc<FastRecognizedNode>>,
+) -> Vec<Rc<FastRecognizedNode>> {
+    let mut folded: Vec<Rc<FastRecognizedNode>> = Vec::new();
     for node in nodes {
-        match node {
+        match node.as_ref() {
             FastRecognizedNode::LeftRecursiveBoundary { rule_index } => {
                 if !folded.is_empty() {
                     let children = std::mem::take(&mut folded);
                     let start_index =
                         fast_recognized_nodes_start_index(&children).unwrap_or_default();
                     let stop_index = fast_recognized_nodes_stop_index(&children);
-                    folded.push(FastRecognizedNode::Rule {
-                        rule_index,
+                    folded.push(Rc::new(FastRecognizedNode::Rule {
+                        rule_index: *rule_index,
                         invoking_state: -1,
                         start_index,
                         stop_index,
                         children,
-                    });
+                    }));
                 }
             }
-            node => folded.push(node),
+            _ => folded.push(node),
         }
     }
     folded
 }
 
-fn fast_recognized_nodes_start_index(nodes: &[FastRecognizedNode]) -> Option<usize> {
-    nodes.iter().find_map(fast_recognized_node_start_index)
+fn fast_recognized_nodes_start_index(nodes: &[Rc<FastRecognizedNode>]) -> Option<usize> {
+    nodes
+        .iter()
+        .find_map(|node| fast_recognized_node_start_index(node.as_ref()))
 }
 
 const fn fast_recognized_node_start_index(node: &FastRecognizedNode) -> Option<usize> {
@@ -3626,8 +3693,11 @@ const fn fast_recognized_node_start_index(node: &FastRecognizedNode) -> Option<u
     }
 }
 
-fn fast_recognized_nodes_stop_index(nodes: &[FastRecognizedNode]) -> Option<usize> {
-    nodes.iter().rev().find_map(fast_recognized_node_stop_index)
+fn fast_recognized_nodes_stop_index(nodes: &[Rc<FastRecognizedNode>]) -> Option<usize> {
+    nodes
+        .iter()
+        .rev()
+        .find_map(|node| fast_recognized_node_stop_index(node.as_ref()))
 }
 
 const fn fast_recognized_node_stop_index(node: &FastRecognizedNode) -> Option<usize> {
@@ -4360,13 +4430,13 @@ mod tests {
                 column: 0,
                 message: "mismatched input 'x'".to_owned(),
             }],
-            nodes: Vec::new(),
+            nodes: NodeList::new(),
         };
         let second = FastRecognizeOutcome {
             index: first.index,
             consumed_eof: first.consumed_eof,
             diagnostics: Vec::new(),
-            nodes: Vec::new(),
+            nodes: NodeList::new(),
         };
 
         let selected = select_best_fast_outcome(
@@ -4379,7 +4449,7 @@ mod tests {
             index: second.index,
             consumed_eof: true,
             diagnostics: Vec::new(),
-            nodes: Vec::new(),
+            nodes: NodeList::new(),
         };
         let selected =
             select_best_fast_outcome([first.clone(), eof_second].into_iter(), PredictionMode::Sll)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -264,6 +264,14 @@ pub struct BaseParser<S> {
     /// every rule transition; without caching the same DFS would repeat for
     /// every speculative path that visits the same rule.
     first_set_cache: FirstSetCache,
+    /// Whether the fast recognizer's FIRST-set prefilter is enabled. The
+    /// prefilter trims speculative rule calls whose called rule cannot
+    /// match the current lookahead, but it also bypasses single-token
+    /// insertion / deletion recovery that ANTLR runs at the rule's first
+    /// consuming transition. `parse_atn_rule` flips this off and retries
+    /// when the first pass produces no clean outcome so the runtime can
+    /// repair inputs the reference parser would have repaired.
+    fast_first_set_prefilter: bool,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -1006,6 +1014,7 @@ where
             int_members: BTreeMap::new(),
             invoked_predicates: Vec::new(),
             first_set_cache: BTreeMap::new(),
+            fast_first_set_prefilter: true,
         }
     }
 
@@ -1105,32 +1114,31 @@ where
 
         let start_index = self.current_visible_index();
         self.clear_prediction_diagnostics();
-        let mut visiting = BTreeSet::new();
-        let mut memo = BTreeMap::new();
-        let mut expected = ExpectedTokens::default();
-        let outcomes = self.recognize_state_fast(
-            atn,
-            FastRecognizeRequest {
-                state_number: start_state,
-                stop_state,
-                index: start_index,
-                rule_start_index: start_index,
-                decision_start_index: None,
-                precedence: 0,
-                depth: 0,
-                recovery_symbols: BTreeSet::new(),
-                recovery_state: None,
-            },
-            &mut visiting,
-            &mut memo,
-            &mut expected,
-        );
-        let Some(outcome) = select_best_fast_outcome(outcomes.into_iter(), self.prediction_mode)
-        else {
-            let error = self.recognition_error(rule_index, start_index, &expected);
-            report_token_source_errors(&self.input.drain_source_errors());
-            return Err(error);
-        };
+        let (outcome, _expected) =
+            match self.fast_recognize_top(atn, start_state, stop_state, start_index) {
+                Ok(ok) => ok,
+                Err(_) => {
+                    // Retry without the FIRST-set prefilter. The prefilter
+                    // speeds up the common path but bypasses single-token
+                    // insertion / deletion recovery inside child rules — when
+                    // the first pass produces nothing we redo the parse with
+                    // full speculative exploration so ANTLR-style recovery can
+                    // fire.
+                    self.fast_first_set_prefilter = false;
+                    let result =
+                        self.fast_recognize_top(atn, start_state, stop_state, start_index);
+                    self.fast_first_set_prefilter = true;
+                    match result {
+                        Ok(ok) => ok,
+                        Err(expected) => {
+                            let error =
+                                self.recognition_error(rule_index, start_index, &expected);
+                            report_token_source_errors(&self.input.drain_source_errors());
+                            return Err(error);
+                        }
+                    }
+                }
+            };
 
         report_parser_diagnostics(&self.prediction_diagnostics);
         report_parser_diagnostics(&outcome.diagnostics);
@@ -1151,6 +1159,43 @@ where
         self.input.seek(outcome.index);
 
         Ok(self.rule_node(context))
+    }
+
+    /// Runs the fast recognizer once from the rule's start state and returns
+    /// the best outcome or the per-attempt expected-token accumulator. The
+    /// caller flips `fast_first_set_prefilter` between calls when a retry is
+    /// needed, so the FIRST-set cache is left intact across both passes.
+    fn fast_recognize_top(
+        &mut self,
+        atn: &Atn,
+        start_state: usize,
+        stop_state: usize,
+        start_index: usize,
+    ) -> Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens> {
+        let mut visiting = BTreeSet::new();
+        let mut memo = BTreeMap::new();
+        let mut expected = ExpectedTokens::default();
+        let outcomes = self.recognize_state_fast(
+            atn,
+            FastRecognizeRequest {
+                state_number: start_state,
+                stop_state,
+                index: start_index,
+                rule_start_index: start_index,
+                decision_start_index: None,
+                precedence: 0,
+                depth: 0,
+                recovery_symbols: BTreeSet::new(),
+                recovery_state: None,
+            },
+            &mut visiting,
+            &mut memo,
+            &mut expected,
+        );
+        match select_best_fast_outcome(outcomes.into_iter(), self.prediction_mode) {
+            Some(outcome) => Ok((outcome, expected)),
+            None => Err(expected),
+        }
     }
 
     /// Converts a recognized fast-recognizer node into a public parse-tree
@@ -1997,14 +2042,20 @@ where
                     // explore every speculative rule call, producing exponential
                     // work on grammars with many epsilon-reachable rules. When
                     // the rule is non-nullable and its FIRST set excludes the
-                    // current lookahead, recursion can't find a clean path —
-                    // skip it but contribute its FIRST set to the diagnostic
-                    // expected-token accumulator so the rendered error keeps
-                    // matching ANTLR's reference behavior.
+                    // current lookahead, recursion can't find a clean path
+                    // *through this rule*. Skipping is only safe if some sibling
+                    // transition can still consume the lookahead — otherwise the
+                    // rule call is the sole continuation and must run so the
+                    // single-token insertion / deletion recovery inside the
+                    // called rule can fire (mirroring ANTLR's reference behavior
+                    // of conjuring a missing token at child-rule entry).
                     let symbol = self.token_type_at(index);
                     let first =
                         rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
-                    if !first.nullable && !first.symbols.contains(&symbol) {
+                    if self.fast_first_set_prefilter
+                        && !first.nullable
+                        && !first.symbols.contains(&symbol)
+                    {
                         if !first.symbols.is_empty() {
                             match expected.index {
                                 Some(current) if index < current => {}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1114,31 +1114,33 @@ where
 
         let start_index = self.current_visible_index();
         self.clear_prediction_diagnostics();
-        let (outcome, _expected) =
-            match self.fast_recognize_top(atn, start_state, stop_state, start_index) {
-                Ok(ok) => ok,
-                Err(_) => {
-                    // Retry without the FIRST-set prefilter. The prefilter
-                    // speeds up the common path but bypasses single-token
-                    // insertion / deletion recovery inside child rules — when
-                    // the first pass produces nothing we redo the parse with
-                    // full speculative exploration so ANTLR-style recovery can
-                    // fire.
-                    self.fast_first_set_prefilter = false;
-                    let result =
-                        self.fast_recognize_top(atn, start_state, stop_state, start_index);
-                    self.fast_first_set_prefilter = true;
-                    match result {
-                        Ok(ok) => ok,
-                        Err(expected) => {
-                            let error =
-                                self.recognition_error(rule_index, start_index, &expected);
-                            report_token_source_errors(&self.input.drain_source_errors());
-                            return Err(error);
-                        }
-                    }
-                }
-            };
+        let first_pass = self.fast_recognize_top(atn, start_state, stop_state, start_index);
+        let needs_retry = match &first_pass {
+            // The FIRST-set prefilter trims speculative rule calls that can't
+            // match the current lookahead — useful for perf on grammars with
+            // many epsilon-reachable rules, but the trim also bypasses
+            // single-token insertion / deletion recovery that ANTLR's
+            // reference parser runs at the child rule's first consuming
+            // transition. Retry without the prefilter whenever the first pass
+            // either produced no outcome at all or produced a recovered
+            // outcome (diagnostics non-empty), since the second pass might
+            // surface a child-level recovery with cleaner diagnostics or
+            // closer parity to ANTLR's tree shape.
+            Err(_) => true,
+            Ok((outcome, _)) => !outcome.diagnostics.is_empty(),
+        };
+        let (outcome, _expected) = if needs_retry {
+            self.fast_first_set_prefilter = false;
+            let retry = self.fast_recognize_top(atn, start_state, stop_state, start_index);
+            self.fast_first_set_prefilter = true;
+            select_better_top_outcome(first_pass, retry).map_err(|expected| {
+                let error = self.recognition_error(rule_index, start_index, &expected);
+                report_token_source_errors(&self.input.drain_source_errors());
+                error
+            })?
+        } else {
+            first_pass.expect("first_pass is Ok in the no-retry branch")
+        };
 
         report_parser_diagnostics(&self.prediction_diagnostics);
         report_parser_diagnostics(&outcome.diagnostics);
@@ -3873,6 +3875,30 @@ fn state_is_left_recursive_rule(atn: &Atn, state: &AtnState) -> bool {
 /// Chooses the outermost parse result that consumed the most input.
 ///
 /// The recognizer intentionally keeps shorter endpoints available while walking
+/// Picks the better of two `parse_atn_rule` passes (with and without the
+/// FIRST-set prefilter). A clean outcome (no diagnostics) always wins over a
+/// recovered one; among recovered outcomes the second pass is preferred
+/// because the no-prefilter walk reaches ANTLR-style recovery inside child
+/// rules. If both passes failed, the second pass's expected-token snapshot
+/// is returned so the caller renders the same diagnostic ANTLR would.
+fn select_better_top_outcome(
+    first: Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens>,
+    second: Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens>,
+) -> Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens> {
+    match (first, second) {
+        (Ok(first), Ok(second)) => {
+            if first.0.diagnostics.is_empty() {
+                Ok(first)
+            } else {
+                Ok(second)
+            }
+        }
+        (Ok(first), Err(_)) => Ok(first),
+        (Err(_), Ok(second)) => Ok(second),
+        (Err(_), Err(second_expected)) => Err(second_expected),
+    }
+}
+
 /// nested rule transitions so callers can satisfy following tokens such as
 /// `expr 'and' expr`. Only the public rule entry commits to one endpoint.
 fn select_best_fast_outcome(

--- a/tests/kotlin-parity/README.md
+++ b/tests/kotlin-parity/README.md
@@ -5,10 +5,12 @@ upstream antlr/grammars-v4 Kotlin grammar.
 
 ## What runs
 
-`run.sh` clones the Kotlin grammar files, runs the official ANTLR jar to
-generate both Python and Rust parsers, parses every `snippets/*.kt` with
-both, and asserts the dumped trees are byte-identical (the Python dumper
-emits Rust-Debug-shaped string literals so no normalization is needed).
+`run.sh` copies the Kotlin grammar from a local antlr/grammars-v4 checkout
+(passed via `--grammars-v4` / `GRAMMARS_V4`), runs the official ANTLR jar
+to generate both Python and Rust parsers, parses every `snippets/*.kt`
+with both, and asserts the dumped trees are byte-identical. The Python
+dumper emits Rust-Debug-shaped string literals so no normalization is
+needed.
 
 ## Snippets
 

--- a/tests/kotlin-parity/README.md
+++ b/tests/kotlin-parity/README.md
@@ -1,0 +1,33 @@
+# Kotlin parse-tree parity smoke
+
+Compares the Rust runtime's parse tree against `antlr4-python3-runtime` on the
+upstream antlr/grammars-v4 Kotlin grammar.
+
+## What runs
+
+`run.sh` clones the Kotlin grammar files, runs the official ANTLR jar to
+generate both Python and Rust parsers, parses every `snippets/*.kt` with
+both, and asserts the dumped trees are byte-identical (the Python dumper
+emits Rust-Debug-shaped string literals so no normalization is needed).
+
+## Snippets
+
+| File | What it covers |
+| --- | --- |
+| `snippets/01-nested-types.kt` | nested `interface` / `companion object` / `enum class` with a trailing comma / `sealed class` with inheritance call. Exercises the speculative recognizer's greedy loop tie-breaking on `(enumEntry NL*)+`, FIRST-set lookahead pruning across deeply nested rule alternatives, and left-recursive boundary folding under `expression`. |
+| `snippets/02-dataframe.kt` | imports with wildcards, `@DataSchema` annotation, a `dataFrameOf("int")(1).group { int }.into("group").cast<B>(verify = false)` builder chain with a string literal arg, generic type arguments, and indexed access `df[0].group.int`. Exercises the lexer mode stack (string `"..."` open/close inside `(...)` parens — `popMode` must scope back to the right outer mode), function-call chains with multiple parenthesized argument lists, and named arguments. |
+
+Add new snippets by dropping `.kt` files into `snippets/`; the harness picks
+them up automatically.
+
+## Running locally
+
+```sh
+tests/kotlin-parity/run.sh \
+    --antlr-jar /path/to/antlr-4.13.2-complete.jar \
+    --grammars-v4 /path/to/antlr/grammars-v4/checkout
+```
+
+Both arguments can also be supplied via `ANTLR4_JAR` / `GRAMMARS_V4` env vars.
+The CI workflow at `.github/workflows/kotlin-parity.yml` wires the same
+script into a runner that fetches the jar and grammar repo on demand.

--- a/tests/kotlin-parity/dump_python.py
+++ b/tests/kotlin-parity/dump_python.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Parse a source file with an antlr4-python3-runtime parser and dump the parse
+tree in a stable, diff-friendly form.
+
+The script imports a generated lexer and parser produced by `antlr -Dlanguage=Python3`
+from a directory passed as `--gen-dir`. A common module name is required so the
+import works without inventing per-grammar logic; pass `--lexer` and `--parser`
+to override.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+from antlr4 import CommonTokenStream, InputStream
+from antlr4.tree.Tree import TerminalNodeImpl, ErrorNodeImpl
+
+
+def rust_debug_str(text: str) -> str:
+    """Format a Python string the same way Rust's `{:?}` Debug format does for
+    `&str`: double-quoted, escaping `"`, `\\`, and standard ASCII control chars.
+    Keeps the Rust and Python tree dumps byte-identical so the parity check can
+    diff them directly without target-specific repr normalization."""
+    out = ['"']
+    for ch in text:
+        if ch == "\\":
+            out.append("\\\\")
+        elif ch == '"':
+            out.append('\\"')
+        elif ch == "\n":
+            out.append("\\n")
+        elif ch == "\r":
+            out.append("\\r")
+        elif ch == "\t":
+            out.append("\\t")
+        elif ch == "\0":
+            out.append("\\0")
+        elif ord(ch) < 0x20 or ord(ch) == 0x7F:
+            out.append(f"\\u{{{ord(ch):x}}}")
+        else:
+            out.append(ch)
+    out.append('"')
+    return "".join(out)
+
+
+def dump(node, rule_names, depth=0, out=sys.stdout):
+    pad = "  " * depth
+    if isinstance(node, TerminalNodeImpl):
+        out.write(f"{pad}Term({rust_debug_str(node.getText())})\n")
+        return
+    if isinstance(node, ErrorNodeImpl):
+        out.write(f"{pad}Err({rust_debug_str(node.getText())})\n")
+        return
+    rule_index = node.getRuleIndex()
+    name = rule_names[rule_index] if 0 <= rule_index < len(rule_names) else "<?>"
+    children = node.children or []
+    out.write(f"{pad}Rule({name}, children={len(children)})\n")
+    for child in children:
+        dump(child, rule_names, depth + 1, out)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--gen-dir", required=True, help="Directory with Python ANTLR-generated modules")
+    parser.add_argument("--lexer", required=True, help="Lexer module name, e.g. KotlinLexer")
+    parser.add_argument("--parser", required=True, help="Parser module name, e.g. KotlinParser")
+    parser.add_argument("--rule", required=True, help="Entry-point rule name, e.g. kotlinFile")
+    parser.add_argument("--input", required=True, help="Source file to parse")
+    parser.add_argument("--output", default="-", help="Output path (default: stdout)")
+    args = parser.parse_args()
+
+    sys.path.insert(0, args.gen_dir)
+    lexer_module = importlib.import_module(args.lexer)
+    parser_module = importlib.import_module(args.parser)
+    lexer_cls = getattr(lexer_module, args.lexer)
+    parser_cls = getattr(parser_module, args.parser)
+
+    src = Path(args.input).read_text()
+    stream = CommonTokenStream(lexer_cls(InputStream(src)))
+    parser_obj = parser_cls(stream)
+    tree = getattr(parser_obj, args.rule)()
+    out = sys.stdout if args.output == "-" else open(args.output, "w")
+    try:
+        dump(tree, parser_obj.ruleNames, out=out)
+    finally:
+        if out is not sys.stdout:
+            out.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/kotlin-parity/dumper/.gitignore
+++ b/tests/kotlin-parity/dumper/.gitignore
@@ -1,0 +1,4 @@
+/target/
+/Cargo.lock
+/src/generated/kotlin_lexer.rs
+/src/generated/kotlin_parser.rs

--- a/tests/kotlin-parity/dumper/Cargo.toml
+++ b/tests/kotlin-parity/dumper/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "kotlin-parity-dumper"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+antlr4_runtime = { package = "antlr-rust-runtime", path = "../../.." }
+
+[[bin]]
+name = "kotlin-parity-dumper"
+path = "src/main.rs"

--- a/tests/kotlin-parity/dumper/src/main.rs
+++ b/tests/kotlin-parity/dumper/src/main.rs
@@ -1,0 +1,108 @@
+//! Parses a Kotlin source file with the Rust runtime's generated parser and
+//! prints the parse tree in the same diff-friendly form as
+//! `tests/kotlin-parity/dump_python.py`. The smoke workflow compares the two
+//! outputs to enforce parser-tree parity with antlr4-python3-runtime.
+use std::env;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use antlr4_runtime::{CommonTokenStream, InputStream, ParseTree};
+
+mod generated {
+    #![allow(dead_code, unused_imports, unreachable_pub, unused_qualifications)]
+    pub mod kotlin_lexer;
+    pub mod kotlin_parser;
+}
+
+use generated::kotlin_lexer::KotlinLexer;
+use generated::kotlin_parser::KotlinParser;
+
+fn dump(out: &mut dyn Write, tree: &ParseTree, rule_names: &[String], depth: usize) -> io::Result<()> {
+    let pad = "  ".repeat(depth);
+    match tree {
+        ParseTree::Rule(rl) => {
+            let name = rule_names
+                .get(rl.context().rule_index())
+                .map(String::as_str)
+                .unwrap_or("<?>");
+            writeln!(
+                out,
+                "{pad}Rule({name}, children={})",
+                rl.context().children().len()
+            )?;
+            for c in rl.context().children() {
+                dump(out, c, rule_names, depth + 1)?;
+            }
+        }
+        ParseTree::Terminal(t) => writeln!(out, "{pad}Term({:?})", t.text())?,
+        ParseTree::Error(e) => writeln!(out, "{pad}Err({:?})", e.text())?,
+    }
+    Ok(())
+}
+
+fn main() -> ExitCode {
+    let mut args = env::args().skip(1);
+    let mut input: Option<PathBuf> = None;
+    let mut output: Option<PathBuf> = None;
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--input" => input = args.next().map(PathBuf::from),
+            "--output" => output = args.next().map(PathBuf::from),
+            other => {
+                eprintln!("unknown argument: {other}");
+                return ExitCode::from(2);
+            }
+        }
+    }
+    let Some(input) = input else {
+        eprintln!("missing --input <path>");
+        return ExitCode::from(2);
+    };
+    let src = match fs::read_to_string(&input) {
+        Ok(text) => text,
+        Err(err) => {
+            eprintln!("failed to read {}: {err}", input.display());
+            return ExitCode::from(1);
+        }
+    };
+
+    let lexer = KotlinLexer::new(InputStream::new(&src));
+    let tokens = CommonTokenStream::new(lexer);
+    let mut parser = KotlinParser::new(tokens);
+    let tree = match parser.kotlin_file() {
+        Ok(tree) => tree,
+        Err(err) => {
+            eprintln!("parse failed: {err}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let rule_names: Vec<String> = KotlinParser::<KotlinLexer<InputStream>>::metadata()
+        .rule_names()
+        .iter()
+        .map(|s| (*s).to_string())
+        .collect();
+
+    let mut sink: Box<dyn Write> = match output {
+        Some(path) => match fs::File::create(&path) {
+            Ok(file) => Box::new(io::BufWriter::new(file)),
+            Err(err) => {
+                eprintln!("failed to create {}: {err}", path.display());
+                return ExitCode::from(1);
+            }
+        },
+        None => Box::new(io::stdout().lock()),
+    };
+    if let Err(err) = dump(sink.as_mut(), &tree, &rule_names, 0) {
+        eprintln!("write failed: {err}");
+        return ExitCode::from(1);
+    }
+    if let Err(err) = sink.flush() {
+        eprintln!("flush failed: {err}");
+        return ExitCode::from(1);
+    }
+
+    ExitCode::SUCCESS
+}

--- a/tests/kotlin-parity/run.sh
+++ b/tests/kotlin-parity/run.sh
@@ -23,12 +23,19 @@ ANTLR4_JAR="${ANTLR4_JAR:-}"
 GRAMMARS_V4="${GRAMMARS_V4:-}"
 PYTHON="${PYTHON:-python3}"
 
+require_value() {
+    if [ "$#" -lt 2 ]; then
+        echo "missing value for $1" >&2
+        exit 2
+    fi
+}
+
 while [ "$#" -gt 0 ]; do
     case "$1" in
-        --antlr-jar)   ANTLR4_JAR="$2"; shift 2 ;;
-        --grammars-v4) GRAMMARS_V4="$2"; shift 2 ;;
-        --work-dir)    WORK_DIR="$2"; shift 2 ;;
-        --python)      PYTHON="$2"; shift 2 ;;
+        --antlr-jar)   require_value "$@"; ANTLR4_JAR="$2"; shift 2 ;;
+        --grammars-v4) require_value "$@"; GRAMMARS_V4="$2"; shift 2 ;;
+        --work-dir)    require_value "$@"; WORK_DIR="$2"; shift 2 ;;
+        --python)      require_value "$@"; PYTHON="$2"; shift 2 ;;
         *) echo "unknown argument: $1" >&2; exit 2 ;;
     esac
 done

--- a/tests/kotlin-parity/run.sh
+++ b/tests/kotlin-parity/run.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# End-to-end Kotlin parse-tree parity smoke. Generates Python and Rust parsers
+# from the antlr/grammars-v4 Kotlin grammar, parses every snippet under
+# tests/kotlin-parity/snippets/*.kt with both, and asserts the dumped trees are
+# byte-identical.
+#
+# Required environment / arguments:
+#   ANTLR4_JAR (or --antlr-jar):     path to antlr-4.13.2-complete.jar
+#   GRAMMARS_V4 (or --grammars-v4):  path to a checkout of antlr/grammars-v4
+#                                    (e.g. cloned via git sparse-checkout)
+#
+# Optional:
+#   WORK_DIR (or --work-dir):  scratch directory; defaults to a tempdir.
+#   PYTHON   (or --python):    Python interpreter with antlr4-python3-runtime;
+#                              defaults to `python3` on PATH.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+WORK_DIR=""
+ANTLR4_JAR="${ANTLR4_JAR:-}"
+GRAMMARS_V4="${GRAMMARS_V4:-}"
+PYTHON="${PYTHON:-python3}"
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --antlr-jar)   ANTLR4_JAR="$2"; shift 2 ;;
+        --grammars-v4) GRAMMARS_V4="$2"; shift 2 ;;
+        --work-dir)    WORK_DIR="$2"; shift 2 ;;
+        --python)      PYTHON="$2"; shift 2 ;;
+        *) echo "unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$ANTLR4_JAR" ]; then
+    echo "ANTLR4_JAR is required (env var or --antlr-jar)" >&2
+    exit 2
+fi
+if [ -z "$GRAMMARS_V4" ]; then
+    echo "GRAMMARS_V4 is required (env var or --grammars-v4)" >&2
+    exit 2
+fi
+
+if [ -z "$WORK_DIR" ]; then
+    WORK_DIR="$(mktemp -d -t kotlin-parity.XXXXXX)"
+    trap 'rm -rf "$WORK_DIR"' EXIT
+fi
+mkdir -p "$WORK_DIR/grammar" "$WORK_DIR/py-gen" "$WORK_DIR/interp"
+
+KOTLIN_DIR="$GRAMMARS_V4/kotlin/kotlin"
+for grammar in KotlinLexer.g4 KotlinParser.g4 UnicodeClasses.g4; do
+    src="$KOTLIN_DIR/$grammar"
+    if [ ! -f "$src" ]; then
+        echo "missing $src; pass --grammars-v4 to a grammars-v4 checkout" >&2
+        exit 2
+    fi
+    cp "$src" "$WORK_DIR/grammar/"
+done
+
+# --- Generate parsers once for all snippets ---
+(
+    cd "$WORK_DIR/grammar"
+    java -jar "$ANTLR4_JAR" -Dlanguage=Python3 -o "$WORK_DIR/py-gen" \
+        KotlinLexer.g4 KotlinParser.g4
+    java -jar "$ANTLR4_JAR" -o "$WORK_DIR/interp" -Xexact-output-dir \
+        KotlinLexer.g4 KotlinParser.g4
+)
+DUMPER_DIR="$SCRIPT_DIR/dumper"
+DUMPER_GEN="$DUMPER_DIR/src/generated"
+mkdir -p "$DUMPER_GEN"
+cargo run --quiet --release --manifest-path "$REPO_ROOT/Cargo.toml" \
+    --bin antlr4-rust-gen -- \
+    --lexer  "$WORK_DIR/interp/KotlinLexer.interp" \
+    --parser "$WORK_DIR/interp/KotlinParser.interp" \
+    --out-dir "$WORK_DIR/rust-gen"
+cp "$WORK_DIR/rust-gen/kotlin_lexer.rs" "$WORK_DIR/rust-gen/kotlin_parser.rs" "$DUMPER_GEN/"
+cargo build --quiet --release --manifest-path "$DUMPER_DIR/Cargo.toml"
+DUMPER_BIN="$DUMPER_DIR/target/release/kotlin-parity-dumper"
+
+# --- Run each snippet ---
+shopt -s nullglob
+SNIPPETS=("$SCRIPT_DIR"/snippets/*.kt)
+if [ "${#SNIPPETS[@]}" -eq 0 ]; then
+    echo "no snippets found under $SCRIPT_DIR/snippets" >&2
+    exit 2
+fi
+
+failures=0
+for snippet in "${SNIPPETS[@]}"; do
+    name="$(basename "$snippet" .kt)"
+    py_out="$WORK_DIR/$name.python.txt"
+    rs_out="$WORK_DIR/$name.rust.txt"
+    "$PYTHON" "$SCRIPT_DIR/dump_python.py" \
+        --gen-dir "$WORK_DIR/py-gen" \
+        --lexer KotlinLexer \
+        --parser KotlinParser \
+        --rule kotlinFile \
+        --input "$snippet" \
+        --output "$py_out"
+    "$DUMPER_BIN" --input "$snippet" --output "$rs_out"
+    if diff -u "$py_out" "$rs_out"; then
+        echo "Kotlin parity [$name]: parse trees match"
+    else
+        echo "Kotlin parity [$name]: parse trees diverge (diff above)" >&2
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$failures" -gt 0 ]; then
+    echo "Kotlin parity: $failures snippet(s) failed" >&2
+    exit 1
+fi

--- a/tests/kotlin-parity/snippets/01-nested-types.kt
+++ b/tests/kotlin-parity/snippets/01-nested-types.kt
@@ -1,0 +1,16 @@
+interface A {
+    interface B {
+        interface C
+    }
+
+    companion object D {
+        enum class E {
+            E1,
+            E2,
+        }
+
+        sealed class F {
+            class G : F()
+        }
+    }
+}

--- a/tests/kotlin-parity/snippets/02-dataframe.kt
+++ b/tests/kotlin-parity/snippets/02-dataframe.kt
@@ -1,0 +1,24 @@
+import org.jetbrains.kotlinx.dataframe.*
+import org.jetbrains.kotlinx.dataframe.annotations.*
+import org.jetbrains.kotlinx.dataframe.api.*
+import org.jetbrains.kotlinx.dataframe.io.*
+
+@DataSchema
+interface A {
+    val int: Int
+}
+
+@DataSchema
+interface B {
+    val group: A
+}
+
+fun box(): String {
+    val df = dataFrameOf("int")(1)
+        .group { int }.into("group")
+        .cast<B>(verify = false)
+
+    df[0].group.int
+
+    return "OK"
+}


### PR DESCRIPTION
## Summary

Closes #2.

Three changes land together because each is needed for `parse_atn_rule` to actually emit ANTLR-shaped parse trees on real grammars:

- **Nested rule contexts**: the fast recognizer now carries a small `FastRecognizedNode` tree (Token / ErrorToken / MissingToken / Rule / LeftRecursiveBoundary). `parse_atn_rule` walks it into a `ParserRuleContext` instead of streaming consumed tokens, and `LeftRecursiveBoundary` markers fold into wrapper rule nodes so precedence-rule LHS shaping matches ANTLR.
- **Recognizer perf + greedy tie-break**: lookahead-based pruning of `Rule` transitions short-circuits speculative paths whose FIRST set excludes the current lookahead (FIRST-empty rules stay viable as nullable); skipped rules contribute their FIRST set to the diagnostic accumulator so error messages keep matching ANTLR. Outcome dedup is rewritten to preserve ATN transition-discovery order so greedy `*`/`+` loops keep the loop-body fragment when two paths tie.
- **Lexer mode scoping**: `LexerActionTrace` now carries the rule index of its source action transition, and non-Custom commands (`pushMode`, `popMode`, `mode`, …) only fire when the action's rule matches the accepted rule (or comes from a fragment). This fixes mode-stack drift on the Kotlin grammar's `Inside_QUOTE_OPEN : QUOTE_OPEN -> pushMode(LineString), type(QUOTE_OPEN)` pattern.

## Smoke test + CI

`tests/kotlin-parity/` adds a parity smoke against `antlr4-python3-runtime` on the upstream Kotlin grammar:
- `snippets/01-nested-types.kt` — nested `interface` / `companion object` / `enum class` with trailing comma / `sealed class : F()`. Exercises greedy loop tie-breaking, FIRST-set pruning, and left-recursive boundary folding.
- `snippets/02-dataframe.kt` — DataFrame builder chain `dataFrameOf(\"int\")(1).group { int }.into(\"group\").cast<B>(verify = false)`. Exercises lexer mode scoping (string `\"...\"` inside parens), generic type args, and named arguments.

`.github/workflows/kotlin-parity.yml` runs the smoke on PRs and pushes to main, pinning grammars-v4 to a known commit.

## Test plan

- [x] `cargo test --lib` — 35/35
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings`
- [x] Runtime testsuite groups (manual): ParseTrees 10/10, ParserExec 50/50, ParserErrors 34/34 (was 32/34 — 2 regressions fixed), LeftRecursion 98/98, SemPredEvalParser 26/26, Listeners 7/7, FullContextParsing 15/15, CompositeParsers 15/15, Sets 31/31, LexerExec 42/42, LexerErrors 12/12, SemPredEvalLexer 8/8, CompositeLexers 2/2
- [x] Java20 reproducer from issue #2 — Rust tree matches Python tree byte-for-byte
- [x] Kotlin parity smoke — both snippets match Python tree byte-for-byte

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Kotlin parser parity smoke test suite and CI workflow to run it on push/PRs/manual runs.
* **Documentation**
  * Updated compatibility strategy to emphasize parse-tree shape alignment with ANTLR targets and listener/caching behavior.
* **Tests**
  * Added end-to-end parity test runner, language snippet fixtures, and matching Rust/Python dumper tools to compare parse-tree outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ophidiarium/antlr-rust-runtime/pull/3?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->