### PR TITLE
[codex] Add ParserRuleContext child helpers

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -320,15 +320,21 @@ impl ParserRuleContext {
         })
     }
 
-    /// Finds the first direct terminal child with `token_type`.
+    /// Finds the first direct token child with `token_type`.
+    ///
+    /// Includes recovery error nodes, which ANTLR treats as terminal nodes for
+    /// token-getter helpers.
     pub fn child_token(&self, token_type: i32) -> Option<&TerminalNode> {
         self.children.iter().find_map(|child| match child {
             ParseTree::Terminal(node) if node.symbol().token_type() == token_type => Some(node),
+            ParseTree::Error(node) if node.symbol().token_type() == token_type => {
+                Some(node.terminal())
+            }
             _ => None,
         })
     }
 
-    /// Returns whether this context has a direct terminal child with `token_type`.
+    /// Returns whether this context has a direct token child with `token_type`.
     pub fn has_token(&self, token_type: i32) -> bool {
         self.child_token(token_type).is_some()
     }
@@ -404,26 +410,32 @@ impl TerminalNode {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ErrorNode {
-    token: TokenRef,
+    terminal: TerminalNode,
 }
 
 impl ErrorNode {
     pub fn new(token: CommonToken) -> Self {
         Self {
-            token: Rc::new(token),
+            terminal: TerminalNode::new(token),
         }
     }
 
     pub(crate) const fn from_ref(token: TokenRef) -> Self {
-        Self { token }
+        Self {
+            terminal: TerminalNode::from_ref(token),
+        }
+    }
+
+    const fn terminal(&self) -> &TerminalNode {
+        &self.terminal
     }
 
     pub fn symbol(&self) -> &CommonToken {
-        self.token.as_ref()
+        self.terminal.symbol()
     }
 
     pub fn text(&self) -> String {
-        self.token.text().unwrap_or("").to_owned()
+        self.terminal.text()
     }
 }
 
@@ -575,6 +587,7 @@ mod tests {
 
         assert_eq!(root.child_count(), 4);
         assert!(root.has_token(10));
+        assert!(root.has_token(12));
         assert_eq!(
             root.child_token(10).map(TerminalNode::text),
             Some("direct".to_owned())
@@ -583,7 +596,10 @@ mod tests {
             root.child_token(11).map(TerminalNode::text),
             Some("other".to_owned())
         );
-        assert!(root.child_token(12).is_none());
+        assert_eq!(
+            root.child_token(12).map(TerminalNode::text),
+            Some("error".to_owned())
+        );
         assert!(root.child_token(13).is_none());
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -300,6 +300,39 @@ impl ParserRuleContext {
         &self.children
     }
 
+    /// Returns the number of direct children in this context.
+    pub const fn child_count(&self) -> usize {
+        self.children.len()
+    }
+
+    /// Finds the first direct child rule with `rule_index`.
+    pub fn child_rule(&self, rule_index: usize) -> Option<&Self> {
+        self.child_rules(rule_index).next()
+    }
+
+    /// Iterates over direct child rules with `rule_index`.
+    pub fn child_rules(&self, rule_index: usize) -> impl Iterator<Item = &Self> + '_ {
+        self.children.iter().filter_map(move |child| match child {
+            ParseTree::Rule(rule) if rule.context().rule_index() == rule_index => {
+                Some(rule.context())
+            }
+            ParseTree::Rule(_) | ParseTree::Terminal(_) | ParseTree::Error(_) => None,
+        })
+    }
+
+    /// Finds the first direct terminal child with `token_type`.
+    pub fn child_token(&self, token_type: i32) -> Option<&TerminalNode> {
+        self.children.iter().find_map(|child| match child {
+            ParseTree::Terminal(node) if node.symbol().token_type() == token_type => Some(node),
+            ParseTree::Rule(_) | ParseTree::Terminal(_) | ParseTree::Error(_) => None,
+        })
+    }
+
+    /// Returns whether this context has a direct terminal child with `token_type`.
+    pub fn has_token(&self, token_type: i32) -> bool {
+        self.child_token(token_type).is_some()
+    }
+
     pub fn add_child(&mut self, child: ParseTree) {
         self.matched_child = true;
         self.children.push(child);
@@ -485,5 +518,72 @@ mod tests {
             tree.rule_invocation_stack(1, &["s".to_owned(), "a".to_owned()]),
             Some(vec!["a".to_owned(), "s".to_owned()])
         );
+    }
+
+    #[test]
+    fn finds_direct_child_rules_by_index() {
+        let mut direct = ParserRuleContext::new(1, -1);
+        direct.add_child(ParseTree::Terminal(TerminalNode::new(
+            CommonToken::new(10).with_text("direct"),
+        )));
+
+        let mut nested_match = ParserRuleContext::new(1, -1);
+        nested_match.add_child(ParseTree::Terminal(TerminalNode::new(
+            CommonToken::new(11).with_text("nested"),
+        )));
+        let mut wrapper = ParserRuleContext::new(2, -1);
+        wrapper.add_child(ParseTree::Rule(RuleNode::new(nested_match)));
+
+        let mut root = ParserRuleContext::new(0, -1);
+        root.add_child(ParseTree::Terminal(TerminalNode::new(
+            CommonToken::new(12).with_text("prefix"),
+        )));
+        root.add_child(ParseTree::Rule(RuleNode::new(direct)));
+        root.add_child(ParseTree::Rule(RuleNode::new(wrapper)));
+
+        assert_eq!(root.child_count(), 3);
+        assert_eq!(root.child_rules(1).count(), 1);
+        assert_eq!(
+            root.child_rule(1).map(ParserRuleContext::text),
+            Some("direct".to_owned())
+        );
+        assert_eq!(
+            root.child_rule(2).map(ParserRuleContext::rule_index),
+            Some(2)
+        );
+        assert!(root.child_rule(3).is_none());
+    }
+
+    #[test]
+    fn finds_direct_terminal_children_by_token_type() {
+        let mut nested = ParserRuleContext::new(1, -1);
+        nested.add_child(ParseTree::Terminal(TerminalNode::new(
+            CommonToken::new(13).with_text("nested"),
+        )));
+
+        let mut root = ParserRuleContext::new(0, -1);
+        root.add_child(ParseTree::Error(ErrorNode::new(
+            CommonToken::new(12).with_text("error"),
+        )));
+        root.add_child(ParseTree::Terminal(TerminalNode::new(
+            CommonToken::new(10).with_text("direct"),
+        )));
+        root.add_child(ParseTree::Terminal(TerminalNode::new(
+            CommonToken::new(11).with_text("other"),
+        )));
+        root.add_child(ParseTree::Rule(RuleNode::new(nested)));
+
+        assert_eq!(root.child_count(), 4);
+        assert!(root.has_token(10));
+        assert_eq!(
+            root.child_token(10).map(TerminalNode::text),
+            Some("direct".to_owned())
+        );
+        assert_eq!(
+            root.child_token(11).map(TerminalNode::text),
+            Some("other".to_owned())
+        );
+        assert!(root.child_token(12).is_none());
+        assert!(root.child_token(13).is_none());
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -316,7 +316,7 @@ impl ParserRuleContext {
             ParseTree::Rule(rule) if rule.context().rule_index() == rule_index => {
                 Some(rule.context())
             }
-            ParseTree::Rule(_) | ParseTree::Terminal(_) | ParseTree::Error(_) => None,
+            _ => None,
         })
     }
 
@@ -324,7 +324,7 @@ impl ParserRuleContext {
     pub fn child_token(&self, token_type: i32) -> Option<&TerminalNode> {
         self.children.iter().find_map(|child| match child {
             ParseTree::Terminal(node) if node.symbol().token_type() == token_type => Some(node),
-            ParseTree::Rule(_) | ParseTree::Terminal(_) | ParseTree::Error(_) => None,
+            _ => None,
         })
     }
 


### PR DESCRIPTION
## Summary

- Add direct-child navigation helpers on `ParserRuleContext`: `child_count`, `child_rule`, `child_rules`, `child_token`, and `has_token`.
- Keep lookup semantics direct-child only, leaving recursive traversal on the existing `ParseTree` helpers.
- Add focused unit tests for direct rule lookup/count behavior and terminal token lookup/count behavior.

## Validation

- `cargo +1.95.0 test --locked`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 fmt --all --check` fails only on existing rustfmt drift in `src/atn/parser.rs` and `src/prediction.rs`; I left those out of this scoped issue #28 PR.

Closes #28