### PR TITLE
perf: lexer + recognizer micro-optimizations on the C# hot path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,42 @@
 # Development notes
 
+## Inner loop
+
+```bash
+cargo test --locked                                                 # unit tests
+cargo clippy --locked --all-targets --all-features -- -D warnings   # what CI runs
+```
+
+CI's clippy runs with the same `-D warnings` and promotes nursery/pedantic lints
+(`clippy::excessive-nesting`, `clippy::disallowed_types`, …) to errors — reproduce
+locally before pushing.
+
+## Source layout
+
+- `src/lib.rs` — public exports
+- `src/lexer.rs`, `src/atn/lexer.rs` — `BaseLexer` + lexer ATN simulator
+- `src/parser.rs` — `BaseParser` and the recursive `recognize_state_fast` walker
+- `src/atn/`, `src/atn/serialized.rs` — ATN graph + ANTLR `.interp` deserializer
+- `src/prediction.rs` — `PredictionContext`, `AtnConfig`, `PredictionFxHasher`
+- `src/token.rs`, `src/token_stream.rs`, `src/char_stream.rs` — input + token plumbing
+- `src/tree.rs` — public `ParseTree` / `ParserRuleContext`
+- `src/bin/antlr4-rust-gen.rs` — `.interp` → Rust parser code generator
+- `src/bin/antlr4-runtime-testsuite.rs` — conformance harness (see below)
+- `tests/kotlin-parity/` — Kotlin parity dumper + snippets
+- `tools/parse-bench/` — Python harness comparing rust/go/python/tree-sitter parse times
+
+## Generated parser codegen
+
+```bash
+cargo run --release --bin antlr4-rust-gen -- \
+    --lexer  path/to/Foo.interp \
+    --parser path/to/FooParser.interp \
+    --out-dir crates/foo/src/generated
+```
+
+The output crate must depend on this runtime (`antlr-rust-runtime = { path = ... }`).
+Both the kotlin-parity dumper and the parse-bench runner are examples.
+
 ## Kotlin parser parity perf benchmark
 
 Reproduces the timings against the Kotlin grammar from `antlr/grammars-v4`.
@@ -81,6 +118,38 @@ cargo run --release --quiet --bin antlr4-runtime-testsuite -- --case ParserError
 
 Per-case scratch crates land under `target/antlr-runtime-testsuite/<case>/`. Stale dirs from a killed run can fail a re-run with `Os { code: 66, ... DirectoryNotEmpty }` — `rm -rf target/antlr-runtime-testsuite/*` to recover.
 
+## Parse benchmark (vs Go / Python / tree-sitter)
+
+`tools/parse-bench/` runs ANTLR-generated Kotlin and C# parsers and reports
+min/avg parse time per fixture. CI runs it on every PR.
+
+The C# fixtures need an extra grammar checked out (Kotlin is in the one-time
+setup above):
+
+```bash
+git -C /tmp/antlr-cleanroom/grammars-v4 sparse-checkout set kotlin/kotlin csharp/v7
+python3 -m pip install -r tools/parse-bench/requirements.txt
+python3 tools/parse-bench/run.py \
+    --antlr-jar /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar \
+    --grammars-v4 /tmp/antlr-cleanroom/grammars-v4
+```
+
+See `tools/parse-bench/README.md` for `--quick`, `--languages`, `--runtimes`,
+JSON / Markdown output, and the per-runner build details.
+
+## perf-counters feature
+
+```bash
+cargo build --release --features perf-counters
+ANTLR_PERF_DUMP=1 ./your-parser-binary  # dumps RFS_CALLS, MEMO_HITS, OUTCOMES_RETURN_*, …
+```
+
+Opt-in counters compiled out by default; useful for "where did the new ms come
+from?" investigations. Disabled in default builds so they don't tax the inner
+loop.
+
 ## CI parity
 
 CI runs `cargo clippy --locked --all-targets --all-features -- -D warnings`, so reproduce locally with the same flags before pushing — `clippy::excessive-nesting`, `clippy::disallowed_types`, and similar nursery/pedantic lints all promote to errors there.
+
+`AGENTS.md` mirrors this file for Codex / generic agents — keep them in sync when adding sections.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ path = "src/lib.rs"
 [features]
 default = []
 std = []
+perf-counters = []
 
 [dependencies]
 thiserror = "2"

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -1,4 +1,5 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashSet};
+use std::hash::BuildHasherDefault;
 
 use crate::atn::{Atn, AtnStateKind, LexerAction, Transition};
 use crate::char_stream::{CharStream, TextInterval};
@@ -7,12 +8,16 @@ use crate::lexer::{
     BaseLexer, Lexer, LexerCustomAction, LexerDfaActionKey, LexerDfaCachedAccept,
     LexerDfaCachedState, LexerDfaCachedTransition, LexerDfaConfigKey, LexerDfaKey, LexerPredicate,
 };
+use crate::prediction::PredictionFxHasher;
 use crate::token::{CommonToken, DEFAULT_CHANNEL, INVALID_TOKEN_TYPE, TokenFactory};
+
+#[allow(clippy::disallowed_types)]
+type FxHashSet<K> = HashSet<K, BuildHasherDefault<PredictionFxHasher>>;
 
 const MIN_CHAR_VALUE: i32 = 0;
 const MAX_CHAR_VALUE: i32 = 0x0010_FFFF;
 
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct LexerConfig {
     state: usize,
     position: usize,
@@ -23,7 +28,7 @@ struct LexerConfig {
     actions: Vec<LexerActionTrace>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 struct LexerActionTrace {
     action_index: usize,
     position: usize,
@@ -100,7 +105,7 @@ impl LexerActionResult {
 /// Accumulates one epsilon-closure expansion, including whether predicate
 /// evaluation made the closure input-position-sensitive.
 struct ClosureState {
-    seen: BTreeSet<LexerConfig>,
+    seen: FxHashSet<LexerConfig>,
     closed: Vec<LexerConfig>,
     has_semantic_context: bool,
 }
@@ -723,7 +728,7 @@ where
     P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
 {
     let mut state = ClosureState {
-        seen: BTreeSet::new(),
+        seen: FxHashSet::default(),
         closed: Vec::new(),
         has_semantic_context: false,
     };

--- a/src/atn/mod.rs
+++ b/src/atn/mod.rs
@@ -359,9 +359,19 @@ impl IntervalSet {
 
     /// Returns true when `value` falls inside any stored interval.
     pub fn contains(&self, value: i32) -> bool {
-        self.ranges
-            .iter()
-            .any(|(start, stop)| (*start..=*stop).contains(&value))
+        // Ranges are kept sorted and coalesced by `normalize`, so the first
+        // range whose `start > value` cannot contain `value` and neither can
+        // any range after it. Binary searching for that boundary turns
+        // membership lookup from O(n) to O(log n), which matters because
+        // parser/lexer hot paths call this once per `Set`/`NotSet`/`Wildcard`
+        // transition probe.
+        match self
+            .ranges
+            .binary_search_by(|(start, _)| start.cmp(&value))
+        {
+            Ok(_) => true,
+            Err(pos) => pos > 0 && self.ranges[pos - 1].1 >= value,
+        }
     }
 
     pub fn ranges(&self) -> &[(i32, i32)] {

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,10 +1,15 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{BTreeSet, HashMap};
+use std::hash::BuildHasherDefault;
 use std::rc::Rc;
 
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
+use crate::prediction::PredictionFxHasher;
 use crate::recognizer::{Recognizer, RecognizerData};
 use crate::token::{CommonToken, CommonTokenFactory, TokenFactory, TokenSourceError, TokenSpec};
+
+#[allow(clippy::disallowed_types)]
+type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<PredictionFxHasher>>;
 
 pub const SKIP: i32 = -3;
 pub const MORE: i32 = -2;
@@ -114,29 +119,29 @@ pub struct BaseLexer<I, F = CommonTokenFactory> {
 /// runtime-suite descriptors.
 #[derive(Clone, Debug, Default)]
 struct LexerDfaTrace {
-    state_numbers: BTreeMap<LexerDfaKey, usize>,
-    accept_predictions: BTreeMap<usize, i32>,
+    state_numbers: FxHashMap<LexerDfaKey, usize>,
+    accept_predictions: FxHashMap<usize, i32>,
     edges: BTreeSet<LexerDfaEdge>,
-    cached_states: BTreeMap<usize, Rc<LexerDfaCachedState>>,
-    transitions: BTreeMap<(usize, i32), LexerDfaCachedTransition>,
-    mode_starts: BTreeMap<i32, usize>,
+    cached_states: FxHashMap<usize, Rc<LexerDfaCachedState>>,
+    transitions: FxHashMap<(usize, i32), LexerDfaCachedTransition>,
+    mode_starts: FxHashMap<i32, usize>,
 }
 
 impl LexerDfaTrace {
-    const fn new() -> Self {
+    fn new() -> Self {
         Self {
-            state_numbers: BTreeMap::new(),
-            accept_predictions: BTreeMap::new(),
+            state_numbers: FxHashMap::default(),
+            accept_predictions: FxHashMap::default(),
             edges: BTreeSet::new(),
-            cached_states: BTreeMap::new(),
-            transitions: BTreeMap::new(),
-            mode_starts: BTreeMap::new(),
+            cached_states: FxHashMap::default(),
+            transitions: FxHashMap::default(),
+            mode_starts: FxHashMap::default(),
         }
     }
 }
 
 /// Normalized lexer ATN config-set identity used for observed DFA traces.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct LexerDfaKey {
     configs: Vec<LexerDfaConfigKey>,
 }
@@ -149,7 +154,7 @@ impl LexerDfaKey {
 }
 
 /// One lexer ATN config identity with the absolute input position removed.
-#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct LexerDfaConfigKey {
     pub(crate) state: usize,
     pub(crate) alt_rule_index: Option<usize>,
@@ -159,7 +164,7 @@ pub(crate) struct LexerDfaConfigKey {
     pub(crate) actions: Vec<LexerDfaActionKey>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) struct LexerDfaActionKey {
     pub(crate) action_index: usize,
     pub(crate) position_delta: usize,
@@ -221,7 +226,7 @@ where
     I: CharStream,
 {
     /// Creates a lexer base using `CommonTokenFactory`.
-    pub const fn new(input: I, data: RecognizerData) -> Self {
+    pub fn new(input: I, data: RecognizerData) -> Self {
         Self::with_factory(input, data, CommonTokenFactory)
     }
 }
@@ -232,7 +237,7 @@ where
     F: TokenFactory,
 {
     /// Creates a lexer base with a custom token factory.
-    pub const fn with_factory(input: I, data: RecognizerData, factory: F) -> Self {
+    pub fn with_factory(input: I, data: RecognizerData, factory: F) -> Self {
         Self {
             input,
             data,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -1,4 +1,5 @@
 use std::collections::{BTreeMap, BTreeSet};
+use std::rc::Rc;
 
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
@@ -116,7 +117,7 @@ struct LexerDfaTrace {
     state_numbers: BTreeMap<LexerDfaKey, usize>,
     accept_predictions: BTreeMap<usize, i32>,
     edges: BTreeSet<LexerDfaEdge>,
-    cached_states: BTreeMap<usize, LexerDfaCachedState>,
+    cached_states: BTreeMap<usize, Rc<LexerDfaCachedState>>,
     transitions: BTreeMap<(usize, i32), LexerDfaCachedTransition>,
     mode_starts: BTreeMap<i32, usize>,
 }
@@ -530,7 +531,7 @@ where
             .or_insert(transition);
     }
 
-    pub(crate) fn cached_lexer_dfa_state(&self, state: usize) -> Option<LexerDfaCachedState> {
+    pub(crate) fn cached_lexer_dfa_state(&self, state: usize) -> Option<Rc<LexerDfaCachedState>> {
         self.lexer_dfa.cached_states.get(&state).cloned()
     }
 
@@ -542,7 +543,7 @@ where
         self.lexer_dfa
             .cached_states
             .entry(state)
-            .or_insert(cached_state);
+            .or_insert_with(|| Rc::new(cached_state));
     }
 
     pub(crate) fn cached_lexer_mode_start(&self, mode: i32) -> Option<usize> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5753,8 +5753,36 @@ fn dedupe_clean_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
     if outcomes.len() < 2 {
         return;
     }
-    let mut seen = BTreeSet::new();
-    outcomes.retain(|outcome| seen.insert((outcome.index, outcome.consumed_eof)));
+    // Most outcomes lists are 2-4 entries; an inline scan beats BTreeSet
+    // here because BTreeSet's allocation + per-insert balancing dominates
+    // O(log n) wins on tiny n. Retains the original order so callers that
+    // depend on alt ordering (e.g. fast outcome selection) stay correct.
+    let mut keep_keys: [(usize, bool); 8] = [(0, false); 8];
+    let mut keep_len = 0_usize;
+    outcomes.retain(|outcome| {
+        let key = (outcome.index, outcome.consumed_eof);
+        if keep_len < keep_keys.len() {
+            for &existing in &keep_keys[..keep_len] {
+                if existing == key {
+                    return false;
+                }
+            }
+            keep_keys[keep_len] = key;
+            keep_len += 1;
+            true
+        } else {
+            // Fallback for the rare case where there are more than 8
+            // distinct outcomes — scan all kept entries.
+            for &existing in &keep_keys[..] {
+                if existing == key {
+                    return false;
+                }
+            }
+            true
+        }
+    });
+    let _ = keep_keys;
+    let _ = keep_len;
 }
 
 /// Sorts and removes equivalent endpoints, including their action traces.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5,6 +5,7 @@
 // apply to these uses.
 #[allow(clippy::disallowed_types)]
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::cell::RefCell;
 use std::hash::{BuildHasherDefault, Hash, Hasher};
 use std::rc::Rc;
 
@@ -83,6 +84,80 @@ use crate::vocabulary::Vocabulary;
 /// non-viable. Long expression-regression descriptors legitimately walk tens
 /// of thousands of ATN edges.
 const RECOGNITION_DEPTH_LIMIT: usize = 100_000;
+
+#[cfg(feature = "perf-counters")]
+mod perf_counters {
+    use std::cell::Cell;
+    thread_local! {
+        pub(super) static RFS_CALLS: Cell<u64> = const { Cell::new(0) };
+        pub(super) static RFS_MEMO_HITS: Cell<u64> = const { Cell::new(0) };
+        pub(super) static RFS_MEMO_MISSES: Cell<u64> = const { Cell::new(0) };
+        pub(super) static RFS_VISITING_CYCLE: Cell<u64> = const { Cell::new(0) };
+        pub(super) static MEMO_INSERTED: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOMES_PUSHED: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOMES_CLONED: Cell<u64> = const { Cell::new(0) };
+    }
+    pub(super) fn inc(c: &'static std::thread::LocalKey<Cell<u64>>, n: u64) {
+        c.with(|v| v.set(v.get() + n));
+    }
+    thread_local! {
+        pub(super) static EPSILON_TRANSITIONS: Cell<u64> = const { Cell::new(0) };
+        pub(super) static RULE_TRANSITIONS: Cell<u64> = const { Cell::new(0) };
+        pub(super) static ATOM_RANGE_TRANSITIONS: Cell<u64> = const { Cell::new(0) };
+        pub(super) static SINGLE_TRANS_BODY: Cell<u64> = const { Cell::new(0) };
+        pub(super) static MULTI_TRANS_BODY: Cell<u64> = const { Cell::new(0) };
+        pub(super) static SINGLE_TRANS_RULE: Cell<u64> = const { Cell::new(0) };
+        pub(super) static SINGLE_TRANS_ATOM: Cell<u64> = const { Cell::new(0) };
+        pub(super) static SINGLE_TRANS_OTHER: Cell<u64> = const { Cell::new(0) };
+    }
+    pub(super) fn snapshot() -> [(&'static str, u64); 15] {
+        [
+            ("rfs_calls", RFS_CALLS.with(Cell::get)),
+            ("rfs_memo_hits", RFS_MEMO_HITS.with(Cell::get)),
+            ("rfs_memo_misses", RFS_MEMO_MISSES.with(Cell::get)),
+            ("rfs_visiting_cycle", RFS_VISITING_CYCLE.with(Cell::get)),
+            ("memo_inserted", MEMO_INSERTED.with(Cell::get)),
+            ("outcomes_pushed", OUTCOMES_PUSHED.with(Cell::get)),
+            ("outcomes_cloned", OUTCOMES_CLONED.with(Cell::get)),
+            ("epsilon_transitions", EPSILON_TRANSITIONS.with(Cell::get)),
+            ("rule_transitions", RULE_TRANSITIONS.with(Cell::get)),
+            ("atom_range_transitions", ATOM_RANGE_TRANSITIONS.with(Cell::get)),
+            ("single_trans_body", SINGLE_TRANS_BODY.with(Cell::get)),
+            ("multi_trans_body", MULTI_TRANS_BODY.with(Cell::get)),
+            ("single_trans_rule", SINGLE_TRANS_RULE.with(Cell::get)),
+            ("single_trans_atom", SINGLE_TRANS_ATOM.with(Cell::get)),
+            ("single_trans_other", SINGLE_TRANS_OTHER.with(Cell::get)),
+        ]
+    }
+    pub fn reset() {
+        RFS_CALLS.with(|c| c.set(0));
+        RFS_MEMO_HITS.with(|c| c.set(0));
+        RFS_MEMO_MISSES.with(|c| c.set(0));
+        RFS_VISITING_CYCLE.with(|c| c.set(0));
+        MEMO_INSERTED.with(|c| c.set(0));
+        OUTCOMES_PUSHED.with(|c| c.set(0));
+        OUTCOMES_CLONED.with(|c| c.set(0));
+        EPSILON_TRANSITIONS.with(|c| c.set(0));
+        RULE_TRANSITIONS.with(|c| c.set(0));
+        ATOM_RANGE_TRANSITIONS.with(|c| c.set(0));
+        SINGLE_TRANS_BODY.with(|c| c.set(0));
+        MULTI_TRANS_BODY.with(|c| c.set(0));
+        SINGLE_TRANS_RULE.with(|c| c.set(0));
+        SINGLE_TRANS_ATOM.with(|c| c.set(0));
+        SINGLE_TRANS_OTHER.with(|c| c.set(0));
+    }
+    pub fn dump() {
+        for (name, value) in snapshot() {
+            #[allow(clippy::print_stderr)]
+            {
+                eprintln!("perf {name}={value}");
+            }
+        }
+    }
+}
+
+#[cfg(feature = "perf-counters")]
+pub use perf_counters::{dump as dump_perf_counters, reset as reset_perf_counters};
 /// Preserve lazy lexing for short or failing inputs, but eagerly fill once the
 /// fast recognizer has probed far enough that per-token stream sync dominates.
 /// Sixty-four tokens is a small rule-sized window: it keeps startup lazy while
@@ -830,6 +905,49 @@ struct FirstSet {
 /// `BTreeSet<i32>`.
 type FirstSetCache = FxHashMap<(usize, usize), Rc<FirstSet>>;
 
+// Thread-local FIRST-set caches keyed by the ATN pointer. The FIRST set
+// and decision-lookahead entries are purely functions of the grammar's
+// ATN, so caching across parses lets repeated parsing of the same grammar
+// (the common case for a CLI tool or language server) avoid redoing the
+// closure work. Generated parsers hand us a `&'static Atn` whose address
+// is stable, which is what we hash on.
+type DecisionLookaheadCache = FxHashMap<usize, Rc<DecisionLookahead>>;
+
+#[derive(Default)]
+struct SharedAtnCache {
+    first_set: FirstSetCache,
+    decision_lookahead: DecisionLookaheadCache,
+}
+
+thread_local! {
+    static SHARED_ATN_CACHES: RefCell<FxHashMap<usize, SharedAtnCache>> =
+        RefCell::new(FxHashMap::default());
+}
+
+fn with_shared_first_set_cache<R>(
+    atn: &Atn,
+    f: impl FnOnce(&mut FirstSetCache) -> R,
+) -> R {
+    SHARED_ATN_CACHES.with(|cell| {
+        let key = std::ptr::from_ref::<Atn>(atn) as usize;
+        let mut map = cell.borrow_mut();
+        let cache = map.entry(key).or_default();
+        f(&mut cache.first_set)
+    })
+}
+
+fn with_shared_atn_caches<R>(
+    atn: &Atn,
+    f: impl FnOnce(&mut SharedAtnCache) -> R,
+) -> R {
+    SHARED_ATN_CACHES.with(|cell| {
+        let key = std::ptr::from_ref::<Atn>(atn) as usize;
+        let mut map = cell.borrow_mut();
+        let cache = map.entry(key).or_default();
+        f(cache)
+    })
+}
+
 /// Per-decision-state cached look-1 sets for each outgoing transition.
 ///
 /// At a multi-alternative state, the recognizer would otherwise speculatively
@@ -1518,8 +1636,8 @@ struct FastRecoveryRequest<'a, 'b> {
     expected_symbols: Rc<BTreeSet<i32>>,
     target: usize,
     request: FastRecognizeRequest,
-    visiting: &'b mut FxHashSet<FastRecognizeKey>,
-    memo: &'b mut FxHashMap<FastRecognizeKey, Vec<FastRecognizeOutcome>>,
+    visiting: &'b mut FxHashSet<u64>,
+    memo: &'b mut FxHashMap<FastRecognizeKey, Rc<[FastRecognizeOutcome]>>,
     expected: &'b mut ExpectedTokens,
 }
 
@@ -1527,8 +1645,8 @@ struct FastCurrentTokenDeletionRequest<'a, 'b> {
     atn: &'a Atn,
     expected_symbols: Rc<BTreeSet<i32>>,
     request: FastRecognizeRequest,
-    visiting: &'b mut FxHashSet<FastRecognizeKey>,
-    memo: &'b mut FxHashMap<FastRecognizeKey, Vec<FastRecognizeOutcome>>,
+    visiting: &'b mut FxHashSet<u64>,
+    memo: &'b mut FxHashMap<FastRecognizeKey, Rc<[FastRecognizeOutcome]>>,
     expected: &'b mut ExpectedTokens,
 }
 
@@ -1820,8 +1938,11 @@ where
         // count here. Do not restore an up-front fill just to size this map:
         // the fixed floor avoids small-input churn, and large inputs grow the
         // cache after the deferred-fill threshold without forcing startup
-        // tokenization.
-        let memo_capacity = self.input.size().saturating_mul(4).clamp(65_536, 262_144);
+        // tokenization. The 8x multiplier matches the empirical
+        // memo-insert / token ratio on heavy grammars (C# averages ~6× and
+        // Kotlin ~12× memo entries per token), so the table avoids one
+        // rehash on the typical hot path.
+        let memo_capacity = self.input.size().saturating_mul(8).clamp(65_536, 524_288);
         let mut visiting = FxHashSet::with_capacity_and_hasher(256, FxBuildHasher::default());
         let mut memo = FxHashMap::with_capacity_and_hasher(memo_capacity, FxBuildHasher::default());
         let mut expected = ExpectedTokens::default();
@@ -2693,59 +2814,155 @@ where
 
     /// Attempts to reach `stop_state` from `state_number` without committing
     /// token consumption to the parser's public stream position.
+    #[allow(clippy::too_many_lines)]
     fn recognize_state_fast(
         &mut self,
         atn: &Atn,
         request: FastRecognizeRequest,
-        visiting: &mut FxHashSet<FastRecognizeKey>,
-        memo: &mut FxHashMap<FastRecognizeKey, Vec<FastRecognizeOutcome>>,
+        visiting: &mut FxHashSet<u64>,
+        memo: &mut FxHashMap<FastRecognizeKey, Rc<[FastRecognizeOutcome]>>,
         expected: &mut ExpectedTokens,
     ) -> Vec<FastRecognizeOutcome> {
+        #[cfg(feature = "perf-counters")]
+        perf_counters::inc(&perf_counters::RFS_CALLS, 1);
         let FastRecognizeRequest {
-            state_number,
+            mut state_number,
             stop_state,
             index,
             rule_start_index,
             decision_start_index,
             precedence,
-            depth,
+            mut depth,
             recovery_symbols,
             recovery_state,
         } = request;
-        if depth > RECOGNITION_DEPTH_LIMIT {
-            return Vec::new();
+        // Walk straight-line epsilon chains in a loop instead of recursing
+        // into `recognize_state_fast` for each intermediate state. ATN
+        // serialization places long sequences of `BasicBlock` epsilon
+        // transitions between decisions: turning that chain into a loop
+        // collapses many recursive calls (and their memo lookups, vec
+        // allocations, and visit-set churn) into a single function frame.
+        // The loop exits as soon as we hit the original state's logic
+        // (multi-alt, decision, rule call, atom/range/set, precedence) so
+        // existing fanout, recovery, and memoization still apply unchanged.
+        loop {
+            if depth > RECOGNITION_DEPTH_LIMIT {
+                return Vec::new();
+            }
+            if state_number == stop_state {
+                return vec![FastRecognizeOutcome {
+                    index,
+                    consumed_eof: false,
+                    diagnostics: Vec::new(),
+                    nodes: NodeList::new(),
+                }];
+            }
+            let Some(state) = atn.state(state_number) else {
+                return Vec::new();
+            };
+            if state.transitions.len() == 1
+                && !starts_prediction_decision(state)
+                && !state.precedence_rule_decision
+            {
+                if let Transition::Epsilon { target } = &state.transitions[0] {
+                    if left_recursive_boundary(atn, state, *target).is_none() {
+                        #[cfg(feature = "perf-counters")]
+                        perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
+                        state_number = *target;
+                        depth += 1;
+                        continue;
+                    }
+                }
+            }
+            break;
         }
-        if state_number == stop_state {
-            return vec![FastRecognizeOutcome {
+        // In pass 1 (`fast_recovery_enabled == false`) the recovery-related
+        // fields and the rule/decision boundary indices are pure plumbing —
+        // they only affect the recovery branch and the no-viable diagnostic
+        // recording, neither of which fires when recovery is off. Zeroing
+        // them in the memo key collapses calls that visit the same
+        // `(state, index)` from different rule-call sites onto one cache
+        // entry, which is the dominant cost on large grammars (e.g. C#) where
+        // many rules eventually delegate into the same `expression` /
+        // `primary_expression` / `type` branches.
+        let key = if self.fast_recovery_enabled {
+            FastRecognizeKey {
+                state_number,
+                stop_state,
                 index,
-                consumed_eof: false,
-                diagnostics: Vec::new(),
-                nodes: NodeList::new(),
-            }];
-        }
-        let key = FastRecognizeKey {
-            state_number,
-            stop_state,
-            index,
-            rule_start_index,
-            decision_start_index,
-            precedence,
-            recovery_symbols_id: Rc::as_ptr(&recovery_symbols) as usize,
-            recovery_state,
+                rule_start_index,
+                decision_start_index,
+                precedence,
+                recovery_symbols_id: Rc::as_ptr(&recovery_symbols) as usize,
+                recovery_state,
+            }
+        } else {
+            FastRecognizeKey {
+                state_number,
+                stop_state,
+                index,
+                rule_start_index: 0,
+                decision_start_index: None,
+                precedence,
+                recovery_symbols_id: 0,
+                recovery_state: None,
+            }
         };
         if let Some(outcomes) = memo.get(&key) {
-            return outcomes.clone();
+            #[cfg(feature = "perf-counters")]
+            {
+                perf_counters::inc(&perf_counters::RFS_MEMO_HITS, 1);
+                perf_counters::inc(&perf_counters::OUTCOMES_CLONED, outcomes.len() as u64);
+            }
+            // Materialize a fresh `Vec` from the cached slice; the caller
+            // mutates per-outcome state (eof flags, prepended nodes) so we
+            // can't hand them the shared backing.
+            return outcomes.to_vec();
         }
+        #[cfg(feature = "perf-counters")]
+        perf_counters::inc(&perf_counters::RFS_MEMO_MISSES, 1);
 
-        let visit_key = key.clone();
-        if !visiting.insert(visit_key.clone()) {
-            return Vec::new();
-        }
-
+        // Cycle detection: only insert into the visiting set for states
+        // that *could* re-enter without consuming — multi-alternative
+        // states. Single-transition states are walked in the loop above and
+        // never form cycles (the loop only advances toward the rule stop).
+        // Multi-alt states might contain epsilon-only edges that loop back
+        // to the same `(state, index)` (e.g. left-recursive precedence
+        // loops); we still need the guard there.
         let Some(state) = atn.state(state_number) else {
-            visiting.remove(&visit_key);
             return Vec::new();
         };
+        let needs_cycle_guard = state.transitions.len() > 1;
+        #[cfg(feature = "perf-counters")]
+        if needs_cycle_guard {
+            perf_counters::inc(&perf_counters::MULTI_TRANS_BODY, 1);
+        } else {
+            perf_counters::inc(&perf_counters::SINGLE_TRANS_BODY, 1);
+            match &state.transitions[0] {
+                Transition::Rule { .. } => {
+                    perf_counters::inc(&perf_counters::SINGLE_TRANS_RULE, 1);
+                }
+                Transition::Atom { .. }
+                | Transition::Range { .. }
+                | Transition::Set { .. }
+                | Transition::NotSet { .. }
+                | Transition::Wildcard { .. } => {
+                    perf_counters::inc(&perf_counters::SINGLE_TRANS_ATOM, 1);
+                }
+                _ => {
+                    perf_counters::inc(&perf_counters::SINGLE_TRANS_OTHER, 1);
+                }
+            }
+        }
+        let visit_id = (state_number as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
+            ^ (index as u64);
+        if needs_cycle_guard {
+            if !visiting.insert(visit_id) {
+                #[cfg(feature = "perf-counters")]
+                perf_counters::inc(&perf_counters::RFS_VISITING_CYCLE, 1);
+                return Vec::new();
+            }
+        }
         let next_decision_start_index = if starts_prediction_decision(state) {
             Some(index)
         } else {
@@ -2775,7 +2992,8 @@ where
         //   * left-recursive precedence loops (the precedence transition's
         //     gating is dynamic),
         //   * states with too few alternatives to benefit.
-        let lookahead_filter = if state.transitions.len() > 1
+        let transition_count = state.transitions.len();
+        let lookahead_filter = if transition_count > 1
             && self.fast_first_set_prefilter
             && !state.precedence_rule_decision
             && (!self.fast_recovery_enabled || state.kind != AtnStateKind::RuleStart)
@@ -2792,8 +3010,13 @@ where
             None
         };
         let lookahead_filter = lookahead_filter.as_ref();
-        let transition_count = state.transitions.len();
-        let mut outcomes = Vec::with_capacity(transition_count);
+        // Pre-size only when we expect at least one outcome to land — most
+        // single-transition fall-throughs (the loop above didn't catch
+        // because they're atom/rule/predicate) push at most one entry, so
+        // reserving one slot avoids a reallocation while keeping the
+        // unused-slot waste at one element.
+        let mut outcomes: Vec<FastRecognizeOutcome> =
+            Vec::with_capacity(transition_count.min(2));
         for (transition_index, transition) in state.transitions.iter().enumerate() {
             if should_skip_via_lookahead(
                 transition,
@@ -2809,6 +3032,8 @@ where
                 Transition::Epsilon { target }
                 | Transition::Predicate { target, .. }
                 | Transition::Action { target, .. } => {
+                    #[cfg(feature = "perf-counters")]
+                    perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
                     let boundary = left_recursive_boundary(atn, state, *target);
                     outcomes.extend(
                         self.recognize_state_fast(
@@ -2882,6 +3107,8 @@ where
                     precedence: rule_precedence,
                     ..
                 } => {
+                    #[cfg(feature = "perf-counters")]
+                    perf_counters::inc(&perf_counters::RULE_TRANSITIONS, 1);
                     let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied()
                     else {
                         continue;
@@ -2900,32 +3127,28 @@ where
                     let symbol = self.token_type_at(index);
                     if self.fast_first_set_prefilter {
                         let first_key = (*target, child_stop);
-                        if !self.first_set_cache.contains_key(&first_key) {
-                            let _ =
-                                rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
-                        }
-                        if let Some(first) = self.first_set_cache.get(&first_key) {
-                            if should_skip_rule_via_first_set(
-                                first,
-                                symbol,
-                                self.fast_recovery_enabled,
-                                index,
-                                expected,
-                            ) {
-                                continue;
+                        // Probe the shared cross-parse cache first; build
+                        // the entry on miss and intern it there. The
+                        // computation is purely a function of the ATN, so
+                        // the cached entry is reused across parses (and
+                        // freshly-instantiated parser values that share
+                        // the same `&'static Atn`).
+                        let first = with_shared_first_set_cache(atn, |cache| {
+                            if !cache.contains_key(&first_key) {
+                                rule_first_set(atn, *target, child_stop, cache);
                             }
-                        } else {
-                            let first =
-                                rule_first_set(atn, *target, child_stop, &mut self.first_set_cache);
-                            if should_skip_rule_via_first_set(
-                                &first,
-                                symbol,
-                                self.fast_recovery_enabled,
-                                index,
-                                expected,
-                            ) {
-                                continue;
-                            }
+                            Rc::clone(cache.get(&first_key).expect(
+                                "rule_first_set inserts the FIRST entry before returning",
+                            ))
+                        });
+                        if should_skip_rule_via_first_set(
+                            &first,
+                            symbol,
+                            self.fast_recovery_enabled,
+                            index,
+                            expected,
+                        ) {
+                            continue;
                         }
                     }
                     let expected_before_child =
@@ -3002,6 +3225,8 @@ where
                 | Transition::Set { target, .. }
                 | Transition::NotSet { target, .. }
                 | Transition::Wildcard { target, .. } => {
+                    #[cfg(feature = "perf-counters")]
+                    perf_counters::inc(&perf_counters::ATOM_RANGE_TRANSITIONS, 1);
                     let symbol = self.token_type_at(index);
                     if transition.matches(symbol, 1, atn.max_token_type()) {
                         let next_index = self.consume_index(index, symbol);
@@ -3036,6 +3261,16 @@ where
                             }),
                         );
                     } else {
+                        if !self.fast_recovery_enabled {
+                            // In pass 1 there is no recovery to attempt; the
+                            // recovery branch below would never run, and the
+                            // `expected_symbols` computation is just there
+                            // to gate that branch. Skipping it eliminates
+                            // ~1× `state_expected_symbols` lookup per failed
+                            // atom transition (≈82K on mono-statement.cs)
+                            // for zero observable behavior change.
+                            continue;
+                        }
                         let expected_symbols = fast_recovery_expected_symbols(
                             self,
                             atn,
@@ -3045,7 +3280,7 @@ where
                         if expected_symbols.contains(&symbol) {
                             continue;
                         }
-                        if self.fast_recovery_enabled {
+                        {
                             expected.record_transition(index, transition, atn.max_token_type());
                             record_no_viable_if_ambiguous(
                                 expected,
@@ -3124,8 +3359,13 @@ where
             }
         }
 
-        visiting.remove(&visit_key);
-        if self.prediction_mode == PredictionMode::Ll {
+        if needs_cycle_guard {
+            visiting.remove(&visit_id);
+        }
+        if self.prediction_mode == PredictionMode::Ll && self.fast_recovery_enabled {
+            // Without recovery enabled every outcome already has empty
+            // diagnostics, so the discard pass is a no-op — skipping it
+            // saves an iter+retain on each of the ~1M visits.
             discard_recovered_fast_outcomes_if_clean_path_exists(&mut outcomes);
         }
         if self.fast_recovery_enabled {
@@ -3133,8 +3373,30 @@ where
         } else {
             dedupe_clean_fast_outcomes(&mut outcomes);
         }
-        if self.fast_recovery_enabled || !outcomes.is_empty() {
-            memo.insert(key, outcomes.clone());
+        // Skip memoization for single-transition states whose outcome is
+        // unambiguous: they only get re-entered if the caller revisits the
+        // exact same call site, which is rare since the loop above already
+        // collapsed straight-line epsilon walks. Multi-alternative states
+        // are where backtracking actually revisits the same coordinate, so
+        // we still memoize there. With recovery on we keep the existing
+        // memoization unconditionally because the recovery branch may
+        // record diagnostics that the cache must surface to repeated
+        // failed visits.
+        let should_memoize = self.fast_recovery_enabled || transition_count > 1;
+        if should_memoize && (self.fast_recovery_enabled || !outcomes.is_empty()) {
+            #[cfg(feature = "perf-counters")]
+            {
+                perf_counters::inc(&perf_counters::MEMO_INSERTED, 1);
+                perf_counters::inc(&perf_counters::OUTCOMES_PUSHED, outcomes.len() as u64);
+            }
+            // Materialize the result into a shared `Rc<[..]>` once, then
+            // hand the caller a fresh `Vec` cloned from the same slice.
+            // `Rc::from(Vec)` reuses the existing allocation when possible,
+            // so the cache write skips an extra copy versus inserting a
+            // freshly cloned `Vec` and then cloning it again to return.
+            let stored: Rc<[FastRecognizeOutcome]> = Rc::from(outcomes);
+            memo.insert(key, Rc::clone(&stored));
+            return stored.to_vec();
         }
         outcomes
     }
@@ -4110,29 +4372,31 @@ where
     /// recognition; sharing the entry through `Rc` keeps the prefilter to one
     /// hash lookup per visit.
     fn cached_decision_lookahead(
-        &mut self,
+        &self,
         atn: &Atn,
         state: &AtnState,
         rule_stop_state: usize,
     ) -> Rc<DecisionLookahead> {
-        if let Some(cached) = self.decision_lookahead_cache.get(&state.state_number) {
-            return Rc::clone(cached);
-        }
-        let mut entry = DecisionLookahead {
-            transitions: Vec::with_capacity(state.transitions.len()),
-        };
-        for transition in &state.transitions {
-            entry.transitions.push(transition_first_set(
-                atn,
-                transition,
-                rule_stop_state,
-                &mut self.first_set_cache,
-            ));
-        }
-        let entry = Rc::new(entry);
-        self.decision_lookahead_cache
-            .insert(state.state_number, Rc::clone(&entry));
-        entry
+        with_shared_atn_caches(atn, |cache| {
+            if let Some(cached) = cache.decision_lookahead.get(&state.state_number) {
+                return Rc::clone(cached);
+            }
+            let mut entry = DecisionLookahead {
+                transitions: Vec::with_capacity(state.transitions.len()),
+            };
+            for transition in &state.transitions {
+                entry.transitions.push(transition_first_set(
+                    atn,
+                    transition,
+                    rule_stop_state,
+                    &mut cache.first_set,
+                ));
+            }
+            let entry = Rc::new(entry);
+            cache.decision_lookahead
+                .insert(state.state_number, Rc::clone(&entry));
+            entry
+        })
     }
 
     /// Clones the visible token at an absolute token-stream index.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -527,22 +527,19 @@ struct FastRecognizeOutcome {
 /// same head-first order as the original `Vec<FastRecognizedNode>` they
 /// replaced. Shared tails across speculative outcomes amortize the cost of
 /// chaining a child rule's nodes onto every follow outcome.
+///
+/// `One` is an inline single-element variant: most outcomes carry only one
+/// node (a single token or a single rule wrapper), so storing that node
+/// directly avoids allocating an `Rc<NodeList>` tail wrapper.
 #[derive(Clone, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
 enum NodeList {
     #[default]
     Empty,
+    One(Rc<FastRecognizedNode>),
     Cons {
         head: Rc<FastRecognizedNode>,
         tail: Rc<Self>,
     },
-}
-
-thread_local! {
-    /// Shared tail for `NodeList::Cons` that wraps the empty list — used to
-    /// avoid `Rc::new(NodeList::Empty)` allocations on every prepend onto an
-    /// empty list. Cons cells whose tail is the shared empty Rc keep the
-    /// list's clone semantics intact.
-    static EMPTY_NODELIST: Rc<NodeList> = Rc::new(NodeList::Empty);
 }
 
 impl NodeList {
@@ -551,18 +548,16 @@ impl NodeList {
         Self::Empty
     }
 
-    fn shared_empty() -> Rc<Self> {
-        EMPTY_NODELIST.with(Rc::clone)
-    }
-
     /// Prepends `node` and returns the new list. Both shared tails and the
     /// new head are reference-counted so this is `O(1)`.
     fn cons(self, node: Rc<FastRecognizedNode>) -> Self {
-        let tail = match self {
-            Self::Empty => Self::shared_empty(),
-            cons @ Self::Cons { .. } => Rc::new(cons),
-        };
-        Self::Cons { head: node, tail }
+        match self {
+            Self::Empty => Self::One(node),
+            existing @ (Self::One(_) | Self::Cons { .. }) => Self::Cons {
+                head: node,
+                tail: Rc::new(existing),
+            },
+        }
     }
 
     /// In-place prepend that takes ownership of `self` via [`std::mem::take`]
@@ -579,9 +574,18 @@ impl NodeList {
     fn to_vec(&self) -> Vec<Rc<FastRecognizedNode>> {
         let mut out = Vec::new();
         let mut cursor = self;
-        while let Self::Cons { head, tail } = cursor {
-            out.push(Rc::clone(head));
-            cursor = tail.as_ref();
+        loop {
+            match cursor {
+                Self::Empty => break,
+                Self::One(node) => {
+                    out.push(Rc::clone(node));
+                    break;
+                }
+                Self::Cons { head, tail } => {
+                    out.push(Rc::clone(head));
+                    cursor = tail.as_ref();
+                }
+            }
         }
         out
     }
@@ -630,6 +634,10 @@ impl<'a> Iterator for NodeListIter<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.cursor {
             NodeList::Empty => None,
+            NodeList::One(node) => {
+                self.cursor = &NodeList::Empty;
+                Some(node)
+            }
             NodeList::Cons { head, tail } => {
                 self.cursor = tail.as_ref();
                 Some(head)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -439,11 +439,11 @@ pub struct BaseParser<S> {
     /// current lookahead, letting common SLL decisions reduce to a single
     /// transition walk instead of a full speculative fan-out.
     decision_lookahead_cache: FxHashMap<usize, Rc<DecisionLookahead>>,
-    /// Per-parser fast-path mirror of `SharedAtnCache::ll1_decision_cache`.
+    /// Caches the LL(1) alt selection per `(state, lookahead_token)`.
     /// Each multi-trans visit asks "given this decision state and this
     /// lookahead token, which alt do I commit to?" Hitting this cache
-    /// turns the question into a hashmap probe (no thread-local +
-    /// RefCell + entry dance). Filled lazily from the shared cache.
+    /// turns the question into a hashmap probe instead of re-scanning
+    /// the decision's per-transition FIRST sets every visit.
     ll1_decision_cache: FxHashMap<(usize, i32), Option<usize>>,
     /// Empty recovery-symbols singleton used as the default at rule entry and
     /// after token consumption.
@@ -2953,14 +2953,14 @@ where
                 && !state.precedence_rule_decision
             {
                 match &state.transitions[0] {
-                    Transition::Epsilon { target } => {
-                        if left_recursive_boundary(atn, state, *target).is_none() {
-                            #[cfg(feature = "perf-counters")]
-                            perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
-                            state_number = *target;
-                            depth += 1;
-                            continue;
-                        }
+                    Transition::Epsilon { target }
+                        if left_recursive_boundary(atn, state, *target).is_none() =>
+                    {
+                        #[cfg(feature = "perf-counters")]
+                        perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
+                        state_number = *target;
+                        depth += 1;
+                        continue;
                     }
                     // Single-atom / range / set / wildcard / not-set states
                     // are common (~17K of ~125K calls on C#) and almost
@@ -5782,32 +5782,36 @@ fn dedupe_clean_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
     // here because BTreeSet's allocation + per-insert balancing dominates
     // O(log n) wins on tiny n. Retains the original order so callers that
     // depend on alt ordering (e.g. fast outcome selection) stay correct.
-    let mut keep_keys: [(usize, bool); 8] = [(0, false); 8];
-    let mut keep_len = 0_usize;
+    //
+    // Beyond the inline buffer we promote to a heap Vec so all kept entries
+    // continue to participate in dedup — leaking duplicates here on
+    // pathological grammars (e.g. ktor's deeply ambiguous Kotlin parse)
+    // explodes the speculative cache one step up the recursion.
+    let mut inline_keys: [(usize, bool); 8] = [(0, false); 8];
+    let mut inline_len = 0_usize;
+    let mut overflow: Vec<(usize, bool)> = Vec::new();
     outcomes.retain(|outcome| {
         let key = (outcome.index, outcome.consumed_eof);
-        if keep_len < keep_keys.len() {
-            for &existing in &keep_keys[..keep_len] {
-                if existing == key {
-                    return false;
-                }
+        for &existing in &inline_keys[..inline_len] {
+            if existing == key {
+                return false;
             }
-            keep_keys[keep_len] = key;
-            keep_len += 1;
-            true
-        } else {
-            // Fallback for the rare case where there are more than 8
-            // distinct outcomes — scan all kept entries.
-            for &existing in &keep_keys[..] {
-                if existing == key {
-                    return false;
-                }
-            }
-            true
         }
+        if !overflow.is_empty() {
+            for &existing in &overflow {
+                if existing == key {
+                    return false;
+                }
+            }
+        }
+        if inline_len < inline_keys.len() {
+            inline_keys[inline_len] = key;
+            inline_len += 1;
+        } else {
+            overflow.push(key);
+        }
+        true
     });
-    let _ = keep_keys;
-    let _ = keep_len;
 }
 
 /// Sorts and removes equivalent endpoints, including their action traces.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2842,7 +2842,7 @@ where
         let FastRecognizeRequest {
             mut state_number,
             stop_state,
-            index,
+            mut index,
             rule_start_index,
             decision_start_index,
             precedence,
@@ -2859,16 +2859,32 @@ where
         // The loop exits as soon as we hit the original state's logic
         // (multi-alt, decision, rule call, atom/range/set, precedence) so
         // existing fanout, recovery, and memoization still apply unchanged.
+        //
+        // The inline case also handles single-atom-match states on the
+        // happy-pass path: when the lone consuming transition matches the
+        // current lookahead, advance the index and continue without paying
+        // for a full `recognize_state_fast` recursion. We track tokens we
+        // consumed inline in `inline_consumed_tokens` so they can be
+        // prepended onto the eventual outcome list once we hit a state
+        // whose handling falls outside this fast loop.
+        let mut inline_consumed_tokens: Vec<usize> = Vec::new();
+        let mut inline_consumed_eof = false;
         loop {
             if depth > RECOGNITION_DEPTH_LIMIT {
                 return Vec::new();
             }
             if state_number == stop_state {
+                let mut nodes = NodeList::new();
+                if self.fast_token_nodes_enabled {
+                    for token_index in inline_consumed_tokens.iter().rev() {
+                        nodes.prepend(Rc::new(FastRecognizedNode::Token { index: *token_index }));
+                    }
+                }
                 return vec![FastRecognizeOutcome {
                     index,
-                    consumed_eof: false,
+                    consumed_eof: inline_consumed_eof,
                     diagnostics: Vec::new(),
-                    nodes: NodeList::new(),
+                    nodes,
                 }];
             }
             let Some(state) = atn.state(state_number) else {
@@ -2878,18 +2894,58 @@ where
                 && !starts_prediction_decision(state)
                 && !state.precedence_rule_decision
             {
-                if let Transition::Epsilon { target } = &state.transitions[0] {
-                    if left_recursive_boundary(atn, state, *target).is_none() {
-                        #[cfg(feature = "perf-counters")]
-                        perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
-                        state_number = *target;
-                        depth += 1;
-                        continue;
+                match &state.transitions[0] {
+                    Transition::Epsilon { target } => {
+                        if left_recursive_boundary(atn, state, *target).is_none() {
+                            #[cfg(feature = "perf-counters")]
+                            perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
+                            state_number = *target;
+                            depth += 1;
+                            continue;
+                        }
                     }
+                    // Single-atom / range / set / wildcard / not-set states
+                    // are common (~17K of ~125K calls on C#) and almost
+                    // always succeed in pass 1: no fanout, no recovery, no
+                    // diagnostics. Inline the token match and continue
+                    // walking instead of recursing — the recursive path
+                    // would just allocate a Vec, build one outcome, prepend
+                    // a Token node, and return. Skip pass 2 (recovery
+                    // enabled): there the failure branch matters and the
+                    // existing recursive code records expected symbols.
+                    Transition::Atom { target, .. }
+                    | Transition::Range { target, .. }
+                    | Transition::Set { target, .. }
+                    | Transition::NotSet { target, .. }
+                    | Transition::Wildcard { target, .. }
+                        if !self.fast_recovery_enabled =>
+                    {
+                        let symbol = self.token_type_at(index);
+                        let transition = &state.transitions[0];
+                        if transition.matches(symbol, 1, atn.max_token_type()) {
+                            #[cfg(feature = "perf-counters")]
+                            perf_counters::inc(&perf_counters::ATOM_RANGE_TRANSITIONS, 1);
+                            if self.fast_token_nodes_enabled {
+                                inline_consumed_tokens.push(index);
+                            }
+                            inline_consumed_eof |= symbol == TOKEN_EOF;
+                            index = self.consume_index(index, symbol);
+                            state_number = *target;
+                            depth += 1;
+                            continue;
+                        }
+                        // Fall through to break and let the regular
+                        // body handle the no-match case (returns empty).
+                    }
+                    _ => {}
                 }
             }
             break;
         }
+        // If we collected token nodes inline but bail to the recursive
+        // body (decision state, rule call, etc.), the outcomes returned
+        // below will need those token nodes prepended.
+        let inline_pending = !inline_consumed_tokens.is_empty() || inline_consumed_eof;
         // In pass 1 (`fast_recovery_enabled == false`) the recovery-related
         // fields and the rule/decision boundary indices are pure plumbing —
         // they only affect the recovery branch and the no-viable diagnostic
@@ -2931,6 +2987,27 @@ where
             // Materialize a fresh `Vec` from the cached slice; the caller
             // mutates per-outcome state (eof flags, prepended nodes) so we
             // can't hand them the shared backing.
+            if !inline_consumed_tokens.is_empty() || inline_consumed_eof {
+                let inline_eof = inline_consumed_eof;
+                let inline_tokens = &inline_consumed_tokens;
+                return outcomes
+                    .iter()
+                    .cloned()
+                    .map(|mut outcome| {
+                        if inline_eof {
+                            outcome.consumed_eof = true;
+                        }
+                        if self.fast_token_nodes_enabled {
+                            for token_index in inline_tokens.iter().rev() {
+                                outcome.nodes.prepend(Rc::new(FastRecognizedNode::Token {
+                                    index: *token_index,
+                                }));
+                            }
+                        }
+                        outcome
+                    })
+                    .collect();
+            }
             return outcomes.to_vec();
         }
         #[cfg(feature = "perf-counters")]
@@ -3397,6 +3474,22 @@ where
         // record diagnostics that the cache must surface to repeated
         // failed visits.
         let should_memoize = self.fast_recovery_enabled || transition_count > 1;
+        // Apply inline pending state to each outcome before returning.
+        // Tokens consumed inline by the loop-collapse don't appear in the
+        // recursive recognizer's output, so we need to prepend them here.
+        let apply_inline_pending = |mut outcome: FastRecognizeOutcome| -> FastRecognizeOutcome {
+            if inline_consumed_eof {
+                outcome.consumed_eof = true;
+            }
+            if !inline_consumed_tokens.is_empty() {
+                for token_index in inline_consumed_tokens.iter().rev() {
+                    outcome
+                        .nodes
+                        .prepend(Rc::new(FastRecognizedNode::Token { index: *token_index }));
+                }
+            }
+            outcome
+        };
         if should_memoize && (self.fast_recovery_enabled || !outcomes.is_empty()) {
             #[cfg(feature = "perf-counters")]
             {
@@ -3408,13 +3501,15 @@ where
                     _ => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_N, 1),
                 }
             }
-            // Materialize the result into a shared `Rc<[..]>` once, then
-            // hand the caller a fresh `Vec` cloned from the same slice.
-            // `Rc::from(Vec)` reuses the existing allocation when possible,
-            // so the cache write skips an extra copy versus inserting a
-            // freshly cloned `Vec` and then cloning it again to return.
+            // The memo is keyed by the loop-exit `(state_number, index)` so
+            // the inline-consumed tokens belong to *this* call's output, not
+            // the cached result. Memoize the bare outcomes (without the
+            // inline-pending data), then prepend the inline data on return.
             let stored: Rc<[FastRecognizeOutcome]> = Rc::from(outcomes);
             memo.insert(key, Rc::clone(&stored));
+            if inline_pending {
+                return stored.iter().cloned().map(apply_inline_pending).collect();
+            }
             return stored.to_vec();
         }
         #[cfg(feature = "perf-counters")]
@@ -3422,6 +3517,9 @@ where
             0 => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_0, 1),
             1 => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_1, 1),
             _ => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_N, 1),
+        }
+        if inline_pending {
+            return outcomes.into_iter().map(apply_inline_pending).collect();
         }
         outcomes
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3301,11 +3301,16 @@ where
                             stop_index: self.rule_stop_token_index(child_index, child_consumed_eof),
                             children: child.nodes,
                         });
+                        let child_diags_empty = child_diagnostics.is_empty();
                         outcomes.extend(follow_outcomes.into_iter().map(|mut outcome| {
                             outcome.consumed_eof |= child_consumed_eof;
-                            let mut diagnostics = child_diagnostics.clone();
-                            diagnostics.append(&mut outcome.diagnostics);
-                            outcome.diagnostics = diagnostics;
+                            // Skip the prepend dance when there's nothing to
+                            // merge from the child — common case in pass 1.
+                            if !child_diags_empty {
+                                let mut diagnostics = child_diagnostics.clone();
+                                diagnostics.append(&mut outcome.diagnostics);
+                                outcome.diagnostics = diagnostics;
+                            }
                             outcome.nodes.prepend(Rc::clone(&child_node));
                             outcome
                         }));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -439,6 +439,12 @@ pub struct BaseParser<S> {
     /// current lookahead, letting common SLL decisions reduce to a single
     /// transition walk instead of a full speculative fan-out.
     decision_lookahead_cache: FxHashMap<usize, Rc<DecisionLookahead>>,
+    /// Per-parser fast-path mirror of `SharedAtnCache::ll1_decision_cache`.
+    /// Each multi-trans visit asks "given this decision state and this
+    /// lookahead token, which alt do I commit to?" Hitting this cache
+    /// turns the question into a hashmap probe (no thread-local +
+    /// RefCell + entry dance). Filled lazily from the shared cache.
+    ll1_decision_cache: FxHashMap<(usize, i32), Option<usize>>,
     /// Empty recovery-symbols singleton used as the default at rule entry and
     /// after token consumption.
     empty_recovery_symbols: Rc<BTreeSet<i32>>,
@@ -1788,6 +1794,7 @@ where
             state_expected_cache: FxHashMap::default(),
             recovery_symbols_intern: FxHashMap::default(),
             decision_lookahead_cache: FxHashMap::default(),
+            ll1_decision_cache: FxHashMap::default(),
             empty_recovery_symbols: Rc::new(BTreeSet::new()),
             fast_first_set_prefilter: true,
             fast_recovery_enabled: true,
@@ -3148,10 +3155,20 @@ where
         // alternative. The recursive recognizer can then commit to that single
         // alt without iterating every transition through `should_skip_via_lookahead`
         // — saving (transition_count - 1) filter probes per visit.
+        //
+        // Result is cached per `(state, lookahead_token)` on the parser
+        // instance, so subsequent visits skip the FIRST-set scan entirely.
         let ll1_only_alt: Option<usize> = if transition_count > 1
             && let Some((symbol, entry)) = lookahead_filter.as_ref()
         {
-            ll1_unique_alt(entry, *symbol)
+            let key = (state.state_number, *symbol);
+            if let Some(&cached) = self.ll1_decision_cache.get(&key) {
+                cached
+            } else {
+                let result = ll1_unique_alt(entry, *symbol);
+                self.ll1_decision_cache.insert(key, result);
+                result
+            }
         } else {
             None
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -531,19 +531,32 @@ enum NodeList {
     },
 }
 
+thread_local! {
+    /// Shared tail for `NodeList::Cons` that wraps the empty list — used to
+    /// avoid `Rc::new(NodeList::Empty)` allocations on every prepend onto an
+    /// empty list. Cons cells whose tail is the shared empty Rc keep the
+    /// list's clone semantics intact.
+    static EMPTY_NODELIST: Rc<NodeList> = Rc::new(NodeList::Empty);
+}
+
 impl NodeList {
     /// Creates an empty list.
     const fn new() -> Self {
         Self::Empty
     }
 
+    fn shared_empty() -> Rc<Self> {
+        EMPTY_NODELIST.with(Rc::clone)
+    }
+
     /// Prepends `node` and returns the new list. Both shared tails and the
     /// new head are reference-counted so this is `O(1)`.
     fn cons(self, node: Rc<FastRecognizedNode>) -> Self {
-        Self::Cons {
-            head: node,
-            tail: Rc::new(self),
-        }
+        let tail = match self {
+            Self::Empty => Self::shared_empty(),
+            cons @ Self::Cons { .. } => Rc::new(cons),
+        };
+        Self::Cons { head: node, tail }
     }
 
     /// In-place prepend that takes ownership of `self` via [`std::mem::take`]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1702,7 +1702,7 @@ struct FastRecoveryRequest<'a, 'b> {
     expected_symbols: Rc<BTreeSet<i32>>,
     target: usize,
     request: FastRecognizeRequest,
-    visiting: &'b mut FxHashSet<u64>,
+    visiting: &'b mut FxHashSet<(usize, usize)>,
     memo: &'b mut FxHashMap<FastRecognizeKey, Rc<[FastRecognizeOutcome]>>,
     expected: &'b mut ExpectedTokens,
 }
@@ -1711,7 +1711,7 @@ struct FastCurrentTokenDeletionRequest<'a, 'b> {
     atn: &'a Atn,
     expected_symbols: Rc<BTreeSet<i32>>,
     request: FastRecognizeRequest,
-    visiting: &'b mut FxHashSet<u64>,
+    visiting: &'b mut FxHashSet<(usize, usize)>,
     memo: &'b mut FxHashMap<FastRecognizeKey, Rc<[FastRecognizeOutcome]>>,
     expected: &'b mut ExpectedTokens,
 }
@@ -2891,7 +2891,7 @@ where
         &mut self,
         atn: &Atn,
         request: FastRecognizeRequest,
-        visiting: &mut FxHashSet<u64>,
+        visiting: &mut FxHashSet<(usize, usize)>,
         memo: &mut FxHashMap<FastRecognizeKey, Rc<[FastRecognizeOutcome]>>,
         expected: &mut ExpectedTokens,
     ) -> Vec<FastRecognizeOutcome> {
@@ -3103,14 +3103,11 @@ where
                 }
             }
         }
-        let visit_id = (state_number as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15)
-            ^ (index as u64);
-        if needs_cycle_guard {
-            if !visiting.insert(visit_id) {
-                #[cfg(feature = "perf-counters")]
-                perf_counters::inc(&perf_counters::RFS_VISITING_CYCLE, 1);
-                return Vec::new();
-            }
+        let visit_id = (state_number, index);
+        if needs_cycle_guard && !visiting.insert(visit_id) {
+            #[cfg(feature = "perf-counters")]
+            perf_counters::inc(&perf_counters::RFS_VISITING_CYCLE, 1);
+            return Vec::new();
         }
         let next_decision_start_index = if starts_prediction_decision(state) {
             Some(index)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1157,6 +1157,36 @@ fn transition_first_set(
 /// transition is pruned, its FIRST set is folded into `expected` so failed
 /// parses produce the same `mismatched input ... expecting ...` diagnostic
 /// the no-prefilter baseline would emit.
+/// Returns the unique alt index (0-based) when `symbol` falls into exactly
+/// one transition's FIRST set and no transition is nullable. Used as an
+/// LL(1) commit point: when prediction is unambiguous from the lookahead
+/// alone, the recursive recognizer can skip every other alt without paying
+/// for the per-transition filter probe.
+///
+/// `None` signals the caller to fall back to per-transition lookahead
+/// filtering. Returning `Some` for an alt whose transition cannot actually
+/// match would prune the only viable parse path; this is why we require
+/// strict disjointness *and* no nullable transitions in the decision.
+fn ll1_unique_alt(entry: &DecisionLookahead, symbol: i32) -> Option<usize> {
+    let mut chosen: Option<usize> = None;
+    for (i, t) in entry.transitions.iter().enumerate() {
+        // Nullable transitions can match without consuming `symbol`, so
+        // they're always potentially viable. Bail and fall back to the
+        // standard filter loop.
+        if t.nullable {
+            return None;
+        }
+        if t.symbols.contains(symbol) {
+            if chosen.is_some() {
+                // Two transitions both contain this symbol — not LL(1).
+                return None;
+            }
+            chosen = Some(i);
+        }
+    }
+    chosen
+}
+
 fn should_skip_via_lookahead(
     transition: &Transition,
     transition_index: usize,
@@ -3113,6 +3143,18 @@ where
         } else {
             None
         };
+        // LL(1) fast path: when the FIRST sets for the decision are disjoint
+        // and none is nullable, the lookahead deterministically selects one
+        // alternative. The recursive recognizer can then commit to that single
+        // alt without iterating every transition through `should_skip_via_lookahead`
+        // — saving (transition_count - 1) filter probes per visit.
+        let ll1_only_alt: Option<usize> = if transition_count > 1
+            && let Some((symbol, entry)) = lookahead_filter.as_ref()
+        {
+            ll1_unique_alt(entry, *symbol)
+        } else {
+            None
+        };
         let lookahead_filter = lookahead_filter.as_ref();
         // Pre-size only when we expect at least one outcome to land — most
         // single-transition fall-throughs (the loop above didn't catch
@@ -3122,7 +3164,12 @@ where
         let mut outcomes: Vec<FastRecognizeOutcome> =
             Vec::with_capacity(transition_count.min(2));
         for (transition_index, transition) in state.transitions.iter().enumerate() {
-            if should_skip_via_lookahead(
+            if let Some(alt) = ll1_only_alt {
+                // LL(1) determinism: skip every alt except the chosen one.
+                if alt != transition_index {
+                    continue;
+                }
+            } else if should_skip_via_lookahead(
                 transition,
                 transition_index,
                 lookahead_filter,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3302,20 +3302,20 @@ where
                     // of conjuring a missing token at child-rule entry).
                     let symbol = self.token_type_at(index);
                     if self.fast_first_set_prefilter {
-                        let first_key = (*target, child_stop);
                         // Probe the shared cross-parse cache first; build
                         // the entry on miss and intern it there. The
                         // computation is purely a function of the ATN, so
                         // the cached entry is reused across parses (and
                         // freshly-instantiated parser values that share
                         // the same `&'static Atn`).
+                        //
+                        // `rule_first_set` returns the computed entry
+                        // directly — it intentionally skips inserting into
+                        // the cache when the FIRST-set walk hit a cycle, so
+                        // we cannot assume the entry is in the cache after
+                        // computing it.
                         let first = with_shared_first_set_cache(atn, |cache| {
-                            if !cache.contains_key(&first_key) {
-                                rule_first_set(atn, *target, child_stop, cache);
-                            }
-                            Rc::clone(cache.get(&first_key).expect(
-                                "rule_first_set inserts the FIRST entry before returning",
-                            ))
+                            rule_first_set(atn, *target, child_stop, cache)
                         });
                         if should_skip_rule_via_first_set(
                             &first,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4513,12 +4513,21 @@ where
     /// recognition; sharing the entry through `Rc` keeps the prefilter to one
     /// hash lookup per visit.
     fn cached_decision_lookahead(
-        &self,
+        &mut self,
         atn: &Atn,
         state: &AtnState,
         rule_stop_state: usize,
     ) -> Rc<DecisionLookahead> {
-        with_shared_atn_caches(atn, |cache| {
+        // Hit the parser-instance cache first. Decision lookahead is purely
+        // a function of the ATN/state, so on a warm cache we skip the
+        // thread-local + RefCell + HashMap-entry dance through
+        // SHARED_ATN_CACHES — which on multi-trans-heavy grammars (C# does
+        // ~58K multi-trans visits per parse) shows up as RefCell borrow and
+        // hashmap-entry overhead in profiles.
+        if let Some(cached) = self.decision_lookahead_cache.get(&state.state_number) {
+            return Rc::clone(cached);
+        }
+        let entry = with_shared_atn_caches(atn, |cache| {
             if let Some(cached) = cache.decision_lookahead.get(&state.state_number) {
                 return Rc::clone(cached);
             }
@@ -4537,7 +4546,10 @@ where
             cache.decision_lookahead
                 .insert(state.state_number, Rc::clone(&entry));
             entry
-        })
+        });
+        self.decision_lookahead_cache
+            .insert(state.state_number, Rc::clone(&entry));
+        entry
     }
 
     /// Clones the visible token at an absolute token-stream index.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4950,6 +4950,7 @@ where
     fn reset_per_parse_caches(&mut self) {
         self.first_set_cache.clear();
         self.decision_lookahead_cache.clear();
+        self.ll1_decision_cache.clear();
         self.recovery_symbols_intern.clear();
         self.state_expected_cache.clear();
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,8 +109,11 @@ mod perf_counters {
         pub(super) static SINGLE_TRANS_RULE: Cell<u64> = const { Cell::new(0) };
         pub(super) static SINGLE_TRANS_ATOM: Cell<u64> = const { Cell::new(0) };
         pub(super) static SINGLE_TRANS_OTHER: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOMES_RETURN_0: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOMES_RETURN_1: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOMES_RETURN_N: Cell<u64> = const { Cell::new(0) };
     }
-    pub(super) fn snapshot() -> [(&'static str, u64); 15] {
+    pub(super) fn snapshot() -> [(&'static str, u64); 18] {
         [
             ("rfs_calls", RFS_CALLS.with(Cell::get)),
             ("rfs_memo_hits", RFS_MEMO_HITS.with(Cell::get)),
@@ -127,6 +130,9 @@ mod perf_counters {
             ("single_trans_rule", SINGLE_TRANS_RULE.with(Cell::get)),
             ("single_trans_atom", SINGLE_TRANS_ATOM.with(Cell::get)),
             ("single_trans_other", SINGLE_TRANS_OTHER.with(Cell::get)),
+            ("outcomes_return_0", OUTCOMES_RETURN_0.with(Cell::get)),
+            ("outcomes_return_1", OUTCOMES_RETURN_1.with(Cell::get)),
+            ("outcomes_return_n", OUTCOMES_RETURN_N.with(Cell::get)),
         ]
     }
     pub fn reset() {
@@ -145,6 +151,9 @@ mod perf_counters {
         SINGLE_TRANS_RULE.with(|c| c.set(0));
         SINGLE_TRANS_ATOM.with(|c| c.set(0));
         SINGLE_TRANS_OTHER.with(|c| c.set(0));
+        OUTCOMES_RETURN_0.with(|c| c.set(0));
+        OUTCOMES_RETURN_1.with(|c| c.set(0));
+        OUTCOMES_RETURN_N.with(|c| c.set(0));
     }
     pub fn dump() {
         for (name, value) in snapshot() {
@@ -1964,6 +1973,11 @@ where
             &mut memo,
             &mut expected,
         );
+        #[cfg(feature = "perf-counters")]
+        if std::env::var("ANTLR_PERF_DUMP").is_ok() {
+            perf_counters::dump();
+            perf_counters::reset();
+        }
         match select_best_fast_outcome(outcomes.into_iter(), self.prediction_mode) {
             Some(outcome) => Ok((outcome, expected)),
             None => Err(expected),
@@ -3388,6 +3402,11 @@ where
             {
                 perf_counters::inc(&perf_counters::MEMO_INSERTED, 1);
                 perf_counters::inc(&perf_counters::OUTCOMES_PUSHED, outcomes.len() as u64);
+                match outcomes.len() {
+                    0 => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_0, 1),
+                    1 => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_1, 1),
+                    _ => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_N, 1),
+                }
             }
             // Materialize the result into a shared `Rc<[..]>` once, then
             // hand the caller a fresh `Vec` cloned from the same slice.
@@ -3397,6 +3416,12 @@ where
             let stored: Rc<[FastRecognizeOutcome]> = Rc::from(outcomes);
             memo.insert(key, Rc::clone(&stored));
             return stored.to_vec();
+        }
+        #[cfg(feature = "perf-counters")]
+        match outcomes.len() {
+            0 => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_0, 1),
+            1 => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_1, 1),
+            _ => perf_counters::inc(&perf_counters::OUTCOMES_RETURN_N, 1),
         }
         outcomes
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -956,8 +956,37 @@ struct SharedAtnCache {
 }
 
 thread_local! {
-    static SHARED_ATN_CACHES: RefCell<FxHashMap<usize, SharedAtnCache>> =
+    static SHARED_ATN_CACHES: RefCell<FxHashMap<SharedAtnCacheKey, SharedAtnCache>> =
         RefCell::new(FxHashMap::default());
+}
+
+/// Compound key for `SHARED_ATN_CACHES`.
+///
+/// Generated parsers feed us a `&'static Atn` from a `OnceLock<Atn>`, so the
+/// pointer identifies one grammar for the program's lifetime. For the
+/// non-`'static` case (a dropped `Atn` whose allocation is later reused),
+/// the secondary fields below catch the pointer collision: a new grammar
+/// would need to match all of `(states ptr, states len, max_token_type)` to
+/// be mistaken for the dropped one. That combination changing under us
+/// without a rebuild is implausible enough to treat as a bug; bundling them
+/// into the key is otherwise a few extra bytes per lookup.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct SharedAtnCacheKey {
+    atn: usize,
+    states: usize,
+    state_count: usize,
+    max_token_type: i32,
+}
+
+impl SharedAtnCacheKey {
+    fn for_atn(atn: &Atn) -> Self {
+        Self {
+            atn: std::ptr::from_ref::<Atn>(atn) as usize,
+            states: atn.states().as_ptr() as usize,
+            state_count: atn.states().len(),
+            max_token_type: atn.max_token_type(),
+        }
+    }
 }
 
 fn with_shared_first_set_cache<R>(
@@ -965,7 +994,7 @@ fn with_shared_first_set_cache<R>(
     f: impl FnOnce(&mut FirstSetCache) -> R,
 ) -> R {
     SHARED_ATN_CACHES.with(|cell| {
-        let key = std::ptr::from_ref::<Atn>(atn) as usize;
+        let key = SharedAtnCacheKey::for_atn(atn);
         let mut map = cell.borrow_mut();
         let cache = map.entry(key).or_default();
         f(&mut cache.first_set)
@@ -977,7 +1006,7 @@ fn with_shared_atn_caches<R>(
     f: impl FnOnce(&mut SharedAtnCache) -> R,
 ) -> R {
     SHARED_ATN_CACHES.with(|cell| {
-        let key = std::ptr::from_ref::<Atn>(atn) as usize;
+        let key = SharedAtnCacheKey::for_atn(atn);
         let mut map = cell.borrow_mut();
         let cache = map.entry(key).or_default();
         f(cache)

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -54,7 +54,7 @@ impl Hasher for PredictionFxHasher {
 
     #[inline]
     fn write_i32(&mut self, value: i32) {
-        self.write_u32(value.cast_unsigned());
+        self.write_u32(i32::cast_unsigned(value));
     }
 
     #[inline]

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -1,7 +1,67 @@
 use std::collections::BTreeSet;
+use std::hash::Hasher;
 use std::rc::Rc;
 
 pub const EMPTY_RETURN_STATE: usize = usize::MAX;
+
+/// Lightweight `FxHash`-style hasher.
+///
+/// Used by `BaseLexer`'s DFA-trace map and the `epsilon_closure` `seen`
+/// set to avoid the `SipHash` overhead of `std::collections::HashMap`'s
+/// default hasher on the hot lexer path.
+#[derive(Debug, Default)]
+pub struct PredictionFxHasher {
+    hash: u64,
+}
+
+const FX_ROT: u32 = 5;
+const FX_SEED: u64 = 0x51_7c_c1_b7_27_22_0a_95;
+
+impl Hasher for PredictionFxHasher {
+    #[inline]
+    fn write(&mut self, bytes: &[u8]) {
+        let mut bytes = bytes;
+        while bytes.len() >= 8 {
+            let (head, rest) = bytes.split_at(8);
+            let word = u64::from_le_bytes(head.try_into().expect("8-byte chunk"));
+            self.hash = (self.hash.rotate_left(FX_ROT) ^ word).wrapping_mul(FX_SEED);
+            bytes = rest;
+        }
+        for &b in bytes {
+            self.hash = (self.hash.rotate_left(FX_ROT) ^ u64::from(b)).wrapping_mul(FX_SEED);
+        }
+    }
+
+    #[inline]
+    fn write_u8(&mut self, value: u8) {
+        self.hash = (self.hash.rotate_left(FX_ROT) ^ u64::from(value)).wrapping_mul(FX_SEED);
+    }
+
+    #[inline]
+    fn write_u32(&mut self, value: u32) {
+        self.hash = (self.hash.rotate_left(FX_ROT) ^ u64::from(value)).wrapping_mul(FX_SEED);
+    }
+
+    #[inline]
+    fn write_u64(&mut self, value: u64) {
+        self.hash = (self.hash.rotate_left(FX_ROT) ^ value).wrapping_mul(FX_SEED);
+    }
+
+    #[inline]
+    fn write_usize(&mut self, value: usize) {
+        self.hash = (self.hash.rotate_left(FX_ROT) ^ value as u64).wrapping_mul(FX_SEED);
+    }
+
+    #[inline]
+    fn write_i32(&mut self, value: i32) {
+        self.write_u32(value.cast_unsigned());
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        self.hash
+    }
+}
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub enum PredictionContext {


### PR DESCRIPTION
## Summary

Targeted micro-optimizations to the lexer and recursive recognizer that
came out of profiling the C# parse benchmark. Each commit is a
self-contained, measurable wins; together they produce a meaningful
speedup on C# while leaving Kotlin (already fast) untouched or slightly
faster.

**This is *not* a full Adaptive-LL implementation.** I scaffolded one
in earlier iterations, couldn't make it fast enough on C#'s grammar
shape (closures explode the merge graph past the per-call deadline)
and stripped it out before sending this PR. Closing the remaining gap
to Go on C# requires that architectural change (per-decision DFA
caching across parses, or generated parser methods that dispatch via
`AdaptivePredict`) — out of scope here.

## Benchmark deltas (release, 5 iters + 2 warmups)

C#, vs upstream Go ANTLR runtime:

| fixture | before | after | go | rust vs go |
|---|---|---|---|---|
| dotnet-wpf-datagrid-column | 73.5 ms | 41 ms | 16 ms | 0.40× |
| mono-anonymous | 115.3 ms | 66 ms | 34 ms | 0.52× |
| mono-codegen | 61.9 ms | 37 ms | 32 ms | 0.88× |
| mono-statement | 377 ms | 228 ms | 120 ms | 0.53× |

Kotlin: still 9-17× faster than Go; no regression.

## What's in the commits

Lexer (cumulative ~30% on C# parse time):
- Rc-wrap cached lexer DFA state so lookups are an Rc bump, not a deep
  Vec clone
- Switch the closure-state `seen` set from `BTreeSet<LexerConfig>` to
  `FxHashSet`
- Switch `LexerDfaTrace` BTreeMap fields to FxHashMap
- New `PredictionFxHasher` providing the hash function

Parser (cumulative ~25-30% on C# parse time):
- Inline single-atom-match and single-epsilon transitions in the fast
  loop, avoiding a recursive `recognize_state_fast` call per visit
- Skip the diagnostics clone in the rule-call follow when the child
  produced no diagnostics (always true on pass 1)
- Intern an empty NodeList tail to avoid `Rc::new(NodeList::Empty)` per
  prepend onto an empty list
- Per-instance `decision_lookahead_cache`, eliminating thread-local +
  RefCell + entry overhead on every multi-trans visit
- LL(1) early-commit + per-instance cache when the FIRST sets are
  disjoint and not nullable; collapses the per-transition filter loop
  to a single hash probe
- Inline-scan dedupe instead of BTreeSet for outcome lists ≤8 entries
  (with a heap Vec fallback for the overflow case — fixed a bug where
  duplicates leaked past 8 distinct entries)
- New `NodeList::One` inline variant to avoid the Rc<NodeList> tail
  allocation when the list has a single node

Tooling:
- Opt-in `perf-counters` feature exposing outcome-distribution counters
  via `ANTLR_PERF_DUMP=1` for future investigation

## Test plan

- [x] `cargo test --release --lib` — 37 passing
- [x] `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean
- [x] `cargo build --release --features perf-counters` — clean
- [x] parse-bench C# fixtures — improvements above
- [x] parse-bench Kotlin fixtures — no regression (9-17× vs Go)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional perf-counters feature with runtime dump/reset controls for performance diagnostics.

* **Performance**
  * Faster lexer and parser via hash-based caching and shared cross-parse caches.
  * LL(1) fast path for deterministic decisions.
  * Custom hashing and faster set membership lookups to reduce hot-path overhead.

* **Documentation**
  * Expanded developer guide, benchmarking instructions, and perf-counters usage notes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ophidiarium/antlr-rust-runtime/pull/10?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->