### PR TITLE
perf(prediction): two warm-path wins toward C#–Go parse-time parity

### DIFF
--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -851,6 +851,8 @@ impl<'a> ParserAtnSimulator<'a> {
             if let Some(prediction) = self.alt_that_finished_decision_entry_rule(configs) {
                 let mut dfa_state = DfaState::new(configs.clone());
                 dfa_state.mark_accept(prediction);
+                dfa_state.has_semantic_context_for_alt =
+                    configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
                 let target_state = self.add_dfa_state(edge.decision, dfa_state);
                 if let Some(source) =
                     self.decision_to_dfa[edge.decision].state_mut(edge.source_state)
@@ -892,6 +894,8 @@ impl<'a> ParserAtnSimulator<'a> {
             dfa_state.mark_accept(prediction);
             dfa_state.requires_full_context = requires_full_context;
             dfa_state.conflicting_alts = conflicting_alts;
+            dfa_state.has_semantic_context_for_alt =
+                configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
         }
         let target_state = self.add_dfa_state(edge.decision, dfa_state);
         if let Some(source) = self.decision_to_dfa[edge.decision].state_mut(edge.source_state) {
@@ -1252,10 +1256,9 @@ impl<'a> ParserAtnSimulator<'a> {
                         prediction: ParserAtnPrediction {
                             alt,
                             requires_full_context: state.requires_full_context,
-                            has_semantic_context: configs_have_semantic_context_for_alt(
-                                &state.configs,
-                                alt,
-                            ),
+                            // Precomputed at accept time (see compute_target_state)
+                            // so this warm-hit path avoids an O(configs) rescan.
+                            has_semantic_context: state.has_semantic_context_for_alt,
                             diagnostic: None,
                         },
                         conflicting_alts,

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -851,8 +851,10 @@ impl<'a> ParserAtnSimulator<'a> {
             if let Some(prediction) = self.alt_that_finished_decision_entry_rule(configs) {
                 let mut dfa_state = DfaState::new(configs.clone());
                 dfa_state.mark_accept(prediction);
-                dfa_state.has_semantic_context_for_alt =
-                    configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
+                // The set-wide flag gates the per-alt scan: if no config in the
+                // set carries a semantic context, no alt can either.
+                dfa_state.has_semantic_context_for_alt = dfa_state.configs.has_semantic_context()
+                    && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
                 let target_state = self.add_dfa_state(edge.decision, dfa_state);
                 if let Some(source) =
                     self.decision_to_dfa[edge.decision].state_mut(edge.source_state)
@@ -894,8 +896,10 @@ impl<'a> ParserAtnSimulator<'a> {
             dfa_state.mark_accept(prediction);
             dfa_state.requires_full_context = requires_full_context;
             dfa_state.conflicting_alts = conflicting_alts;
-            dfa_state.has_semantic_context_for_alt =
-                configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
+            // The set-wide flag gates the per-alt scan: if no config in the set
+            // carries a semantic context, no alt can either.
+            dfa_state.has_semantic_context_for_alt = dfa_state.configs.has_semantic_context()
+                && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
         }
         let target_state = self.add_dfa_state(edge.decision, dfa_state);
         if let Some(source) = self.decision_to_dfa[edge.decision].state_mut(edge.source_state) {

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -943,7 +943,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 intermediate
             } else {
                 self.close_intermediate_reach_set(
-                    &intermediate,
+                    intermediate,
                     full_context,
                     precedence,
                     symbol,
@@ -952,7 +952,7 @@ impl<'a> ParserAtnSimulator<'a> {
             }
         } else {
             self.close_intermediate_reach_set(
-                &intermediate,
+                intermediate,
                 full_context,
                 precedence,
                 symbol,
@@ -974,7 +974,7 @@ impl<'a> ParserAtnSimulator<'a> {
 
     fn close_intermediate_reach_set(
         &self,
-        intermediate: &AtnConfigSet,
+        intermediate: AtnConfigSet,
         full_context: bool,
         precedence: i32,
         symbol: i32,
@@ -987,8 +987,10 @@ impl<'a> ParserAtnSimulator<'a> {
             collect_predicates: false,
             treat_eof_as_epsilon: symbol == TOKEN_EOF,
         };
-        for config in intermediate.configs() {
-            self.closure(config.clone(), &mut reach, merge_cache, &mut scratch, params);
+        // `closure` takes `AtnConfig` by value, so drain the intermediate set by
+        // move instead of cloning each config.
+        for config in intermediate.into_configs() {
+            self.closure(config, &mut reach, merge_cache, &mut scratch, params);
         }
         reach
     }

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -156,6 +156,11 @@ pub struct DfaState {
     pub prediction: Option<usize>,
     pub requires_full_context: bool,
     pub conflicting_alts: Vec<usize>,
+    /// Whether any config for the predicted alt carries a semantic context.
+    /// Precomputed once at accept time (mirrors Go's `DFAState.predicates`) so
+    /// warm DFA hits don't rescan `configs` on every prediction lookup. Only
+    /// meaningful when `prediction` is `Some`; `false` for non-accept states.
+    pub has_semantic_context_for_alt: bool,
 }
 
 impl DfaState {
@@ -168,6 +173,7 @@ impl DfaState {
             prediction: None,
             requires_full_context: false,
             conflicting_alts: Vec::new(),
+            has_semantic_context_for_alt: false,
         }
     }
 

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -160,7 +160,12 @@ pub struct DfaState {
     /// Precomputed once at accept time (mirrors Go's `DFAState.predicates`) so
     /// warm DFA hits don't rescan `configs` on every prediction lookup. Only
     /// meaningful when `prediction` is `Some`; `false` for non-accept states.
-    pub has_semantic_context_for_alt: bool,
+    ///
+    /// Crate-private: this is an internal derived cache (a pure function of
+    /// `configs` + `prediction`), kept off the public `DfaState` contract so it
+    /// is neither a struct-literal source break nor a surprising participant in
+    /// the public type's identity.
+    pub(crate) has_semantic_context_for_alt: bool,
 }
 
 impl DfaState {

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -1024,6 +1024,13 @@ impl AtnConfigSet {
         &self.configs
     }
 
+    /// Consumes the set and returns its configs, letting callers drain configs
+    /// by value (e.g. feeding `closure`, which takes `AtnConfig` by value)
+    /// instead of cloning each one.
+    pub(crate) fn into_configs(self) -> Vec<AtnConfig> {
+        self.configs
+    }
+
     pub const fn is_empty(&self) -> bool {
         self.configs.is_empty()
     }


### PR DESCRIPTION
## What

Two small, independently-validated steps toward C# parse-time parity with the Go ANTLR
runtime, on the shared adaptive-prediction hot path. Both mirror what the Go/Java reference
runtimes already do, are behavior-identical, and regress no language.

- **`perf: precompute DFA accept semantic-context flag`** — every warm DFA hit on an accept
  state rescanned the whole config set (`configs_have_semantic_context_for_alt`, up to ~480
  entries on the C# `wpf` fixture) on every prediction lookup. Go computes this once at DFA-state
  creation (`DFAState.predicates`). Now precomputed at accept time and stored on `DfaState`; the
  warm path reads the flag. The value depends only on `(config.alt, config.semantic_context)`,
  neither mutated after creation, so it is provably equal to the old on-the-fly scan — a pure work
  relocation.
- **`perf: drain intermediate reach set into closure instead of cloning`** — `close_intermediate_reach_set`
  cloned each config before handing it to `closure`, which already takes `AtnConfig` by value.
  Take the intermediate set by value and drain it (move), deleting the per-config clone.

## Why

The Rust runtime is ~2.2–3× slower than Go on C# (and ~2.5× on Trino) while being 8–14× faster
on Kotlin and ~parity on Java. A two-round adversarial research campaign localized the remaining
gap to the closure driver's context re-expansion (tracked separately — see the closure-driver-rework
issue). These two changes are the safe, structural wins that fell out of that investigation; they
do not touch the contested merge/closure-driver areas.

## Validation

- **Conformance (behavior identity):** full upstream runtime testsuite `357 passed, 0 failed,
  0 skipped, 357 run` after each commit — the decisive proof, since both touch the shared
  `execATN`/reach path Java and Kotlin also walk.
- `cargo test --locked` (91 + 4 + 64) and `cargo clippy --locked --all-targets --all-features
  -- -D warnings` clean.
- **Interleaved A/B** (candidate vs baseline runtime over byte-identical generated parsers; many
  rounds, min-of-N, alternating order, quiet machine) across **all four** language groups:
  targeted C# fixtures improve, Kotlin/Java/Trino within ±noise. No language regresses.
  (Cross-run absolute-ms comparison is invalid here — effect sizes are below ambient noise — so
  the A/B harness is the measurement of record.)

## Scope

Two commits, each independently validated and committed separately. No public API change. No
codegen change (generated parsers are byte-identical). The larger closure-driver rework that would
actually close the gap is intentionally **not** here — it is captured as a separate issue with the
full diagnosis and the list of disproven dead ends.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved parsing prediction by caching whether the predicted alternative includes semantic context, reducing repeated semantic-context checks during prediction.
  * Refined internal reach-set construction by consuming configuration sets directly, cutting down on cloning while building prediction/reach information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->