### PR TITLE
[codex] Surface unsupported lexer actions

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -4332,6 +4332,7 @@ fn lexer_action_templates(
     }
     let templates = extract_lexer_action_templates(grammar_source, &data.rule_names);
     if actions.len() == templates.len() {
+        reject_mixed_lexer_action_templates(&templates)?;
         return Ok(actions.into_iter().zip(templates).collect());
     }
     Err(io::Error::new(
@@ -4374,6 +4375,26 @@ fn extract_lexer_action_templates(
         ));
     }
     actions
+}
+
+fn reject_mixed_lexer_action_templates(actions: &[ActionTemplate]) -> io::Result<()> {
+    let has_supported_dispatch = actions.iter().any(lexer_action_template_needs_dispatch);
+    if !has_supported_dispatch {
+        return Ok(());
+    }
+    if let Some(ActionTemplate::UnsupportedLexerAction { rule_name, body }) = actions
+        .iter()
+        .find(|action| matches!(action, ActionTemplate::UnsupportedLexerAction { .. }))
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported embedded lexer action in rule {rule_name}: {{{body}}}; \
+                 rewrite target-specific actions as portable lexer commands where possible"
+            ),
+        ));
+    }
+    Ok(())
 }
 
 fn parse_lexer_action_block_template(body: &str) -> Option<ActionTemplate> {
@@ -6367,10 +6388,16 @@ fn render_lexer_action_method(actions: &[((i32, i32), ActionTemplate)]) -> Strin
 }
 
 fn lexer_actions_need_dispatch(actions: &[((i32, i32), ActionTemplate)]) -> bool {
-    actions.iter().any(|(_, template)| match template {
+    actions
+        .iter()
+        .any(|(_, template)| lexer_action_template_needs_dispatch(template))
+}
+
+fn lexer_action_template_needs_dispatch(template: &ActionTemplate) -> bool {
+    match template {
         ActionTemplate::UnsupportedLexerAction { .. } => false,
         _ => !render_lexer_action_statement(template).is_empty(),
-    })
+    }
 }
 
 /// Renders one supported lexer target-template action as Rust code.
@@ -9778,6 +9805,25 @@ ID: [a-z]+ { customJava(); };
         assert!(method.contains("TODO unsupported embedded lexer action in rule ID"));
         assert!(!method.contains("fn run_action"));
         assert_eq!(rust_block_comment_text("a */ b"), "a * / b");
+    }
+
+    #[test]
+    fn mixed_supported_and_unsupported_lexer_actions_fail_generation() {
+        let actions = vec![
+            ActionTemplate::UnsupportedLexerAction {
+                rule_name: "ID".to_owned(),
+                body: "setType(Foo);".to_owned(),
+            },
+            ActionTemplate::LexerPopMode,
+        ];
+
+        let error = reject_mixed_lexer_action_templates(&actions).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains(
+            "unsupported embedded lexer action in rule ID: {setType(Foo);}; \
+                 rewrite target-specific actions as portable lexer commands where possible"
+        ));
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -42,7 +42,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .lexer_name
             .clone()
             .unwrap_or_else(|| grammar_name_from_path(&lexer));
-        let module = render_lexer(&grammar_name, &data, grammar_source.as_deref())?;
+        let module = render_lexer(
+            &grammar_name,
+            &data,
+            grammar_source.as_deref(),
+            args.allow_unsupported_lexer_actions,
+        )?;
         fs::write(
             args.out_dir
                 .join(format!("{}.rs", module_name(&grammar_name))),
@@ -83,6 +88,7 @@ struct Args {
     grammar: Option<PathBuf>,
     out_dir: PathBuf,
     require_generated_parser: bool,
+    allow_unsupported_lexer_actions: bool,
 }
 
 impl Args {
@@ -101,6 +107,7 @@ impl Args {
         let mut grammar = None;
         let mut out_dir = None;
         let mut require_generated_parser = false;
+        let mut allow_unsupported_lexer_actions = false;
 
         let mut iter = env::args().skip(1);
         while let Some(arg) = iter.next() {
@@ -112,6 +119,7 @@ impl Args {
                 "--grammar" => grammar = Some(PathBuf::from(next_arg(&mut iter, "--grammar")?)),
                 "--out-dir" => out_dir = Some(PathBuf::from(next_arg(&mut iter, "--out-dir")?)),
                 "--require-generated-parser" => require_generated_parser = true,
+                "--allow-unsupported-lexer-actions" => allow_unsupported_lexer_actions = true,
                 "--help" | "-h" => return Err(usage()),
                 other => return Err(format!("unknown argument {other}\n\n{}", usage())),
             }
@@ -132,6 +140,7 @@ impl Args {
             grammar,
             out_dir: out_dir.unwrap_or_else(|| PathBuf::from(".")),
             require_generated_parser,
+            allow_unsupported_lexer_actions,
         })
     }
 }
@@ -142,7 +151,7 @@ fn next_arg(iter: &mut impl Iterator<Item = String>, flag: &str) -> Result<Strin
 }
 
 fn usage() -> String {
-    "usage: antlr4-rust-gen [--lexer Lexer.interp] [--parser Parser.interp] [--grammar Grammar.g4] [--out-dir DIR] [--require-generated-parser]"
+    "usage: antlr4-rust-gen [--lexer Lexer.interp] [--parser Parser.interp] [--grammar Grammar.g4] [--out-dir DIR] [--require-generated-parser] [--allow-unsupported-lexer-actions]"
         .to_owned()
 }
 
@@ -266,13 +275,14 @@ fn render_lexer(
     grammar_name: &str,
     data: &InterpData,
     grammar_source: Option<&str>,
+    allow_unsupported_lexer_actions: bool,
 ) -> io::Result<String> {
     let type_name = rust_type_name(grammar_name);
     let metadata = render_metadata(grammar_name, data);
     let token_constants = render_token_constants(data);
     let actions = grammar_source.map_or_else(
         || Ok(Vec::new()),
-        |source| lexer_action_templates(data, source),
+        |source| lexer_action_templates(data, source, allow_unsupported_lexer_actions),
     )?;
     let predicates = grammar_source.map_or_else(
         || Ok(Vec::new()),
@@ -4325,6 +4335,7 @@ struct IntMemberTemplate {
 fn lexer_action_templates(
     data: &InterpData,
     grammar_source: &str,
+    allow_unsupported_only: bool,
 ) -> io::Result<Vec<((i32, i32), ActionTemplate)>> {
     let actions = lexer_custom_actions(data)?;
     if actions.is_empty() {
@@ -4332,7 +4343,7 @@ fn lexer_action_templates(
     }
     let templates = extract_lexer_action_templates(grammar_source, &data.rule_names);
     if actions.len() == templates.len() {
-        reject_mixed_lexer_action_templates(&templates)?;
+        reject_unsupported_lexer_action_templates(&templates, allow_unsupported_only)?;
         return Ok(actions.into_iter().zip(templates).collect());
     }
     Err(io::Error::new(
@@ -4377,15 +4388,18 @@ fn extract_lexer_action_templates(
     actions
 }
 
-fn reject_mixed_lexer_action_templates(actions: &[ActionTemplate]) -> io::Result<()> {
-    let has_supported_dispatch = actions.iter().any(lexer_action_template_needs_dispatch);
-    if !has_supported_dispatch {
-        return Ok(());
-    }
+fn reject_unsupported_lexer_action_templates(
+    actions: &[ActionTemplate],
+    allow_unsupported_only: bool,
+) -> io::Result<()> {
     if let Some(ActionTemplate::UnsupportedLexerAction { rule_name, body }) = actions
         .iter()
         .find(|action| matches!(action, ActionTemplate::UnsupportedLexerAction { .. }))
     {
+        let has_supported_dispatch = actions.iter().any(lexer_action_template_needs_dispatch);
+        if allow_unsupported_only && !has_supported_dispatch {
+            return Ok(());
+        }
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!(
@@ -9805,10 +9819,19 @@ ID: [a-z]+ { customJava(); };
         assert!(method.contains("TODO unsupported embedded lexer action in rule ID"));
         assert!(!method.contains("fn run_action"));
         assert_eq!(rust_block_comment_text("a */ b"), "a * / b");
+
+        let error = reject_unsupported_lexer_action_templates(&actions, false).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains(
+            "unsupported embedded lexer action in rule ID: {customJava();}; \
+                 rewrite target-specific actions as portable lexer commands where possible"
+        ));
+        reject_unsupported_lexer_action_templates(&actions, true)
+            .expect("unsupported-only lexer actions should be allowed in compatibility mode");
     }
 
     #[test]
-    fn mixed_supported_and_unsupported_lexer_actions_fail_generation() {
+    fn mixed_supported_and_unsupported_lexer_actions_fail_even_when_allowed() {
         let actions = vec![
             ActionTemplate::UnsupportedLexerAction {
                 rule_name: "ID".to_owned(),
@@ -9817,7 +9840,7 @@ ID: [a-z]+ { customJava(); };
             ActionTemplate::LexerPopMode,
         ];
 
-        let error = reject_mixed_lexer_action_templates(&actions).unwrap_err();
+        let error = reject_unsupported_lexer_action_templates(&actions, true).unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert!(error.to_string().contains(

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -22,9 +22,9 @@ use rust_names::{
 };
 use templates::{
     is_after_action, is_definitions_action, is_init_action, is_members_action, is_options_block,
-    matching_template_close, named_action_templates, next_parser_action_block,
-    next_predicate_action_block, next_template_block, parse_template_string,
-    split_template_arguments, template_sequence_bodies,
+    matching_action_brace, matching_template_close, named_action_templates,
+    next_parser_action_block, next_predicate_action_block, next_template_block,
+    parse_template_string, split_template_arguments, template_sequence_bodies,
 };
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -279,6 +279,7 @@ fn render_lexer(
         |source| lexer_predicate_templates(data, source),
     )?;
     let adjusts_accept_position = grammar_source.is_some_and(uses_position_adjusting_lexer);
+    let has_action_dispatch = lexer_actions_need_dispatch(&actions);
     let action_method = render_lexer_action_method(&actions);
     let predicate_method = render_lexer_predicate_method(&predicates);
     let accept_adjust_method = if adjusts_accept_position {
@@ -287,7 +288,7 @@ fn render_lexer(
         String::new()
     };
     let next_token_call = match (
-        actions.is_empty(),
+        !has_action_dispatch,
         predicates.is_empty(),
         adjusts_accept_position,
     ) {
@@ -4188,6 +4189,11 @@ enum ActionTemplate {
         member: String,
         newline: bool,
     },
+    LexerPopMode,
+    UnsupportedLexerAction {
+        rule_name: String,
+        body: String,
+    },
     Sequence(Vec<Self>),
 }
 
@@ -4320,31 +4326,126 @@ fn lexer_action_templates(
     data: &InterpData,
     grammar_source: &str,
 ) -> io::Result<Vec<((i32, i32), ActionTemplate)>> {
-    let templates = extract_supported_action_templates(grammar_source)?;
-    if templates.is_empty() {
-        return Ok(Vec::new());
-    }
     let actions = lexer_custom_actions(data)?;
     if actions.is_empty() {
         return Ok(Vec::new());
     }
+    let templates = extract_lexer_action_templates(grammar_source, &data.rule_names);
     if actions.len() == templates.len() {
         return Ok(actions.into_iter().zip(templates).collect());
     }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "lexer ATN has {} custom action(s), but grammar source yielded {} lexer action template(s)",
+            actions.len(),
+            templates.len()
+        ),
+    ))
+}
 
-    let filtered_templates =
-        extract_supported_rule_action_templates(grammar_source, &data.rule_names)?;
-    if actions.len() != filtered_templates.len() {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!(
-                "grammar has {} supported action template(s), but lexer ATN has {} custom action(s)",
-                filtered_templates.len(),
-                actions.len()
-            ),
+/// Extracts lexer action templates in the same source order ANTLR uses for
+/// custom lexer-action indexes.
+fn extract_lexer_action_templates(
+    grammar_source: &str,
+    rule_names: &[String],
+) -> Vec<ActionTemplate> {
+    let mut actions = Vec::new();
+    let mut offset = 0;
+    while let Some(block) = next_action_block(grammar_source, offset) {
+        offset = block.after_brace;
+        if block.predicate
+            || !rule_action_included(grammar_source, block.open_brace, Some(rule_names))
+            || is_after_action(grammar_source, block.open_brace)
+            || is_init_action(grammar_source, block.open_brace)
+            || is_definitions_action(grammar_source, block.open_brace)
+            || is_members_action(grammar_source, block.open_brace)
+            || is_options_block(grammar_source, block.open_brace)
+        {
+            continue;
+        }
+        let template = parse_lexer_action_block_template(block.body).unwrap_or_else(|| {
+            unsupported_lexer_action_template(grammar_source, block.open_brace, block.body)
+        });
+        actions.push(resolve_action_template_labels(
+            template,
+            grammar_source,
+            block.open_brace,
         ));
     }
-    Ok(actions.into_iter().zip(filtered_templates).collect())
+    actions
+}
+
+fn parse_lexer_action_block_template(body: &str) -> Option<ActionTemplate> {
+    parse_action_block_template(body).or_else(|| parse_lexer_pop_mode_action(body))
+}
+
+fn parse_lexer_pop_mode_action(body: &str) -> Option<ActionTemplate> {
+    let body = body
+        .chars()
+        .filter(|ch| !ch.is_ascii_whitespace() && *ch != ';')
+        .collect::<String>();
+    matches!(
+        body.as_str(),
+        "popMode()"
+            | "this.popMode()"
+            | "if(!_modeStack.isEmpty()){popMode()}"
+            | "if(!this._modeStack.isEmpty()){popMode()}"
+            | "if(!_modeStack.isEmpty())popMode()"
+            | "if(!this._modeStack.isEmpty())popMode()"
+    )
+    .then_some(ActionTemplate::LexerPopMode)
+}
+
+fn unsupported_lexer_action_template(
+    source: &str,
+    open_brace: usize,
+    body: &str,
+) -> ActionTemplate {
+    let rule = statement_rule_header(source, open_brace).map_or("<unknown>", |header| header.name);
+    ActionTemplate::UnsupportedLexerAction {
+        rule_name: rule.to_owned(),
+        body: one_line_action_body(body),
+    }
+}
+
+fn one_line_action_body(body: &str) -> String {
+    const ACTION_SUMMARY_LIMIT: usize = 96;
+
+    let mut out = String::new();
+    for (index, part) in body.split_whitespace().enumerate() {
+        if index > 0 {
+            out.push(' ');
+        }
+        out.push_str(part);
+        if out.len() > ACTION_SUMMARY_LIMIT {
+            let mut limit = ACTION_SUMMARY_LIMIT;
+            while !out.is_char_boundary(limit) {
+                limit -= 1;
+            }
+            out.truncate(limit);
+            out.push_str("...");
+            break;
+        }
+    }
+    out
+}
+
+fn rust_block_comment_text(value: &str) -> String {
+    let mut out = String::new();
+    let mut cursor = 0;
+    while let Some(relative_index) = value[cursor..].find("*/") {
+        let index = cursor + relative_index;
+        out.push_str(&value[cursor..index]);
+        out.push_str("* /");
+        cursor = index + 2;
+    }
+    if cursor == 0 {
+        value.to_owned()
+    } else {
+        out.push_str(&value[cursor..]);
+        out
+    }
 }
 
 /// Pairs supported lexer semantic predicates with serialized predicate
@@ -4630,6 +4731,103 @@ fn rule_action_included(source: &str, position: usize, rule_names: Option<&[Stri
     };
     rule_names.is_none_or(|names| names.iter().any(|name| name == header.name))
         && !has_prior_rule_definition(source, header.name, header.start)
+}
+
+fn next_action_block(source: &str, offset: usize) -> Option<templates::TemplateBlock<'_>> {
+    let open_brace = find_action_open_brace(source, offset)?;
+    let close_brace = matching_action_brace(source, open_brace + 1)?;
+    let after_brace = close_brace + 1;
+    Some(templates::TemplateBlock {
+        open_brace,
+        body: &source[open_brace + 1..close_brace],
+        after_brace,
+        predicate: source[after_brace..].trim_start().starts_with('?'),
+    })
+}
+
+fn find_action_open_brace(source: &str, offset: usize) -> Option<usize> {
+    let mut index = offset;
+    let mut single_quoted = false;
+    let mut double_quoted = false;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut char_set = false;
+    while let Some(ch) = source[index..].chars().next() {
+        let size = ch.len_utf8();
+        if line_comment {
+            line_comment = ch != '\n';
+            index += size;
+            continue;
+        }
+        if block_comment {
+            if source.as_bytes().get(index..index + 2) == Some(b"*/") {
+                block_comment = false;
+                index += 2;
+            } else {
+                index += size;
+            }
+            continue;
+        }
+        if char_set {
+            match ch {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                ']' => char_set = false,
+                _ => {}
+            }
+            index += size;
+            continue;
+        }
+        if escaped {
+            escaped = false;
+            index += size;
+            continue;
+        }
+        if single_quoted {
+            match ch {
+                '\\' => escaped = true,
+                '\'' => single_quoted = false,
+                _ => {}
+            }
+            index += size;
+            continue;
+        }
+        if double_quoted {
+            match ch {
+                '\\' => escaped = true,
+                '"' => double_quoted = false,
+                _ => {}
+            }
+            index += size;
+            continue;
+        }
+        match ch {
+            '/' if source.as_bytes().get(index..index + 2) == Some(b"//") => {
+                line_comment = true;
+                index += 2;
+            }
+            '/' if source.as_bytes().get(index..index + 2) == Some(b"/*") => {
+                block_comment = true;
+                index += 2;
+            }
+            '\'' => {
+                single_quoted = true;
+                index += size;
+            }
+            '"' => {
+                double_quoted = true;
+                index += size;
+            }
+            '[' => {
+                char_set = true;
+                index += size;
+            }
+            '{' => return Some(index),
+            _ => index += size,
+        }
+    }
+    None
 }
 
 /// Finds grammar predicate templates in the same order as ANTLR serializes
@@ -5914,7 +6112,9 @@ fn render_inline_parser_action_statement(
         | ActionTemplate::TokenDisplay { .. }
         | ActionTemplate::ExpectedTokenNames { .. }
         | ActionTemplate::Literal { .. }
-        | ActionTemplate::MemberValue { .. } => Ok(String::new()),
+        | ActionTemplate::MemberValue { .. }
+        | ActionTemplate::UnsupportedLexerAction { .. }
+        | ActionTemplate::LexerPopMode => Ok(String::new()),
     }
 }
 
@@ -6022,7 +6222,9 @@ fn collect_return_actions(
         | ActionTemplate::Literal { .. }
         | ActionTemplate::SetMember { .. }
         | ActionTemplate::AddMember { .. }
-        | ActionTemplate::MemberValue { .. } => {}
+        | ActionTemplate::MemberValue { .. }
+        | ActionTemplate::UnsupportedLexerAction { .. }
+        | ActionTemplate::LexerPopMode => {}
     }
 }
 
@@ -6071,7 +6273,9 @@ fn collect_member_actions(
         | ActionTemplate::ExpectedTokenNames { .. }
         | ActionTemplate::Literal { .. }
         | ActionTemplate::SetMember { .. }
-        | ActionTemplate::MemberValue { .. } => {}
+        | ActionTemplate::MemberValue { .. }
+        | ActionTemplate::UnsupportedLexerAction { .. }
+        | ActionTemplate::LexerPopMode => {}
     }
     Ok(())
 }
@@ -6133,6 +6337,20 @@ fn render_lexer_action_method(actions: &[((i32, i32), ActionTemplate)]) -> Strin
     if actions.is_empty() {
         return String::new();
     }
+    let mut comments = String::new();
+    for (_, template) in actions {
+        if let ActionTemplate::UnsupportedLexerAction { rule_name, body } = template {
+            writeln!(
+                comments,
+                "    {}",
+                render_unsupported_lexer_action_comment(rule_name, body)
+            )
+            .expect("writing to a string cannot fail");
+        }
+    }
+    if !lexer_actions_need_dispatch(actions) {
+        return comments;
+    }
     let mut arms = String::new();
     for ((rule_index, action_index), template) in actions {
         let statement = render_lexer_action_statement(template);
@@ -6144,8 +6362,15 @@ fn render_lexer_action_method(actions: &[((i32, i32), ActionTemplate)]) -> Strin
     }
     arms.push_str("            _ => {}\n");
     format!(
-        "    fn run_action(_base: &mut BaseLexer<I>, action: antlr4_runtime::LexerCustomAction) {{\n        match (action.rule_index(), action.action_index()) {{\n{arms}        }}\n    }}\n"
+        "{comments}    fn run_action(_base: &mut BaseLexer<I>, action: antlr4_runtime::LexerCustomAction) {{\n        match (action.rule_index(), action.action_index()) {{\n{arms}        }}\n    }}\n"
     )
+}
+
+fn lexer_actions_need_dispatch(actions: &[((i32, i32), ActionTemplate)]) -> bool {
+    actions.iter().any(|(_, template)| match template {
+        ActionTemplate::UnsupportedLexerAction { .. } => false,
+        _ => !render_lexer_action_statement(template).is_empty(),
+    })
 }
 
 /// Renders one supported lexer target-template action as Rust code.
@@ -6192,6 +6417,10 @@ fn render_lexer_action_statement(template: &ActionTemplate) -> String {
         ActionTemplate::SetMember { .. } => String::new(),
         ActionTemplate::AddMember { .. } => String::new(),
         ActionTemplate::MemberValue { .. } => String::new(),
+        ActionTemplate::LexerPopMode => "_base.pop_mode();".to_owned(),
+        ActionTemplate::UnsupportedLexerAction { rule_name, body } => {
+            render_unsupported_lexer_action_comment(rule_name, body)
+        }
         ActionTemplate::Sequence(actions) => actions
             .iter()
             .map(render_lexer_action_statement)
@@ -6202,6 +6431,14 @@ fn render_lexer_action_statement(template: &ActionTemplate) -> String {
             format!("{write}(\"{}\");", rust_string(value))
         }
     }
+}
+
+fn render_unsupported_lexer_action_comment(rule_name: &str, body: &str) -> String {
+    format!(
+        "/* TODO unsupported embedded lexer action in rule {}: {{{}}}; rewrite target-specific actions as portable lexer commands where possible */",
+        rust_block_comment_text(rule_name),
+        rust_block_comment_text(body)
+    )
 }
 
 /// Emits the generated lexer predicate dispatcher for grammar-specific
@@ -6427,6 +6664,8 @@ fn render_action_statement(
                 "{write}(\"{{}}\", self.base.int_member({member}).unwrap_or_default());"
             ))
         }
+        ActionTemplate::UnsupportedLexerAction { .. } => Ok(String::new()),
+        ActionTemplate::LexerPopMode => Ok(String::new()),
         ActionTemplate::Sequence(actions) => {
             let mut rendered = Vec::with_capacity(actions.len());
             for action in actions {
@@ -6534,7 +6773,9 @@ fn render_parser_after_action_statement(template: &ActionTemplate, rule_index: u
         ActionTemplate::SetIntReturn { .. }
         | ActionTemplate::SetMember { .. }
         | ActionTemplate::AddMember { .. }
-        | ActionTemplate::MemberValue { .. } => String::new(),
+        | ActionTemplate::MemberValue { .. }
+        | ActionTemplate::UnsupportedLexerAction { .. }
+        | ActionTemplate::LexerPopMode => String::new(),
         ActionTemplate::Sequence(actions) => actions
             .iter()
             .map(|action| render_parser_after_action_statement(action, rule_index))
@@ -9449,6 +9690,103 @@ continue returns [<IntArg("return")>] : {<AssignLocal("$return","0")>} ;"#,
                 text: "var".to_owned(),
             })
         );
+    }
+
+    #[test]
+    fn maps_kotlin_rcurl_java_action_to_lexer_pop_mode() {
+        for body in [
+            "popMode()",
+            "popMode();",
+            "this.popMode()",
+            "this.popMode();",
+            "if (!_modeStack.isEmpty()) { popMode(); }",
+            "if (!this._modeStack.isEmpty()) { popMode(); }",
+            "if (!_modeStack.isEmpty()) popMode()",
+            "if (!this._modeStack.isEmpty()) popMode();",
+        ] {
+            assert_eq!(
+                parse_lexer_pop_mode_action(body),
+                Some(ActionTemplate::LexerPopMode),
+                "{body}"
+            );
+        }
+
+        let grammar = r#"
+lexer grammar KotlinLexer;
+
+LCURL: '{' -> pushMode(DEFAULT_MODE);
+RCURL: '}' { if (!_modeStack.isEmpty()) { popMode(); } };
+LineStrRef: '${' -> pushMode(DEFAULT_MODE);
+"#;
+        let rule_names = vec![
+            "LCURL".to_owned(),
+            "RCURL".to_owned(),
+            "LineStrRef".to_owned(),
+        ];
+
+        let actions = extract_lexer_action_templates(grammar, &rule_names);
+
+        assert_eq!(actions, [ActionTemplate::LexerPopMode]);
+        let method = render_lexer_action_method(&[((1, 0), actions[0].clone())]);
+        assert!(method.contains("fn run_action"));
+        assert!(method.contains("_base.pop_mode();"));
+    }
+
+    #[test]
+    fn lexer_action_scan_ignores_braces_inside_character_sets() {
+        let grammar = r#"
+lexer grammar L;
+
+LETTER: [\p{L}{}]+;
+ESCAPED_RBRACK: [\]]+;
+RCURL: '}' { popMode(); };
+"#;
+        let rule_names = vec![
+            "LETTER".to_owned(),
+            "ESCAPED_RBRACK".to_owned(),
+            "RCURL".to_owned(),
+        ];
+
+        let actions = extract_lexer_action_templates(grammar, &rule_names);
+
+        assert_eq!(actions, [ActionTemplate::LexerPopMode]);
+    }
+
+    #[test]
+    fn unsupported_lexer_action_renders_todo_marker() {
+        let grammar = r#"
+lexer grammar L;
+
+ID: [a-z]+ { customJava(); };
+"#;
+        let rule_names = vec!["ID".to_owned()];
+
+        let actions = extract_lexer_action_templates(grammar, &rule_names);
+
+        assert_eq!(
+            actions,
+            [ActionTemplate::UnsupportedLexerAction {
+                rule_name: "ID".to_owned(),
+                body: "customJava();".to_owned(),
+            }]
+        );
+        assert_eq!(
+            render_lexer_action_statement(&actions[0]),
+            "/* TODO unsupported embedded lexer action in rule ID: {customJava();}; rewrite target-specific actions as portable lexer commands where possible */"
+        );
+        let method = render_lexer_action_method(&[((1, 0), actions[0].clone())]);
+        assert!(method.contains("TODO unsupported embedded lexer action in rule ID"));
+        assert!(!method.contains("fn run_action"));
+        assert_eq!(rust_block_comment_text("a */ b"), "a * / b");
+    }
+
+    #[test]
+    fn lexer_action_diagnostic_summary_truncates_on_char_boundary() {
+        let body = format!("{}\u{00e9} tail", "a".repeat(95));
+
+        let summary = one_line_action_body(&body);
+
+        assert_eq!(summary, format!("{}...", "a".repeat(95)));
     }
 
     fn linear_rule_atn() -> Atn {

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -4944,21 +4944,108 @@ struct RuleHeader<'a> {
 /// Returns the grammar rule that owns an action or signature position by reading
 /// the current rule header before the first colon in the statement.
 fn statement_rule_header(source: &str, position: usize) -> Option<RuleHeader<'_>> {
-    let prefix = source.get(..position)?;
-    let (start, header) = prefix.rfind(':').map_or_else(
-        || {
-            let header_start = prefix.rfind([';', '}']).map_or(0, |index| index + 1);
-            (header_start, &prefix[header_start..])
-        },
-        |colon| {
-            let header_start = source[..colon]
-                .rfind([';', '}'])
-                .map_or(0, |index| index + 1);
-            (header_start, &source[header_start..colon])
-        },
-    );
+    source.get(..position)?;
+    let colon = last_rule_header_colon(source, position)?;
+    let start = source[..colon]
+        .rfind([';', '}'])
+        .map_or(0, |index| index + 1);
+    let header = &source[start..colon];
     let name = leading_rule_name(header)?;
     Some(RuleHeader { name, start })
+}
+
+fn last_rule_header_colon(source: &str, position: usize) -> Option<usize> {
+    let mut last = None;
+    let mut index = 0;
+    let mut single_quoted = false;
+    let mut double_quoted = false;
+    let mut escaped = false;
+    let mut line_comment = false;
+    let mut block_comment = false;
+    let mut char_set = false;
+    while index < position {
+        let ch = source[index..].chars().next()?;
+        let size = ch.len_utf8();
+        if line_comment {
+            line_comment = ch != '\n';
+            index += size;
+            continue;
+        }
+        if block_comment {
+            if source.as_bytes().get(index..index + 2) == Some(b"*/") {
+                block_comment = false;
+                index += 2;
+            } else {
+                index += size;
+            }
+            continue;
+        }
+        if char_set {
+            match ch {
+                _ if escaped => escaped = false,
+                '\\' => escaped = true,
+                ']' => char_set = false,
+                _ => {}
+            }
+            index += size;
+            continue;
+        }
+        if escaped {
+            escaped = false;
+            index += size;
+            continue;
+        }
+        if single_quoted {
+            match ch {
+                '\\' => escaped = true,
+                '\'' => single_quoted = false,
+                _ => {}
+            }
+            index += size;
+            continue;
+        }
+        if double_quoted {
+            match ch {
+                '\\' => escaped = true,
+                '"' => double_quoted = false,
+                _ => {}
+            }
+            index += size;
+            continue;
+        }
+        match ch {
+            '/' if source.as_bytes().get(index..index + 2) == Some(b"//") => {
+                line_comment = true;
+                index += 2;
+            }
+            '/' if source.as_bytes().get(index..index + 2) == Some(b"/*") => {
+                block_comment = true;
+                index += 2;
+            }
+            '\'' => {
+                single_quoted = true;
+                index += size;
+            }
+            '"' => {
+                double_quoted = true;
+                index += size;
+            }
+            '[' => {
+                char_set = true;
+                index += size;
+            }
+            '{' => {
+                index = matching_action_brace(source, index + 1)
+                    .map_or(index + size, |close| close.saturating_add(1).min(position));
+            }
+            ':' => {
+                last = Some(index);
+                index += size;
+            }
+            _ => index += size,
+        }
+    }
+    last
 }
 
 /// Reports whether an earlier rule with the same name already owns the active
@@ -9791,6 +9878,46 @@ RCURL: '}' { popMode(); };
         let actions = extract_lexer_action_templates(grammar, &rule_names);
 
         assert_eq!(actions, [ActionTemplate::LexerPopMode]);
+    }
+
+    #[test]
+    fn lexer_action_scan_keeps_actions_after_prior_action_templates() {
+        let grammar = r#"
+lexer grammar L;
+I : ({<PlusText("stuff fail: "):writeln()>} 'a'
+| {<PlusText("stuff0:"):writeln()>}
+       'a' {<PlusText("stuff1: "):writeln()>}
+       'b' {<PlusText("stuff2: "):writeln()>})
+       {<Text():writeln()>} ;
+WS : (' '|'\n') -> skip ;
+J : .;
+"#;
+        let rule_names = vec!["I".to_owned(), "WS".to_owned(), "J".to_owned()];
+
+        let actions = extract_lexer_action_templates(grammar, &rule_names);
+
+        assert_eq!(
+            actions,
+            [
+                ActionTemplate::TextWithPrefix {
+                    prefix: "stuff fail: ".to_owned(),
+                    newline: true,
+                },
+                ActionTemplate::TextWithPrefix {
+                    prefix: "stuff0:".to_owned(),
+                    newline: true,
+                },
+                ActionTemplate::TextWithPrefix {
+                    prefix: "stuff1: ".to_owned(),
+                    newline: true,
+                },
+                ActionTemplate::TextWithPrefix {
+                    prefix: "stuff2: ".to_owned(),
+                    newline: true,
+                },
+                ActionTemplate::Text { newline: true },
+            ]
+        );
     }
 
     #[test]

--- a/tests/kotlin-parity/README.md
+++ b/tests/kotlin-parity/README.md
@@ -18,6 +18,7 @@ needed.
 | --- | --- |
 | `snippets/01-nested-types.kt` | nested `interface` / `companion object` / `enum class` with a trailing comma / `sealed class` with inheritance call. Exercises the speculative recognizer's greedy loop tie-breaking on `(enumEntry NL*)+`, FIRST-set lookahead pruning across deeply nested rule alternatives, and left-recursive boundary folding under `expression`. |
 | `snippets/02-dataframe.kt` | imports with wildcards, `@DataSchema` annotation, a `dataFrameOf("int")(1).group { int }.into("group").cast<B>(verify = false)` builder chain with a string literal arg, generic type arguments, and indexed access `df[0].group.int`. Exercises the lexer mode stack (string `"..."` open/close inside `(...)` parens — `popMode` must scope back to the right outer mode), function-call chains with multiple parenthesized argument lists, and named arguments. |
+| `snippets/03-string-templates.kt` | line string templates with `${foo()}`, suffix text after `}`, and following declarations. Regresses the Kotlin `RCURL` mode-pop path: the generated lexer must return to line-string mode after `}` so template suffix text and later statements are tokenized correctly. |
 
 Add new snippets by dropping `.kt` files into `snippets/`; the harness picks
 them up automatically.

--- a/tests/kotlin-parity/snippets/03-string-templates.kt
+++ b/tests/kotlin-parity/snippets/03-string-templates.kt
@@ -1,0 +1,8 @@
+fun foo(): String = "ok"
+
+fun box(): String {
+    val first = "x ${foo()} y"
+    val second = "v=${foo()}"
+
+    return first + second
+}

--- a/tools/parse-bench/run.py
+++ b/tools/parse-bench/run.py
@@ -345,6 +345,7 @@ def generate_rust_modules(
             str(interp_dir / f"{spec.lexer_name}.interp"),
             "--grammar",
             str(grammar_dir / spec.grammar_files[0]),
+            "--allow-unsupported-lexer-actions",
         ]
     )
     parser_cmd = [


### PR DESCRIPTION
## Summary

- Map the Kotlin-style embedded lexer `popMode()` Java action to the Rust lexer `pop_mode()` hook when the serialized ATN contains a custom lexer action.
- Fail generation with an explicit diagnostic for unsupported embedded lexer actions instead of silently omitting them.
- Add a Kotlin string-template parity snippet covering suffix text after `${...}` and following declarations.

## Validation

- `cargo +1.95.0 test --locked`
- `cargo +1.95.0 clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTUP_TOOLCHAIN=1.95.0 tests/kotlin-parity/run.sh --antlr-jar /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar --grammars-v4 /tmp/antlr-cleanroom/grammars-v4 --python /tmp/antlr-cleanroom/venv/bin/python`
- Focused Rust-only Kotlin run with `StrExpr_RCURL` rewritten to the embedded Java `{ if (!_modeStack.isEmpty()) { popMode(); } }` action; generated lexer emitted `_base.pop_mode()` and parsed the string-template snippet.

Note: `cargo fmt --all --check` was run and reports pre-existing rustfmt diffs in `src/atn/parser.rs` and `src/prediction.rs`, which this PR intentionally leaves untouched.

Closes #35