### PR TITLE
FullContextParsing 15/15: Java-parity prediction routing and diagnostics

### DIFF
--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -3,8 +3,9 @@ use crate::dfa::{Dfa, DfaState};
 use crate::int_stream::IntStream;
 use crate::prediction::{
     AtnConfig, AtnConfigSet, EMPTY_RETURN_STATE, PredictionContext, PredictionContextCache,
-    PredictionContextMergeCache, PredictionFxHasher, SemanticContext,
-    has_sll_conflict_terminating_prediction, resolves_to_just_one_viable_alt,
+    PredictionContextMergeCache, PredictionFxHasher, SemanticContext, all_subsets_conflict,
+    all_subsets_equal, conflicting_alt_subsets, has_sll_conflict_terminating_prediction,
+    single_viable_alt,
 };
 use crate::token::TOKEN_EOF;
 use std::cell::RefCell;
@@ -20,6 +21,10 @@ pub struct ParserAtnSimulator<'a> {
     decision_to_dfa: Vec<Dfa>,
     shared_cache_key: Option<usize>,
     context_cache: Rc<RefCell<PredictionContextCache>>,
+    /// Java's `LL_EXACT_AMBIG_DETECTION`: the full-context loop keeps
+    /// consuming past "resolves to one viable alt" conflicts until every
+    /// `(state, context)` subset conflicts over the same alt set.
+    exact_ambig_detection: bool,
 }
 
 thread_local! {
@@ -43,6 +48,10 @@ pub struct ParserAtnPredictionDiagnostic {
     pub sll_stop_index: usize,
     pub ll_stop_index: usize,
     pub conflicting_alts: Vec<usize>,
+    /// For [`ParserAtnPredictionDiagnosticKind::Ambiguity`]: whether the
+    /// full-context loop proved an exact ambiguity (Java's `exact` flag —
+    /// the default `DiagnosticErrorListener` only reports exact ones).
+    pub exact: bool,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -95,7 +104,35 @@ struct DfaPredictionInfo {
 struct FullContextPrediction {
     prediction: ParserAtnPrediction,
     stop_index: usize,
-    ambiguity_alts: Option<Vec<usize>>,
+    resolution: FullContextResolution,
+}
+
+/// How the full-context loop settled, mirroring the two exits of Java's
+/// `execATNWithFullContext`: a truly unique alt (reported as context
+/// sensitivity) or a conflict resolution (reported as ambiguity, exact or
+/// not).
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum FullContextResolution {
+    Unique,
+    Ambiguous { exact: bool, alts: Vec<usize> },
+}
+
+fn full_context_prediction(
+    alt: usize,
+    configs: &AtnConfigSet,
+    stop_index: usize,
+    resolution: FullContextResolution,
+) -> FullContextPrediction {
+    FullContextPrediction {
+        prediction: ParserAtnPrediction {
+            alt,
+            requires_full_context: true,
+            has_semantic_context: configs_have_semantic_context_for_alt(configs, alt),
+            diagnostic: None,
+        },
+        stop_index,
+        resolution,
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
@@ -319,7 +356,14 @@ impl<'a> ParserAtnSimulator<'a> {
             decision_to_dfa: initial_decision_dfas(atn),
             shared_cache_key: None,
             context_cache: Rc::new(RefCell::new(PredictionContextCache::new())),
+            exact_ambig_detection: false,
         }
+    }
+
+    /// Switches the full-context resolution strategy (Java's
+    /// `LL_EXACT_AMBIG_DETECTION` versus plain `LL`).
+    pub const fn set_exact_ambig_detection(&mut self, exact: bool) {
+        self.exact_ambig_detection = exact;
     }
 
     /// Creates a simulator that starts from, and publishes back into, a
@@ -389,6 +433,7 @@ impl<'a> ParserAtnSimulator<'a> {
             decision_to_dfa,
             shared_cache_key: Some(key),
             context_cache,
+            exact_ambig_detection: false,
         }
     }
 
@@ -704,14 +749,18 @@ impl<'a> ParserAtnSimulator<'a> {
                 outer_context,
                 merge_cache,
             )?;
-            let (kind, conflicting_alts) = if let Some(ambiguity_alts) = full_context.ambiguity_alts
-            {
-                (ParserAtnPredictionDiagnosticKind::Ambiguity, ambiguity_alts)
-            } else {
-                (
+            let (kind, exact, conflicting_alts) = match full_context.resolution {
+                FullContextResolution::Ambiguous { exact, ref alts } => {
+                    (ParserAtnPredictionDiagnosticKind::Ambiguity, exact, alts.clone())
+                }
+                // A unique full-context alt after an SLL conflict is Java's
+                // reportContextSensitivity; the SLL state's conflicting alts
+                // describe the conflict that forced the retry.
+                FullContextResolution::Unique => (
                     ParserAtnPredictionDiagnosticKind::ContextSensitivity,
+                    false,
                     info.conflicting_alts,
-                )
+                ),
             };
             let mut prediction = full_context.prediction;
             if conflicting_alts.len() > 1 {
@@ -721,6 +770,7 @@ impl<'a> ParserAtnSimulator<'a> {
                     sll_stop_index,
                     ll_stop_index: full_context.stop_index,
                     conflicting_alts,
+                    exact,
                 });
             }
             return Ok(Some(prediction));
@@ -870,18 +920,21 @@ impl<'a> ParserAtnSimulator<'a> {
             precedence,
             merge_cache,
         );
+        // Java's `execATNWithFullContext`: after each reach set a truly
+        // unique alt resolves as context sensitivity. Otherwise default LL
+        // mode stops at the first "resolves to just one viable alt" conflict
+        // — reported as a NON-exact ambiguity, which the exactOnly listener
+        // suppresses — while LL_EXACT_AMBIG_DETECTION keeps consuming until
+        // every (state, context) subset conflicts over the same alt set: an
+        // exact ambiguity.
         loop {
             if let Some(alt) = configs.unique_alt() {
-                return Ok(FullContextPrediction {
-                    prediction: ParserAtnPrediction {
-                        alt,
-                        requires_full_context: true,
-                        has_semantic_context: configs_have_semantic_context_for_alt(&configs, alt),
-                        diagnostic: None,
-                    },
-                    stop_index: input.index(),
-                    ambiguity_alts: None,
-                });
+                return Ok(full_context_prediction(
+                    alt,
+                    &configs,
+                    input.index(),
+                    FullContextResolution::Unique,
+                ));
             }
             let symbol = input.la(1);
             let reach = self.compute_reach_set(&configs, symbol, true, precedence, merge_cache);
@@ -893,48 +946,59 @@ impl<'a> ParserAtnSimulator<'a> {
             }
             configs = reach;
             if let Some(alt) = configs.unique_alt() {
-                return Ok(FullContextPrediction {
-                    prediction: ParserAtnPrediction {
+                return Ok(full_context_prediction(
+                    alt,
+                    &configs,
+                    input.index(),
+                    FullContextResolution::Unique,
+                ));
+            }
+            if !configs.has_semantic_context() {
+                let subsets = conflicting_alt_subsets(configs.configs());
+                if self.exact_ambig_detection {
+                    if all_subsets_conflict(&subsets) && all_subsets_equal(&subsets) {
+                        let alts: Vec<usize> = configs.alts().into_iter().collect();
+                        let alt = alts[0];
+                        return Ok(full_context_prediction(
+                            alt,
+                            &configs,
+                            input.index(),
+                            FullContextResolution::Ambiguous { exact: true, alts },
+                        ));
+                    }
+                } else if let Some(alt) = single_viable_alt(&subsets) {
+                    let alts: Vec<usize> = configs.alts().into_iter().collect();
+                    return Ok(full_context_prediction(
                         alt,
-                        requires_full_context: true,
-                        has_semantic_context: configs_have_semantic_context_for_alt(&configs, alt),
-                        diagnostic: None,
-                    },
-                    stop_index: input.index(),
-                    ambiguity_alts: None,
-                });
+                        &configs,
+                        input.index(),
+                        FullContextResolution::Ambiguous { exact: false, alts },
+                    ));
+                }
             }
             if symbol == TOKEN_EOF || self.configs_all_reached_rule_stop(&configs) {
-                let alts = configs.alts();
-                let alt = alts
-                    .iter()
-                    .next()
-                    .copied()
+                // Safety net Java reaches implicitly: at EOF every surviving
+                // path sits in a rule-stop config, so the checks above
+                // resolve; guard against pathological sets instead of
+                // spinning on an unconsumable EOF.
+                let alts: Vec<usize> = configs.alts().into_iter().collect();
+                let alt = *alts
+                    .first()
                     .ok_or(ParserAtnSimulatorError::PredictionRequiresMoreLookahead)?;
-                return Ok(FullContextPrediction {
-                    prediction: ParserAtnPrediction {
-                        alt,
-                        requires_full_context: true,
-                        has_semantic_context: configs_have_semantic_context_for_alt(&configs, alt),
-                        diagnostic: None,
-                    },
-                    stop_index: input.index(),
-                    ambiguity_alts: (alts.len() > 1).then(|| alts.into_iter().collect()),
-                });
-            }
-            if !configs.has_semantic_context()
-                && let Some(alt) = resolves_to_just_one_viable_alt(configs.configs())
-            {
-                return Ok(FullContextPrediction {
-                    prediction: ParserAtnPrediction {
-                        alt,
-                        requires_full_context: true,
-                        has_semantic_context: configs_have_semantic_context_for_alt(&configs, alt),
-                        diagnostic: None,
-                    },
-                    stop_index: input.index(),
-                    ambiguity_alts: None,
-                });
+                let resolution = if alts.len() > 1 {
+                    FullContextResolution::Ambiguous {
+                        exact: self.exact_ambig_detection,
+                        alts,
+                    }
+                } else {
+                    FullContextResolution::Unique
+                };
+                return Ok(full_context_prediction(
+                    alt,
+                    &configs,
+                    input.index(),
+                    resolution,
+                ));
             }
             input.consume();
         }
@@ -1602,6 +1666,7 @@ mod tests {
                     sll_stop_index: 0,
                     ll_stop_index: 0,
                     conflicting_alts: vec![1, 2],
+                    exact: false,
                 }),
             }
         );
@@ -1698,6 +1763,7 @@ mod tests {
                     sll_stop_index: 0,
                     ll_stop_index: 0,
                     conflicting_alts: vec![1, 2],
+                    exact: false,
                 }),
             }
         );
@@ -1751,6 +1817,7 @@ mod tests {
                     sll_stop_index: 0,
                     ll_stop_index: 1,
                     conflicting_alts: vec![1, 2],
+                    exact: false,
                 }),
             }
         );

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -956,9 +956,14 @@ impl<'a> ParserAtnSimulator<'a> {
             if !configs.has_semantic_context() {
                 let subsets = conflicting_alt_subsets(configs.configs());
                 if self.exact_ambig_detection {
-                    if all_subsets_conflict(&subsets) && all_subsets_equal(&subsets) {
-                        let alts: Vec<usize> = configs.alts().into_iter().collect();
-                        let alt = alts[0];
+                    let alts: Vec<usize> = configs.alts().into_iter().collect();
+                    // Both subset checks hold vacuously for an empty list; a
+                    // real exact ambiguity always carries alternatives, so
+                    // guard the pick instead of indexing.
+                    if all_subsets_conflict(&subsets)
+                        && all_subsets_equal(&subsets)
+                        && let Some(&alt) = alts.first()
+                    {
                         return Ok(full_context_prediction(
                             alt,
                             &configs,

--- a/src/bin/antlr4-runtime-testsuite.rs
+++ b/src/bin/antlr4-runtime-testsuite.rs
@@ -730,24 +730,6 @@ fn unsupported_reason(descriptor: &Descriptor) -> Option<&'static str> {
     if !descriptor.flags.is_empty() && !runtime_flags_supported(descriptor) {
         return Some("diagnostic/profile/DFA flags are not implemented in the Rust harness yet");
     }
-    // Honest residuals: these descriptors FAIL when run (nothing is faked);
-    // they are skipped with the missing feature named until it lands.
-    if matches!(
-        descriptor.id().as_str(),
-        "FullContextParsing/AmbiguityNoLoop"
-            | "FullContextParsing/CtxSensitiveDFATwoDiffInput"
-            | "FullContextParsing/ExprAmbiguity_2"
-            | "FullContextParsing/FullContextIF_THEN_ELSEParse_1"
-            | "FullContextParsing/FullContextIF_THEN_ELSEParse_3"
-            | "FullContextParsing/FullContextIF_THEN_ELSEParse_4"
-            | "FullContextParsing/FullContextIF_THEN_ELSEParse_5"
-            | "FullContextParsing/FullContextIF_THEN_ELSEParse_6"
-            | "FullContextParsing/LoopsSimulateTailRecursion"
-    ) {
-        return Some(
-            "full-context DFA learning does not yet reproduce Java's per-decision dump/diagnostics",
-        );
-    }
     if descriptor.id() == "LexerExec/PositionAdjustingLexer" {
         return Some("lexer subclass method overrides are not supported yet");
     }

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9,6 +9,7 @@ use std::path::{Path, PathBuf};
 use antlr4_runtime::atn::lexer_dfa::CompiledLexerDfa;
 use antlr4_runtime::atn::serialized::{AtnDeserializer, SerializedAtn};
 use antlr4_runtime::atn::{Atn, AtnStateKind, LexerAction, Transition};
+use antlr4_runtime::token::TOKEN_EOF;
 
 #[path = "../bin_support/rust_names.rs"]
 mod rust_names;
@@ -1996,15 +1997,45 @@ struct LeftRecursiveLoopRender<'a> {
 /// predicate expressions, per-rule attrs presence, and `@after` bodies.
 #[derive(Clone, Copy)]
 struct EmbeddedStepRender<'a> {
-    /// The grammar dumps the learned DFA; keep every decision on the
-    /// adaptive simulator (no LL(1)/fast-path shortcuts) so the learned
-    /// states match Java's.
+    /// Keep every decision on the adaptive simulator (no LL(1)/fast-path
+    /// shortcuts) regardless of the tool classification.
     force_adaptive: bool,
+    /// Tool-classified non-LL(1) decisions ([`tool_decision_analysis`]).
+    adaptive_decisions: &'a BTreeSet<usize>,
+    /// Tool LOOK(1) dispatch intervals for LL(1)-disjoint decisions.
+    ll1_decision_arms: &'a BTreeMap<usize, Vec<Vec<(i32, i32)>>>,
     predicates: &'a BTreeMap<(usize, usize), (String, Option<String>)>,
     rule_has_attrs: &'a [bool],
     after: &'a BTreeMap<usize, String>,
     call_args: &'a BTreeMap<usize, String>,
     rule_arg0: &'a [Option<String>],
+}
+
+impl EmbeddedStepRender<'_> {
+    /// Java routes this decision through `adaptivePredict` — only there are
+    /// DFA states learned and full-context diagnostics emitted — so the
+    /// generated code must skip its LL(1)/fast-path shortcuts for it.
+    fn adaptive_decision(&self, decision: usize) -> bool {
+        self.force_adaptive || self.adaptive_decisions.contains(&decision)
+    }
+
+    /// Complete dispatch table for a tool-LL(1) decision, exit alternatives
+    /// included — Java's switch compilation. Legit input never reaches the
+    /// simulator through this, so no DFA state is ever learned for the
+    /// decision (matching the dump).
+    fn tool_ll1_fast_path(&self, decision: usize) -> Option<GeneratedDecisionFastPath> {
+        let arms = self.ll1_decision_arms.get(&decision)?;
+        Some(GeneratedDecisionFastPath {
+            arms: arms
+                .iter()
+                .enumerate()
+                .map(|(index, intervals)| GeneratedDecisionFastArm {
+                    alt: index + 1,
+                    intervals: intervals.clone(),
+                })
+                .collect(),
+        })
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -4386,12 +4417,18 @@ fn render_generated_decision(
         alts,
     } = decision_info;
     let pad = "    ".repeat(indent);
+    // A tool-LL(1) decision dispatches on the tool's complete LOOK table
+    // (exit alternatives included), like Java's switch compilation.
+    let tool_fast_path = render_context
+        .embedded
+        .and_then(|embedded| embedded.tool_ll1_fast_path(decision));
+    let fast_path = tool_fast_path.as_ref().or(fast_path);
     if let Some(fast_path) = fast_path.filter(|_| {
         !allow_semantic_context
             && !force_context
             && !render_context
                 .embedded
-                .is_some_and(|embedded| embedded.force_adaptive)
+                .is_some_and(|embedded| embedded.adaptive_decision(decision))
     }) {
         writeln!(
             out,
@@ -4430,9 +4467,11 @@ fn render_generated_decision(
         .expect("writing to a string cannot fail");
         let force_adaptive = render_context
             .embedded
-            .is_some_and(|embedded| embedded.force_adaptive);
-        if allow_semantic_context || force_context || force_adaptive {
+            .is_some_and(|embedded| embedded.adaptive_decision(decision));
+        if allow_semantic_context || force_context {
             render_generated_adaptive_prediction(out, &pad, decision);
+        } else if force_adaptive {
+            render_generated_two_stage_adaptive_assignment(out, &pad, decision);
         } else {
             render_generated_ll1_then_adaptive_prediction(out, &pad, state, decision, true);
         }
@@ -4488,6 +4527,16 @@ fn render_generated_fast_prediction_arms(
         )
         .expect("writing to a string cannot fail");
     }
+}
+
+/// Two-stage adaptive prediction without the LL(1) shortcut — Java's plain
+/// `adaptivePredict`: the SLL probe resolves or flags a full-context
+/// conflict, and the retry with real outer context only runs when the
+/// parser's prediction mode allows it (never in SLL mode).
+fn render_generated_two_stage_adaptive_assignment(out: &mut String, pad: &str, decision: usize) {
+    writeln!(out, "{pad}let __prediction = {{").expect("writing to a string cannot fail");
+    render_generated_sll_then_context_prediction_with_indent(out, pad, decision, 1);
+    writeln!(out, "{pad}}};").expect("writing to a string cannot fail");
 }
 
 fn render_generated_ll1_then_adaptive_prediction(
@@ -4883,6 +4932,11 @@ fn render_generated_adaptive_prediction_with_indent(
     .expect("writing to a string cannot fail");
     writeln!(
         out,
+        "{nested}__simulator.set_exact_ambig_detection(self.base.prediction_mode() == antlr4_runtime::PredictionMode::LlExactAmbigDetection);"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(
+        out,
         "{nested}__simulator.adaptive_predict_stream_info_with_context({decision}, 0, self.base.input(), &__prediction_context)"
     )
     .expect("writing to a string cannot fail");
@@ -4966,6 +5020,12 @@ fn render_generated_star_loop(
     } = loop_info;
     let (enter_alt, exit_alt) = alts;
     let pad = "    ".repeat(indent);
+    // A tool-LL(1) loop decision dispatches on the tool's complete LOOK
+    // table (exit alternative included), like Java's switch-driven loops.
+    let tool_fast_path = render_context
+        .embedded
+        .and_then(|embedded| embedded.tool_ll1_fast_path(decision));
+    let fast_path = tool_fast_path.as_ref().or(fast_path);
     // Per-loop "iteration started" flag, threaded into `sync_decision` so it
     // recovers like ANTLR: a `*` loop's first sync is at the loop ENTRY
     // (single-token deletion), every later sync is a loop-BACK (multi-token
@@ -4981,7 +5041,7 @@ fn render_generated_star_loop(
             && !force_context
             && !render_context
                 .embedded
-                .is_some_and(|embedded| embedded.force_adaptive)
+                .is_some_and(|embedded| embedded.adaptive_decision(decision))
     }) {
         writeln!(
             out,
@@ -5016,9 +5076,11 @@ fn render_generated_star_loop(
         .expect("writing to a string cannot fail");
         let force_adaptive = render_context
             .embedded
-            .is_some_and(|embedded| embedded.force_adaptive);
-        if allow_semantic_context || force_context || force_adaptive {
+            .is_some_and(|embedded| embedded.adaptive_decision(decision));
+        if allow_semantic_context || force_context {
             render_generated_adaptive_prediction(out, &inner_pad, decision);
+        } else if force_adaptive {
+            render_generated_two_stage_adaptive_assignment(out, &inner_pad, decision);
         } else {
             render_generated_ll1_then_adaptive_prediction(out, &inner_pad, state, decision, true);
         }
@@ -5102,6 +5164,11 @@ fn render_generated_left_recursive_loop(
     writeln!(
         out,
         "{pad}        let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(
+        out,
+        "{pad}        __simulator.set_exact_ambig_detection(self.base.prediction_mode() == antlr4_runtime::PredictionMode::LlExactAmbigDetection);"
     )
     .expect("writing to a string cannot fail");
     writeln!(
@@ -5515,6 +5582,185 @@ struct EmbeddedParserData {
     impl_items: String,
     /// `@members` structs/impls and generated support types.
     module_items: String,
+    /// Decisions the ANTLR tool would compile to `adaptivePredict` calls
+    /// (non-LL(1) per [`tool_decision_analysis`]); the generated code must
+    /// route these through the simulator on every visit.
+    adaptive_decisions: BTreeSet<usize>,
+    /// Tool LOOK(1) dispatch intervals for LL(1)-disjoint decisions.
+    ll1_decision_arms: BTreeMap<usize, Vec<Vec<(i32, i32)>>>,
+}
+
+/// LOOK(1) of one decision alternative, plus whether the walk crossed a
+/// predicate — Java nulls such alternatives, forcing the decision adaptive.
+#[derive(Debug, Default)]
+struct DecisionAltLook {
+    symbols: BTreeSet<i32>,
+    hit_pred: bool,
+}
+
+/// Ports the ANTLR tool's `AnalysisPipeline` classification: the decisions
+/// whose alternatives' LOOK(1) sets are not pairwise disjoint (or hit a
+/// predicate, or come up empty). Java compiles LL(1)-disjoint decisions to
+/// plain token switches — no simulator, no learned DFA — and routes every
+/// other decision through `adaptivePredict`, the only place DFA states are
+/// learned and full-context diagnostics fire. `dumpDFA` and diagnostic
+/// output therefore only match Java when the generated routing agrees.
+fn tool_decision_analysis(data: &InterpData) -> io::Result<ToolDecisionAnalysis> {
+    let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
+        .deserialize()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let mut analysis = ToolDecisionAnalysis::default();
+    for (decision, &state_number) in atn.decision_to_state().iter().enumerate() {
+        let Some(state) = atn.state(state_number) else {
+            continue;
+        };
+        let looks: Vec<DecisionAltLook> = state
+            .transitions
+            .iter()
+            .map(|transition| {
+                let mut look = DecisionAltLook::default();
+                let mut walk = DecisionLookWalk {
+                    atn: &atn,
+                    busy: BTreeSet::new(),
+                    called_rules: vec![false; atn.rule_to_start_state().len()],
+                };
+                walk.walk(transition.target(), &mut Vec::new(), &mut look);
+                look
+            })
+            .collect();
+        if decision_alt_looks_disjoint(&looks) {
+            analysis.ll1_decision_arms.insert(
+                decision,
+                looks
+                    .iter()
+                    .map(|look| symbol_intervals(&look.symbols))
+                    .collect(),
+            );
+        } else {
+            analysis.adaptive_decisions.insert(decision);
+        }
+    }
+    Ok(analysis)
+}
+
+/// Tool-side decision classification (see [`tool_decision_analysis`]).
+#[derive(Debug, Default)]
+struct ToolDecisionAnalysis {
+    /// Decisions Java compiles to `adaptivePredict` calls.
+    adaptive_decisions: BTreeSet<usize>,
+    /// Complete LOOK(1) dispatch intervals per alt for LL(1)-disjoint
+    /// decisions — exit alternatives included, unlike the within-rule
+    /// fast-path/LL(1) analyses, so legit input never falls through to the
+    /// simulator (Java's switch never does).
+    ll1_decision_arms: BTreeMap<usize, Vec<Vec<(i32, i32)>>>,
+}
+
+/// Collapses a sorted symbol set into inclusive intervals.
+fn symbol_intervals(symbols: &BTreeSet<i32>) -> Vec<(i32, i32)> {
+    let mut intervals: Vec<(i32, i32)> = Vec::new();
+    for &symbol in symbols {
+        match intervals.last_mut() {
+            Some((_, stop)) if *stop + 1 == symbol => *stop = symbol,
+            _ => intervals.push((symbol, symbol)),
+        }
+    }
+    intervals
+}
+
+/// `AnalysisPipeline.disjoint`: pairwise-disjoint alt LOOK sets, with
+/// Java's `getDecisionLookahead` nulling (empty or predicate-hitting sets)
+/// folded in as an immediate non-LL(1) verdict.
+fn decision_alt_looks_disjoint(looks: &[DecisionAltLook]) -> bool {
+    let mut combined = BTreeSet::new();
+    for look in looks {
+        if look.hit_pred || look.symbols.is_empty() {
+            return false;
+        }
+        if look.symbols.intersection(&combined).next().is_some() {
+            return false;
+        }
+        combined.extend(look.symbols.iter().copied());
+    }
+    true
+}
+
+struct DecisionLookWalk<'a> {
+    atn: &'a Atn,
+    /// Java's `lookBusy`: (state, calling context) pairs already expanded.
+    busy: BTreeSet<(usize, Vec<usize>)>,
+    /// Java's `calledRuleStack`: rules on the walk's invocation path, the
+    /// recursion guard that bounds the context stack.
+    called_rules: Vec<bool>,
+}
+
+impl DecisionLookWalk<'_> {
+    /// `LL1Analyzer._LOOK` with an initially empty context: nested rule
+    /// invocations return precisely through `ctx`; the decision's own rule
+    /// boundary falls through the rule-stop state's return edges — the
+    /// deserializer materializes one per call site, which is exactly the
+    /// context-free FOLLOW Java walks there.
+    fn walk(&mut self, state_number: usize, ctx: &mut Vec<usize>, look: &mut DecisionAltLook) {
+        if !self.busy.insert((state_number, ctx.clone())) {
+            return;
+        }
+        let Some(state) = self.atn.state(state_number) else {
+            return;
+        };
+        if state.kind == AtnStateKind::RuleStop {
+            if let Some(return_state) = ctx.pop() {
+                let cleared = state
+                    .rule_index
+                    .map(|rule| std::mem::replace(&mut self.called_rules[rule], false));
+                self.walk(return_state, ctx, look);
+                if let (Some(rule), Some(flag)) = (state.rule_index, cleared) {
+                    self.called_rules[rule] = flag;
+                }
+                ctx.push(return_state);
+                return;
+            }
+            if state.transitions.is_empty() {
+                // The walk escaped through a stop state with no call sites —
+                // the start rule's end, where the only lookahead is EOF.
+                look.symbols.insert(TOKEN_EOF);
+                return;
+            }
+        }
+        for transition in &state.transitions {
+            match transition {
+                Transition::Rule {
+                    target,
+                    rule_index,
+                    follow_state,
+                    ..
+                } => {
+                    if self.called_rules.get(*rule_index).copied().unwrap_or(true) {
+                        continue;
+                    }
+                    self.called_rules[*rule_index] = true;
+                    ctx.push(*follow_state);
+                    self.walk(*target, ctx, look);
+                    ctx.pop();
+                    self.called_rules[*rule_index] = false;
+                }
+                Transition::Predicate { .. } | Transition::Precedence { .. } => {
+                    look.hit_pred = true;
+                }
+                Transition::Epsilon { target } | Transition::Action { target, .. } => {
+                    self.walk(*target, ctx, look);
+                }
+                _ => {
+                    // Terminal edge: enumerate the vocabulary through the
+                    // shared `matches` so atoms, ranges, sets, negations and
+                    // wildcards agree with the simulator exactly.
+                    for symbol in TOKEN_EOF..=self.atn.max_token_type() {
+                        if transition.matches(symbol, 1, self.atn.max_token_type()) {
+                            look.symbols.insert(symbol);
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Builds the embedded translation of every action, predicate, `@init` and
@@ -5540,8 +5786,11 @@ fn build_embedded_parser_data(
     let finish_body =
         |body: &str, translated: &str| -> String { post_process_embedded(body, translated, type_name) };
 
+    let decision_analysis = tool_decision_analysis(data)?;
     let mut out = EmbeddedParserData {
         rule_has_attrs: model.rules.iter().map(embedded::RuleModel::has_attrs).collect(),
+        adaptive_decisions: decision_analysis.adaptive_decisions,
+        ll1_decision_arms: decision_analysis.ll1_decision_arms,
         ..EmbeddedParserData::default()
     };
 
@@ -6305,11 +6554,14 @@ fn render_public_rule_methods(public_rule_method_names: &[String]) -> String {
 
 /// Step-render view over the embedded data.
 ///
-/// `force_adaptive` stays off: adaptive-everywhere learns more DFA states
-/// than Java, whose tool inlines simple decisions like our LL(1) shortcut.
+/// `force_adaptive` stays off: per-decision routing follows the tool
+/// classification in `adaptive_decisions` instead, matching which decisions
+/// Java compiles to switches versus `adaptivePredict` calls.
 fn embedded_step_render(embedded: &EmbeddedParserData) -> EmbeddedStepRender<'_> {
     EmbeddedStepRender {
         force_adaptive: false,
+        adaptive_decisions: &embedded.adaptive_decisions,
+        ll1_decision_arms: &embedded.ll1_decision_arms,
         predicates: &embedded.predicates,
         rule_has_attrs: &embedded.rule_has_attrs,
         after: &embedded.after,
@@ -11839,7 +12091,7 @@ atn:
         assert_eq!(body.entry_state, 0);
         assert_eq!(
             body.steps,
-            [mt(1, 2), mt(antlr4_runtime::token::TOKEN_EOF, 3)]
+            [mt(1, 2), mt(TOKEN_EOF, 3)]
         );
 
         let rendered = render_generated_rule_dispatch(
@@ -14637,7 +14889,7 @@ ID: [a-z]+ { customJava(); };
             .expect("state 2")
             .add_transition(Transition::Atom {
                 target: 3,
-                label: antlr4_runtime::token::TOKEN_EOF,
+                label: TOKEN_EOF,
             });
         atn.set_rule_to_start_state(vec![0]);
         atn.set_rule_to_stop_state(vec![3]);

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5614,6 +5614,14 @@ fn tool_decision_analysis(data: &InterpData) -> io::Result<ToolDecisionAnalysis>
         let Some(state) = atn.state(state_number) else {
             continue;
         };
+        // The tool never LL(1)-compiles non-greedy or left-recursion
+        // precedence decisions, disjoint LOOK or not — Java always emits
+        // `adaptivePredict` for them (a token switch would make a
+        // non-greedy loop greedy).
+        if state.non_greedy || state.precedence_rule_decision {
+            analysis.adaptive_decisions.insert(decision);
+            continue;
+        }
         let looks: Vec<DecisionAltLook> = state
             .transitions
             .iter()

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3290,12 +3290,11 @@ where
         let result_token = self.token_at(diagnostic.ll_stop_index);
         let message = match diagnostic.kind {
             ParserAtnPredictionDiagnosticKind::Ambiguity => {
-                // Java's default LL prediction stops at the first full-context
-                // conflict without exact-ambiguity detection, so
-                // `reportAmbiguity` fires with `exact == false` there and the
-                // `DiagnosticErrorListener` (exactOnly by default) suppresses
-                // it. Only LL_EXACT_AMBIG_DETECTION produces exact ambiguities.
-                if self.prediction_mode != PredictionMode::LlExactAmbigDetection {
+                // Java's DiagnosticErrorListener is exactOnly by default:
+                // non-exact ambiguities (default LL mode stopping at the
+                // first resolvable conflict) report the attempt above but
+                // suppress the ambiguity line itself.
+                if !diagnostic.exact {
                     return;
                 }
                 format!(
@@ -10527,6 +10526,7 @@ mod tests {
                     sll_stop_index: 1,
                     ll_stop_index: 0,
                     conflicting_alts: vec![1, 2],
+                    exact: false,
                 }),
             },
         );
@@ -10547,6 +10547,7 @@ mod tests {
                     sll_stop_index: 1,
                     ll_stop_index: 1,
                     conflicting_alts: vec![1, 2],
+                    exact: false,
                 }),
             },
         );

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -1181,7 +1181,22 @@ pub fn resolves_to_just_one_viable_alt(configs: &[AtnConfig]) -> Option<usize> {
     single_viable_alt(&conflicting_alt_subsets(configs))
 }
 
-fn single_viable_alt(alt_subsets: &[BTreeSet<usize>]) -> Option<usize> {
+/// Java `PredictionMode.allSubsetsConflict`: every `(state, context)` subset
+/// holds more than one alternative.
+pub fn all_subsets_conflict(alt_subsets: &[BTreeSet<usize>]) -> bool {
+    alt_subsets.iter().all(|alts| alts.len() > 1)
+}
+
+/// Java `PredictionMode.allSubsetsEqual`: every subset is the same alt set.
+pub fn all_subsets_equal(alt_subsets: &[BTreeSet<usize>]) -> bool {
+    let mut subsets = alt_subsets.iter();
+    let Some(first) = subsets.next() else {
+        return true;
+    };
+    subsets.all(|alts| alts == first)
+}
+
+pub fn single_viable_alt(alt_subsets: &[BTreeSet<usize>]) -> Option<usize> {
     let mut result = None;
     for alts in alt_subsets {
         let min_alt = alts.iter().next().copied()?;

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -322,8 +322,12 @@ where
         if start > stop || start >= self.tokens.len() {
             return String::new();
         }
+        // Java's `BufferedTokenStream.getText(Interval)` stops at the first
+        // EOF token, so an interval whose stop index lands on EOF renders
+        // without a trailing `<EOF>` (diagnostics rely on this).
         self.tokens[start..=stop.min(self.tokens.len().saturating_sub(1))]
             .iter()
+            .take_while(|token| token.token_type() != TOKEN_EOF)
             .map(|token| token.text())
             .collect::<Vec<_>>()
             .join("")


### PR DESCRIPTION
Closes #58. Full sweep: **356 passed, 0 failed, 1 skipped** (only `LexerExec/PositionAdjustingLexer` remains skipped) — up from 347/0/10. All nine skip-listed FullContextParsing descriptors now pass honestly and their skip entries are removed.

Four root causes, fixed in dependency order:

1. **`getText` EOF parity** (runtime): `CommonTokenStream::text` now stops at EOF tokens like Java's `BufferedTokenStream.getText(Interval)`, so diagnostic input intervals ending on EOF render as `'a@'`, not `'a@<EOF>'`.
2. **Full-context resolution semantics** (runtime): the loop now mirrors `execATNWithFullContext` — a truly unique alt is context sensitivity; default LL stops at the first resolves-to-one-viable-alt conflict as a *non-exact* ambiguity (suppressed by the exactOnly listener); `LL_EXACT_AMBIG_DETECTION` keeps consuming until every `(state, context)` subset conflicts over the same alt set, an exact ambiguity. The simulator learns the mode via `set_exact_ambig_detection` and the diagnostic carries Java's `exact` flag, which the reporter gates on. (Previously "resolved to one viable alt" was misreported as context sensitivity, and exact mode didn't exist.)
3. **Tool-parity decision routing** (generator): a port of ANTLR's `AnalysisPipeline` — per-alternative LOOK(1) with cross-rule FOLLOW (`LL1Analyzer` semantics: empty-context fan-out through rule-stop follow edges, `calledRuleStack` recursion guard, predicate hits nulling the alt). LL(1)-disjoint decisions dispatch on the tool's complete look tables (exit alternatives included) exactly like Java's switch compilation and never touch the simulator; every other decision runs adaptive prediction on each visit — the only place DFA states are learned and full-context diagnostics fire. This is what makes `dumpDFA` output match: the earlier `force_adaptive` experiment failed because adaptive-*everywhere* learns DFAs Java's switch-compiled decisions never create, and the LL(1)-shortcut-everywhere approach learns none where Java learns some.
4. **SLL mode preservation**: tool-forced adaptive decisions use the two-stage probe form, so `PredictionMode::Sll` never runs the full-context retry (caught live by a `ParserExec/PredictionMode_SLL` regression during the sweep).

Clippy `-D warnings` and all 299 unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)