### PR TITLE
[codex] Document parser entry rule selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ fn main() -> Result<(), antlr4_runtime::AntlrError> {
 }
 ```
 
+### Choosing Parser Entry Rules
+
+Generated parsers expose one public method per grammar rule. Call the method
+that matches the grammar's intended top-level rule for the input; the generator
+cannot infer that semantic choice from `.interp` metadata. The generated parser
+rustdoc lists the available rule methods.
+
+For the JSON grammar above, `json()` is the natural entry. Larger grammars may
+have several top-level forms: with the Kotlin grammar, `.kt` compilation units
+typically use `kotlin_file()`, while script-style `.kts` input uses `script()`.
+Calling the wrong rule can still recover and return a parse tree with error
+nodes, so check parser diagnostics when adding a new input form.
+
 ## Technical Notes
 
 - Pure Rust runtime implementation.

--- a/docs/kotlin-build.md
+++ b/docs/kotlin-build.md
@@ -37,6 +37,21 @@ This emits:
 
 The generated lexer and parser cache a deserialized ATN with `OnceLock` and delegate recognition to `antlr4_runtime`.
 
+## Choose the Kotlin Entry Rule
+
+`antlr4-rust-gen` emits one public parser method for every grammar rule and
+lists those methods in the generated parser rustdoc. Choose the method that
+matches the Kotlin input shape rather than assuming the first rule is always
+right:
+
+- `.kt` compilation units use `parser.kotlin_file()`.
+- `.kts` script-style input uses `parser.script()`.
+
+ANTLR recovery can produce a parse tree even when the wrong entry rule is used,
+but the tree will contain recovered error nodes and diagnostics. When adding a
+new Kotlin input form, confirm the entry rule against the upstream grammar and
+check parser diagnostics.
+
 ## Smoke Crate
 
 Create any Rust crate that depends on this runtime:

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3826,6 +3826,7 @@ fn render_parser_with_options(
     );
     let parse_convenience = render_parser_parse_convenience(&type_name);
     let base_initialization = render_parser_base_initialization(&int_members);
+    let parser_rustdoc = render_parser_rustdoc(data);
     let mut rule_methods = String::new();
     for (index, rule) in data.rule_names.iter().enumerate() {
         writeln!(
@@ -3868,7 +3869,7 @@ fn atn() -> &'static Atn {{
 
 {parse_convenience}
 
-#[derive(Debug)]
+{parser_rustdoc}#[derive(Debug)]
 pub struct {type_name}<S>
 where
     S: TokenSource,
@@ -7033,6 +7034,42 @@ fn render_with_target_rule(template: &str, rule_index: usize) -> String {
     out
 }
 
+/// Renders the generated parser type rustdoc that surfaces callable rule methods.
+fn render_parser_rustdoc(data: &InterpData) -> String {
+    let method_capacity = data
+        .rule_names
+        .iter()
+        .map(|rule| rule.len() + "/// - `()`\n".len())
+        .sum::<usize>();
+    let mut out = String::with_capacity(256 + method_capacity);
+    writeln!(
+        out,
+        "/// Generated parser. Each grammar rule is exposed as a public method."
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(out, "///").expect("writing to a string cannot fail");
+    writeln!(
+        out,
+        "/// Pick the method that matches the grammar's intended top-level rule for"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(
+        out,
+        "/// the input being parsed; the generator cannot infer that semantic choice."
+    )
+    .expect("writing to a string cannot fail");
+    if !data.rule_names.is_empty() {
+        writeln!(out, "///").expect("writing to a string cannot fail");
+        writeln!(out, "/// Available parser entry-rule methods:")
+            .expect("writing to a string cannot fail");
+        for rule in &data.rule_names {
+            writeln!(out, "/// - `{}()`", rust_function_name(rule))
+                .expect("writing to a string cannot fail");
+        }
+    }
+    out
+}
+
 /// Renders static grammar metadata shared by generated lexers and parsers.
 fn render_metadata(grammar_name: &str, data: &InterpData) -> String {
     format!(
@@ -7480,6 +7517,39 @@ atn:
         assert_eq!(rust_function_name("try"), "r#try");
         assert_eq!(rust_function_name("Self"), "r#self");
         assert!(is_rust_keyword("Self"));
+    }
+
+    #[test]
+    fn renders_parser_rustdoc_with_entry_rule_methods() {
+        let data = InterpData {
+            rule_names: vec![
+                "kotlinFile".to_owned(),
+                "script".to_owned(),
+                "try".to_owned(),
+            ],
+            ..InterpData::default()
+        };
+
+        let rendered = render_parser_rustdoc(&data);
+
+        assert!(rendered.contains("Available parser entry-rule methods:"));
+        assert!(rendered.contains("/// - `kotlin_file()`"));
+        assert!(rendered.contains("/// - `script()`"));
+        assert!(rendered.contains("/// - `r#try()`"));
+        assert!(rendered.contains("cannot infer that semantic choice"));
+    }
+
+    #[test]
+    fn generated_parser_rustdoc_is_attached_to_parser_type() {
+        let rendered =
+            render_parser("DemoParser", &minimal_parser_data(), None).expect("parser renders");
+
+        assert!(rendered.contains(
+            "/// Generated parser. Each grammar rule is exposed as a public method.\n///\n/// Pick the method"
+        ));
+        assert!(rendered.contains(
+            "/// Available parser entry-rule methods:\n/// - `s()`\n#[derive(Debug)]\npub struct DemoParser<S>"
+        ));
     }
 
     fn compile_test_parser_rule(


### PR DESCRIPTION
## Summary

- Document how to choose parser entry rules, including Kotlin `.kt` versus `.kts` guidance.
- Emit generated parser rustdoc that lists the callable parser entry-rule methods derived from grammar rules.
- Include focused generator tests for the rustdoc output.

Closes #31

## Validation

- `cargo +1.95.0 fmt --all --check`
- `cargo +1.95.0 test --locked`
- `cargo +1.95.0 doc --locked --no-deps`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95.0 tests/kotlin-parity/run.sh --antlr-jar /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar --grammars-v4 /tmp/antlr-cleanroom/grammars-v4 --python /tmp/antlr-cleanroom/kotlin-parity-venv/bin/python`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Choosing Parser Entry Rules" section to README explaining parser entry point selection and alternatives
  * Added Kotlin entry rule selection guide to build documentation with examples for compilation units and scripts

* **Code Quality**
  * Generated parsers now include enhanced rustdoc documenting available entry-rule methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->