### PR TITLE
[codex] Expose parser token stream access

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3879,12 +3879,10 @@ fn render_parser_with_options(
     );
     let parse_convenience = render_parser_parse_convenience(&type_name);
     let base_initialization = render_parser_base_initialization(&int_members);
-    let parser_rustdoc = render_parser_rustdoc(data);
+    let public_rule_method_names = parser_public_rule_method_names(&data.rule_names);
+    let parser_rustdoc = render_parser_rustdoc(&public_rule_method_names);
     let mut rule_methods = String::new();
-    for (index, rule_method_name) in parser_public_rule_method_names(&data.rule_names)
-        .iter()
-        .enumerate()
-    {
+    for (index, rule_method_name) in public_rule_method_names.iter().enumerate() {
         writeln!(
             rule_methods,
             "    pub fn {rule_method_name}(&mut self) -> Result<antlr4_runtime::ParseTree, antlr4_runtime::AntlrError> {{"
@@ -7456,11 +7454,10 @@ fn render_with_target_rule(template: &str, rule_index: usize) -> String {
 }
 
 /// Renders the generated parser type rustdoc that surfaces callable rule methods.
-fn render_parser_rustdoc(data: &InterpData) -> String {
-    let method_capacity = data
-        .rule_names
+fn render_parser_rustdoc(public_rule_method_names: &[String]) -> String {
+    let method_capacity = public_rule_method_names
         .iter()
-        .map(|rule| rule.len() + "/// - `()`\n".len())
+        .map(|method| method.len() + "/// - `()`\n".len())
         .sum::<usize>();
     let mut out = String::with_capacity(256 + method_capacity);
     writeln!(
@@ -7479,13 +7476,12 @@ fn render_parser_rustdoc(data: &InterpData) -> String {
         "/// the input being parsed; the generator cannot infer that semantic choice."
     )
     .expect("writing to a string cannot fail");
-    if !data.rule_names.is_empty() {
+    if !public_rule_method_names.is_empty() {
         writeln!(out, "///").expect("writing to a string cannot fail");
         writeln!(out, "/// Available parser entry-rule methods:")
             .expect("writing to a string cannot fail");
-        for rule in &data.rule_names {
-            writeln!(out, "/// - `{}()`", rust_function_name(rule))
-                .expect("writing to a string cannot fail");
+        for method_name in public_rule_method_names {
+            writeln!(out, "/// - `{method_name}()`").expect("writing to a string cannot fail");
         }
     }
     out
@@ -7951,7 +7947,7 @@ atn:
             ..InterpData::default()
         };
 
-        let rendered = render_parser_rustdoc(&data);
+        let rendered = render_parser_rustdoc(&parser_public_rule_method_names(&data.rule_names));
 
         assert!(rendered.contains("Available parser entry-rule methods:"));
         assert!(rendered.contains("/// - `kotlin_file()`"));
@@ -9158,6 +9154,8 @@ s : ;
         assert!(rendered.contains(
             "pub fn token_stream_rule(&mut self) -> Result<antlr4_runtime::ParseTree, antlr4_runtime::AntlrError>"
         ));
+        assert!(rendered.contains("/// - `token_stream_rule()`"));
+        assert!(!rendered.contains("/// - `token_stream()`"));
         assert!(!rendered.contains("pub fn token_stream(&mut self)"));
     }
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3687,6 +3687,48 @@ fn render_parser(
     )
 }
 
+const GENERATED_PARSER_RESERVED_RULE_METHODS: &[&str] = &["token_stream", "into_token_stream"];
+
+fn parser_public_rule_method_names(rule_names: &[String]) -> Vec<String> {
+    let mut used = GENERATED_PARSER_RESERVED_RULE_METHODS
+        .iter()
+        .map(|name| (*name).to_owned())
+        .collect::<BTreeSet<_>>();
+    rule_names
+        .iter()
+        .map(|rule| {
+            let base = rust_function_name(rule);
+            let name = unique_rule_method_name(&base, &used);
+            used.insert(name.clone());
+            name
+        })
+        .collect()
+}
+
+fn unique_rule_method_name(base: &str, used: &BTreeSet<String>) -> String {
+    if !used.contains(base) {
+        return base.to_owned();
+    }
+
+    let plain = base.strip_prefix("r#").unwrap_or(base);
+    let reserved_collision = GENERATED_PARSER_RESERVED_RULE_METHODS.contains(&base);
+    let stem = if reserved_collision {
+        format!("{plain}_rule")
+    } else {
+        plain.to_owned()
+    };
+    let (mut candidate, mut suffix) = if reserved_collision {
+        (stem.clone(), 2)
+    } else {
+        (format!("{stem}_2"), 3)
+    };
+    while used.contains(&candidate) {
+        candidate = format!("{stem}_{suffix}");
+        suffix += 1;
+    }
+    candidate
+}
+
 fn render_parser_with_options(
     grammar_name: &str,
     data: &InterpData,
@@ -3839,11 +3881,13 @@ fn render_parser_with_options(
     let base_initialization = render_parser_base_initialization(&int_members);
     let parser_rustdoc = render_parser_rustdoc(data);
     let mut rule_methods = String::new();
-    for (index, rule) in data.rule_names.iter().enumerate() {
+    for (index, rule_method_name) in parser_public_rule_method_names(&data.rule_names)
+        .iter()
+        .enumerate()
+    {
         writeln!(
             rule_methods,
-            "    pub fn {}(&mut self) -> Result<antlr4_runtime::ParseTree, antlr4_runtime::AntlrError> {{",
-            rust_function_name(rule)
+            "    pub fn {rule_method_name}(&mut self) -> Result<antlr4_runtime::ParseTree, antlr4_runtime::AntlrError> {{"
         )
         .expect("writing to a string cannot fail");
         writeln!(rule_methods, "        self.parse_rule({index})")
@@ -7929,6 +7973,26 @@ atn:
         ));
     }
 
+    #[test]
+    fn parser_rule_method_names_reserve_token_stream_accessors() {
+        let rule_names = vec![
+            "tokenStream".to_owned(),
+            "into_token_stream".to_owned(),
+            "token_stream_rule".to_owned(),
+            "regularRule".to_owned(),
+        ];
+
+        assert_eq!(
+            parser_public_rule_method_names(&rule_names),
+            [
+                "token_stream_rule",
+                "into_token_stream_rule",
+                "token_stream_rule_2",
+                "regular_rule"
+            ]
+        );
+    }
+
     fn compile_test_parser_rule(
         atn: &Atn,
         rule_index: usize,
@@ -9081,6 +9145,20 @@ s : ;
         assert!(rendered.contains("self.base.token_stream()"));
         assert!(rendered.contains("pub fn into_token_stream(self) -> CommonTokenStream<S>"));
         assert!(rendered.contains("self.base.into_token_stream()"));
+    }
+
+    #[test]
+    fn generated_parser_renames_rule_wrapper_that_collides_with_token_stream_accessor() {
+        let mut data = minimal_parser_data();
+        data.rule_names = vec!["tokenStream".to_owned()];
+
+        let rendered = render_parser("TParser", &data, None).expect("parser should render");
+
+        assert!(rendered.contains("pub const fn token_stream(&self) -> &CommonTokenStream<S>"));
+        assert!(rendered.contains(
+            "pub fn token_stream_rule(&mut self) -> Result<antlr4_runtime::ParseTree, antlr4_runtime::AntlrError>"
+        ));
+        assert!(!rendered.contains("pub fn token_stream(&mut self)"));
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3958,6 +3958,16 @@ where
         metadata()
     }}
 
+    #[must_use]
+    pub const fn token_stream(&self) -> &CommonTokenStream<S> {{
+        self.base.token_stream()
+    }}
+
+    #[must_use]
+    pub fn into_token_stream(self) -> CommonTokenStream<S> {{
+        self.base.into_token_stream()
+    }}
+
     #[allow(dead_code)]
     fn simulator(&mut self) -> &mut antlr4_runtime::ParserAtnSimulator<'static> {{
         self.simulator
@@ -9060,6 +9070,17 @@ s : ;
         assert!(rendered.contains("if __from_generated && allow_generated_fallback {"));
         assert!(rendered.contains("self.base.report_generated_parser_diagnostics();"));
         assert!(!rendered.contains("self.base.report_token_source_errors();"));
+    }
+
+    #[test]
+    fn generated_parser_exposes_owned_token_stream() {
+        let rendered =
+            render_parser("TParser", &minimal_parser_data(), None).expect("parser should render");
+
+        assert!(rendered.contains("pub const fn token_stream(&self) -> &CommonTokenStream<S>"));
+        assert!(rendered.contains("self.base.token_stream()"));
+        assert!(rendered.contains("pub fn into_token_stream(self) -> CommonTokenStream<S>"));
+        assert!(rendered.contains("self.base.into_token_stream()"));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2316,6 +2316,18 @@ where
         &mut self.input
     }
 
+    /// Returns the token stream owned by this parser.
+    #[must_use]
+    pub const fn token_stream(&self) -> &CommonTokenStream<S> {
+        &self.input
+    }
+
+    /// Consumes this parser and returns its token stream.
+    #[must_use]
+    pub fn into_token_stream(self) -> CommonTokenStream<S> {
+        self.input
+    }
+
     /// Emits diagnostics buffered by the token stream while generated parser
     /// code was fetching lexer tokens directly.
     pub fn report_token_source_errors(&mut self) {
@@ -9445,6 +9457,34 @@ mod tests {
                 .token_type(),
             TOKEN_EOF
         );
+    }
+
+    #[test]
+    fn parser_exposes_buffered_token_stream_after_parse() {
+        let atn = token_then_eof_atn();
+        let mut parser = mini_parser(vec![
+            CommonToken::new(1).with_text("x"),
+            CommonToken::eof("parser-test", 1, 1, 1),
+        ]);
+
+        let tree = parser
+            .parse_atn_rule(&atn, 0)
+            .expect("artificial parser rule should parse");
+        assert_eq!(tree.text(), "x<EOF>");
+
+        let stream = parser.token_stream();
+        let source_index_after_parse = stream.token_source().index;
+        let buffered = stream.tokens();
+        assert_eq!(buffered.len(), 2);
+        assert_eq!(buffered[0].text(), Some("x"));
+        assert_eq!(buffered[0].token_index(), 0);
+        assert_eq!(buffered[1].token_type(), TOKEN_EOF);
+        assert_eq!(stream.token_source().index, source_index_after_parse);
+
+        let stream = parser.into_token_stream();
+        assert_eq!(stream.token_source().index, source_index_after_parse);
+        assert_eq!(stream.tokens()[0].text(), Some("x"));
+        assert_eq!(stream.tokens()[1].token_type(), TOKEN_EOF);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `BaseParser::token_stream(&self)` and `BaseParser::into_token_stream(self)` so callers can inspect or recover the parser-owned `CommonTokenStream` after parsing.
- Render the same forwarding accessors on generated parser types.
- Cover the post-parse buffered-token inspection path and generated-template output with focused tests.

Closes #25

## Validation

- `cargo +1.95.0 test --locked`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo +1.95.0 fmt --all --check` currently reports pre-existing formatting diffs in `src/atn/parser.rs` and `src/prediction.rs`, outside this PR's scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved potential name collisions in generated parser rule methods.

* **New Features**
  * Added public methods to access the underlying token stream from parser instances.

* **Tests**
  * Extended test coverage for new token stream accessor functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->