### PR TITLE
[codex] Reduce parser token cloning overhead

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -566,6 +566,7 @@ struct GeneratedStepRenderContext<'a> {
     init_entry_action_statements: &'a BTreeMap<usize, String>,
     return_action_statements: &'a BTreeMap<usize, Vec<(String, i64)>>,
     track_alt_numbers: bool,
+    needs_child_action_buffering: bool,
     direct_generated_rule_calls: &'a [bool],
     atn_preferred_rule_calls: &'a [bool],
 }
@@ -1930,6 +1931,7 @@ fn render_generated_rule_dispatch(
         &BTreeMap::new(),
         return_action_statements,
         track_alt_numbers,
+        true,
     )
 }
 
@@ -1943,6 +1945,7 @@ fn render_generated_rule_dispatch_with_rule_names(
     init_entry_action_statements: &BTreeMap<usize, String>,
     return_action_statements: &BTreeMap<usize, Vec<(String, i64)>>,
     track_alt_numbers: bool,
+    needs_child_action_buffering: bool,
 ) -> String {
     let mut out = String::new();
     let atn_preferred_rule_calls = generated_atn_preferred_rule_calls(rules, rule_names);
@@ -1982,6 +1985,7 @@ fn render_generated_rule_dispatch_with_rule_names(
         init_entry_action_statements,
         return_action_statements,
         track_alt_numbers,
+        needs_child_action_buffering,
         direct_generated_rule_calls,
         atn_preferred_rule_calls: &atn_preferred_rule_calls,
     };
@@ -2116,7 +2120,8 @@ fn render_generated_rule_method(
         "                if let Some(__error) = __sync_error {{"
     )
     .expect("writing to a string cannot fail");
-    writeln!(out, "                    if allow_fallback {{").expect("writing to a string cannot fail");
+    writeln!(out, "                    if allow_fallback {{")
+        .expect("writing to a string cannot fail");
     writeln!(out, "                        self.base.exit_rule();")
         .expect("writing to a string cannot fail");
     writeln!(
@@ -2150,7 +2155,8 @@ fn render_generated_rule_method(
         "                    let __tree = self.base.finish_rule(__ctx, __consumed_eof);"
     )
     .expect("writing to a string cannot fail");
-    writeln!(out, "                    return Ok(__tree);").expect("writing to a string cannot fail");
+    writeln!(out, "                    return Ok(__tree);")
+        .expect("writing to a string cannot fail");
     writeln!(out, "                }}").expect("writing to a string cannot fail");
     writeln!(
         out,
@@ -2270,7 +2276,8 @@ fn render_generated_left_recursive_rule_method(
         "                if let Some(__error) = __sync_error {{"
     )
     .expect("writing to a string cannot fail");
-    writeln!(out, "                    if allow_fallback {{").expect("writing to a string cannot fail");
+    writeln!(out, "                    if allow_fallback {{")
+        .expect("writing to a string cannot fail");
     writeln!(
         out,
         "                        self.base.unroll_recursion_context();"
@@ -2307,7 +2314,8 @@ fn render_generated_left_recursive_rule_method(
         "                    let __tree = self.base.finish_recursion_rule(__ctx, __consumed_eof);"
     )
     .expect("writing to a string cannot fail");
-    writeln!(out, "                    return Ok(__tree);").expect("writing to a string cannot fail");
+    writeln!(out, "                    return Ok(__tree);")
+        .expect("writing to a string cannot fail");
     writeln!(out, "                }}").expect("writing to a string cannot fail");
     writeln!(
         out,
@@ -2553,6 +2561,20 @@ fn render_generated_step(
             } else {
                 generated_child_call
             };
+            if !render_context.needs_child_action_buffering {
+                writeln!(out, "{pad}let __child = {child_call};")
+                    .expect("writing to a string cannot fail");
+                writeln!(
+                    out,
+                    "{pad}self.base.discard_invoking_state(__invoking_marker);"
+                )
+                .expect("writing to a string cannot fail");
+                writeln!(out, "{pad}let __child = __child?;")
+                    .expect("writing to a string cannot fail");
+                writeln!(out, "{pad}self.base.add_parse_child(&mut __ctx, __child);")
+                    .expect("writing to a string cannot fail");
+                return;
+            }
             // Snapshot the buffer length and member state before the child so we
             // can tell, after it returns, whether it ran on the interpreter path.
             writeln!(
@@ -2616,8 +2638,11 @@ fn render_generated_step(
                 "{pad}    let __child_members = self.base.int_members_checkpoint();"
             )
             .expect("writing to a string cannot fail");
-            writeln!(out, "{pad}    if __child_members != __child_member_checkpoint {{")
-                .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "{pad}    if __child_members != __child_member_checkpoint {{"
+            )
+            .expect("writing to a string cannot fail");
             writeln!(
                 out,
                 "{pad}        self.generated_actions.push(GeneratedAction::MemberSnapshot(__child_members));"
@@ -3739,6 +3764,7 @@ fn render_parser_with_options(
         &init_entry_action_statements,
         &generated_return_action_statements(&return_actions),
         track_alt_numbers,
+        has_action_dispatch || has_return_actions,
     );
     let init_action_rules = init_actions
         .iter()
@@ -5955,7 +5981,10 @@ fn init_entry_action_statements(
 ) -> io::Result<BTreeMap<usize, String>> {
     let mut statements = BTreeMap::new();
     for (rule_index, action) in init_actions.iter().enumerate() {
-        let Some(action) = action.as_ref().filter(|a| init_action_mutates_members_only(a)) else {
+        let Some(action) = action
+            .as_ref()
+            .filter(|a| init_action_mutates_members_only(a))
+        else {
             continue;
         };
         statements.insert(rule_index, render_action_statement(action, members)?);
@@ -7561,9 +7590,7 @@ atn:
             false,
         );
         assert!(rendered.contains("parse_generated_rule_0"));
-        assert!(rendered.contains(
-            "sync_decision(atn(), 1, !__ctx.has_matched_child(), false)"
-        ));
+        assert!(rendered.contains("sync_decision(atn(), 1, !__ctx.has_matched_child(), false)"));
         assert!(rendered.contains("ll1_decision_prediction(atn(), 1)"));
         // Stage 1 is the SLL probe (no LL loop on the empty-context conflict);
         // stage 2 re-runs with the real context only when full context is needed.
@@ -7616,9 +7643,9 @@ atn:
         // A `*` loop starts NOT iterated: its first sync is at the loop entry
         // (single-token deletion), so the iteration flag inits to `false`.
         assert!(rendered.contains("let mut __loop_iter_1 = false;"));
-        assert!(rendered.contains(
-            "sync_decision(atn(), 1, !__ctx.has_matched_child(), __loop_iter_1)"
-        ));
+        assert!(
+            rendered.contains("sync_decision(atn(), 1, !__ctx.has_matched_child(), __loop_iter_1)")
+        );
         assert!(rendered.contains("__loop_iter_1 = true;"));
         assert!(rendered.contains("1 => {"));
         assert!(rendered.contains("2 => {"));
@@ -7665,9 +7692,9 @@ atn:
         // flag inits to `true`: its first loop-back sync recovers with multi-token
         // `consumeUntil`, matching ANTLR's PLUS_LOOP_BACK.
         assert!(rendered.contains("let mut __loop_iter_4 = true;"));
-        assert!(rendered.contains(
-            "sync_decision(atn(), 4, !__ctx.has_matched_child(), __loop_iter_4)"
-        ));
+        assert!(
+            rendered.contains("sync_decision(atn(), 4, !__ctx.has_matched_child(), __loop_iter_4)")
+        );
     }
 
     #[test]
@@ -7916,7 +7943,9 @@ atn:
             &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
-            false);
+            false,
+            true,
+        );
 
         // ATN-preferred children route through `parse_rule_precedence_from_generated`:
         // the rule's generated dispatch arm is `generated_only()`-guarded, so in normal
@@ -7953,7 +7982,9 @@ atn:
             &BTreeMap::new(),
             &BTreeMap::new(),
             &BTreeMap::new(),
-            false);
+            false,
+            true,
+        );
 
         assert!(rendered.contains(
             "0 if self.generated_only() => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
@@ -8287,6 +8318,7 @@ atn:
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -8304,6 +8336,7 @@ atn:
     fn render_call_rule_step(
         direct_generated_rule_calls: &[bool],
         atn_preferred_rule_calls: &[bool],
+        needs_child_action_buffering: bool,
     ) -> String {
         let mut rendered = String::new();
         render_generated_step(
@@ -8319,6 +8352,7 @@ atn:
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering,
                 direct_generated_rule_calls,
                 atn_preferred_rule_calls,
             },
@@ -8333,7 +8367,7 @@ atn:
         // `parse_rule_precedence_from_generated`, which preserves interpreted routing
         // (the rule's generated dispatch arm is guarded by `generated_only()`) while
         // BUFFERING the child's body actions and `@after` in position.
-        let rendered = render_call_rule_step(&[true, false], &[true, true]);
+        let rendered = render_call_rule_step(&[true, false], &[true, true], true);
 
         assert!(rendered.contains("self.parse_rule_precedence_from_generated(1, 0)"));
         assert!(!rendered.contains("self.parse_interpreted_rule_precedence(1, 0)"));
@@ -8348,7 +8382,7 @@ atn:
         // parent's buffered actions. The wrapper buffers them in position instead while
         // still parsing the child interpreted (the dispatch arm is `generated_only()`
         // guarded).
-        let rendered = render_call_rule_step(&[true, true], &[true, true]);
+        let rendered = render_call_rule_step(&[true, true], &[true, true], true);
 
         assert!(rendered.contains("self.parse_rule_precedence_from_generated(1, 0)"));
         assert!(!rendered.contains("self.parse_interpreted_rule_precedence(1, 0)"));
@@ -8433,7 +8467,9 @@ atn:
 
         // Each buffered action is pushed as `GeneratedAction::Parser { action, tree }`,
         // tagging `$ctx`-rooted actions with this child's tree (the rest `None`).
-        assert!(fallback.contains("self.generated_actions.push(GeneratedAction::Parser { action, tree: __tree });"));
+        assert!(fallback.contains(
+            "self.generated_actions.push(GeneratedAction::Parser { action, tree: __tree });"
+        ));
         assert!(fallback.contains("CTX_ROOTED_ACTION_STATES.contains(&action.source_state())"));
         assert!(!fallback.contains("self.run_action(action, &tree);"));
         assert!(fallback.contains("Ok(tree)"));
@@ -8449,7 +8485,9 @@ atn:
         .expect("parser should render");
 
         assert!(rendered.contains("matches!(rule_index, 0)"));
-        assert!(rendered.contains("let __has_after_actions = Self::has_after_actions(rule_index);"));
+        assert!(
+            rendered.contains("let __has_after_actions = Self::has_after_actions(rule_index);")
+        );
         // The @after start comes from the rule context (first visible token), not
         // the raw pre-rule cursor, so a leading hidden prefix is excluded.
         assert!(rendered.contains(
@@ -8567,8 +8605,8 @@ s @init {<GetExpectedTokenNames():writeln()>} : ;
         // on the parent context, losing the child subtree). Assert the generated
         // catch arm gates the `Fatal` return on `allow_fallback` and otherwise runs
         // `recover_generated_rule` + `finish_rule` + `Ok`.
-        let rendered = render_parser("TParser", &minimal_parser_data(), None)
-            .expect("parser should render");
+        let rendered =
+            render_parser("TParser", &minimal_parser_data(), None).expect("parser should render");
         let sync_arm = rendered
             .find("if let Some(__error) = __sync_error {")
             .expect("sync-error catch arm present");
@@ -8580,12 +8618,18 @@ s @init {<GetExpectedTokenNames():writeln()>} : ;
         let fatal = rest
             .find("return Err(GeneratedRuleError::Fatal(__error));")
             .expect("fatal return present");
-        assert!(guard < fatal, "Fatal return must be inside the allow_fallback guard");
+        assert!(
+            guard < fatal,
+            "Fatal return must be inside the allow_fallback guard"
+        );
         // And the nested-child path recovers locally and returns Ok.
         let recover = rest
             .find("self.base.recover_generated_rule(&mut __ctx, atn(), __error);")
             .expect("local recovery present in sync arm");
-        assert!(recover > guard, "recover path follows the guarded fatal return");
+        assert!(
+            recover > guard,
+            "recover path follows the guarded fatal return"
+        );
         assert!(rest[recover..].contains("return Ok(__tree);"));
     }
 
@@ -8652,6 +8696,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -8662,7 +8707,8 @@ s @init {<SetMember("i","1")>} : ;
         // changed members (i.e. it ran interpreted).
         assert!(rendered.contains("let __child_action_marker = self.generated_actions.len();"));
         assert!(
-            rendered.contains("let __child_member_checkpoint = self.base.int_members_checkpoint();")
+            rendered
+                .contains("let __child_member_checkpoint = self.base.int_members_checkpoint();")
         );
         assert!(rendered.contains("if self.generated_actions.len() == __child_action_marker {"));
         assert!(rendered.contains("if __child_members != __child_member_checkpoint {"));
@@ -8672,8 +8718,24 @@ s @init {<SetMember("i","1")>} : ;
         // Marker capture must precede the child call, which must precede the snapshot.
         let marker = rendered.find("__child_action_marker = ").expect("marker");
         let call = rendered.find("let __child =").expect("child call");
-        let snapshot = rendered.find("GeneratedAction::MemberSnapshot").expect("snapshot");
+        let snapshot = rendered
+            .find("GeneratedAction::MemberSnapshot")
+            .expect("snapshot");
         assert!(marker < call && call < snapshot);
+    }
+
+    #[test]
+    fn call_rule_step_skips_child_action_scaffolding_without_parser_actions() {
+        let rendered = render_call_rule_step(&[true, true], &[false, false], false);
+
+        assert!(rendered.contains("let __child = self.parse_generated_rule_1_dispatch(0, false).map_err(GeneratedRuleError::into_error);"));
+        assert!(rendered.contains("self.base.discard_invoking_state(__invoking_marker);"));
+        assert!(rendered.contains("let __child = __child?;"));
+        assert!(rendered.contains("self.base.add_parse_child(&mut __ctx, __child);"));
+        assert!(!rendered.contains("__child_action_marker"));
+        assert!(!rendered.contains("__child_member_checkpoint"));
+        assert!(!rendered.contains("GeneratedAction::MemberSnapshot"));
+        assert!(!rendered.contains("CTX_ROOTED_ACTION_STATES.contains"));
     }
 
     #[test]
@@ -8695,9 +8757,9 @@ s @init {<SetMember("i","1")>} : ;
                 newline: false,
             },
         ])));
-        assert!(!action_is_ctx_rooted(&ActionTemplate::RuleInvocationStack {
-            newline: true
-        }));
+        assert!(!action_is_ctx_rooted(
+            &ActionTemplate::RuleInvocationStack { newline: true }
+        ));
         assert!(!action_is_ctx_rooted(&ActionTemplate::StringTree {
             target: StringTreeTarget::Rule(1),
             newline: true,
@@ -8706,7 +8768,9 @@ s @init {<SetMember("i","1")>} : ;
             target: StringTreeTarget::Label("r".to_owned()),
             newline: true,
         }));
-        assert!(!action_is_ctx_rooted(&ActionTemplate::Text { newline: true }));
+        assert!(!action_is_ctx_rooted(&ActionTemplate::Text {
+            newline: true
+        }));
     }
 
     #[test]
@@ -8715,12 +8779,12 @@ s @init {<SetMember("i","1")>} : ;
         // its own tagged tree when present (a child's $ctx action), falling back to
         // the replay tree only when untagged (a rule's own / tree-search actions).
         // The ctx-rooted allowlist const is always emitted.
-        let rendered = render_parser("TParser", &minimal_parser_data(), None)
-            .expect("parser should render");
-        assert!(rendered.contains(
-            "GeneratedAction::Parser { action, tree: action_tree } => {"
-        ));
-        assert!(rendered.contains("self.run_action(action, action_tree.as_ref().unwrap_or(tree));"));
+        let rendered =
+            render_parser("TParser", &minimal_parser_data(), None).expect("parser should render");
+        assert!(rendered.contains("GeneratedAction::Parser { action, tree: action_tree } => {"));
+        assert!(
+            rendered.contains("self.run_action(action, action_tree.as_ref().unwrap_or(tree));")
+        );
         assert!(rendered.contains("const CTX_ROOTED_ACTION_STATES: &[usize] = &["));
     }
 
@@ -8729,10 +8793,11 @@ s @init {<SetMember("i","1")>} : ;
         // The CallRule step emits the re-tag loop that tags the child's untagged
         // `$ctx`-rooted buffered actions with the child tree (innermost-wins via the
         // `is_none()` guard).
-        let rendered = render_call_rule_step(&[], &[]);
-        assert!(rendered.contains(
-            "for __buffered in &mut self.generated_actions[__child_action_marker..]"
-        ));
+        let rendered = render_call_rule_step(&[], &[], true);
+        assert!(
+            rendered
+                .contains("for __buffered in &mut self.generated_actions[__child_action_marker..]")
+        );
         assert!(rendered.contains(
             "if tree.is_none() && CTX_ROOTED_ACTION_STATES.contains(&action.source_state())"
         ));
@@ -8775,7 +8840,9 @@ s @init {<SetMember("i","1")>} : ;
 
         assert!(rendered.contains("parser_action_at_current(4, 0"));
         assert!(rendered.contains("parser_action_at_current(6, 0"));
-        assert!(rendered.contains("self.generated_actions.push(GeneratedAction::Parser { action, tree: None });"));
+        assert!(rendered.contains(
+            "self.generated_actions.push(GeneratedAction::Parser { action, tree: None });"
+        ));
         assert!(rendered.contains("println!(\"alt 2\");"));
     }
 
@@ -8802,9 +8869,9 @@ s @init {<SetMember("i","1")>} : ;
 
         // Recovering not-set over 1..=max with an empty exclusion = "any token",
         // threading the wildcard's follow state for EOF-insertion follow checks.
-        assert!(rendered.contains(
-            "match_not_set_recovering(&[], 1, atn().max_token_type(), 7, atn())"
-        ));
+        assert!(
+            rendered.contains("match_not_set_recovering(&[], 1, atn().max_token_type(), 7, atn())")
+        );
         assert!(rendered.contains("__consumed_eof |= __match.consumed_eof();"));
         // The old non-recovering call must be gone.
         assert!(!rendered.contains("self.base.match_wildcard()"));
@@ -8832,6 +8899,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -8880,6 +8948,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -8922,6 +8991,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -8965,6 +9035,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -9010,6 +9081,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -9067,6 +9139,7 @@ s @init {<SetMember("i","1")>} : ;
                 init_entry_action_statements: &BTreeMap::new(),
                 return_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
+                needs_child_action_buffering: true,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
             },
@@ -9105,7 +9178,9 @@ s @init {<SetMember("i","1")>} : ;
         );
 
         assert!(rendered.contains("__ctx.set_int_return(\"y\", 1000);"));
-        assert!(rendered.contains("self.generated_actions.push(GeneratedAction::Parser { action, tree: None });"));
+        assert!(rendered.contains(
+            "self.generated_actions.push(GeneratedAction::Parser { action, tree: None });"
+        ));
     }
 
     #[test]
@@ -9676,4 +9751,3 @@ continue returns [<IntArg("return")>] : {<AssignLocal("$return","0")>} ;"#,
         }
     }
 }
-

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3189,8 +3189,7 @@ where
     pub fn match_wildcard(&mut self) -> Result<ParseTree, AntlrError> {
         let current = self
             .input
-            .lt(1)
-            .cloned()
+            .lt_ref(1)
             .ok_or_else(|| AntlrError::ParserError {
                 line: 0,
                 column: 0,
@@ -3203,7 +3202,7 @@ where
             });
         }
         self.consume();
-        Ok(ParseTree::Terminal(TerminalNode::new(current)))
+        Ok(ParseTree::Terminal(TerminalNode::from_ref(current)))
     }
 
     /// Generated parser synchronization hook. The current interpreter owns

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -79,7 +79,7 @@ use crate::errors::AntlrError;
 use crate::int_stream::IntStream;
 use crate::prediction::{EMPTY_RETURN_STATE, PredictionContext};
 use crate::recognizer::{Recognizer, RecognizerData};
-use crate::token::{CommonToken, TOKEN_EOF, Token, TokenSource, TokenSourceError};
+use crate::token::{CommonToken, TOKEN_EOF, Token, TokenRef, TokenSource, TokenSourceError};
 use crate::token_stream::CommonTokenStream;
 use crate::tree::{ErrorNode, ParseTree, ParserRuleContext, RuleNode, TerminalNode};
 use crate::vocabulary::Vocabulary;
@@ -2516,8 +2516,7 @@ where
     pub fn match_token(&mut self, token_type: i32) -> Result<ParseTree, AntlrError> {
         let current = self
             .input
-            .lt(1)
-            .cloned()
+            .lt_ref(1)
             .ok_or_else(|| AntlrError::ParserError {
                 line: 0,
                 column: 0,
@@ -2525,7 +2524,7 @@ where
             })?;
         if current.token_type() == token_type {
             self.consume();
-            Ok(ParseTree::Terminal(TerminalNode::new(current)))
+            Ok(ParseTree::Terminal(TerminalNode::from_ref(current)))
         } else {
             Err(AntlrError::MismatchedInput {
                 expected: self.vocabulary().display_name(token_type),
@@ -2545,8 +2544,7 @@ where
     ) -> Result<GeneratedMatch, AntlrError> {
         let current = self
             .input
-            .lt(1)
-            .cloned()
+            .lt_ref(1)
             .ok_or_else(|| AntlrError::ParserError {
                 line: 0,
                 column: 0,
@@ -2557,15 +2555,19 @@ where
             let consumed_eof = current.token_type() == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Terminal(TerminalNode::new(current))],
+                children: vec![ParseTree::Terminal(TerminalNode::from_ref(current))],
                 consumed_eof,
             });
         }
         let mut expected_symbols = BTreeSet::new();
         expected_symbols.insert(token_type);
-        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
-            symbol == token_type
-        })
+        self.recover_generated_match(
+            current.as_ref().clone(),
+            &expected_symbols,
+            follow_state,
+            atn,
+            |symbol| symbol == token_type,
+        )
     }
 
     pub fn match_set_recovering(
@@ -2576,8 +2578,7 @@ where
     ) -> Result<GeneratedMatch, AntlrError> {
         let current = self
             .input
-            .lt(1)
-            .cloned()
+            .lt_ref(1)
             .ok_or_else(|| AntlrError::ParserError {
                 line: 0,
                 column: 0,
@@ -2588,14 +2589,18 @@ where
             let consumed_eof = current.token_type() == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Terminal(TerminalNode::new(current))],
+                children: vec![ParseTree::Terminal(TerminalNode::from_ref(current))],
                 consumed_eof,
             });
         }
         let expected_symbols = interval_symbols(intervals);
-        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
-            interval_set_contains(intervals, symbol)
-        })
+        self.recover_generated_match(
+            current.as_ref().clone(),
+            &expected_symbols,
+            follow_state,
+            atn,
+            |symbol| interval_set_contains(intervals, symbol),
+        )
     }
 
     pub fn match_not_set_recovering(
@@ -2608,8 +2613,7 @@ where
     ) -> Result<GeneratedMatch, AntlrError> {
         let current = self
             .input
-            .lt(1)
-            .cloned()
+            .lt_ref(1)
             .ok_or_else(|| AntlrError::ParserError {
                 line: 0,
                 column: 0,
@@ -2622,16 +2626,22 @@ where
             let consumed_eof = current.token_type() == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Terminal(TerminalNode::new(current))],
+                children: vec![ParseTree::Terminal(TerminalNode::from_ref(current))],
                 consumed_eof,
             });
         }
         let expected_symbols =
             interval_complement_symbols(intervals, min_vocabulary, max_vocabulary);
-        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
-            (min_vocabulary..=max_vocabulary).contains(&symbol)
-                && !interval_set_contains(intervals, symbol)
-        })
+        self.recover_generated_match(
+            current.as_ref().clone(),
+            &expected_symbols,
+            follow_state,
+            atn,
+            |symbol| {
+                (min_vocabulary..=max_vocabulary).contains(&symbol)
+                    && !interval_set_contains(intervals, symbol)
+            },
+        )
     }
 
     fn recover_generated_match(
@@ -2767,8 +2777,7 @@ where
     ) -> Result<ParseTree, AntlrError> {
         let current = self
             .input
-            .lt(1)
-            .cloned()
+            .lt_ref(1)
             .ok_or_else(|| AntlrError::ParserError {
                 line: 0,
                 column: 0,
@@ -2776,7 +2785,7 @@ where
             })?;
         if matches(current.token_type()) {
             self.consume();
-            Ok(ParseTree::Terminal(TerminalNode::new(current)))
+            Ok(ParseTree::Terminal(TerminalNode::from_ref(current)))
         } else {
             Err(AntlrError::MismatchedInput {
                 expected: self.interval_display(intervals),
@@ -2820,8 +2829,8 @@ where
         self.invalidate_prediction_context_cache();
         let start_index = self.current_visible_index();
         let mut context = ParserRuleContext::new(rule_index, invoking_state);
-        if let Some(token) = self.token_at(start_index) {
-            context.set_start(token);
+        if let Some(token) = self.token_ref_at(start_index) {
+            context.set_start_ref(token);
         }
         context
     }
@@ -2901,8 +2910,8 @@ where
     /// Finishes a generated parser rule and returns its parse-tree node.
     pub fn finish_rule(&mut self, mut context: ParserRuleContext, consumed_eof: bool) -> ParseTree {
         let stop_index = self.rule_stop_token_index(self.input.index(), consumed_eof);
-        if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
-            context.set_stop(token);
+        if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
+            context.set_stop_ref(token);
         }
         self.exit_rule();
         self.rule_node(context)
@@ -2987,8 +2996,8 @@ where
         consumed_eof: bool,
     ) -> ParseTree {
         let stop_index = self.rule_stop_token_index(self.input.index(), consumed_eof);
-        if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
-            context.set_stop(token);
+        if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
+            context.set_stop_ref(token);
         }
         self.unroll_recursion_context();
         self.rule_node(context)
@@ -3026,15 +3035,15 @@ where
         self.set_state(state);
         if let Some(stop) = self
             .rule_stop_token_index(self.input.index(), false)
-            .and_then(|index| self.token_at(index))
+            .and_then(|index| self.token_ref_at(index))
         {
-            current.set_stop(stop);
+            current.set_stop_ref(stop);
         }
         let invoking_state = current.invoking_state();
-        let start = current.start().cloned();
+        let start = current.start_ref();
         let mut replacement = ParserRuleContext::new(rule_index, invoking_state);
         if let Some(start) = start {
-            replacement.set_start(start);
+            replacement.set_start_ref(start);
         }
         let previous = std::mem::replace(current, replacement);
         if self.build_parse_trees {
@@ -3671,12 +3680,12 @@ where
                 0
             },
         );
-        if let Some(token) = self.token_at(start_index) {
-            context.set_start(token);
+        if let Some(token) = self.token_ref_at(start_index) {
+            context.set_start_ref(token);
         }
         let stop_index = self.rule_stop_token_index(outcome.index, outcome.consumed_eof);
-        if let Some(token) = stop_index.and_then(|token_index| self.token_at(token_index)) {
-            context.set_stop(token);
+        if let Some(token) = stop_index.and_then(|token_index| self.token_ref_at(token_index)) {
+            context.set_stop_ref(token);
         }
         if self.build_parse_trees {
             if outcome.nodes.has_left_recursive_boundary() {
@@ -3779,28 +3788,26 @@ where
     ) -> Result<ParseTree, AntlrError> {
         match node {
             FastRecognizedNode::Token { index } => {
-                let token =
-                    self.input
-                        .get(*index)
-                        .cloned()
-                        .ok_or_else(|| AntlrError::ParserError {
-                            line: 0,
-                            column: 0,
-                            message: format!("missing token at index {index}"),
-                        })?;
-                Ok(ParseTree::Terminal(TerminalNode::new(token)))
+                let token = self
+                    .input
+                    .get_ref(*index)
+                    .ok_or_else(|| AntlrError::ParserError {
+                        line: 0,
+                        column: 0,
+                        message: format!("missing token at index {index}"),
+                    })?;
+                Ok(ParseTree::Terminal(TerminalNode::from_ref(token)))
             }
             FastRecognizedNode::ErrorToken { index } => {
-                let token =
-                    self.input
-                        .get(*index)
-                        .cloned()
-                        .ok_or_else(|| AntlrError::ParserError {
-                            line: 0,
-                            column: 0,
-                            message: format!("missing error token at index {index}"),
-                        })?;
-                Ok(ParseTree::Error(ErrorNode::new(token)))
+                let token = self
+                    .input
+                    .get_ref(*index)
+                    .ok_or_else(|| AntlrError::ParserError {
+                        line: 0,
+                        column: 0,
+                        message: format!("missing error token at index {index}"),
+                    })?;
+                Ok(ParseTree::Error(ErrorNode::from_ref(token)))
             }
             FastRecognizedNode::MissingToken {
                 token_type,
@@ -3829,11 +3836,11 @@ where
                     *invoking_state,
                     children.len(),
                 );
-                if let Some(token) = self.token_at(*start_index) {
-                    context.set_start(token);
+                if let Some(token) = self.token_ref_at(*start_index) {
+                    context.set_start_ref(token);
                 }
-                if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
-                    context.set_stop(token);
+                if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
+                    context.set_stop_ref(token);
                 }
                 if children.has_left_recursive_boundary() {
                     let folded = fold_fast_left_recursive_boundaries(children.to_vec());
@@ -3872,11 +3879,11 @@ where
                     *invoking_state,
                     children.len(),
                 );
-                if let Some(token) = self.token_at(*start_index) {
-                    context.set_start(token);
+                if let Some(token) = self.token_ref_at(*start_index) {
+                    context.set_start_ref(token);
                 }
-                if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
-                    context.set_stop(token);
+                if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
+                    context.set_stop_ref(token);
                 }
                 if children.has_left_recursive_boundary() {
                     let folded = fold_fast_left_recursive_boundaries(children.to_vec());
@@ -3970,15 +3977,14 @@ where
             }
             let token = self
                 .input
-                .get(index)
-                .cloned()
+                .get_ref(index)
                 .ok_or_else(|| AntlrError::ParserError {
                     line: 0,
                     column: 0,
                     message: format!("missing token at index {index}"),
                 })?;
             let is_eof = token.token_type() == TOKEN_EOF;
-            context.add_child(ParseTree::Terminal(TerminalNode::new(token)));
+            context.add_child(ParseTree::Terminal(TerminalNode::from_ref(token)));
             if is_eof {
                 return Ok(None);
             }
@@ -4158,11 +4164,11 @@ where
         for (name, value) in outcome.return_values {
             context.set_int_return(name, value);
         }
-        if let Some(token) = self.token_at(start_index) {
-            context.set_start(token);
+        if let Some(token) = self.token_ref_at(start_index) {
+            context.set_start_ref(token);
         }
-        if let Some(token) = self.rule_stop_token(outcome.index, outcome.consumed_eof) {
-            context.set_stop(token);
+        if let Some(token) = self.rule_stop_token_ref(outcome.index, outcome.consumed_eof) {
+            context.set_stop_ref(token);
         }
         if self.build_parse_trees {
             let nodes = fold_left_recursive_boundaries(outcome.nodes);
@@ -6645,6 +6651,11 @@ where
         self.input.get(index).cloned()
     }
 
+    /// Clones the shared token handle at an absolute token-stream index.
+    fn token_ref_at(&mut self, index: usize) -> Option<TokenRef> {
+        self.input.get_ref(index)
+    }
+
     /// Normalizes the current token-stream cursor to the next parser-visible
     /// token before capturing a rule start boundary.
     fn current_visible_index(&mut self) -> usize {
@@ -6768,9 +6779,9 @@ where
     ///
     /// EOF transitions do not advance the token-stream cursor, so an EOF match
     /// must use the current token rather than the previous visible token.
-    fn rule_stop_token(&mut self, index: usize, consumed_eof: bool) -> Option<CommonToken> {
+    fn rule_stop_token_ref(&mut self, index: usize, consumed_eof: bool) -> Option<TokenRef> {
         self.rule_stop_token_index(index, consumed_eof)
-            .and_then(|token_index| self.token_at(token_index))
+            .and_then(|token_index| self.token_ref_at(token_index))
     }
 
     /// Recovers from a semantic predicate with an ANTLR `<fail='...'>` option.
@@ -7171,28 +7182,26 @@ where
     ) -> Result<ParseTree, AntlrError> {
         match node {
             RecognizedNode::Token { index } => {
-                let token =
-                    self.input
-                        .get(*index)
-                        .cloned()
-                        .ok_or_else(|| AntlrError::ParserError {
-                            line: 0,
-                            column: 0,
-                            message: format!("missing token at index {index}"),
-                        })?;
-                Ok(ParseTree::Terminal(TerminalNode::new(token)))
+                let token = self
+                    .input
+                    .get_ref(*index)
+                    .ok_or_else(|| AntlrError::ParserError {
+                        line: 0,
+                        column: 0,
+                        message: format!("missing token at index {index}"),
+                    })?;
+                Ok(ParseTree::Terminal(TerminalNode::from_ref(token)))
             }
             RecognizedNode::ErrorToken { index } => {
-                let token =
-                    self.input
-                        .get(*index)
-                        .cloned()
-                        .ok_or_else(|| AntlrError::ParserError {
-                            line: 0,
-                            column: 0,
-                            message: format!("missing error token at index {index}"),
-                        })?;
-                Ok(ParseTree::Error(ErrorNode::new(token)))
+                let token = self
+                    .input
+                    .get_ref(*index)
+                    .ok_or_else(|| AntlrError::ParserError {
+                        line: 0,
+                        column: 0,
+                        message: format!("missing error token at index {index}"),
+                    })?;
+                Ok(ParseTree::Error(ErrorNode::from_ref(token)))
             }
             RecognizedNode::MissingToken {
                 token_type,
@@ -7225,11 +7234,11 @@ where
                 for (name, value) in return_values {
                     context.set_int_return(name.clone(), *value);
                 }
-                if let Some(token) = self.token_at(*start_index) {
-                    context.set_start(token);
+                if let Some(token) = self.token_ref_at(*start_index) {
+                    context.set_start_ref(token);
                 }
-                if let Some(token) = stop_index.and_then(|index| self.token_at(index)) {
-                    context.set_stop(token);
+                if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
+                    context.set_stop_ref(token);
                 }
                 for child in children {
                     context.add_child(self.recognized_node_tree(child, track_alt_numbers)?);
@@ -7341,14 +7350,14 @@ where
                 0
             },
         );
-        if let Some(token) = self.parser.token_at(start_index) {
-            context.set_start(token);
+        if let Some(token) = self.parser.token_ref_at(start_index) {
+            context.set_start_ref(token);
         }
         let stop_index = self
             .parser
             .rule_stop_token_index(self.parser.input.index(), consumed_eof);
-        if let Some(token) = stop_index.and_then(|index| self.parser.token_at(index)) {
-            context.set_stop(token);
+        if let Some(token) = stop_index.and_then(|index| self.parser.token_ref_at(index)) {
+            context.set_stop_ref(token);
         }
         if self.parser.build_parse_trees {
             for child in children {
@@ -7483,14 +7492,13 @@ where
                 DirectAdaptiveFallback::TokenMismatch,
             ));
         }
-        let token =
-            self.parser
-                .input
-                .lt(1)
-                .cloned()
-                .ok_or(DirectAdaptiveParseControl::Fallback(
-                    DirectAdaptiveFallback::TokenMismatch,
-                ))?;
+        let token = self
+            .parser
+            .input
+            .lt_ref(1)
+            .ok_or(DirectAdaptiveParseControl::Fallback(
+                DirectAdaptiveFallback::TokenMismatch,
+            ))?;
         let matched_eof = symbol == TOKEN_EOF;
         if !matched_eof {
             self.parser.consume();
@@ -7498,7 +7506,7 @@ where
         let child = self
             .parser
             .build_parse_trees
-            .then(|| ParseTree::Terminal(TerminalNode::new(token)));
+            .then(|| ParseTree::Terminal(TerminalNode::from_ref(token)));
         Ok((matched_eof, child))
     }
 }
@@ -8598,7 +8606,11 @@ mod tests {
             .expect("single token before EOF recovers");
         assert_eq!(children.len(), 1);
         assert!(matches!(children[0], ParseTree::Error(_)));
-        assert_eq!(parser.la(1), TOKEN_EOF, "EOF is left for the rule's EOF match");
+        assert_eq!(
+            parser.la(1),
+            TOKEN_EOF,
+            "EOF is left for the rule's EOF match"
+        );
     }
 
     #[test]
@@ -8626,7 +8638,11 @@ mod tests {
             }
             other => panic!("expected mismatched-input ParserError, got {other:?}"),
         }
-        assert_eq!(parser.la(1), 2, "nothing consumed; cursor still on first `c`");
+        assert_eq!(
+            parser.la(1),
+            2,
+            "nothing consumed; cursor still on first `c`"
+        );
     }
 
     #[test]
@@ -9383,7 +9399,10 @@ mod tests {
         parser.set_build_parse_trees(false);
         let mut ctx = ParserRuleContext::new(0, 0);
         assert!(!ctx.has_matched_child());
-        parser.add_parse_child(&mut ctx, ParseTree::Terminal(TerminalNode::new(token.clone())));
+        parser.add_parse_child(
+            &mut ctx,
+            ParseTree::Terminal(TerminalNode::new(token.clone())),
+        );
         // Tree building is off, so no child is stored...
         assert!(ctx.children().is_empty());
         // ...but the match is recorded, so the context is no longer "empty".

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,10 +1,14 @@
 use crate::int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
-use crate::token::{CommonToken, DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenSource, TokenSourceError};
+use std::rc::Rc;
+
+use crate::token::{
+    CommonToken, DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenRef, TokenSource, TokenSourceError,
+};
 
 #[derive(Debug)]
 pub struct CommonTokenStream<S> {
     source: S,
-    tokens: Vec<CommonToken>,
+    tokens: Vec<TokenRef>,
     next_visible_after: Vec<usize>,
     cursor: usize,
     fetched_eof: bool,
@@ -48,7 +52,13 @@ where
     /// as needed.
     pub fn get(&mut self, index: usize) -> Option<&CommonToken> {
         self.sync(index);
-        self.tokens.get(index)
+        self.tokens.get(index).map(Rc::as_ref)
+    }
+
+    /// Returns a shared reference-counted token at an absolute buffered index.
+    pub fn get_ref(&mut self, index: usize) -> Option<TokenRef> {
+        self.sync(index);
+        self.tokens.get(index).map(Rc::clone)
     }
 
     /// Returns the token at one-based lookahead/lookbehind offset, skipping
@@ -71,7 +81,30 @@ where
             remaining -= 1;
         }
         self.sync(index);
-        self.tokens.get(index)
+        self.tokens.get(index).map(Rc::as_ref)
+    }
+
+    /// Returns the token at one-based lookahead/lookbehind offset as a shared
+    /// reference-counted token.
+    pub fn lt_ref(&mut self, offset: isize) -> Option<TokenRef> {
+        if offset == 0 {
+            return None;
+        }
+        if offset < 0 {
+            return offset
+                .checked_neg()
+                .map(isize::cast_unsigned)
+                .and_then(|offset| self.lb_ref(offset));
+        }
+
+        let mut index = self.next_token_on_channel(self.cursor, self.channel);
+        let mut remaining = offset;
+        while remaining > 1 {
+            index = self.next_token_on_channel(index + 1, self.channel);
+            remaining -= 1;
+        }
+        self.sync(index);
+        self.tokens.get(index).map(Rc::clone)
     }
 
     pub fn lb(&self, offset: usize) -> Option<&CommonToken> {
@@ -84,15 +117,28 @@ where
             index = self.previous_token_on_channel(index, self.channel)?;
             remaining -= 1;
         }
-        self.tokens.get(index)
+        self.tokens.get(index).map(Rc::as_ref)
+    }
+
+    fn lb_ref(&self, offset: usize) -> Option<TokenRef> {
+        if offset == 0 || self.cursor == 0 {
+            return None;
+        }
+        let mut index = self.cursor;
+        let mut remaining = offset;
+        while remaining > 0 {
+            index = self.previous_token_on_channel(index, self.channel)?;
+            remaining -= 1;
+        }
+        self.tokens.get(index).map(Rc::clone)
     }
 
     pub const fn token_source(&self) -> &S {
         &self.source
     }
 
-    pub fn tokens(&self) -> &[CommonToken] {
-        &self.tokens
+    pub fn tokens(&self) -> impl Iterator<Item = &CommonToken> {
+        self.tokens.iter().map(Rc::as_ref)
     }
 
     /// Ensures the buffer contains `index`, unless EOF has already been fetched.
@@ -120,7 +166,7 @@ where
         let token_index = isize::try_from(self.tokens.len()).unwrap_or(isize::MAX);
         token.set_token_index(token_index);
         self.fetched_eof = token.token_type() == TOKEN_EOF;
-        self.tokens.push(token);
+        self.tokens.push(Rc::new(token));
         self.next_visible_after.push(UNKNOWN_NEXT_VISIBLE);
     }
 
@@ -224,7 +270,9 @@ where
     /// round-trip when they only need lookahead types.
     pub fn token_type_at_index(&mut self, index: usize) -> i32 {
         self.sync(index);
-        self.tokens.get(index).map_or(TOKEN_EOF, Token::token_type)
+        self.tokens
+            .get(index)
+            .map_or(TOKEN_EOF, |token| token.token_type())
     }
 
     /// Returns the next parser-visible token index after consuming the token
@@ -268,7 +316,7 @@ where
         }
         self.tokens[start..=stop.min(self.tokens.len().saturating_sub(1))]
             .iter()
-            .filter_map(Token::text)
+            .filter_map(|token| token.text())
             .collect::<Vec<_>>()
             .join("")
     }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -9,6 +9,7 @@ use crate::token::{
 pub struct CommonTokenStream<S> {
     source: S,
     tokens: Vec<TokenRef>,
+    public_tokens: Vec<CommonToken>,
     next_visible_after: Vec<usize>,
     cursor: usize,
     fetched_eof: bool,
@@ -32,6 +33,7 @@ where
         Self {
             source,
             tokens: Vec::new(),
+            public_tokens: Vec::new(),
             next_visible_after: Vec::new(),
             cursor: 0,
             fetched_eof: false,
@@ -137,8 +139,8 @@ where
         &self.source
     }
 
-    pub fn tokens(&self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = &CommonToken> {
-        self.tokens.iter().map(Rc::as_ref)
+    pub fn tokens(&self) -> &[CommonToken] {
+        &self.public_tokens
     }
 
     /// Ensures the buffer contains `index`, unless EOF has already been fetched.
@@ -166,7 +168,8 @@ where
         let token_index = isize::try_from(self.tokens.len()).unwrap_or(isize::MAX);
         token.set_token_index(token_index);
         self.fetched_eof = token.token_type() == TOKEN_EOF;
-        self.tokens.push(Rc::new(token));
+        self.tokens.push(Rc::new(token.clone()));
+        self.public_tokens.push(token);
         self.next_visible_after.push(UNKNOWN_NEXT_VISIBLE);
     }
 
@@ -428,7 +431,7 @@ mod tests {
     }
 
     #[test]
-    fn tokens_iterator_keeps_slice_like_capabilities() {
+    fn tokens_returns_public_slice() {
         let source = VecTokenSource {
             tokens: vec![
                 CommonToken::new(1).with_text("a"),
@@ -440,8 +443,17 @@ mod tests {
         let mut stream = CommonTokenStream::new(source);
         stream.fill();
 
-        let mut tokens = stream.tokens();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens.next_back().map(Token::token_type), Some(TOKEN_EOF));
+        fn token_count(tokens: &[CommonToken]) -> usize {
+            tokens.len()
+        }
+
+        let tokens = stream.tokens();
+        assert_eq!(token_count(tokens), 3);
+        assert_eq!(tokens[0].token_type(), 1);
+        assert_eq!(tokens.first().map(Token::token_type), Some(1));
+        assert_eq!(
+            tokens.iter().next_back().map(Token::token_type),
+            Some(TOKEN_EOF)
+        );
     }
 }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -137,7 +137,7 @@ where
         &self.source
     }
 
-    pub fn tokens(&self) -> impl Iterator<Item = &CommonToken> {
+    pub fn tokens(&self) -> impl DoubleEndedIterator + ExactSizeIterator<Item = &CommonToken> {
         self.tokens.iter().map(Rc::as_ref)
     }
 
@@ -425,5 +425,23 @@ mod tests {
         let mut stream = CommonTokenStream::new(source);
 
         assert_eq!(stream.text(10, 12), "");
+    }
+
+    #[test]
+    fn tokens_iterator_keeps_slice_like_capabilities() {
+        let source = VecTokenSource {
+            tokens: vec![
+                CommonToken::new(1).with_text("a"),
+                CommonToken::new(2).with_text("b"),
+                CommonToken::eof("vec", 2, 1, 2),
+            ],
+            index: 0,
+        };
+        let mut stream = CommonTokenStream::new(source);
+        stream.fill();
+
+        let mut tokens = stream.tokens();
+        assert_eq!(tokens.len(), 3);
+        assert_eq!(tokens.next_back().map(Token::token_type), Some(TOKEN_EOF));
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1,5 +1,7 @@
 use crate::errors::AntlrError;
-use crate::token::{CommonToken, Token};
+use std::rc::Rc;
+
+use crate::token::{CommonToken, Token, TokenRef};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -175,8 +177,8 @@ pub struct ParserRuleContext {
     rule_index: usize,
     invoking_state: isize,
     alt_number: usize,
-    start: Option<CommonToken>,
-    stop: Option<CommonToken>,
+    start: Option<TokenRef>,
+    stop: Option<TokenRef>,
     int_returns: Option<Box<IntReturns>>,
     children: Vec<ParseTree>,
     /// Whether any child has been offered to this context, independent of whether
@@ -243,19 +245,31 @@ impl ParserRuleContext {
         self.alt_number = alt_number;
     }
 
-    pub const fn start(&self) -> Option<&CommonToken> {
-        self.start.as_ref()
+    pub fn start(&self) -> Option<&CommonToken> {
+        self.start.as_deref()
     }
 
-    pub const fn stop(&self) -> Option<&CommonToken> {
-        self.stop.as_ref()
+    pub(crate) fn start_ref(&self) -> Option<TokenRef> {
+        self.start.as_ref().map(Rc::clone)
+    }
+
+    pub fn stop(&self) -> Option<&CommonToken> {
+        self.stop.as_deref()
     }
 
     pub fn set_start(&mut self, token: CommonToken) {
+        self.start = Some(Rc::new(token));
+    }
+
+    pub(crate) fn set_start_ref(&mut self, token: TokenRef) {
         self.start = Some(token);
     }
 
     pub fn set_stop(&mut self, token: CommonToken) {
+        self.stop = Some(Rc::new(token));
+    }
+
+    pub(crate) fn set_stop_ref(&mut self, token: TokenRef) {
         self.stop = Some(token);
     }
 
@@ -332,16 +346,22 @@ impl ParserRuleContext {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TerminalNode {
-    token: CommonToken,
+    token: TokenRef,
 }
 
 impl TerminalNode {
-    pub const fn new(token: CommonToken) -> Self {
+    pub fn new(token: CommonToken) -> Self {
+        Self {
+            token: Rc::new(token),
+        }
+    }
+
+    pub(crate) const fn from_ref(token: TokenRef) -> Self {
         Self { token }
     }
 
-    pub const fn symbol(&self) -> &CommonToken {
-        &self.token
+    pub fn symbol(&self) -> &CommonToken {
+        self.token.as_ref()
     }
 
     pub fn text(&self) -> String {
@@ -351,16 +371,22 @@ impl TerminalNode {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ErrorNode {
-    token: CommonToken,
+    token: TokenRef,
 }
 
 impl ErrorNode {
-    pub const fn new(token: CommonToken) -> Self {
+    pub fn new(token: CommonToken) -> Self {
+        Self {
+            token: Rc::new(token),
+        }
+    }
+
+    pub(crate) const fn from_ref(token: TokenRef) -> Self {
         Self { token }
     }
 
-    pub const fn symbol(&self) -> &CommonToken {
-        &self.token
+    pub fn symbol(&self) -> &CommonToken {
+        self.token.as_ref()
     }
 
     pub fn text(&self) -> String {


### PR DESCRIPTION
## Summary

Refs #15.

This PR reduces generated parser overhead by avoiding full `CommonToken` clones on hot parse-tree construction paths:

- Store buffered tokens in `CommonTokenStream` as shared token references.
- Add ref-returning token accessors and use them for parser success paths, rule context start/stop boundaries, direct adaptive token nodes, and recognized-node tree materialization.
- Keep public tree/token accessors returning `&CommonToken` while preserving owned-token constructors for synthesized recovery tokens.
- Skip generated child action-buffer scaffolding for grammars with no parser actions or return actions, which removes dead call-site work for the C# parser.

## Benchmark

Current branch C# Rust vs Go benchmark:

```text
ANTLR4_JAR="$PWD/target/antlr-cleanroom/tools/antlr-4.13.2-complete.jar" \
GRAMMARS_V4="$PWD/target/antlr-cleanroom/grammars-v4" \
RUSTUP_TOOLCHAIN=1.95.0-aarch64-apple-darwin \
GOMODCACHE="$PWD/target/go-mod" GOPATH="$PWD/target/go" GOCACHE="$PWD/target/go-cache" \
python3 tools/parse-bench/run.py \
  --work-dir target/parse-bench-pr-csharp \
  --languages csharp \
  --runtimes rust-antlr,go-antlr \
  --iters 10 --warmups 2 --rust-generated-only \
  --json target/parse-bench-reports/pr-csharp-rust-go.json \
  --markdown target/parse-bench-reports/pr-csharp-rust-go.md
```

C# avg totals from that run:

- Rust: 486.074 ms
- Go: 234.226 ms
- Rust/Go: 2.08x

Earlier full-language Rust-only comparison against `origin/main` showed avg totals improving across the benchmark set:

- Kotlin: -1.68%
- C#: -9.73%
- Java: -2.47%
- Trino SQL: -11.99%

This narrows the C# gap but does not close issue #15 by itself, so this is intentionally `Refs #15`, not `Fixes #15`.

## Validation

- `git diff --check`
- `RUSTUP_TOOLCHAIN=1.95.0-aarch64-apple-darwin cargo test --locked`
- `RUSTUP_TOOLCHAIN=1.95.0-aarch64-apple-darwin cargo clippy --locked --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized parser token handling to reduce memory usage by implementing reference-counted token management.
  * Updated parse-tree construction and rule-context boundary tracking to use efficient token references.
  * Enhanced codegen for parser action buffering and child-rule handling logic.

* **Tests**
  * Updated test assertions and parameters to reflect parser infrastructure changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->