### PR TITLE
[codex] Generate parser parse convenience

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,22 @@ mod generated {
 }
 ```
 
-Call the generated lexer and parser:
+Call the generated parser helper for the compact path:
+
+```rust
+use generated::json::{self, Json};
+use generated::json_lexer::JsonLexer;
+
+fn main() -> Result<(), antlr4_runtime::AntlrError> {
+    let tree = json::parse(r#"{"a":1}"#, JsonLexer::new, Json::json)?;
+
+    println!("{}", tree.text());
+    Ok(())
+}
+```
+
+Or construct each layer explicitly when you need to set source names, parser
+options, or custom error handling before invoking the entry rule:
 
 ```rust
 use antlr4_runtime::{CommonTokenStream, InputStream};

--- a/docs/kotlin-build.md
+++ b/docs/kotlin-build.md
@@ -51,6 +51,19 @@ Replace the path with the relative path from the smoke crate to this checkout.
 Then include the generated modules and parse a Kotlin sample:
 
 ```rust
+use generated::kotlin_lexer::KotlinLexer;
+use generated::kotlin_parser::{self, KotlinParser};
+
+let tree = kotlin_parser::parse("fun main() {}", KotlinLexer::new, KotlinParser::kotlin_file)
+    .expect("entry rule parses");
+assert!(tree.text().contains("fun"));
+```
+
+The generated helper is additive. The explicit path is still available when the
+caller needs to name the input source, adjust parser options, or attach custom
+error handling before the entry rule:
+
+```rust
 use antlr4_runtime::{CommonTokenStream, InputStream};
 use generated::kotlin_lexer::KotlinLexer;
 use generated::kotlin_parser::KotlinParser;

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -1115,8 +1115,8 @@ impl<'a> ParserAtnSimulator<'a> {
                         // ANTLR: stop collecting predicates once an action edge is
                         // crossed, so a predicate after an action is deferred to
                         // parse time rather than evaluated during prediction.
-                        let target_collect_predicates = collect_predicates
-                            && !matches!(transition, Transition::Action { .. });
+                        let target_collect_predicates =
+                            collect_predicates && !matches!(transition, Transition::Action { .. });
                         scratch.stack.push((target, target_collect_predicates));
                     }
                 } else if treat_eof_as_epsilon

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -7362,7 +7362,7 @@ pub fn parse<L, R>(
 where
     L: TokenSource,
 {{
-    let lexer = lexer(antlr4_runtime::InputStream::new(input));
+    let lexer = lexer(antlr4_runtime::InputStream::new(input.as_ref()));
     let tokens = CommonTokenStream::new(lexer);
     let mut parser = {type_name}::new(tokens);
     entry(&mut parser)
@@ -8592,6 +8592,7 @@ s : ;
 
         assert!(rendered.contains("pub fn parse<L, R>("));
         assert!(rendered.contains("lexer: impl FnOnce(antlr4_runtime::InputStream) -> L"));
+        assert!(rendered.contains("antlr4_runtime::InputStream::new(input.as_ref())"));
         assert!(rendered.contains("let tokens = CommonTokenStream::new(lexer);"));
         assert!(rendered.contains("pub fn new(input: CommonTokenStream<S>) -> Self"));
     }

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3821,6 +3821,7 @@ fn render_parser_with_options(
         "#[allow(dead_code)]\nconst CTX_ROOTED_ACTION_STATES: &[usize] = &{};\n",
         render_usize_array(&ctx_rooted_action_states.iter().copied().collect::<Vec<_>>())
     );
+    let parse_convenience = render_parser_parse_convenience(&type_name);
     let base_initialization = render_parser_base_initialization(&int_members);
     let mut rule_methods = String::new();
     for (index, rule) in data.rule_names.iter().enumerate() {
@@ -3861,6 +3862,8 @@ fn atn() -> &'static Atn {{
             .expect("generated parser contains a valid ANTLR serialized ATN")
     }})
 }}
+
+{parse_convenience}
 
 #[derive(Debug)]
 pub struct {type_name}<S>
@@ -7342,6 +7345,31 @@ fn render_parser_base_initialization(members: &[IntMemberTemplate]) -> String {
     out
 }
 
+/// Renders the parser-module convenience that wires text input through the
+/// caller-selected lexer, token stream, parser, and entry rule in one call.
+fn render_parser_parse_convenience(type_name: &str) -> String {
+    format!(
+        r#"/// Parses UTF-8 text by constructing the lexer, token stream, parser, and
+/// caller-selected entry rule in one call.
+///
+/// Pass the generated lexer constructor and a parser entry rule, for example
+/// `parse(src, MyGrammarLexer::new, {type_name}::file)`.
+pub fn parse<L, R>(
+    input: impl AsRef<str>,
+    lexer: impl FnOnce(antlr4_runtime::InputStream) -> L,
+    entry: impl FnOnce(&mut {type_name}<L>) -> Result<R, antlr4_runtime::AntlrError>,
+) -> Result<R, antlr4_runtime::AntlrError>
+where
+    L: TokenSource,
+{{
+    let lexer = lexer(antlr4_runtime::InputStream::new(input));
+    let tokens = CommonTokenStream::new(lexer);
+    let mut parser = {type_name}::new(tokens);
+    entry(&mut parser)
+}}"#
+    )
+}
+
 fn member_id(members: &[IntMemberTemplate], name: &str) -> io::Result<usize> {
     members
         .iter()
@@ -8555,6 +8583,17 @@ s : ;
             error.to_string(),
             "generated parser did not emit 1 rule(s): s"
         );
+    }
+
+    #[test]
+    fn renders_parse_convenience_without_replacing_manual_constructor() {
+        let rendered =
+            render_parser("TParser", &minimal_parser_data(), None).expect("parser should render");
+
+        assert!(rendered.contains("pub fn parse<L, R>("));
+        assert!(rendered.contains("lexer: impl FnOnce(antlr4_runtime::InputStream) -> L"));
+        assert!(rendered.contains("let tokens = CommonTokenStream::new(lexer);"));
+        assert!(rendered.contains("pub fn new(input: CommonTokenStream<S>) -> Self"));
     }
 
     #[test]

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -321,24 +321,28 @@ fn merge_two_context_entries(
     if left_return_state == right_return_state && left_parent == right_parent {
         return PredictionContext::singleton(left_parent, left_return_state);
     }
-    let (first_parent, first_return_state, second_parent, second_return_state) =
-        if compare_entries(&right_parent, right_return_state, &left_parent, left_return_state)
-            == Ordering::Less
-        {
-            (
-                right_parent,
-                right_return_state,
-                left_parent,
-                left_return_state,
-            )
-        } else {
-            (
-                left_parent,
-                left_return_state,
-                right_parent,
-                right_return_state,
-            )
-        };
+    let (first_parent, first_return_state, second_parent, second_return_state) = if compare_entries(
+        &right_parent,
+        right_return_state,
+        &left_parent,
+        left_return_state,
+    )
+        == Ordering::Less
+    {
+        (
+            right_parent,
+            right_return_state,
+            left_parent,
+            left_return_state,
+        )
+    } else {
+        (
+            left_parent,
+            left_return_state,
+            right_parent,
+            right_return_state,
+        )
+    };
     PredictionContext::array(
         vec![first_parent, second_parent],
         vec![first_return_state, second_return_state],
@@ -354,10 +358,7 @@ fn merge_array_with_entry(
     entry_on_left: bool,
 ) -> Rc<PredictionContext> {
     let mut insert_index = array_parents.len();
-    for (index, (parent, return_state)) in array_parents
-        .iter()
-        .zip(array_return_states)
-        .enumerate()
+    for (index, (parent, return_state)) in array_parents.iter().zip(array_return_states).enumerate()
     {
         let ordering = compare_entries(&entry_parent, entry_return_state, parent, *return_state);
         if ordering == Ordering::Equal && parent == &entry_parent {
@@ -392,7 +393,8 @@ fn merge_arrays(
     right_return_states: &[usize],
 ) -> Rc<PredictionContext> {
     let mut parents = Vec::with_capacity(left_parents.len() + right_parents.len());
-    let mut return_states = Vec::with_capacity(left_return_states.len() + right_return_states.len());
+    let mut return_states =
+        Vec::with_capacity(left_return_states.len() + right_return_states.len());
     let mut left_index = 0;
     let mut right_index = 0;
 
@@ -1379,12 +1381,9 @@ mod tests {
         // operand order. (A shared trailing entry keeps both operands distinct so
         // `merge` does not short-circuit on `left == right`.)
         let shared = PredictionContext::singleton(Rc::clone(&empty), 30);
-        let left_array = PredictionContext::array(
-            vec![Rc::clone(&parent_a), Rc::clone(&shared)],
-            vec![7, 30],
-        );
-        let right_array =
-            PredictionContext::array(vec![Rc::clone(&parent_b), shared], vec![7, 30]);
+        let left_array =
+            PredictionContext::array(vec![Rc::clone(&parent_a), Rc::clone(&shared)], vec![7, 30]);
+        let right_array = PredictionContext::array(vec![Rc::clone(&parent_b), shared], vec![7, 30]);
         let merged_arrays_lr =
             PredictionContext::merge(Rc::clone(&left_array), Rc::clone(&right_array));
         let merged_arrays_rl = PredictionContext::merge(right_array, left_array);

--- a/tests/kotlin-parity/dumper/src/main.rs
+++ b/tests/kotlin-parity/dumper/src/main.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
 
-use antlr4_runtime::{CommonTokenStream, InputStream, ParseTree};
+use antlr4_runtime::{InputStream, ParseTree};
 
 mod generated {
     #![allow(dead_code, unused_imports, unreachable_pub, unused_qualifications)]
@@ -24,7 +24,7 @@ mod generated {
 }
 
 use generated::kotlin_lexer::KotlinLexer;
-use generated::kotlin_parser::KotlinParser;
+use generated::kotlin_parser::{self, KotlinParser};
 
 fn dump(out: &mut dyn Write, tree: &ParseTree, rule_names: &[String], depth: usize) -> io::Result<()> {
     let pad = "  ".repeat(depth);
@@ -95,18 +95,21 @@ fn main() -> ExitCode {
     let mut min_us: u128 = u128::MAX;
     let mut total_us: u128 = 0;
     for _ in 0..iters {
-        let lexer = KotlinLexer::new(InputStream::new(&src));
-        let tokens = CommonTokenStream::new(lexer);
-        let mut parser = KotlinParser::new(tokens);
-        let started = Instant::now();
-        let tree = match parser.kotlin_file() {
+        let mut started = None;
+        let tree = match kotlin_parser::parse(&src, KotlinLexer::new, |parser| {
+            started = Some(Instant::now());
+            parser.kotlin_file()
+        }) {
             Ok(tree) => tree,
             Err(err) => {
                 eprintln!("parse failed: {err}");
                 return ExitCode::from(1);
             }
         };
-        let elapsed = started.elapsed().as_micros();
+        let elapsed = started
+            .expect("parse helper should enter the entry rule")
+            .elapsed()
+            .as_micros();
         min_us = min_us.min(elapsed);
         total_us += elapsed;
         last_tree = Some(tree);


### PR DESCRIPTION
## Summary

- Generate a parser-module `parse` helper that wires UTF-8 input through a caller-selected lexer constructor, `CommonTokenStream`, parser construction, and entry-rule callback in one call.
- Keep the existing manual `new(CommonTokenStream<_>)` path intact for source naming, parser options, and custom error handling.
- Update README/Kotlin smoke docs and exercise the helper in the Kotlin parity dumper.
- Apply Rust 1.95 formatter output needed for `cargo fmt --all --check` to pass.

Closes #30

## Validation

- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 test --locked`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95.0 tests/kotlin-parity/run.sh --antlr-jar /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar --grammars-v4 /tmp/antlr-cleanroom/grammars-v4 --python /tmp/antlr-cleanroom/kotlin-parity-venv/bin/python`