### PR TITLE
[codex] Add parser syntax error count API

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2155,6 +2155,11 @@ fn render_generated_rule_method(
     .expect("writing to a string cannot fail");
     writeln!(
         out,
+        "                        self.base.record_generated_syntax_error();"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(
+        out,
         "                        return Err(GeneratedRuleError::Fatal(__error));"
     )
     .expect("writing to a string cannot fail");
@@ -2310,6 +2315,11 @@ fn render_generated_left_recursive_rule_method(
     writeln!(
         out,
         "                        self.base.restore_generated_diagnostics(__generated_diagnostic_marker);"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(
+        out,
+        "                        self.base.record_generated_syntax_error();"
     )
     .expect("writing to a string cannot fail");
     writeln!(
@@ -9215,6 +9225,13 @@ s @init {<GetExpectedTokenNames():writeln()>} : ;
         assert!(
             guard < fatal,
             "Fatal return must be inside the allow_fallback guard"
+        );
+        let count = rest
+            .find("self.base.record_generated_syntax_error();")
+            .expect("fatal sync path records syntax error");
+        assert!(
+            guard < count && count < fatal,
+            "fatal sync path must increment before returning"
         );
         // And the nested-child path recovers locally and returns Ok.
         let recover = rest

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -4179,6 +4179,7 @@ where
 {{
     fn build_parse_trees(&self) -> bool {{ self.base.build_parse_trees() }}
     fn set_build_parse_trees(&mut self, build: bool) {{ self.base.set_build_parse_trees(build); }}
+    fn number_of_syntax_errors(&self) -> usize {{ self.base.number_of_syntax_errors() }}
     fn report_diagnostic_errors(&self) -> bool {{ self.base.report_diagnostic_errors() }}
     fn set_report_diagnostic_errors(&mut self, report: bool) {{ self.base.set_report_diagnostic_errors(report); }}
     fn prediction_mode(&self) -> antlr4_runtime::PredictionMode {{ self.base.prediction_mode() }}
@@ -9129,6 +9130,7 @@ s : ;
 
         assert!(rendered.contains("if __from_generated && allow_generated_fallback {"));
         assert!(rendered.contains("self.base.report_generated_parser_diagnostics();"));
+        assert!(rendered.contains("fn number_of_syntax_errors(&self) -> usize"));
         assert!(!rendered.contains("self.base.report_token_source_errors();"));
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -788,12 +788,6 @@ impl NodeList {
         })
     }
 
-    fn syntax_error_count(&self) -> usize {
-        self.iter()
-            .map(|node| fast_recognized_node_syntax_error_count(node.as_ref()))
-            .sum()
-    }
-
     /// Builds a list from an already ordered vector.
     fn from_vec(nodes: Vec<Rc<FastRecognizedNode>>) -> Self {
         let mut list = Self::new();
@@ -2981,7 +2975,6 @@ where
         self.push_generated_parser_diagnostic(diagnostic);
         self.generated_sync_expected = None;
         let recovery_symbols = self.context_expected_symbols(atn);
-        let mut recovered_errors = 0_usize;
         loop {
             let symbol = self.la(1);
             if symbol == TOKEN_EOF || recovery_symbols.contains(&symbol) {
@@ -2992,9 +2985,8 @@ where
             };
             self.consume();
             self.add_parse_child(context, ParseTree::Error(ErrorNode::new(token)));
-            recovered_errors += 1;
         }
-        self.record_syntax_errors(recovered_errors.max(1));
+        self.record_syntax_errors(1);
     }
 
     fn push_generated_parser_diagnostic(&mut self, diagnostic: ParserDiagnostic) {
@@ -3388,7 +3380,7 @@ where
                         current_token.as_ref(),
                         message,
                     ));
-                    self.record_syntax_errors(skipped.len());
+                    self.record_syntax_errors(1);
                     let mut children = Vec::with_capacity(skipped.len());
                     for index in skipped {
                         if let Some(token) = self.token_at(index) {
@@ -3721,11 +3713,7 @@ where
             first_pass.expect("first_pass is Ok in the no-retry branch")
         };
 
-        let syntax_error_count = outcome
-            .nodes
-            .syntax_error_count()
-            .max(outcome.diagnostics.len());
-        self.record_syntax_errors(syntax_error_count);
+        self.record_syntax_errors(outcome.diagnostics.len());
         report_parser_diagnostics(&self.prediction_diagnostics);
         report_parser_diagnostics(&outcome.diagnostics);
         report_token_source_errors(&self.input.drain_source_errors());
@@ -4204,9 +4192,7 @@ where
             return Err(error);
         };
 
-        let syntax_error_count =
-            recognized_nodes_syntax_error_count(&outcome.nodes).max(outcome.diagnostics.len());
-        self.record_syntax_errors(syntax_error_count);
+        self.record_syntax_errors(outcome.diagnostics.len());
         report_parser_diagnostics(&self.prediction_diagnostics);
         report_parser_diagnostics(&outcome.diagnostics);
         report_token_source_errors(&self.input.drain_source_errors());
@@ -7692,14 +7678,6 @@ fn fast_node_has_left_recursive_boundary(node: &FastRecognizedNode) -> bool {
     }
 }
 
-fn fast_recognized_node_syntax_error_count(node: &FastRecognizedNode) -> usize {
-    match node {
-        FastRecognizedNode::ErrorToken { .. } | FastRecognizedNode::MissingToken { .. } => 1,
-        FastRecognizedNode::Rule { children, .. } => children.syntax_error_count(),
-        FastRecognizedNode::Token { .. } | FastRecognizedNode::LeftRecursiveBoundary { .. } => 0,
-    }
-}
-
 fn fast_recognized_nodes_start_index(nodes: &[Rc<FastRecognizedNode>]) -> Option<usize> {
     nodes
         .iter()
@@ -7752,18 +7730,6 @@ const fn fast_recognized_node_stop_index(node: &FastRecognizedNode) -> Option<us
 
 fn recognized_nodes_start_index(nodes: &[RecognizedNode]) -> Option<usize> {
     nodes.iter().find_map(recognized_node_start_index)
-}
-
-fn recognized_nodes_syntax_error_count(nodes: &[RecognizedNode]) -> usize {
-    nodes.iter().map(recognized_node_syntax_error_count).sum()
-}
-
-fn recognized_node_syntax_error_count(node: &RecognizedNode) -> usize {
-    match node {
-        RecognizedNode::ErrorToken { .. } | RecognizedNode::MissingToken { .. } => 1,
-        RecognizedNode::Rule { children, .. } => recognized_nodes_syntax_error_count(children),
-        RecognizedNode::Token { .. } | RecognizedNode::LeftRecursiveBoundary { .. } => 0,
-    }
 }
 
 const fn recognized_node_start_index(node: &RecognizedNode) -> Option<usize> {
@@ -8754,7 +8720,7 @@ mod tests {
             .expect("loop-back multi-token deletion recovers onto EOF");
         assert_eq!(children.len(), 2, "both `c`s deleted as error nodes");
         assert!(children.iter().all(|c| matches!(c, ParseTree::Error(_))));
-        assert_eq!(parser.number_of_syntax_errors(), 2);
+        assert_eq!(parser.number_of_syntax_errors(), 1);
         assert_eq!(parser.la(1), TOKEN_EOF, "EOF left for the rule's EOF match");
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2349,6 +2349,12 @@ where
         self.syntax_errors
     }
 
+    /// Records a syntax error that generated parser code returns as fatal before
+    /// it can recover into the current rule context.
+    pub const fn record_generated_syntax_error(&mut self) {
+        self.record_syntax_errors(1);
+    }
+
     const fn record_syntax_errors(&mut self, count: usize) {
         self.syntax_errors = self.syntax_errors.saturating_add(count);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3706,6 +3706,7 @@ where
             };
             selected.map_err(|expected| {
                 let error = self.recognition_error(rule_index, start_index, &expected);
+                self.record_syntax_errors(1);
                 report_token_source_errors(&self.input.drain_source_errors());
                 error
             })?
@@ -4188,6 +4189,7 @@ where
         );
         let Some(outcome) = select_best_outcome(outcomes.into_iter(), self.prediction_mode) else {
             let error = self.recognition_error(rule_index, start_index, &expected);
+            self.record_syntax_errors(1);
             report_token_source_errors(&self.input.drain_source_errors());
             return Err(error);
         };
@@ -9629,6 +9631,22 @@ mod tests {
                 .text(),
             Some("y")
         );
+    }
+
+    #[test]
+    fn parser_syntax_error_count_tracks_failed_interpreted_parse() {
+        let atn = token_then_eof_atn();
+        let mut parser = mini_parser(vec![
+            CommonToken::new(2).with_text("y"),
+            CommonToken::eof("parser-test", 1, 1, 1),
+        ]);
+
+        let error = parser
+            .parse_atn_rule(&atn, 0)
+            .expect_err("start-rule mismatch should remain a parser error");
+
+        assert_eq!(parser.number_of_syntax_errors(), 1);
+        assert!(matches!(error, AntlrError::ParserError { .. }));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -449,6 +449,12 @@ pub trait Parser: Recognizer {
     /// Enables or disables parse-tree construction for subsequent rule calls.
     fn set_build_parse_trees(&mut self, build: bool);
 
+    /// Returns the number of parser syntax errors recorded by committed parse
+    /// paths so far.
+    fn number_of_syntax_errors(&self) -> usize {
+        0
+    }
+
     /// Reports whether prediction diagnostic-listener messages are emitted
     /// during parser ATN recognition.
     fn report_diagnostic_errors(&self) -> bool {
@@ -480,6 +486,7 @@ pub struct BaseParser<S> {
     input: CommonTokenStream<S>,
     data: RecognizerData,
     build_parse_trees: bool,
+    syntax_errors: usize,
     report_diagnostic_errors: bool,
     prediction_mode: PredictionMode,
     prediction_diagnostics: Vec<ParserDiagnostic>,
@@ -564,6 +571,13 @@ pub struct BaseParser<S> {
     /// selected rule spans after recognition, avoiding many speculative `Rc`
     /// nodes that are thrown away with losing paths.
     fast_token_nodes_enabled: bool,
+}
+
+/// Rollback marker for speculative generated parser paths.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GeneratedDiagnosticsCheckpoint {
+    diagnostics_len: usize,
+    syntax_errors: usize,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -772,6 +786,12 @@ impl NodeList {
                     | FastRecognizedNode::MissingToken { .. }
             )
         })
+    }
+
+    fn syntax_error_count(&self) -> usize {
+        self.iter()
+            .map(|node| fast_recognized_node_syntax_error_count(node.as_ref()))
+            .sum()
     }
 
     /// Builds a list from an already ordered vector.
@@ -2280,6 +2300,7 @@ where
             input,
             data,
             build_parse_trees: true,
+            syntax_errors: 0,
             report_diagnostic_errors: false,
             prediction_mode: PredictionMode::Ll,
             prediction_diagnostics: Vec::new(),
@@ -2328,21 +2349,36 @@ where
         self.input
     }
 
+    /// Returns the number of parser syntax errors recorded by committed parse
+    /// paths so far.
+    pub const fn number_of_syntax_errors(&self) -> usize {
+        self.syntax_errors
+    }
+
+    const fn record_syntax_errors(&mut self, count: usize) {
+        self.syntax_errors = self.syntax_errors.saturating_add(count);
+    }
+
     /// Emits diagnostics buffered by the token stream while generated parser
     /// code was fetching lexer tokens directly.
     pub fn report_token_source_errors(&mut self) {
         report_token_source_errors(&self.input.drain_source_errors());
     }
 
-    /// Captures the current generated-parser diagnostic buffer length before a
+    /// Captures generated-parser diagnostics and syntax-error count before a
     /// speculative generated rule path.
-    pub const fn generated_diagnostics_checkpoint(&self) -> usize {
-        self.generated_parser_diagnostics.len()
+    pub const fn generated_diagnostics_checkpoint(&self) -> GeneratedDiagnosticsCheckpoint {
+        GeneratedDiagnosticsCheckpoint {
+            diagnostics_len: self.generated_parser_diagnostics.len(),
+            syntax_errors: self.syntax_errors,
+        }
     }
 
     /// Restores generated-parser diagnostics after a speculative rule path failed.
-    pub fn restore_generated_diagnostics(&mut self, marker: usize) {
-        self.generated_parser_diagnostics.truncate(marker);
+    pub fn restore_generated_diagnostics(&mut self, marker: GeneratedDiagnosticsCheckpoint) {
+        self.generated_parser_diagnostics
+            .truncate(marker.diagnostics_len);
+        self.syntax_errors = marker.syntax_errors;
         self.generated_sync_expected = None;
     }
 
@@ -2673,8 +2709,8 @@ where
                 "extraneous input {} expecting {expected_display}",
                 token_input_display(&current)
             );
-            self.generated_parser_diagnostics
-                .push(diagnostic_for_token(Some(&current), message));
+            self.push_generated_parser_diagnostic(diagnostic_for_token(Some(&current), message));
+            self.record_syntax_errors(1);
             self.generated_sync_expected = None;
             // Single-token deletion: skip `current`, then accept `next`. The
             // accepted token can be EOF only if it is a real EOF terminal.
@@ -2712,8 +2748,8 @@ where
                 "missing {expected_display} at {}",
                 token_input_display(&current)
             );
-            self.generated_parser_diagnostics
-                .push(diagnostic_for_token(Some(&current), message));
+            self.push_generated_parser_diagnostic(diagnostic_for_token(Some(&current), message));
+            self.record_syntax_errors(1);
             self.generated_sync_expected = None;
             let token_type = expected_symbols.iter().next().copied().unwrap_or(TOKEN_EOF);
             let mut missing_symbol = BTreeSet::new();
@@ -2945,6 +2981,7 @@ where
         self.push_generated_parser_diagnostic(diagnostic);
         self.generated_sync_expected = None;
         let recovery_symbols = self.context_expected_symbols(atn);
+        let mut recovered_errors = 0_usize;
         loop {
             let symbol = self.la(1);
             if symbol == TOKEN_EOF || recovery_symbols.contains(&symbol) {
@@ -2955,7 +2992,9 @@ where
             };
             self.consume();
             self.add_parse_child(context, ParseTree::Error(ErrorNode::new(token)));
+            recovered_errors += 1;
         }
+        self.record_syntax_errors(recovered_errors.max(1));
     }
 
     fn push_generated_parser_diagnostic(&mut self, diagnostic: ParserDiagnostic) {
@@ -3345,8 +3384,11 @@ where
                             .map_or_else(|| "'<EOF>'".to_owned(), token_input_display),
                         self.expected_symbols_display(&expected_symbols)
                     );
-                    self.generated_parser_diagnostics
-                        .push(diagnostic_for_token(current_token.as_ref(), message));
+                    self.push_generated_parser_diagnostic(diagnostic_for_token(
+                        current_token.as_ref(),
+                        message,
+                    ));
+                    self.record_syntax_errors(skipped.len());
                     let mut children = Vec::with_capacity(skipped.len());
                     for index in skipped {
                         if let Some(token) = self.token_at(index) {
@@ -3679,6 +3721,11 @@ where
             first_pass.expect("first_pass is Ok in the no-retry branch")
         };
 
+        let syntax_error_count = outcome
+            .nodes
+            .syntax_error_count()
+            .max(outcome.diagnostics.len());
+        self.record_syntax_errors(syntax_error_count);
         report_parser_diagnostics(&self.prediction_diagnostics);
         report_parser_diagnostics(&outcome.diagnostics);
         report_token_source_errors(&self.input.drain_source_errors());
@@ -4157,6 +4204,9 @@ where
             return Err(error);
         };
 
+        let syntax_error_count =
+            recognized_nodes_syntax_error_count(&outcome.nodes).max(outcome.diagnostics.len());
+        self.record_syntax_errors(syntax_error_count);
         report_parser_diagnostics(&self.prediction_diagnostics);
         report_parser_diagnostics(&outcome.diagnostics);
         report_token_source_errors(&self.input.drain_source_errors());
@@ -7642,6 +7692,14 @@ fn fast_node_has_left_recursive_boundary(node: &FastRecognizedNode) -> bool {
     }
 }
 
+fn fast_recognized_node_syntax_error_count(node: &FastRecognizedNode) -> usize {
+    match node {
+        FastRecognizedNode::ErrorToken { .. } | FastRecognizedNode::MissingToken { .. } => 1,
+        FastRecognizedNode::Rule { children, .. } => children.syntax_error_count(),
+        FastRecognizedNode::Token { .. } | FastRecognizedNode::LeftRecursiveBoundary { .. } => 0,
+    }
+}
+
 fn fast_recognized_nodes_start_index(nodes: &[Rc<FastRecognizedNode>]) -> Option<usize> {
     nodes
         .iter()
@@ -7694,6 +7752,18 @@ const fn fast_recognized_node_stop_index(node: &FastRecognizedNode) -> Option<us
 
 fn recognized_nodes_start_index(nodes: &[RecognizedNode]) -> Option<usize> {
     nodes.iter().find_map(recognized_node_start_index)
+}
+
+fn recognized_nodes_syntax_error_count(nodes: &[RecognizedNode]) -> usize {
+    nodes.iter().map(recognized_node_syntax_error_count).sum()
+}
+
+fn recognized_node_syntax_error_count(node: &RecognizedNode) -> usize {
+    match node {
+        RecognizedNode::ErrorToken { .. } | RecognizedNode::MissingToken { .. } => 1,
+        RecognizedNode::Rule { children, .. } => recognized_nodes_syntax_error_count(children),
+        RecognizedNode::Token { .. } | RecognizedNode::LeftRecursiveBoundary { .. } => 0,
+    }
 }
 
 const fn recognized_node_start_index(node: &RecognizedNode) -> Option<usize> {
@@ -8321,6 +8391,10 @@ where
         self.build_parse_trees = build;
     }
 
+    fn number_of_syntax_errors(&self) -> usize {
+        Self::number_of_syntax_errors(self)
+    }
+
     fn report_diagnostic_errors(&self) -> bool {
         self.report_diagnostic_errors
     }
@@ -8554,6 +8628,7 @@ mod tests {
             .expect("single extraneous token recovers");
         assert_eq!(children.len(), 1);
         assert!(matches!(children[0], ParseTree::Error(_)));
+        assert_eq!(single.number_of_syntax_errors(), 1);
         // Exactly one token consumed (the cursor now sits on `b`).
         assert_eq!(single.la(1), 2);
 
@@ -8617,6 +8692,7 @@ mod tests {
             .expect("single token before EOF recovers");
         assert_eq!(children.len(), 1);
         assert!(matches!(children[0], ParseTree::Error(_)));
+        assert_eq!(parser.number_of_syntax_errors(), 1);
         assert_eq!(
             parser.la(1),
             TOKEN_EOF,
@@ -8678,6 +8754,7 @@ mod tests {
             .expect("loop-back multi-token deletion recovers onto EOF");
         assert_eq!(children.len(), 2, "both `c`s deleted as error nodes");
         assert!(children.iter().all(|c| matches!(c, ParseTree::Error(_))));
+        assert_eq!(parser.number_of_syntax_errors(), 2);
         assert_eq!(parser.la(1), TOKEN_EOF, "EOF left for the rule's EOF match");
     }
 
@@ -9043,6 +9120,7 @@ mod tests {
                 invoking_state: 1,
             },
         ];
+        assert_eq!(parser.number_of_syntax_errors(), 0);
 
         let node = parser
             .match_token_recovering(2, 5, &atn)
@@ -9054,6 +9132,7 @@ mod tests {
         // so no EOF terminal is consumed even though lookahead is EOF.
         assert!(!node.consumed_eof());
         assert_eq!(parser.la(1), TOKEN_EOF);
+        assert_eq!(parser.number_of_syntax_errors(), 1);
         assert_eq!(
             parser.generated_parser_diagnostics,
             [ParserDiagnostic {
@@ -9062,6 +9141,81 @@ mod tests {
                 message: "missing 'Y' at '<EOF>'".to_owned(),
             }]
         );
+    }
+
+    #[test]
+    fn generated_match_token_counts_single_token_deletion_recovery() {
+        let atn = generated_match_recovery_atn();
+        let data = RecognizerData::new(
+            "Mini.g4",
+            Vocabulary::new(
+                [None, Some("'X'"), Some("'Y'"), Some("'Z'")],
+                [None, Some("X"), Some("Y"), Some("Z")],
+                [None::<&str>, None, None, None],
+            ),
+        );
+        let mut parser = BaseParser::new(
+            CommonTokenStream::new(Source {
+                tokens: vec![
+                    CommonToken::new(3).with_text("z"),
+                    CommonToken::new(2).with_text("y"),
+                    CommonToken::eof("parser-test", 3, 1, 3),
+                ],
+                index: 0,
+            }),
+            data,
+        );
+
+        let node = parser
+            .match_token_recovering(2, 5, &atn)
+            .expect("generated match should delete the extraneous token");
+
+        assert_eq!(node.children().len(), 2);
+        assert!(matches!(node.children()[0], ParseTree::Error(_)));
+        assert_eq!(node.children()[0].text(), "z");
+        assert_eq!(node.children()[1].text(), "y");
+        assert_eq!(parser.number_of_syntax_errors(), 1);
+    }
+
+    #[test]
+    fn generated_diagnostic_restore_rolls_back_syntax_error_count() {
+        let atn = generated_match_recovery_atn();
+        let data = RecognizerData::new(
+            "Mini.g4",
+            Vocabulary::new(
+                [None, Some("'X'"), Some("'Y'")],
+                [None, Some("X"), Some("Y")],
+                [None::<&str>, None, None],
+            ),
+        );
+        let mut parser = BaseParser::new(
+            CommonTokenStream::new(Source {
+                tokens: vec![CommonToken::eof("parser-test", 3, 1, 3)],
+                index: 0,
+            }),
+            data,
+        );
+        parser.rule_context_stack = vec![
+            RuleContextFrame {
+                rule_index: 0,
+                invoking_state: 0,
+            },
+            RuleContextFrame {
+                rule_index: 1,
+                invoking_state: 1,
+            },
+        ];
+        let marker = parser.generated_diagnostics_checkpoint();
+
+        let _ = parser
+            .match_token_recovering(2, 5, &atn)
+            .expect("generated match should insert missing token");
+        assert_eq!(parser.number_of_syntax_errors(), 1);
+
+        parser.restore_generated_diagnostics(marker);
+
+        assert_eq!(parser.number_of_syntax_errors(), 0);
+        assert!(parser.generated_parser_diagnostics.is_empty());
     }
 
     #[test]
@@ -9265,6 +9419,7 @@ mod tests {
 
         assert_eq!(parser.la(1), TOKEN_EOF);
         assert_eq!(tree.to_string_tree(&["s", "a"]), "(a z)");
+        assert_eq!(parser.number_of_syntax_errors(), 1);
         assert_eq!(
             parser.generated_parser_diagnostics,
             [ParserDiagnostic {
@@ -9436,6 +9591,7 @@ mod tests {
             .parse_atn_rule(&atn, 0)
             .expect("artificial parser rule should parse");
         assert_eq!(tree.text(), "x<EOF>");
+        assert_eq!(parser.number_of_syntax_errors(), 0);
         assert_eq!(
             tree.first_rule_stop(0)
                 .expect("rule should stop at EOF")
@@ -9485,6 +9641,28 @@ mod tests {
         assert_eq!(stream.token_source().index, source_index_after_parse);
         assert_eq!(stream.tokens()[0].text(), Some("x"));
         assert_eq!(stream.tokens()[1].token_type(), TOKEN_EOF);
+    }
+
+    #[test]
+    fn parser_syntax_error_count_tracks_interpreted_recovery() {
+        let atn = token_then_eof_atn();
+        let mut parser = mini_parser(vec![
+            CommonToken::new(1).with_text("x"),
+            CommonToken::new(2).with_text("y"),
+            CommonToken::eof("parser-test", 2, 1, 2),
+        ]);
+
+        let tree = parser
+            .parse_atn_rule(&atn, 0)
+            .expect("invalid token should recover into an error node");
+
+        assert_eq!(parser.number_of_syntax_errors(), 1);
+        assert_eq!(
+            tree.first_error_token()
+                .expect("recovery should embed an error token")
+                .text(),
+            Some("y")
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- add `Parser::number_of_syntax_errors()` and a `BaseParser` counter for committed parser recovery
- count generated and interpreted recovery paths, including rollback for speculative generated branches
- delegate the API from generated parsers and cover insertion/deletion/recovery behavior in tests

Closes #24

## Validation
- `cargo +1.95.0 test --locked`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --all --check` was run, but it reports pre-existing rustfmt diffs in unrelated files (`src/atn/parser.rs`, `src/prediction.rs`) and was not applied to keep this PR scoped.