### PR TITLE
[codex] Optimize C# parse benchmark runtime

### DIFF
--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -398,8 +398,10 @@ where
         semantic_predicate,
     );
     let mut active = prune_after_accepts(atn, start_closure.configs);
-    let mut dfa_state =
-        lexer.lexer_dfa_state(lexer_dfa_key(&active), accept_prediction(atn, &active));
+    let mut dfa_state = lexer.lexer_dfa_state(
+        lexer_dfa_key(&active, start),
+        accept_prediction(atn, &active),
+    );
     let mut dfa_state_has_semantic_context = start_closure.has_semantic_context;
 
     let mut best = best_accept(atn, &active);
@@ -438,8 +440,10 @@ where
         let suppress_edge = source_has_semantic_context || target_has_semantic_context;
         active = prune_after_accepts(atn, closure.configs);
         if !active.is_empty() {
-            dfa_state =
-                lexer.lexer_dfa_state(lexer_dfa_key(&active), accept_prediction(atn, &active));
+            dfa_state = lexer.lexer_dfa_state(
+                lexer_dfa_key(&active, start),
+                accept_prediction(atn, &active),
+            );
             dfa_state_has_semantic_context = target_has_semantic_context;
             if !suppress_edge {
                 if let Some(symbol) = edge_symbol {
@@ -518,7 +522,7 @@ where
 
         let source_dfa_state = dfa_state;
         let source_has_semantic_context = cached_state.has_semantic_context;
-        let active = cached_configs_to_configs(&cached_state.configs, position);
+        let active = cached_configs_to_configs(&cached_state.configs, start, position);
         let mut next = Vec::new();
         for config in active {
             let Some(state) = atn.state(config.state) else {
@@ -554,6 +558,7 @@ where
             atn,
             &active,
             target_has_semantic_context,
+            start,
             target_position,
         );
         if !suppress_edge && symbol != EOF {
@@ -615,6 +620,7 @@ where
         &active,
         start_closure.has_semantic_context,
         start,
+        start,
     );
     if !start_closure.has_semantic_context {
         lexer.cache_lexer_mode_start(mode, state);
@@ -627,18 +633,25 @@ fn cache_dfa_state<I, F>(
     atn: &Atn,
     active: &[LexerConfig],
     has_semantic_context: bool,
+    token_start: usize,
     position: usize,
 ) -> usize
 where
     I: CharStream,
     F: TokenFactory,
 {
-    let state = lexer.lexer_dfa_state(lexer_dfa_key(active), accept_prediction(atn, active));
+    let state = lexer.lexer_dfa_state(
+        lexer_dfa_key(active, token_start),
+        accept_prediction(atn, active),
+    );
     lexer.cache_lexer_dfa_state(
         state,
         LexerDfaCachedState {
             has_semantic_context,
-            configs: active.iter().map(normalized_config_key).collect(),
+            configs: active
+                .iter()
+                .map(|config| normalized_config_key(config, token_start))
+                .collect(),
             accept: best_accept(atn, active).map(|accept| LexerDfaCachedAccept {
                 position_delta: accept.position.saturating_sub(position),
                 rule_index: accept.rule_index,
@@ -648,6 +661,7 @@ where
                     .iter()
                     .map(|action| LexerDfaActionKey {
                         action_index: action.action_index,
+                        position_delta: action.position.saturating_sub(token_start),
                         rule_index: action.rule_index,
                     })
                     .collect(),
@@ -672,7 +686,7 @@ fn cached_accept_state(
             .iter()
             .map(|action| LexerActionTrace {
                 action_index: action.action_index,
-                position: token_start,
+                position: token_start + action.position_delta,
                 rule_index: action.rule_index,
             })
             .collect(),
@@ -887,18 +901,18 @@ fn accept_prediction(atn: &Atn, configs: &[LexerConfig]) -> Option<i32> {
 /// Builds a stable DFA state identity from a lexer closure while ignoring the
 /// absolute input position, matching ANTLR's cache shape rather than one input
 /// occurrence.
-fn lexer_dfa_key(configs: &[LexerConfig]) -> LexerDfaKey {
+fn lexer_dfa_key(configs: &[LexerConfig], token_start: usize) -> LexerDfaKey {
     LexerDfaKey::new(
         configs
             .iter()
-            .map(normalized_config_key)
+            .map(|config| normalized_config_key(config, token_start))
             .collect::<Vec<_>>(),
     )
 }
 
 /// Normalizes a config for DFA-state identity without embedding its absolute
 /// character offset in the current input.
-fn normalized_config_key(config: &LexerConfig) -> LexerDfaConfigKey {
+fn normalized_config_key(config: &LexerConfig, token_start: usize) -> LexerDfaConfigKey {
     LexerDfaConfigKey::new(
         config.state,
         config.alt_rule_index,
@@ -910,6 +924,7 @@ fn normalized_config_key(config: &LexerConfig) -> LexerDfaConfigKey {
             .iter()
             .map(|action| LexerDfaActionKey {
                 action_index: action.action_index,
+                position_delta: action.position.saturating_sub(token_start),
                 rule_index: action.rule_index,
             })
             .collect(),
@@ -924,7 +939,11 @@ fn shared_config_position(configs: &[LexerConfig]) -> Option<usize> {
         .then_some(position)
 }
 
-fn cached_configs_to_configs(configs: &[LexerDfaConfigKey], position: usize) -> Vec<LexerConfig> {
+fn cached_configs_to_configs(
+    configs: &[LexerDfaConfigKey],
+    token_start: usize,
+    position: usize,
+) -> Vec<LexerConfig> {
     configs
         .iter()
         .map(|config| LexerConfig {
@@ -939,7 +958,7 @@ fn cached_configs_to_configs(configs: &[LexerDfaConfigKey], position: usize) -> 
                 .iter()
                 .map(|action| LexerActionTrace {
                     action_index: action.action_index,
-                    position,
+                    position: token_start + action.position_delta,
                     rule_index: action.rule_index,
                 })
                 .collect(),

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -922,10 +922,16 @@ fn normalized_config_key(config: &LexerConfig, token_start: usize) -> LexerDfaCo
         config
             .actions
             .iter()
-            .map(|action| LexerDfaActionKey {
-                action_index: action.action_index,
-                position_delta: action.position.saturating_sub(token_start),
-                rule_index: action.rule_index,
+            .map(|action| {
+                debug_assert!(
+                    action.position >= token_start,
+                    "lexer DFA action position must be relative to the current token"
+                );
+                LexerDfaActionKey {
+                    action_index: action.action_index,
+                    position_delta: action.position.saturating_sub(token_start),
+                    rule_index: action.rule_index,
+                }
             })
             .collect(),
     )

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -4,7 +4,8 @@ use crate::atn::{Atn, AtnStateKind, LexerAction, Transition};
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
 use crate::lexer::{
-    BaseLexer, Lexer, LexerCustomAction, LexerDfaConfigKey, LexerDfaKey, LexerPredicate,
+    BaseLexer, Lexer, LexerCustomAction, LexerDfaActionKey, LexerDfaCachedAccept,
+    LexerDfaCachedState, LexerDfaCachedTransition, LexerDfaConfigKey, LexerDfaKey, LexerPredicate,
 };
 use crate::token::{CommonToken, DEFAULT_CHANNEL, INVALID_TOKEN_TYPE, TokenFactory};
 
@@ -118,7 +119,7 @@ where
     I: CharStream,
     F: TokenFactory,
 {
-    next_token_with_hooks(lexer, atn, |_, _| {}, |_, _| true, |_, _, _| {})
+    next_token_with_cache(lexer, atn, |_, _| {}, |_, _| true, |_, _, _| {})
 }
 
 /// Runs one lexer-token match and invokes `custom_action` for embedded
@@ -203,6 +204,55 @@ where
     P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
     E: FnMut(&mut BaseLexer<I, F>, i32, usize),
 {
+    next_token_with_hooks_impl(
+        lexer,
+        atn,
+        &mut custom_action,
+        &mut semantic_predicate,
+        &mut accept_adjuster,
+        false,
+    )
+}
+
+fn next_token_with_cache<I, F, A, P, E>(
+    lexer: &mut BaseLexer<I, F>,
+    atn: &Atn,
+    mut custom_action: A,
+    mut semantic_predicate: P,
+    mut accept_adjuster: E,
+) -> CommonToken
+where
+    I: CharStream,
+    F: TokenFactory,
+    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+{
+    next_token_with_hooks_impl(
+        lexer,
+        atn,
+        &mut custom_action,
+        &mut semantic_predicate,
+        &mut accept_adjuster,
+        true,
+    )
+}
+
+fn next_token_with_hooks_impl<I, F, A, P, E>(
+    lexer: &mut BaseLexer<I, F>,
+    atn: &Atn,
+    custom_action: &mut A,
+    semantic_predicate: &mut P,
+    accept_adjuster: &mut E,
+    use_cache: bool,
+) -> CommonToken
+where
+    I: CharStream,
+    F: TokenFactory,
+    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+{
     let mut continuing_more = false;
     loop {
         if lexer.hit_eof() {
@@ -214,7 +264,12 @@ where
         }
         let mode = lexer.mode();
         let start = lexer.input().index();
-        let accept = match match_token(lexer, atn, mode, start, &mut semantic_predicate) {
+        let token_match = if use_cache {
+            match_token_cached(lexer, atn, mode, start, semantic_predicate)
+        } else {
+            match_token(lexer, atn, mode, start, semantic_predicate)
+        };
+        let accept = match token_match {
             MatchResult::Accept(accept) => accept,
             MatchResult::NoViableAlt { stop } => {
                 lexer.input_mut().seek(start);
@@ -407,6 +462,221 @@ where
         MatchResult::NoViableAlt { stop: error_stop },
         MatchResult::Accept,
     )
+}
+
+fn match_token_cached<I, F, P>(
+    lexer: &mut BaseLexer<I, F>,
+    atn: &Atn,
+    mode: i32,
+    start: usize,
+    semantic_predicate: &mut P,
+) -> MatchResult
+where
+    I: CharStream,
+    F: TokenFactory,
+    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+{
+    let Some(mut dfa_state) = cached_mode_start_state(lexer, atn, mode, start, semantic_predicate)
+    else {
+        return MatchResult::NoViableAlt { stop: start };
+    };
+
+    let mut position = start;
+    let mut best = None;
+    let mut error_stop = start;
+    loop {
+        let Some(cached_state) = lexer.cached_lexer_dfa_state(dfa_state) else {
+            return match_token(lexer, atn, mode, start, semantic_predicate);
+        };
+        if let Some(accept) = cached_state.accept.as_ref() {
+            let accept = cached_accept_state(accept, start, position);
+            if best.as_ref().is_none_or(|current: &AcceptState| {
+                accept.position > current.position
+                    || (accept.position == current.position
+                        && accept.rule_index < current.rule_index)
+            }) {
+                best = Some(accept);
+            }
+        }
+
+        let symbol = symbol_at(lexer, position);
+        if symbol != EOF {
+            error_stop = error_stop.max(position.saturating_add(1));
+        }
+
+        if !cached_state.has_semantic_context {
+            if let Some(cached) = lexer.cached_lexer_dfa_transition(dfa_state, symbol) {
+                let source_state = dfa_state;
+                dfa_state = cached.target_state;
+                position += cached.position_delta;
+                if symbol != EOF {
+                    lexer.record_lexer_dfa_edge(source_state, symbol, dfa_state);
+                }
+                continue;
+            }
+        }
+
+        let source_dfa_state = dfa_state;
+        let source_has_semantic_context = cached_state.has_semantic_context;
+        let active = cached_configs_to_configs(&cached_state.configs, position);
+        let mut next = Vec::new();
+        for config in active {
+            let Some(state) = atn.state(config.state) else {
+                continue;
+            };
+            for transition in &state.transitions {
+                if !transition.matches(symbol, MIN_CHAR_VALUE, MAX_CHAR_VALUE) {
+                    continue;
+                }
+                let mut advanced = config.clone();
+                set_config_state(atn, &mut advanced, transition.target());
+                if symbol == EOF {
+                    advanced.consumed_eof = true;
+                } else {
+                    advanced.position += 1;
+                }
+                next.push(advanced);
+            }
+        }
+
+        let closure = epsilon_closure(lexer, atn, next, semantic_predicate);
+        let target_has_semantic_context = closure.has_semantic_context;
+        let suppress_edge = source_has_semantic_context || target_has_semantic_context;
+        let active = prune_after_accepts(atn, closure.configs);
+        if active.is_empty() {
+            break;
+        }
+        let Some(target_position) = shared_config_position(&active) else {
+            return match_token(lexer, atn, mode, start, semantic_predicate);
+        };
+        dfa_state = cache_dfa_state(
+            lexer,
+            atn,
+            &active,
+            target_has_semantic_context,
+            target_position,
+        );
+        if !suppress_edge && symbol != EOF {
+            lexer.record_lexer_dfa_edge(source_dfa_state, symbol, dfa_state);
+            lexer.cache_lexer_dfa_transition(
+                source_dfa_state,
+                symbol,
+                LexerDfaCachedTransition {
+                    target_state: dfa_state,
+                    position_delta: target_position.saturating_sub(position),
+                },
+            );
+        }
+        position = target_position;
+    }
+
+    best.map_or(
+        MatchResult::NoViableAlt { stop: error_stop },
+        MatchResult::Accept,
+    )
+}
+
+fn cached_mode_start_state<I, F, P>(
+    lexer: &mut BaseLexer<I, F>,
+    atn: &Atn,
+    mode: i32,
+    start: usize,
+    semantic_predicate: &mut P,
+) -> Option<usize>
+where
+    I: CharStream,
+    F: TokenFactory,
+    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+{
+    if let Some(state) = lexer.cached_lexer_mode_start(mode) {
+        return Some(state);
+    }
+
+    let mode_index = usize::try_from(mode).ok()?;
+    let start_state = atn.mode_to_start_state().get(mode_index).copied()?;
+    let start_closure = epsilon_closure(
+        lexer,
+        atn,
+        [LexerConfig {
+            state: start_state,
+            position: start,
+            consumed_eof: false,
+            alt_rule_index: None,
+            passed_non_greedy: false,
+            stack: Vec::new(),
+            actions: Vec::new(),
+        }],
+        semantic_predicate,
+    );
+    let active = prune_after_accepts(atn, start_closure.configs);
+    let state = cache_dfa_state(
+        lexer,
+        atn,
+        &active,
+        start_closure.has_semantic_context,
+        start,
+    );
+    if !start_closure.has_semantic_context {
+        lexer.cache_lexer_mode_start(mode, state);
+    }
+    Some(state)
+}
+
+fn cache_dfa_state<I, F>(
+    lexer: &mut BaseLexer<I, F>,
+    atn: &Atn,
+    active: &[LexerConfig],
+    has_semantic_context: bool,
+    position: usize,
+) -> usize
+where
+    I: CharStream,
+    F: TokenFactory,
+{
+    let state = lexer.lexer_dfa_state(lexer_dfa_key(active), accept_prediction(atn, active));
+    lexer.cache_lexer_dfa_state(
+        state,
+        LexerDfaCachedState {
+            has_semantic_context,
+            configs: active.iter().map(normalized_config_key).collect(),
+            accept: best_accept(atn, active).map(|accept| LexerDfaCachedAccept {
+                position_delta: accept.position.saturating_sub(position),
+                rule_index: accept.rule_index,
+                consumed_eof: accept.consumed_eof,
+                actions: accept
+                    .actions
+                    .iter()
+                    .map(|action| LexerDfaActionKey {
+                        action_index: action.action_index,
+                        rule_index: action.rule_index,
+                    })
+                    .collect(),
+            }),
+        },
+    );
+    state
+}
+
+fn cached_accept_state(
+    accept: &LexerDfaCachedAccept,
+    token_start: usize,
+    state_position: usize,
+) -> AcceptState {
+    let position = state_position + accept.position_delta;
+    AcceptState {
+        position,
+        rule_index: accept.rule_index,
+        consumed_eof: accept.consumed_eof,
+        actions: accept
+            .actions
+            .iter()
+            .map(|action| LexerActionTrace {
+                action_index: action.action_index,
+                position: token_start,
+                rule_index: action.rule_index,
+            })
+            .collect(),
+    }
 }
 
 /// Expands epsilon, rule-call, predicate, precedence, and action transitions
@@ -638,9 +908,43 @@ fn normalized_config_key(config: &LexerConfig) -> LexerDfaConfigKey {
         config
             .actions
             .iter()
-            .map(|action| action.action_index)
+            .map(|action| LexerDfaActionKey {
+                action_index: action.action_index,
+                rule_index: action.rule_index,
+            })
             .collect(),
     )
+}
+
+fn shared_config_position(configs: &[LexerConfig]) -> Option<usize> {
+    let position = configs.first()?.position;
+    configs
+        .iter()
+        .all(|config| config.position == position)
+        .then_some(position)
+}
+
+fn cached_configs_to_configs(configs: &[LexerDfaConfigKey], position: usize) -> Vec<LexerConfig> {
+    configs
+        .iter()
+        .map(|config| LexerConfig {
+            state: config.state,
+            position,
+            consumed_eof: config.consumed_eof,
+            alt_rule_index: config.alt_rule_index,
+            passed_non_greedy: config.passed_non_greedy,
+            stack: config.stack.clone(),
+            actions: config
+                .actions
+                .iter()
+                .map(|action| LexerActionTrace {
+                    action_index: action.action_index,
+                    position,
+                    rule_index: action.rule_index,
+                })
+                .collect(),
+        })
+        .collect()
 }
 
 /// Moves a lexer config to `state_number` and records the top-level lexer rule

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -480,10 +480,14 @@ where
     F: TokenFactory,
     P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
 {
-    let Some(mut dfa_state) = cached_mode_start_state(lexer, atn, mode, start, semantic_predicate)
+    let Some((mut dfa_state, mode_start_has_semantic_context)) =
+        cached_mode_start_state(lexer, atn, mode, start, semantic_predicate)
     else {
         return MatchResult::NoViableAlt { stop: start };
     };
+    if mode_start_has_semantic_context {
+        return match_token(lexer, atn, mode, start, semantic_predicate);
+    }
 
     let mut position = start;
     let mut best = None;
@@ -492,6 +496,9 @@ where
         let Some(cached_state) = lexer.cached_lexer_dfa_state(dfa_state) else {
             return match_token(lexer, atn, mode, start, semantic_predicate);
         };
+        if cached_state.has_semantic_context {
+            return match_token(lexer, atn, mode, start, semantic_predicate);
+        }
         if let Some(accept) = cached_state.accept.as_ref() {
             let accept = cached_accept_state(accept, start, position);
             if best.as_ref().is_none_or(|current: &AcceptState| {
@@ -545,6 +552,9 @@ where
 
         let closure = epsilon_closure(lexer, atn, next, semantic_predicate);
         let target_has_semantic_context = closure.has_semantic_context;
+        if target_has_semantic_context {
+            return match_token(lexer, atn, mode, start, semantic_predicate);
+        }
         let suppress_edge = source_has_semantic_context || target_has_semantic_context;
         let active = prune_after_accepts(atn, closure.configs);
         if active.is_empty() {
@@ -587,14 +597,14 @@ fn cached_mode_start_state<I, F, P>(
     mode: i32,
     start: usize,
     semantic_predicate: &mut P,
-) -> Option<usize>
+) -> Option<(usize, bool)>
 where
     I: CharStream,
     F: TokenFactory,
     P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
 {
     if let Some(state) = lexer.cached_lexer_mode_start(mode) {
-        return Some(state);
+        return Some((state, false));
     }
 
     let mode_index = usize::try_from(mode).ok()?;
@@ -625,7 +635,7 @@ where
     if !start_closure.has_semantic_context {
         lexer.cache_lexer_mode_start(mode, state);
     }
-    Some(state)
+    Some((state, start_closure.has_semantic_context))
 }
 
 fn cache_dfa_state<I, F>(
@@ -644,30 +654,32 @@ where
         lexer_dfa_key(active, token_start),
         accept_prediction(atn, active),
     );
-    lexer.cache_lexer_dfa_state(
-        state,
-        LexerDfaCachedState {
-            has_semantic_context,
-            configs: active
-                .iter()
-                .map(|config| normalized_config_key(config, token_start))
-                .collect(),
-            accept: best_accept(atn, active).map(|accept| LexerDfaCachedAccept {
-                position_delta: accept.position.saturating_sub(position),
-                rule_index: accept.rule_index,
-                consumed_eof: accept.consumed_eof,
-                actions: accept
-                    .actions
+    if !has_semantic_context {
+        lexer.cache_lexer_dfa_state(
+            state,
+            LexerDfaCachedState {
+                has_semantic_context,
+                configs: active
                     .iter()
-                    .map(|action| LexerDfaActionKey {
-                        action_index: action.action_index,
-                        position_delta: action.position.saturating_sub(token_start),
-                        rule_index: action.rule_index,
-                    })
+                    .map(|config| normalized_config_key(config, token_start))
                     .collect(),
-            }),
-        },
-    );
+                accept: best_accept(atn, active).map(|accept| LexerDfaCachedAccept {
+                    position_delta: accept.position.saturating_sub(position),
+                    rule_index: accept.rule_index,
+                    consumed_eof: accept.consumed_eof,
+                    actions: accept
+                        .actions
+                        .iter()
+                        .map(|action| LexerDfaActionKey {
+                            action_index: action.action_index,
+                            position_delta: action.position.saturating_sub(token_start),
+                            rule_index: action.rule_index,
+                        })
+                        .collect(),
+                }),
+            },
+        );
+    }
     state
 }
 
@@ -1025,11 +1037,29 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::atn::AtnType;
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
     use crate::char_stream::InputStream;
     use crate::recognizer::RecognizerData;
     use crate::token::{TOKEN_EOF, Token};
     use crate::vocabulary::Vocabulary;
+
+    #[test]
+    fn predicate_sensitive_lexer_state_is_not_replay_cached() {
+        let atn = Atn::new(AtnType::Lexer, 1);
+        let data = RecognizerData::new(
+            "T",
+            Vocabulary::new([None, Some("T")], [None, Some("T")], [None::<&str>, None]),
+        );
+        let mut lexer = BaseLexer::new(InputStream::new(""), data);
+
+        let predicate_state = cache_dfa_state(&mut lexer, &atn, &[], true, 0, 0);
+        assert!(lexer.cached_lexer_dfa_state(predicate_state).is_none());
+
+        let plain_state = cache_dfa_state(&mut lexer, &atn, &[], false, 0, 0);
+        assert_eq!(predicate_state, plain_state);
+        assert!(lexer.cached_lexer_dfa_state(plain_state).is_some());
+    }
 
     #[test]
     fn lexer_matches_longest_token_and_skips() {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -116,6 +116,9 @@ struct LexerDfaTrace {
     state_numbers: BTreeMap<LexerDfaKey, usize>,
     accept_predictions: BTreeMap<usize, i32>,
     edges: BTreeSet<LexerDfaEdge>,
+    cached_states: BTreeMap<usize, LexerDfaCachedState>,
+    transitions: BTreeMap<(usize, i32), LexerDfaCachedTransition>,
+    mode_starts: BTreeMap<i32, usize>,
 }
 
 impl LexerDfaTrace {
@@ -124,6 +127,9 @@ impl LexerDfaTrace {
             state_numbers: BTreeMap::new(),
             accept_predictions: BTreeMap::new(),
             edges: BTreeSet::new(),
+            cached_states: BTreeMap::new(),
+            transitions: BTreeMap::new(),
+            mode_starts: BTreeMap::new(),
         }
     }
 }
@@ -144,12 +150,18 @@ impl LexerDfaKey {
 /// One lexer ATN config identity with the absolute input position removed.
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct LexerDfaConfigKey {
-    state: usize,
-    alt_rule_index: Option<usize>,
-    consumed_eof: bool,
-    passed_non_greedy: bool,
-    stack: Vec<usize>,
-    actions: Vec<usize>,
+    pub(crate) state: usize,
+    pub(crate) alt_rule_index: Option<usize>,
+    pub(crate) consumed_eof: bool,
+    pub(crate) passed_non_greedy: bool,
+    pub(crate) stack: Vec<usize>,
+    pub(crate) actions: Vec<LexerDfaActionKey>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct LexerDfaActionKey {
+    pub(crate) action_index: usize,
+    pub(crate) rule_index: usize,
 }
 
 impl LexerDfaConfigKey {
@@ -159,7 +171,7 @@ impl LexerDfaConfigKey {
         consumed_eof: bool,
         passed_non_greedy: bool,
         stack: Vec<usize>,
-        actions: Vec<usize>,
+        actions: Vec<LexerDfaActionKey>,
     ) -> Self {
         Self {
             state,
@@ -170,6 +182,27 @@ impl LexerDfaConfigKey {
             actions,
         }
     }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LexerDfaCachedTransition {
+    pub(crate) target_state: usize,
+    pub(crate) position_delta: usize,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LexerDfaCachedAccept {
+    pub(crate) position_delta: usize,
+    pub(crate) rule_index: usize,
+    pub(crate) consumed_eof: bool,
+    pub(crate) actions: Vec<LexerDfaActionKey>,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LexerDfaCachedState {
+    pub(crate) has_semantic_context: bool,
+    pub(crate) configs: Vec<LexerDfaConfigKey>,
+    pub(crate) accept: Option<LexerDfaCachedAccept>,
 }
 
 /// One printable lexer DFA edge keyed so repeated matches keep deterministic
@@ -474,6 +507,49 @@ where
         self.lexer_dfa
             .edges
             .insert(LexerDfaEdge { from, symbol, to });
+    }
+
+    pub(crate) fn cached_lexer_dfa_transition(
+        &self,
+        state: usize,
+        symbol: i32,
+    ) -> Option<LexerDfaCachedTransition> {
+        self.lexer_dfa.transitions.get(&(state, symbol)).cloned()
+    }
+
+    pub(crate) fn cache_lexer_dfa_transition(
+        &mut self,
+        state: usize,
+        symbol: i32,
+        transition: LexerDfaCachedTransition,
+    ) {
+        self.lexer_dfa
+            .transitions
+            .entry((state, symbol))
+            .or_insert(transition);
+    }
+
+    pub(crate) fn cached_lexer_dfa_state(&self, state: usize) -> Option<LexerDfaCachedState> {
+        self.lexer_dfa.cached_states.get(&state).cloned()
+    }
+
+    pub(crate) fn cache_lexer_dfa_state(
+        &mut self,
+        state: usize,
+        cached_state: LexerDfaCachedState,
+    ) {
+        self.lexer_dfa
+            .cached_states
+            .entry(state)
+            .or_insert(cached_state);
+    }
+
+    pub(crate) fn cached_lexer_mode_start(&self, mode: i32) -> Option<usize> {
+        self.lexer_dfa.mode_starts.get(&mode).copied()
+    }
+
+    pub(crate) fn cache_lexer_mode_start(&mut self, mode: i32, state: usize) {
+        self.lexer_dfa.mode_starts.entry(mode).or_insert(state);
     }
 
     /// Serializes the observed default-mode lexer DFA in ANTLR's text shape.

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -161,6 +161,7 @@ pub(crate) struct LexerDfaConfigKey {
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
 pub(crate) struct LexerDfaActionKey {
     pub(crate) action_index: usize,
+    pub(crate) position_delta: usize,
     pub(crate) rule_index: usize,
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,6 +83,7 @@ use crate::vocabulary::Vocabulary;
 /// non-viable. Long expression-regression descriptors legitimately walk tens
 /// of thousands of ATN edges.
 const RECOGNITION_DEPTH_LIMIT: usize = 100_000;
+const FAST_RECOGNIZER_DEFERRED_FILL_AT: usize = 64;
 
 /// Parser semantic action reached while recognizing one ATN path.
 ///
@@ -640,9 +641,43 @@ impl TokenBitSet {
         } else {
             (stop, start)
         };
-        for symbol in start..=stop {
-            self.insert(symbol);
+        if start <= TOKEN_EOF && stop >= TOKEN_EOF {
+            self.insert(TOKEN_EOF);
         }
+        let positive_start = start.max(1);
+        if positive_start > stop {
+            return;
+        }
+        let Some(start_slot) = token_bit_slot(positive_start) else {
+            return;
+        };
+        let Some(stop_slot) = token_bit_slot(stop) else {
+            return;
+        };
+        self.extend_slot_range(start_slot, stop_slot);
+    }
+
+    fn extend_slot_range(&mut self, start_slot: usize, stop_slot: usize) {
+        if start_slot > stop_slot {
+            return;
+        }
+        let start_word = start_slot / u64::BITS as usize;
+        let stop_word = stop_slot / u64::BITS as usize;
+        if stop_word >= self.words.len() {
+            self.words.resize(stop_word + 1, 0);
+        }
+        let start_offset = start_slot % u64::BITS as usize;
+        let stop_offset = stop_slot % u64::BITS as usize;
+        if start_word == stop_word {
+            self.words[start_word] |=
+                (!0_u64 << start_offset) & (!0_u64 >> (u64::BITS as usize - 1 - stop_offset));
+            return;
+        }
+        self.words[start_word] |= !0_u64 << start_offset;
+        for word in &mut self.words[(start_word + 1)..stop_word] {
+            *word = !0_u64;
+        }
+        self.words[stop_word] |= !0_u64 >> (u64::BITS as usize - 1 - stop_offset);
     }
 
     fn extend_iter(&mut self, symbols: impl IntoIterator<Item = i32>) {
@@ -1679,7 +1714,6 @@ where
             })?;
 
         let start_index = self.current_visible_index();
-        self.input.fill();
         self.clear_prediction_diagnostics();
         self.reset_per_parse_caches();
         self.fast_recovery_enabled = false;
@@ -1776,7 +1810,7 @@ where
         stop_state: usize,
         start_index: usize,
     ) -> Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens> {
-        let memo_capacity = self.input.size().saturating_mul(4).min(1_000_000);
+        let memo_capacity = self.input.size().saturating_mul(4).clamp(65_536, 262_144);
         let mut visiting = FxHashSet::with_capacity_and_hasher(256, FxBuildHasher::default());
         let mut memo = FxHashMap::with_capacity_and_hasher(memo_capacity, FxBuildHasher::default());
         let mut expected = ExpectedTokens::default();
@@ -4008,6 +4042,9 @@ where
     /// every state visit, so avoiding the seek round-trip is a measurable
     /// hot-path win on long inputs.
     fn token_type_at(&mut self, index: usize) -> i32 {
+        if index >= FAST_RECOGNIZER_DEFERRED_FILL_AT && !self.input.is_filled() {
+            self.input.fill();
+        }
         self.input.token_type_at_index(index)
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1462,10 +1462,12 @@ struct FastRecognizeRequest {
     recovery_state: Option<usize>,
 }
 
-/// Memo key for the fast recognizer. `recovery_symbols` is interned by the
-/// parser before it reaches this key, so equal sets share one allocation and
-/// the key can store that allocation's address instead of cloning an `Rc` and
-/// walking the full `BTreeSet`.
+/// Memo key for the fast recognizer. `recovery_symbols` must come from
+/// `intern_recovery_symbols` or `empty_recovery_symbols` before it reaches this
+/// key, so equal sets share one allocation and the key can store that
+/// allocation's address instead of cloning an `Rc` and walking the full
+/// `BTreeSet`. Bypassing the interner would turn content-equal recovery sets
+/// into distinct cache coordinates.
 #[derive(Clone, Debug)]
 struct FastRecognizeKey {
     state_number: usize,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -39,8 +39,7 @@ impl Hasher for FxHasher {
             bytes = rest;
         }
         for byte in bytes {
-            self.hash =
-                (self.hash.rotate_left(FX_ROT) ^ u64::from(*byte)).wrapping_mul(FX_SEED);
+            self.hash = (self.hash.rotate_left(FX_ROT) ^ u64::from(*byte)).wrapping_mul(FX_SEED);
         }
     }
     #[inline]
@@ -362,6 +361,15 @@ pub struct BaseParser<S> {
     /// when the first pass produces no clean outcome so the runtime can
     /// repair inputs the reference parser would have repaired.
     fast_first_set_prefilter: bool,
+    /// Whether the fast recognizer should explore parser error-recovery paths.
+    /// Public rule parsing starts with this disabled for the common valid-input
+    /// path and enables it only for the retry that needs ANTLR-style repairs.
+    fast_recovery_enabled: bool,
+    /// Whether the fast recognizer should record terminal-token nodes while
+    /// speculating. Clean valid-input parsing can reconstruct terminals from
+    /// selected rule spans after recognition, avoiding many speculative `Rc`
+    /// nodes that are thrown away with losing paths.
+    fast_token_nodes_enabled: bool,
 }
 
 #[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
@@ -469,6 +477,57 @@ impl NodeList {
         }
         out
     }
+
+    const fn iter(&self) -> NodeListIter<'_> {
+        NodeListIter { cursor: self }
+    }
+
+    fn has_left_recursive_boundary(&self) -> bool {
+        self.iter().any(|node| {
+            matches!(
+                node.as_ref(),
+                FastRecognizedNode::LeftRecursiveBoundary { .. }
+            )
+        })
+    }
+
+    fn has_explicit_token_node(&self) -> bool {
+        self.iter().any(|node| {
+            matches!(
+                node.as_ref(),
+                FastRecognizedNode::Token { .. }
+                    | FastRecognizedNode::ErrorToken { .. }
+                    | FastRecognizedNode::MissingToken { .. }
+            )
+        })
+    }
+
+    /// Builds a list from an already ordered vector.
+    fn from_vec(nodes: Vec<Rc<FastRecognizedNode>>) -> Self {
+        let mut list = Self::new();
+        for node in nodes.into_iter().rev() {
+            list.prepend(node);
+        }
+        list
+    }
+}
+
+struct NodeListIter<'a> {
+    cursor: &'a NodeList,
+}
+
+impl<'a> Iterator for NodeListIter<'a> {
+    type Item = &'a Rc<FastRecognizedNode>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.cursor {
+            NodeList::Empty => None,
+            NodeList::Cons { head, tail } => {
+                self.cursor = tail.as_ref();
+                Some(head)
+            }
+        }
+    }
 }
 
 /// Minimal parse-tree fragment retained by the fast recognizer so the public
@@ -492,7 +551,7 @@ enum FastRecognizedNode {
         invoking_state: isize,
         start_index: usize,
         stop_index: Option<usize>,
-        children: Vec<Rc<Self>>,
+        children: NodeList,
     },
     /// Marker emitted at a precedence-rule loop entry where ANTLR would call
     /// `pushNewRecursionContext`. Folded into a wrapper rule node before the
@@ -549,6 +608,107 @@ impl ExpectedTokens {
                 });
             }
         }
+    }
+}
+
+/// Compact token-type set for parser-internal FIRST/lookahead caches.
+///
+/// Public diagnostics still use `BTreeSet<i32>` for deterministic formatting,
+/// but the hot recognizer path mostly needs `contains` and set union over
+/// small token ids. A bitset avoids tree traversal and per-symbol allocation
+/// while keeping conversion to `BTreeSet` at recovery/reporting boundaries.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct TokenBitSet {
+    words: Vec<u64>,
+}
+
+impl TokenBitSet {
+    fn insert(&mut self, symbol: i32) {
+        let Some(slot) = token_bit_slot(symbol) else {
+            return;
+        };
+        let word = slot / u64::BITS as usize;
+        if word >= self.words.len() {
+            self.words.resize(word + 1, 0);
+        }
+        self.words[word] |= 1_u64 << (slot % u64::BITS as usize);
+    }
+
+    fn extend_range(&mut self, start: i32, stop: i32) {
+        let (start, stop) = if start <= stop {
+            (start, stop)
+        } else {
+            (stop, start)
+        };
+        for symbol in start..=stop {
+            self.insert(symbol);
+        }
+    }
+
+    fn extend_iter(&mut self, symbols: impl IntoIterator<Item = i32>) {
+        for symbol in symbols {
+            self.insert(symbol);
+        }
+    }
+
+    fn extend_from(&mut self, other: &Self) {
+        if other.words.len() > self.words.len() {
+            self.words.resize(other.words.len(), 0);
+        }
+        for (left, right) in self.words.iter_mut().zip(&other.words) {
+            *left |= *right;
+        }
+    }
+
+    fn contains(&self, symbol: i32) -> bool {
+        let Some(slot) = token_bit_slot(symbol) else {
+            return false;
+        };
+        let word = slot / u64::BITS as usize;
+        self.words
+            .get(word)
+            .is_some_and(|bits| bits & (1_u64 << (slot % u64::BITS as usize)) != 0)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.words.iter().all(|word| *word == 0)
+    }
+
+    fn extend_btree_set(&self, target: &mut BTreeSet<i32>) {
+        for (word_index, word) in self.words.iter().copied().enumerate() {
+            let mut bits = word;
+            while bits != 0 {
+                let bit = bits.trailing_zeros() as usize;
+                if let Some(symbol) = token_bit_symbol(word_index * u64::BITS as usize + bit) {
+                    target.insert(symbol);
+                }
+                bits &= bits - 1;
+            }
+        }
+    }
+
+    fn to_btree_set(&self) -> BTreeSet<i32> {
+        let mut out = BTreeSet::new();
+        self.extend_btree_set(&mut out);
+        out
+    }
+}
+
+fn token_bit_slot(symbol: i32) -> Option<usize> {
+    if symbol == TOKEN_EOF {
+        Some(0)
+    } else if symbol > 0 {
+        usize::try_from(symbol).ok()
+    } else {
+        None
+    }
+}
+
+fn token_bit_symbol(slot: usize) -> Option<i32> {
+    if slot == 0 {
+        Some(TOKEN_EOF)
+    } else {
+        i32::try_from(slot).ok()
     }
 }
 
@@ -619,7 +779,7 @@ fn state_expected_symbols(atn: &Atn, state_number: usize) -> BTreeSet<i32> {
 /// possibly match the current lookahead.
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct FirstSet {
-    symbols: BTreeSet<i32>,
+    symbols: TokenBitSet,
     nullable: bool,
 }
 
@@ -652,7 +812,7 @@ struct DecisionLookahead {
 /// when the lookahead consumes nothing further inside the current rule.
 #[derive(Clone, Debug, Default)]
 struct TransitionLookSet {
-    symbols: BTreeSet<i32>,
+    symbols: TokenBitSet,
     nullable: bool,
 }
 
@@ -730,32 +890,49 @@ fn transition_first_set(
     cache: &mut FirstSetCache,
 ) -> TransitionLookSet {
     match transition {
-        Transition::Atom { label, .. } => TransitionLookSet {
-            symbols: BTreeSet::from([*label]),
-            nullable: false,
-        },
-        Transition::Range { start, stop, .. } => TransitionLookSet {
-            symbols: (*start..=*stop).collect(),
-            nullable: false,
-        },
-        Transition::Set { set, .. } => TransitionLookSet {
-            symbols: set.ranges()
-                .iter()
-                .flat_map(|(start, stop)| *start..=*stop)
-                .collect(),
-            nullable: false,
-        },
-        Transition::NotSet { set, .. } => {
-            let max = atn.max_token_type();
+        Transition::Atom { label, .. } => {
+            let mut symbols = TokenBitSet::default();
+            symbols.insert(*label);
             TransitionLookSet {
-                symbols: (1..=max).filter(|symbol| !set.contains(*symbol)).collect(),
+                symbols,
                 nullable: false,
             }
         }
-        Transition::Wildcard { .. } => TransitionLookSet {
-            symbols: (1..=atn.max_token_type()).collect(),
-            nullable: false,
-        },
+        Transition::Range { start, stop, .. } => {
+            let mut symbols = TokenBitSet::default();
+            symbols.extend_range(*start, *stop);
+            TransitionLookSet {
+                symbols,
+                nullable: false,
+            }
+        }
+        Transition::Set { set, .. } => {
+            let mut symbols = TokenBitSet::default();
+            for (start, stop) in set.ranges() {
+                symbols.extend_range(*start, *stop);
+            }
+            TransitionLookSet {
+                symbols,
+                nullable: false,
+            }
+        }
+        Transition::NotSet { set, .. } => {
+            let max = atn.max_token_type();
+            let mut symbols = TokenBitSet::default();
+            symbols.extend_iter((1..=max).filter(|symbol| !set.contains(*symbol)));
+            TransitionLookSet {
+                symbols,
+                nullable: false,
+            }
+        }
+        Transition::Wildcard { .. } => {
+            let mut symbols = TokenBitSet::default();
+            symbols.extend_range(1, atn.max_token_type());
+            TransitionLookSet {
+                symbols,
+                nullable: false,
+            }
+        }
         Transition::Epsilon { target }
         | Transition::Action { target, .. }
         | Transition::Predicate { target, .. }
@@ -781,7 +958,7 @@ fn transition_first_set(
             let mut symbols = child.symbols.clone();
             let nullable = if child.nullable {
                 let follow = rule_first_set(atn, *follow_state, rule_stop_state, cache);
-                symbols.extend(follow.symbols.iter().copied());
+                symbols.extend_from(&follow.symbols);
                 follow.nullable
             } else {
                 false
@@ -806,6 +983,7 @@ fn should_skip_via_lookahead(
     transition_index: usize,
     lookahead_filter: Option<&(i32, Rc<DecisionLookahead>)>,
     index: usize,
+    record_expected: bool,
     expected: &mut ExpectedTokens,
 ) -> bool {
     let prune_non_consuming = matches!(
@@ -825,13 +1003,42 @@ fn should_skip_via_lookahead(
     let Some(set) = entry.transitions.get(transition_index) else {
         return false;
     };
-    if set.symbols.contains(symbol) || set.nullable {
+    if set.symbols.contains(*symbol) || set.nullable {
         return false;
     }
-    if !set.symbols.is_empty() {
+    if record_expected && !set.symbols.is_empty() {
         record_pruned_transition_expected(set, index, expected);
     }
     true
+}
+
+fn should_skip_rule_via_first_set(
+    first: &FirstSet,
+    symbol: i32,
+    record_expected: bool,
+    index: usize,
+    expected: &mut ExpectedTokens,
+) -> bool {
+    if first.nullable || first.symbols.contains(symbol) {
+        return false;
+    }
+    if record_expected && !first.symbols.is_empty() {
+        record_token_bit_expected(&first.symbols, index, expected);
+    }
+    true
+}
+
+fn record_token_bit_expected(symbols: &TokenBitSet, index: usize, expected: &mut ExpectedTokens) {
+    match expected.index {
+        Some(current) if index < current => {}
+        Some(current) if index == current => {
+            symbols.extend_btree_set(&mut expected.symbols);
+        }
+        _ => {
+            expected.index = Some(index);
+            expected.symbols = symbols.to_btree_set();
+        }
+    }
 }
 
 /// Folds a pruned transition's FIRST set into the farthest-expected accumulator.
@@ -843,11 +1050,11 @@ fn record_pruned_transition_expected(
     match expected.index {
         Some(current) if index < current => {}
         Some(current) if index == current => {
-            expected.symbols.extend(set.symbols.iter().copied());
+            set.symbols.extend_btree_set(&mut expected.symbols);
         }
         _ => {
             expected.index = Some(index);
-            expected.symbols.clone_from(&set.symbols);
+            expected.symbols = set.symbols.to_btree_set();
         }
     }
 }
@@ -873,7 +1080,7 @@ fn rule_first_set_inner(
     for transition in &state.transitions {
         let transition_symbols = transition_expected_symbols(transition, atn.max_token_type());
         if !transition_symbols.is_empty() {
-            first.symbols.extend(transition_symbols);
+            first.symbols.extend_iter(transition_symbols);
             continue;
         }
         match transition {
@@ -897,7 +1104,7 @@ fn rule_first_set_inner(
                     ctx.hit_cycle = true;
                 }
                 let child = rule_first_set_cached(atn, *target, child_stop, ctx);
-                first.symbols.extend(child.symbols.iter().copied());
+                first.symbols.extend_from(&child.symbols);
                 if child.nullable {
                     rule_first_set_inner(atn, *follow_state, rule_stop_state, ctx, visited, first);
                 }
@@ -1023,7 +1230,10 @@ where
     }
     let mut combined = (*state_symbols).clone();
     combined.extend(inherited.iter().copied());
-    (parser.intern_recovery_symbols(combined), Some(state.state_number))
+    (
+        parser.intern_recovery_symbols(combined),
+        Some(state.state_number),
+    )
 }
 
 /// Fast-recognizer variant of [`recovery_expected_symbols`] that reuses the
@@ -1214,8 +1424,9 @@ struct FastRecognizeRequest {
 }
 
 /// Memo key for the fast recognizer. `recovery_symbols` is interned by the
-/// parser, so equal sets share one `Rc` and the key hashes/compares on a
-/// pointer instead of walking the full `BTreeSet`.
+/// parser before it reaches this key, so equal sets share one allocation and
+/// the key can store that allocation's address instead of cloning an `Rc` and
+/// walking the full `BTreeSet`.
 #[derive(Clone, Debug)]
 struct FastRecognizeKey {
     state_number: usize,
@@ -1224,7 +1435,7 @@ struct FastRecognizeKey {
     rule_start_index: usize,
     decision_start_index: Option<usize>,
     precedence: i32,
-    recovery_symbols: Rc<BTreeSet<i32>>,
+    recovery_symbols_id: usize,
     recovery_state: Option<usize>,
 }
 
@@ -1237,22 +1448,11 @@ impl PartialEq for FastRecognizeKey {
             || self.decision_start_index != other.decision_start_index
             || self.precedence != other.precedence
             || self.recovery_state != other.recovery_state
+            || self.recovery_symbols_id != other.recovery_symbols_id
         {
             return false;
         }
-        // The interner ensures equal recovery sets share one `Rc`, so
-        // pointer equality is the contract-correct comparison and matches the
-        // pointer-only `Hash` impl below. The debug-only assertion fires if a
-        // future caller forgets to intern an `Rc<BTreeSet<i32>>` before it
-        // ends up in a key, turning a silent `Hash`/`Eq` divergence (and the
-        // unbounded recursion / memo misses it would cause) into a loud test
-        // failure.
-        debug_assert!(
-            Rc::ptr_eq(&self.recovery_symbols, &other.recovery_symbols)
-                || self.recovery_symbols != other.recovery_symbols,
-            "FastRecognizeKey: recovery_symbols compared by content; interner invariant violated",
-        );
-        Rc::ptr_eq(&self.recovery_symbols, &other.recovery_symbols)
+        true
     }
 }
 
@@ -1267,9 +1467,7 @@ impl Hash for FastRecognizeKey {
         self.decision_start_index.hash(hasher);
         self.precedence.hash(hasher);
         self.recovery_state.hash(hasher);
-        // Interning makes equal sets share one allocation, so pointer identity
-        // is enough for hashing without walking the set.
-        (Rc::as_ptr(&self.recovery_symbols) as usize).hash(hasher);
+        self.recovery_symbols_id.hash(hasher);
     }
 }
 
@@ -1381,6 +1579,8 @@ where
             decision_lookahead_cache: FxHashMap::default(),
             empty_recovery_symbols: Rc::new(BTreeSet::new()),
             fast_first_set_prefilter: true,
+            fast_recovery_enabled: true,
+            fast_token_nodes_enabled: true,
         }
     }
 
@@ -1479,9 +1679,14 @@ where
             })?;
 
         let start_index = self.current_visible_index();
+        self.input.fill();
         self.clear_prediction_diagnostics();
         self.reset_per_parse_caches();
+        self.fast_recovery_enabled = false;
+        self.fast_token_nodes_enabled = false;
         let first_pass = self.fast_recognize_top(atn, start_state, stop_state, start_index);
+        self.fast_token_nodes_enabled = true;
+        self.fast_recovery_enabled = true;
         let needs_retry = match &first_pass {
             // The FIRST-set prefilter trims speculative rule calls that can't
             // match the current lookahead — useful for perf on grammars with
@@ -1516,13 +1721,43 @@ where
         if let Some(token) = self.token_at(start_index) {
             context.set_start(token);
         }
-        if let Some(token) = self.rule_stop_token(outcome.index, outcome.consumed_eof) {
+        let stop_index = self.rule_stop_token_index(outcome.index, outcome.consumed_eof);
+        if let Some(token) = stop_index.and_then(|token_index| self.token_at(token_index)) {
             context.set_stop(token);
         }
         if self.build_parse_trees {
-            let folded = fold_fast_left_recursive_boundaries(outcome.nodes.to_vec());
-            for node in &folded {
-                context.add_child(self.fast_recognized_node_tree(node.as_ref())?);
+            if outcome.nodes.has_left_recursive_boundary() {
+                let folded = fold_fast_left_recursive_boundaries(outcome.nodes.to_vec());
+                if folded.iter().any(|node| {
+                    matches!(
+                        node.as_ref(),
+                        FastRecognizedNode::Token { .. }
+                            | FastRecognizedNode::ErrorToken { .. }
+                            | FastRecognizedNode::MissingToken { .. }
+                    )
+                }) {
+                    for node in &folded {
+                        context.add_child(self.fast_recognized_node_tree(node.as_ref())?);
+                    }
+                } else {
+                    self.add_fast_implicit_token_children(
+                        &mut context,
+                        start_index,
+                        stop_index,
+                        &folded,
+                    )?;
+                }
+            } else if outcome.nodes.has_explicit_token_node() {
+                for node in outcome.nodes.iter() {
+                    context.add_child(self.fast_recognized_node_tree(node.as_ref())?);
+                }
+            } else {
+                self.add_fast_implicit_token_children_iter(
+                    &mut context,
+                    start_index,
+                    stop_index,
+                    outcome.nodes.iter(),
+                )?;
             }
         }
         self.input.seek(outcome.index);
@@ -1541,8 +1776,9 @@ where
         stop_state: usize,
         start_index: usize,
     ) -> Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens> {
-        let mut visiting = FxHashSet::default();
-        let mut memo = FxHashMap::default();
+        let memo_capacity = self.input.size().saturating_mul(4).min(1_000_000);
+        let mut visiting = FxHashSet::with_capacity_and_hasher(256, FxBuildHasher::default());
+        let mut memo = FxHashMap::with_capacity_and_hasher(memo_capacity, FxBuildHasher::default());
         let mut expected = ExpectedTokens::default();
         let empty_recovery = self.empty_recovery_symbols();
         let outcomes = self.recognize_state_fast(
@@ -1628,15 +1864,157 @@ where
                 if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
                     context.set_stop(token);
                 }
-                for child in children {
-                    context.add_child(self.fast_recognized_node_tree(child.as_ref())?);
+                if children.has_left_recursive_boundary() {
+                    let folded = fold_fast_left_recursive_boundaries(children.to_vec());
+                    for child in &folded {
+                        context.add_child(self.fast_recognized_node_tree(child.as_ref())?);
+                    }
+                } else {
+                    for child in children.iter() {
+                        context.add_child(self.fast_recognized_node_tree(child.as_ref())?);
+                    }
                 }
                 Ok(self.rule_node(context))
             }
-            FastRecognizedNode::LeftRecursiveBoundary { rule_index } => Err(AntlrError::Unsupported(
-                format!("unfolded left-recursive boundary for rule {rule_index}"),
-            )),
+            FastRecognizedNode::LeftRecursiveBoundary { rule_index } => {
+                Err(AntlrError::Unsupported(format!(
+                    "unfolded left-recursive boundary for rule {rule_index}"
+                )))
+            }
         }
+    }
+
+    fn fast_recognized_node_tree_with_implicit_tokens(
+        &mut self,
+        node: &FastRecognizedNode,
+    ) -> Result<ParseTree, AntlrError> {
+        match node {
+            FastRecognizedNode::Rule {
+                rule_index,
+                invoking_state,
+                start_index,
+                stop_index,
+                children,
+            } => {
+                let mut context = ParserRuleContext::new(*rule_index, *invoking_state);
+                if let Some(token) = self.token_at(*start_index) {
+                    context.set_start(token);
+                }
+                if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
+                    context.set_stop(token);
+                }
+                if children.has_left_recursive_boundary() {
+                    let folded = fold_fast_left_recursive_boundaries(children.to_vec());
+                    self.add_fast_implicit_token_children(
+                        &mut context,
+                        *start_index,
+                        *stop_index,
+                        &folded,
+                    )?;
+                } else {
+                    self.add_fast_implicit_token_children_iter(
+                        &mut context,
+                        *start_index,
+                        *stop_index,
+                        children.iter(),
+                    )?;
+                }
+                Ok(self.rule_node(context))
+            }
+            _ => self.fast_recognized_node_tree(node),
+        }
+    }
+
+    fn add_fast_implicit_token_children(
+        &mut self,
+        context: &mut ParserRuleContext,
+        start_index: usize,
+        stop_index: Option<usize>,
+        children: &[Rc<FastRecognizedNode>],
+    ) -> Result<(), AntlrError> {
+        self.add_fast_implicit_token_children_iter(
+            context,
+            start_index,
+            stop_index,
+            children.iter(),
+        )
+    }
+
+    fn add_fast_implicit_token_children_iter<'a>(
+        &mut self,
+        context: &mut ParserRuleContext,
+        start_index: usize,
+        stop_index: Option<usize>,
+        children: impl IntoIterator<Item = &'a Rc<FastRecognizedNode>>,
+    ) -> Result<(), AntlrError> {
+        let mut cursor = Some(start_index);
+        for child in children {
+            if let Some((child_start, child_stop)) = fast_recognized_node_span(child.as_ref()) {
+                self.add_visible_terminals_before(context, &mut cursor, child_start)?;
+                context.add_child(
+                    self.fast_recognized_node_tree_with_implicit_tokens(child.as_ref())?,
+                );
+                if let Some(child_stop) = child_stop {
+                    cursor = self.next_visible_after_token(child_stop);
+                }
+            } else {
+                context.add_child(
+                    self.fast_recognized_node_tree_with_implicit_tokens(child.as_ref())?,
+                );
+            }
+        }
+        if let Some(stop) = stop_index {
+            self.add_visible_terminals_through(context, cursor, stop)?;
+        }
+        Ok(())
+    }
+
+    fn add_visible_terminals_before(
+        &mut self,
+        context: &mut ParserRuleContext,
+        cursor: &mut Option<usize>,
+        before: usize,
+    ) -> Result<(), AntlrError> {
+        let Some(stop) = before.checked_sub(1) else {
+            return Ok(());
+        };
+        let next = self.add_visible_terminals_through(context, *cursor, stop)?;
+        *cursor = next;
+        Ok(())
+    }
+
+    fn add_visible_terminals_through(
+        &mut self,
+        context: &mut ParserRuleContext,
+        mut cursor: Option<usize>,
+        stop: usize,
+    ) -> Result<Option<usize>, AntlrError> {
+        while let Some(index) = cursor {
+            if index > stop {
+                return Ok(Some(index));
+            }
+            let token = self
+                .input
+                .get(index)
+                .cloned()
+                .ok_or_else(|| AntlrError::ParserError {
+                    line: 0,
+                    column: 0,
+                    message: format!("missing token at index {index}"),
+                })?;
+            let is_eof = token.token_type() == TOKEN_EOF;
+            context.add_child(ParseTree::Terminal(TerminalNode::new(token)));
+            if is_eof {
+                return Ok(None);
+            }
+            cursor = self.next_visible_after_token(index);
+        }
+        Ok(None)
+    }
+
+    fn next_visible_after_token(&mut self, index: usize) -> Option<usize> {
+        let next = self.input.next_visible_after(index);
+        (next != index).then_some(next)
     }
 
     /// Parses a generated rule and returns semantic actions reached on the
@@ -2146,12 +2524,14 @@ where
         .map(|mut outcome| {
             outcome.consumed_eof |= next_symbol == TOKEN_EOF;
             outcome.diagnostics.insert(0, diagnostic.clone());
-            outcome
-                .nodes
-                .prepend(Rc::new(FastRecognizedNode::Token { index: next_index }));
-            outcome
-                .nodes
-                .prepend(Rc::new(FastRecognizedNode::ErrorToken { index }));
+            if self.fast_token_nodes_enabled {
+                outcome
+                    .nodes
+                    .prepend(Rc::new(FastRecognizedNode::Token { index: next_index }));
+                outcome
+                    .nodes
+                    .prepend(Rc::new(FastRecognizedNode::ErrorToken { index }));
+            }
             outcome
         })
         .collect()
@@ -2214,11 +2594,13 @@ where
         .into_iter()
         .map(|mut outcome| {
             outcome.diagnostics.insert(0, diagnostic.clone());
-            outcome.nodes.prepend(Rc::new(FastRecognizedNode::MissingToken {
-                token_type,
-                at_index: index,
-                text: text.clone(),
-            }));
+            outcome
+                .nodes
+                .prepend(Rc::new(FastRecognizedNode::MissingToken {
+                    token_type,
+                    at_index: index,
+                    text: text.clone(),
+                }));
             outcome
         })
         .collect()
@@ -2303,7 +2685,7 @@ where
             rule_start_index,
             decision_start_index,
             precedence,
-            recovery_symbols: Rc::clone(&recovery_symbols),
+            recovery_symbols_id: Rc::as_ptr(&recovery_symbols) as usize,
             recovery_state,
         };
         if let Some(outcomes) = memo.get(&key) {
@@ -2311,12 +2693,19 @@ where
         }
 
         let visit_key = key.clone();
-        if !visiting.insert(visit_key.clone()) {
-            return Vec::new();
-        }
+        let inserted_visit = if self.fast_recovery_enabled {
+            if !visiting.insert(visit_key.clone()) {
+                return Vec::new();
+            }
+            true
+        } else {
+            false
+        };
 
         let Some(state) = atn.state(state_number) else {
-            visiting.remove(&visit_key);
+            if inserted_visit {
+                visiting.remove(&visit_key);
+            }
             return Vec::new();
         };
         let next_decision_start_index = if starts_prediction_decision(state) {
@@ -2324,8 +2713,11 @@ where
         } else {
             decision_start_index
         };
-        let (epsilon_recovery_symbols, epsilon_recovery_state) =
-            fast_next_recovery_context(self, atn, state, &recovery_symbols, recovery_state);
+        let (epsilon_recovery_symbols, epsilon_recovery_state) = if self.fast_recovery_enabled {
+            fast_next_recovery_context(self, atn, state, &recovery_symbols, recovery_state)
+        } else {
+            (Rc::clone(&recovery_symbols), recovery_state)
+        };
 
         // Lookahead-based pruning. At a multi-alternative state we cache the
         // look-1 set of every outgoing transition; on visit we keep only the
@@ -2348,15 +2740,16 @@ where
         let lookahead_filter = if state.transitions.len() > 1
             && self.fast_first_set_prefilter
             && !state.precedence_rule_decision
-            && state.kind != AtnStateKind::RuleStart
+            && (!self.fast_recovery_enabled || state.kind != AtnStateKind::RuleStart)
         {
-            state.rule_index.and_then(|rule_index| {
-                atn.rule_to_stop_state().get(rule_index).copied()
-            }).map(|rule_stop| {
-                let symbol = self.token_type_at(index);
-                let entry = self.cached_decision_lookahead(atn, state, rule_stop);
-                (symbol, entry)
-            })
+            state
+                .rule_index
+                .and_then(|rule_index| atn.rule_to_stop_state().get(rule_index).copied())
+                .map(|rule_stop| {
+                    let symbol = self.token_type_at(index);
+                    let entry = self.cached_decision_lookahead(atn, state, rule_stop);
+                    (symbol, entry)
+                })
         } else {
             None
         };
@@ -2369,6 +2762,7 @@ where
                 transition_index,
                 lookahead_filter,
                 index,
+                self.fast_recovery_enabled,
                 expected,
             ) {
                 continue;
@@ -2435,9 +2829,7 @@ where
                             .map(|mut outcome| {
                                 if let Some(rule_index) = boundary {
                                     outcome.nodes.prepend(Rc::new(
-                                        FastRecognizedNode::LeftRecursiveBoundary {
-                                            rule_index,
-                                        },
+                                        FastRecognizedNode::LeftRecursiveBoundary { rule_index },
                                     ));
                                 }
                                 outcome
@@ -2468,27 +2860,38 @@ where
                     // called rule can fire (mirroring ANTLR's reference behavior
                     // of conjuring a missing token at child-rule entry).
                     let symbol = self.token_type_at(index);
-                    let first =
-                        rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
-                    if self.fast_first_set_prefilter
-                        && !first.nullable
-                        && !first.symbols.contains(&symbol)
-                    {
-                        if !first.symbols.is_empty() {
-                            match expected.index {
-                                Some(current) if index < current => {}
-                                Some(current) if index == current => {
-                                    expected.symbols.extend(first.symbols.iter().copied());
-                                }
-                                _ => {
-                                    expected.index = Some(index);
-                                    expected.symbols.clone_from(&first.symbols);
-                                }
+                    if self.fast_first_set_prefilter {
+                        let first_key = (*target, child_stop);
+                        if !self.first_set_cache.contains_key(&first_key) {
+                            let _ =
+                                rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
+                        }
+                        if let Some(first) = self.first_set_cache.get(&first_key) {
+                            if should_skip_rule_via_first_set(
+                                first,
+                                symbol,
+                                self.fast_recovery_enabled,
+                                index,
+                                expected,
+                            ) {
+                                continue;
+                            }
+                        } else {
+                            let first =
+                                rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
+                            if should_skip_rule_via_first_set(
+                                &first,
+                                symbol,
+                                self.fast_recovery_enabled,
+                                index,
+                                expected,
+                            ) {
+                                continue;
                             }
                         }
-                        continue;
                     }
-                    let expected_before_child = expected.clone();
+                    let expected_before_child =
+                        self.fast_recovery_enabled.then(|| expected.clone());
                     let children = self.recognize_state_fast(
                         atn,
                         FastRecognizeRequest {
@@ -2506,52 +2909,54 @@ where
                         memo,
                         expected,
                     );
-                    if children
-                        .iter()
-                        .any(|child| child.diagnostics.is_empty() && child.index > index)
-                    {
-                        *expected = expected_before_child;
+                    if let Some(expected_before_child) = expected_before_child {
+                        if children
+                            .iter()
+                            .any(|child| child.diagnostics.is_empty() && child.index > index)
+                        {
+                            *expected = expected_before_child;
+                        }
                     }
                     for child in children {
                         let child_index = child.index;
                         let child_consumed_eof = child.consumed_eof;
                         let child_diagnostics = child.diagnostics;
+                        let empty_recovery = self.empty_recovery_symbols();
+                        let follow_outcomes = self.recognize_state_fast(
+                            atn,
+                            FastRecognizeRequest {
+                                state_number: *follow_state,
+                                stop_state,
+                                index: child_index,
+                                rule_start_index,
+                                decision_start_index: next_decision_start_index,
+                                precedence,
+                                depth: depth + 1,
+                                recovery_symbols: empty_recovery,
+                                recovery_state: None,
+                            },
+                            visiting,
+                            memo,
+                            expected,
+                        );
+                        if follow_outcomes.is_empty() {
+                            continue;
+                        }
                         let child_node = Rc::new(FastRecognizedNode::Rule {
                             rule_index: *rule_index,
                             invoking_state: invoking_state_number(state_number),
                             start_index: index,
                             stop_index: self.rule_stop_token_index(child_index, child_consumed_eof),
-                            children: fold_fast_left_recursive_boundaries(child.nodes.to_vec()),
+                            children: child.nodes,
                         });
-                        let empty_recovery = self.empty_recovery_symbols();
-                        outcomes.extend(
-                            self.recognize_state_fast(
-                                atn,
-                                FastRecognizeRequest {
-                                    state_number: *follow_state,
-                                    stop_state,
-                                    index: child_index,
-                                    rule_start_index,
-                                    decision_start_index: next_decision_start_index,
-                                    precedence,
-                                    depth: depth + 1,
-                                    recovery_symbols: empty_recovery,
-                                    recovery_state: None,
-                                },
-                                visiting,
-                                memo,
-                                expected,
-                            )
-                            .into_iter()
-                            .map(|mut outcome| {
-                                outcome.consumed_eof |= child_consumed_eof;
-                                let mut diagnostics = child_diagnostics.clone();
-                                diagnostics.append(&mut outcome.diagnostics);
-                                outcome.diagnostics = diagnostics;
-                                outcome.nodes.prepend(Rc::clone(&child_node));
-                                outcome
-                            }),
-                        );
+                        outcomes.extend(follow_outcomes.into_iter().map(|mut outcome| {
+                            outcome.consumed_eof |= child_consumed_eof;
+                            let mut diagnostics = child_diagnostics.clone();
+                            diagnostics.append(&mut outcome.diagnostics);
+                            outcome.diagnostics = diagnostics;
+                            outcome.nodes.prepend(Rc::clone(&child_node));
+                            outcome
+                        }));
                     }
                 }
                 Transition::Atom { target, .. }
@@ -2584,9 +2989,11 @@ where
                             .into_iter()
                             .map(|mut outcome| {
                                 outcome.consumed_eof |= symbol == TOKEN_EOF;
-                                outcome
-                                    .nodes
-                                    .prepend(Rc::new(FastRecognizedNode::Token { index }));
+                                if self.fast_token_nodes_enabled {
+                                    outcome
+                                        .nodes
+                                        .prepend(Rc::new(FastRecognizedNode::Token { index }));
+                                }
                                 outcome
                             }),
                         );
@@ -2600,32 +3007,14 @@ where
                         if expected_symbols.contains(&symbol) {
                             continue;
                         }
-                        expected.record_transition(index, transition, atn.max_token_type());
-                        record_no_viable_if_ambiguous(expected, next_decision_start_index, index);
-                        outcomes.extend(self.fast_single_token_deletion_recovery(
-                            FastRecoveryRequest {
-                                atn,
-                                transition,
-                                expected_symbols: Rc::clone(&expected_symbols),
-                                target: *target,
-                                request: FastRecognizeRequest {
-                                    state_number,
-                                    stop_state,
-                                    index,
-                                    rule_start_index,
-                                    decision_start_index,
-                                    precedence,
-                                    depth,
-                                    recovery_symbols: Rc::clone(&recovery_symbols),
-                                    recovery_state,
-                                },
-                                visiting,
-                                memo,
+                        if self.fast_recovery_enabled {
+                            expected.record_transition(index, transition, atn.max_token_type());
+                            record_no_viable_if_ambiguous(
                                 expected,
-                            },
-                        ));
-                        if !state_is_left_recursive_rule(atn, state) {
-                            outcomes.extend(self.fast_single_token_insertion_recovery(
+                                next_decision_start_index,
+                                index,
+                            );
+                            outcomes.extend(self.fast_single_token_deletion_recovery(
                                 FastRecoveryRequest {
                                     atn,
                                     transition,
@@ -2647,38 +3036,70 @@ where
                                     expected,
                                 },
                             ));
-                        }
-                        outcomes.extend(self.fast_current_token_deletion_recovery(
-                            FastCurrentTokenDeletionRequest {
-                                atn,
-                                expected_symbols,
-                                request: FastRecognizeRequest {
-                                    state_number,
-                                    stop_state,
-                                    index,
-                                    rule_start_index,
-                                    decision_start_index,
-                                    precedence,
-                                    depth,
-                                    recovery_symbols: Rc::clone(&recovery_symbols),
-                                    recovery_state,
+                            if !state_is_left_recursive_rule(atn, state) {
+                                outcomes.extend(self.fast_single_token_insertion_recovery(
+                                    FastRecoveryRequest {
+                                        atn,
+                                        transition,
+                                        expected_symbols: Rc::clone(&expected_symbols),
+                                        target: *target,
+                                        request: FastRecognizeRequest {
+                                            state_number,
+                                            stop_state,
+                                            index,
+                                            rule_start_index,
+                                            decision_start_index,
+                                            precedence,
+                                            depth,
+                                            recovery_symbols: Rc::clone(&recovery_symbols),
+                                            recovery_state,
+                                        },
+                                        visiting,
+                                        memo,
+                                        expected,
+                                    },
+                                ));
+                            }
+                            outcomes.extend(self.fast_current_token_deletion_recovery(
+                                FastCurrentTokenDeletionRequest {
+                                    atn,
+                                    expected_symbols,
+                                    request: FastRecognizeRequest {
+                                        state_number,
+                                        stop_state,
+                                        index,
+                                        rule_start_index,
+                                        decision_start_index,
+                                        precedence,
+                                        depth,
+                                        recovery_symbols: Rc::clone(&recovery_symbols),
+                                        recovery_state,
+                                    },
+                                    visiting,
+                                    memo,
+                                    expected,
                                 },
-                                visiting,
-                                memo,
-                                expected,
-                            },
-                        ));
+                            ));
+                        }
                     }
                 }
             }
         }
 
-        visiting.remove(&visit_key);
+        if inserted_visit {
+            visiting.remove(&visit_key);
+        }
         if self.prediction_mode == PredictionMode::Ll {
             discard_recovered_fast_outcomes_if_clean_path_exists(&mut outcomes);
         }
-        dedupe_fast_outcomes(&mut outcomes);
-        memo.insert(key, outcomes.clone());
+        if self.fast_recovery_enabled {
+            dedupe_fast_outcomes(&mut outcomes);
+        } else {
+            dedupe_clean_fast_outcomes(&mut outcomes);
+        }
+        if self.fast_recovery_enabled || outcomes.len() > 1 {
+            memo.insert(key, outcomes.clone());
+        }
         outcomes
     }
 
@@ -3625,12 +4046,11 @@ where
     /// Returns the interned `Rc` form of a `recovery_symbols` set so the fast
     /// recognizer can hash and compare keys by pointer.
     ///
-    /// Every `Rc<BTreeSet<i32>>` that flows into a `FastRecognizeKey` (or its
-    /// `recovery_symbols` Rc-clone) must come from this method or the empty
-    /// singleton; otherwise two content-equal `Rc`s could end up with
-    /// different `Rc::as_ptr` values, and the pointer-keyed hash on
-    /// `FastRecognizeKey` would silently disagree with the contract-equality
-    /// check.
+    /// Every `Rc<BTreeSet<i32>>` that flows into a `FastRecognizeKey` must
+    /// come from this method or the empty singleton; otherwise two
+    /// content-equal `Rc`s could end up with different `Rc::as_ptr` values,
+    /// and the pointer-keyed hash on `FastRecognizeKey` would split equivalent
+    /// recognition coordinates.
     fn intern_recovery_symbols(&mut self, set: BTreeSet<i32>) -> Rc<BTreeSet<i32>> {
         if set.is_empty() {
             return Rc::clone(&self.empty_recovery_symbols);
@@ -4248,10 +4668,12 @@ fn fold_fast_left_recursive_boundaries(
     // fold work entirely when none are present. The boundary marker is only
     // emitted at precedence-rule loop entries, which are rare relative to
     // every rule call the recognizer fans out.
-    if !nodes
-        .iter()
-        .any(|node| matches!(node.as_ref(), FastRecognizedNode::LeftRecursiveBoundary { .. }))
-    {
+    if !nodes.iter().any(|node| {
+        matches!(
+            node.as_ref(),
+            FastRecognizedNode::LeftRecursiveBoundary { .. }
+        )
+    }) {
         return nodes;
     }
     let mut folded: Vec<Rc<FastRecognizedNode>> = Vec::with_capacity(nodes.len());
@@ -4268,7 +4690,7 @@ fn fold_fast_left_recursive_boundaries(
                         invoking_state: -1,
                         start_index,
                         stop_index,
-                        children,
+                        children: NodeList::from_vec(children),
                     }));
                 }
             }
@@ -4291,6 +4713,23 @@ const fn fast_recognized_node_start_index(node: &FastRecognizedNode) -> Option<u
         }
         FastRecognizedNode::MissingToken { at_index, .. } => Some(*at_index),
         FastRecognizedNode::Rule { start_index, .. } => Some(*start_index),
+        FastRecognizedNode::LeftRecursiveBoundary { .. } => None,
+    }
+}
+
+const fn fast_recognized_node_span(node: &FastRecognizedNode) -> Option<(usize, Option<usize>)> {
+    match node {
+        FastRecognizedNode::Token { index } | FastRecognizedNode::ErrorToken { index } => {
+            Some((*index, Some(*index)))
+        }
+        FastRecognizedNode::MissingToken { at_index, .. } => {
+            Some((*at_index, at_index.checked_sub(1)))
+        }
+        FastRecognizedNode::Rule {
+            start_index,
+            stop_index,
+            ..
+        } => Some((*start_index, *stop_index)),
         FastRecognizedNode::LeftRecursiveBoundary { .. } => None,
     }
 }
@@ -4807,6 +5246,14 @@ fn dedupe_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
         current += 1;
         result
     });
+}
+
+fn dedupe_clean_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
+    if outcomes.len() < 2 {
+        return;
+    }
+    let mut seen = BTreeSet::new();
+    outcomes.retain(|outcome| seen.insert((outcome.index, outcome.consumed_eof)));
 }
 
 /// Sorts and removes equivalent endpoints, including their action traces.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,6 +83,10 @@ use crate::vocabulary::Vocabulary;
 /// non-viable. Long expression-regression descriptors legitimately walk tens
 /// of thousands of ATN edges.
 const RECOGNITION_DEPTH_LIMIT: usize = 100_000;
+/// Preserve lazy lexing for short or failing inputs, but eagerly fill once the
+/// fast recognizer has probed far enough that per-token stream sync dominates.
+/// Sixty-four tokens is a small rule-sized window: it keeps startup lazy while
+/// switching long inputs to the cheaper filled-stream path before large fanout.
 const FAST_RECOGNIZER_DEFERRED_FILL_AT: usize = 64;
 
 /// Parser semantic action reached while recognizing one ATN path.
@@ -1810,6 +1814,11 @@ where
         stop_state: usize,
         start_index: usize,
     ) -> Result<(FastRecognizeOutcome, ExpectedTokens), ExpectedTokens> {
+        // `input.size()` is intentionally only the currently buffered token
+        // count here. Do not restore an up-front fill just to size this map:
+        // the fixed floor avoids small-input churn, and large inputs grow the
+        // cache after the deferred-fill threshold without forcing startup
+        // tokenization.
         let memo_capacity = self.input.size().saturating_mul(4).clamp(65_536, 262_144);
         let mut visiting = FxHashSet::with_capacity_and_hasher(256, FxBuildHasher::default());
         let mut memo = FxHashMap::with_capacity_and_hasher(memo_capacity, FxBuildHasher::default());
@@ -2727,19 +2736,12 @@ where
         }
 
         let visit_key = key.clone();
-        let inserted_visit = if self.fast_recovery_enabled {
-            if !visiting.insert(visit_key.clone()) {
-                return Vec::new();
-            }
-            true
-        } else {
-            false
-        };
+        if !visiting.insert(visit_key.clone()) {
+            return Vec::new();
+        }
 
         let Some(state) = atn.state(state_number) else {
-            if inserted_visit {
-                visiting.remove(&visit_key);
-            }
+            visiting.remove(&visit_key);
             return Vec::new();
         };
         let next_decision_start_index = if starts_prediction_decision(state) {
@@ -3120,9 +3122,7 @@ where
             }
         }
 
-        if inserted_visit {
-            visiting.remove(&visit_key);
-        }
+        visiting.remove(&visit_key);
         if self.prediction_mode == PredictionMode::Ll {
             discard_recovered_fast_outcomes_if_clean_path_exists(&mut outcomes);
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3131,7 +3131,7 @@ where
         } else {
             dedupe_clean_fast_outcomes(&mut outcomes);
         }
-        if self.fast_recovery_enabled || outcomes.len() > 1 {
+        if self.fast_recovery_enabled || !outcomes.is_empty() {
             memo.insert(key, outcomes.clone());
         }
         outcomes
@@ -4759,9 +4759,7 @@ const fn fast_recognized_node_span(node: &FastRecognizedNode) -> Option<(usize, 
         FastRecognizedNode::Token { index } | FastRecognizedNode::ErrorToken { index } => {
             Some((*index, Some(*index)))
         }
-        FastRecognizedNode::MissingToken { at_index, .. } => {
-            Some((*at_index, at_index.checked_sub(1)))
-        }
+        FastRecognizedNode::MissingToken { at_index, .. } => Some((*at_index, None)),
         FastRecognizedNode::Rule {
             start_index,
             stop_index,

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -278,6 +278,10 @@ where
     pub fn drain_source_errors(&mut self) -> Vec<TokenSourceError> {
         std::mem::take(&mut self.source_errors)
     }
+
+    pub const fn is_filled(&self) -> bool {
+        self.fetched_eof
+    }
 }
 
 #[cfg(test)]

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -5,11 +5,14 @@ use crate::token::{CommonToken, DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenSource, 
 pub struct CommonTokenStream<S> {
     source: S,
     tokens: Vec<CommonToken>,
+    next_visible_after: Vec<usize>,
     cursor: usize,
     fetched_eof: bool,
     channel: i32,
     source_errors: Vec<TokenSourceError>,
 }
+
+const UNKNOWN_NEXT_VISIBLE: usize = usize::MAX;
 
 impl<S> CommonTokenStream<S>
 where
@@ -25,6 +28,7 @@ where
         Self {
             source,
             tokens: Vec::new(),
+            next_visible_after: Vec::new(),
             cursor: 0,
             fetched_eof: false,
             channel,
@@ -117,6 +121,7 @@ where
         token.set_token_index(token_index);
         self.fetched_eof = token.token_type() == TOKEN_EOF;
         self.tokens.push(token);
+        self.next_visible_after.push(UNKNOWN_NEXT_VISIBLE);
     }
 
     /// Moves a raw token index to the next token visible on this stream's
@@ -219,9 +224,7 @@ where
     /// round-trip when they only need lookahead types.
     pub fn token_type_at_index(&mut self, index: usize) -> i32 {
         self.sync(index);
-        self.tokens
-            .get(index)
-            .map_or(TOKEN_EOF, Token::token_type)
+        self.tokens.get(index).map_or(TOKEN_EOF, Token::token_type)
     }
 
     /// Returns the next parser-visible token index after consuming the token
@@ -229,8 +232,18 @@ where
     /// is not modified. Used by speculative recognition that simulates token
     /// consumption thousands of times without committing it.
     pub fn next_visible_after(&mut self, index: usize) -> usize {
+        self.sync(index);
+        if let Some(cached) = self
+            .next_visible_after
+            .get(index)
+            .copied()
+            .filter(|cached| *cached != UNKNOWN_NEXT_VISIBLE)
+        {
+            return cached;
+        }
+
         let mut next = index + 1;
-        loop {
+        let found = loop {
             self.sync(next);
             match self.tokens.get(next) {
                 Some(token)
@@ -239,9 +252,13 @@ where
                     next += 1;
                     continue;
                 }
-                _ => return next,
+                _ => break next,
             }
+        };
+        if let Some(slot) = self.next_visible_after.get_mut(index) {
+            *slot = found;
         }
+        found
     }
 
     pub fn text(&mut self, start: usize, stop: usize) -> String {


### PR DESCRIPTION
## Summary

- Add a direct cached lexer DFA replay path and visible-token jump cache to reduce repeated lexer/token-stream work on large parse-benchmark fixtures.
- Split parser recognition into a clean fast pass and recovery retry, avoiding recovery bookkeeping, terminal node allocation, and visiting-set churn on valid inputs.
- Compact parser FIRST/lookahead sets and defer speculative parse-tree node materialization until an accepted path needs it.

## Impact

The C# Rust benchmark mean is now around the target 200 ms while preserving runtime conformance. The largest C# fixture remains slower than Go, but the Rust runtime is much closer than the prior multi-second baseline.

10-iteration C# comparison:

```text
csharp/dotnet-wpf-datagrid-column.cs  rust-antlr 87.107ms   go-antlr 18.856ms
csharp/mono-codegen.cs                rust-antlr 82.427ms   go-antlr 36.889ms
csharp/mono-anonymous.cs              rust-antlr 150.799ms  go-antlr 39.036ms
csharp/mono-statement.cs              rust-antlr 493.657ms  go-antlr 134.402ms
```

Rust mean across the four C# fixtures: 203.5 ms.

Kotlin quick benchmark remains healthy, with Rust still faster than Go on the checked Kotlin fixtures.

## Validation

- `git diff --check`
- `cargo test --quiet`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `python3 tools/parse-bench/run.py --languages csharp --runtimes rust-antlr,go-antlr --iters 10 --warmups 2 --json target/parse-bench/csharp-rust-go-final-10iters.json --markdown target/parse-bench/csharp-rust-go-final-10iters.md`
- `python3 tools/parse-bench/run.py --quick --languages kotlin --runtimes rust-antlr,go-antlr --json target/parse-bench/kotlin-rust-go-final-quick.json --markdown target/parse-bench/kotlin-rust-go-final-quick.md`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` -> `summary: 357 passed, 0 failed, 0 skipped, 357 run`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized lexer performance with improved caching mechanisms.
  * Enhanced parser recognition efficiency through token-stream improvements.
  * Improved token visibility tracking with caching.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ophidiarium/antlr-rust-runtime/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->