### PR TITLE
[codex] Fix antlr4-rust-gen help output

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2,7 +2,7 @@ use std::collections::{btree_map::Entry, BTreeMap, BTreeSet};
 use std::env;
 use std::fmt::Write as _;
 use std::fs;
-use std::io;
+use std::io::{self, Write as _};
 use std::ops::AddAssign;
 use std::path::{Path, PathBuf};
 
@@ -46,6 +46,15 @@ pub use self::__antlr4_rust_generated::*;
 ";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    if env::args()
+        .skip(1)
+        .any(|arg| arg == "--help" || arg == "-h")
+    {
+        let mut stdout = io::stdout().lock();
+        writeln!(stdout, "{}", usage())?;
+        return Ok(());
+    }
+
     let args = Args::parse()?;
     fs::create_dir_all(&args.out_dir)?;
     let grammar_source = args
@@ -1616,7 +1625,25 @@ fn next_arg(iter: &mut impl Iterator<Item = String>, flag: &str) -> Result<Strin
 }
 
 fn usage() -> String {
-    "usage: antlr4-rust-gen [--lexer Lexer.interp] [--parser Parser.interp] [--grammar Grammar.g4] [--out-dir DIR] [--actions embedded|templates] [--require-generated-parser] [--allow-unsupported-lexer-actions] [--sem-unknown error|hook|assume-true|assume-false] [--sem-patterns FILE] [--require-full-semantics]"
+    "\
+Usage: antlr4-rust-gen [OPTIONS]
+
+Options:
+  --lexer Lexer.interp             Read lexer metadata from Lexer.interp
+  --parser Parser.interp           Read parser metadata from Parser.interp
+  --lexer-name NAME                Override the lexer grammar name
+  --parser-name NAME               Override the parser grammar name
+  --grammar Grammar.g4             Read the source grammar for semantic metadata
+  --out-dir DIR                    Write generated Rust files to DIR
+  --actions embedded|templates     Select real embedded actions or template metadata
+  --require-generated-parser       Require parser source for parser generation
+  --allow-unsupported-lexer-actions
+                                   Ignore unsupported lexer actions
+  --sem-unknown error|hook|assume-true|assume-false
+                                   Choose unsupported semantic predicate policy
+  --sem-patterns FILE              Load semantic helper patterns
+  --require-full-semantics         Fail if any semantic coordinate is unsupported
+  -h, --help                       Print this help"
         .to_owned()
 }
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -46,13 +46,20 @@ pub use self::__antlr4_rust_generated::*;
 ";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    if env::args()
-        .skip(1)
-        .any(|arg| arg == "--help" || arg == "-h")
-    {
-        let mut stdout = io::stdout().lock();
-        writeln!(stdout, "{}", usage())?;
-        return Ok(());
+    let mut args_iter = env::args().skip(1);
+    while let Some(arg) = args_iter.next() {
+        match arg.as_str() {
+            "--lexer" | "--parser" | "--lexer-name" | "--parser-name" | "--grammar"
+            | "--out-dir" | "--sem-patterns" | "--actions" | "--sem-unknown" => {
+                let _ = args_iter.next();
+            }
+            "--help" | "-h" => {
+                let mut stdout = io::stdout().lock();
+                writeln!(stdout, "{}", usage())?;
+                return Ok(());
+            }
+            _ => {}
+        }
     }
 
     let args = Args::parse()?;

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1,0 +1,66 @@
+use std::process::{Command, Output};
+
+fn run_antlr4_rust_gen(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_antlr4-rust-gen"))
+        .args(args)
+        .output()
+        .expect("antlr4-rust-gen should run")
+}
+
+fn utf8(bytes: &[u8]) -> &str {
+    std::str::from_utf8(bytes).expect("process output should be UTF-8")
+}
+
+#[test]
+fn long_help_exits_successfully_on_stdout() {
+    let output = run_antlr4_rust_gen(&["--help"]);
+
+    assert!(
+        output.status.success(),
+        "status: {:?}\nstderr: {}",
+        output.status.code(),
+        utf8(&output.stderr)
+    );
+    assert_eq!(utf8(&output.stderr), "");
+
+    let stdout = utf8(&output.stdout);
+    assert!(
+        stdout.starts_with("Usage: antlr4-rust-gen [OPTIONS]\n"),
+        "{stdout}"
+    );
+    assert!(stdout.contains("  --lexer Lexer.interp"), "{stdout}");
+    assert!(stdout.contains("  -h, --help"), "{stdout}");
+}
+
+#[test]
+fn short_help_exits_successfully_on_stdout() {
+    let output = run_antlr4_rust_gen(&["-h"]);
+
+    assert!(output.status.success(), "stderr: {}", utf8(&output.stderr));
+    assert_eq!(utf8(&output.stderr), "");
+    assert!(utf8(&output.stdout).contains("Usage: antlr4-rust-gen"));
+}
+
+#[test]
+fn missing_inputs_still_report_usage_on_stderr() {
+    let output = run_antlr4_rust_gen(&[]);
+
+    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stdout), "");
+
+    let stderr = utf8(&output.stderr);
+    assert!(stderr.contains("at least one of --lexer or --parser is required"));
+    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+}
+
+#[test]
+fn unknown_arguments_still_report_usage_on_stderr() {
+    let output = run_antlr4_rust_gen(&["--bogus"]);
+
+    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stdout), "");
+
+    let stderr = utf8(&output.stderr);
+    assert!(stderr.contains("unknown argument --bogus"));
+    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+}

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -42,6 +42,18 @@ fn short_help_exits_successfully_on_stdout() {
 }
 
 #[test]
+fn help_flag_as_option_value_is_not_intercepted() {
+    let output = run_antlr4_rust_gen(&["--lexer-name", "--help"]);
+
+    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stdout), "");
+
+    let stderr = utf8(&output.stderr);
+    assert!(stderr.contains("at least one of --lexer or --parser is required"));
+    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+}
+
+#[test]
 fn missing_inputs_still_report_usage_on_stderr() {
     let output = run_antlr4_rust_gen(&[]);
 


### PR DESCRIPTION
## Summary

Fixes #67.

- Handle explicit `-h`/`--help` before normal argument parsing so help exits 0 and writes to stdout.
- Replace the dense one-line usage string with a short `Usage:` header and one line per flag.
- Add process-level CLI tests covering help, missing inputs, and unknown arguments.

## Validation

- `cargo test --test antlr4_rust_gen_cli`
- `cargo test --bin antlr4-rust-gen`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`