### PR TITLE
Beat Go on generated Solidity parser performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,10 +420,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | ~18× faster             |
-| Java     | 4        | ~1.8× faster            |
-| C#       | 4        | ~1.2× faster            |
-| Trino SQL| 5        | ~1.1× faster            |
+| Kotlin   | 4        | ~18.1× faster           |
+| Java     | 4        | ~2.5× faster            |
+| C#       | 4        | ~1.7× faster            |
+| Trino SQL| 5        | ~2.3× faster            |
 
 Rust is faster than Go on every fixture in all four language groups, with
 Kotlin leading dramatically (expression-ladder memoization in the generated
@@ -431,8 +431,10 @@ walker). Lexer DFAs are compiled at generation time and embedded in the
 generated lexer, so tokenization needs no warmup at all; learned parser
 decision DFAs are shared across parser instances, so repeated parses of the
 same grammar — the common case for a CLI tool or language server — skip
-relearning entirely. Numbers are warm-parse minimums on an Apple M3 Pro and
-are indicative — re-run the benchmark on your own hardware for authoritative
+relearning entirely. Shared grammar-level lookahead caches likewise amortize
+left-recursive loop prediction across parses. Numbers are warm-parse minimums
+from 10 measured iterations after two warmups on an Apple M3 Pro and are
+indicative — re-run the benchmark on your own hardware for authoritative
 figures.
 
 ## Useful Information

--- a/README.md
+++ b/README.md
@@ -402,15 +402,17 @@ Run the Rust-vs-Go comparison across all fixture languages:
 python3 tools/parse-bench/run.py \
   --languages kotlin,csharp,java,trino \
   --runtimes rust-antlr,go-antlr \
-  --quick \
+  --iters 10 \
+  --warmups 2 \
   --json target/parse-bench/results.json \
   --markdown target/parse-bench/results.md
 ```
 
 The report prints `min`/`avg` parse time and a ratio against `rust-antlr` for
-every fixture. Drop `--quick` (or add `--iters`/`--warmups`) for longer, lower
-variance runs; add `--runtimes rust-antlr,go-antlr,python-antlr,tree-sitter` to
-include the other runtimes.
+every fixture. Use `--quick` for a 3-iteration/1-warmup smoke run, or adjust
+`--iters`/`--warmups` for longer, lower-variance runs; add
+`--runtimes rust-antlr,go-antlr,python-antlr,tree-sitter` to include the other
+runtimes.
 
 ### Current results
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,7 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 | C#       | 4        | ~1.7× faster            |
 | Trino SQL| 5        | ~2.2× faster            |
 
-Rust is faster than Go on every fixture in all four language groups, with
+Rust is faster than Go on average in all four language groups, with
 Kotlin leading dramatically (expression-ladder memoization in the generated
 walker). Lexer DFAs are compiled at generation time and embedded in the
 generated lexer, so tokenization needs no warmup at all; learned parser

--- a/README.md
+++ b/README.md
@@ -420,10 +420,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | ~18.1× faster           |
+| Kotlin   | 4        | ~18.5× faster           |
 | Java     | 4        | ~2.5× faster            |
 | C#       | 4        | ~1.7× faster            |
-| Trino SQL| 5        | ~2.3× faster            |
+| Trino SQL| 5        | ~2.2× faster            |
 
 Rust is faster than Go on every fixture in all four language groups, with
 Kotlin leading dramatically (expression-ladder memoization in the generated

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3949,9 +3949,13 @@ fn render_generated_rule_dispatch_with_rule_names(
     portable_locals: Option<PortableLocalStepRender<'_>>,
 ) -> String {
     let mut out = String::new();
-    let force_generated_rules = portable_locals.map_or_else(BTreeSet::new, |portable| {
-        generated_rule_callers_reaching(rules, portable.required_generated_rules)
-    });
+    let force_generated_rules = if embedded.is_some() {
+        rules.iter().flatten().map(|rule| rule.rule_index).collect()
+    } else {
+        portable_locals.map_or_else(BTreeSet::new, |portable| {
+            generated_rule_callers_reaching(rules, portable.required_generated_rules)
+        })
+    };
     let atn_preferred_rule_calls =
         generated_atn_preferred_rule_calls_excluding(rules, rule_names, &force_generated_rules);
     writeln!(
@@ -11031,6 +11035,56 @@ atn:
         // The ATN-preferred child call routes through the buffering wrapper.
         assert!(rendered.contains("self.parse_rule_precedence_from_generated(2, 0)"));
         assert!(!rendered.contains("self.parse_interpreted_rule_precedence(2, 0)"));
+    }
+
+    #[test]
+    fn embedded_rules_never_use_atn_preferred_fallback() {
+        let rules = (0..ATN_PREFERRED_LEADING_CALL_CHAIN_MIN)
+            .map(|rule_index| {
+                let next = if rule_index + 1 == ATN_PREFERRED_LEADING_CALL_CHAIN_MIN {
+                    None
+                } else {
+                    Some(rule_index + 1)
+                };
+                Some(expensive_ladder_rule(rule_index, next))
+            })
+            .collect::<Vec<_>>();
+        let direct_generated_rule_calls = vec![true; rules.len()];
+        let adaptive_decisions = BTreeSet::new();
+        let ll1_decision_arms = BTreeMap::new();
+        let predicates = BTreeMap::new();
+        let rule_has_attrs = vec![false; rules.len()];
+        let init_entry = BTreeMap::new();
+        let after = BTreeMap::new();
+        let call_args = BTreeMap::new();
+        let rule_arg0 = vec![None; rules.len()];
+
+        let rendered = render_generated_rule_dispatch_with_rule_names(
+            &rules,
+            &direct_generated_rule_calls,
+            &[],
+            &BTreeMap::new(),
+            true,
+            Some(EmbeddedStepRender {
+                force_adaptive: false,
+                adaptive_decisions: &adaptive_decisions,
+                ll1_decision_arms: &ll1_decision_arms,
+                predicates: &predicates,
+                rule_has_attrs: &rule_has_attrs,
+                init_entry: &init_entry,
+                after: &after,
+                call_args: &call_args,
+                rule_arg0: &rule_arg0,
+            }),
+            None,
+        );
+
+        assert!(!rendered.contains("if self.generated_only()"));
+        assert!(rendered.contains(
+            "0 => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
+        ));
+        assert!(rendered.contains("self.parse_generated_rule_1_dispatch(0, false)"));
+        assert!(!rendered.contains("self.parse_rule_precedence_from_generated(1, 0)"));
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2402,6 +2402,7 @@ impl EmbeddedStepRender<'_> {
 struct PortableLocalStepRender<'a> {
     declarations: &'a [Vec<String>],
     predicates: &'a BTreeMap<(usize, usize), (String, Option<String>)>,
+    required_generated_rules: &'a BTreeSet<usize>,
 }
 
 #[derive(Clone, Copy)]
@@ -2563,9 +2564,18 @@ impl AddAssign for GeneratedRuleShape {
     }
 }
 
+#[cfg(test)]
 fn generated_atn_preferred_rule_calls(
     rules: &[Option<GeneratedParserRule>],
+    rule_names: &[String],
+) -> Vec<bool> {
+    generated_atn_preferred_rule_calls_excluding(rules, rule_names, &BTreeSet::new())
+}
+
+fn generated_atn_preferred_rule_calls_excluding(
+    rules: &[Option<GeneratedParserRule>],
     _rule_names: &[String],
+    force_generated: &BTreeSet<usize>,
 ) -> Vec<bool> {
     let leading_rule_calls = rules
         .iter()
@@ -2612,8 +2622,57 @@ fn generated_atn_preferred_rule_calls(
         }
     }
     propagate_atn_preferred_wrappers(rules, &shapes, &mut preferred);
+    for rule_index in force_generated {
+        if let Some(entry) = preferred.get_mut(*rule_index) {
+            *entry = false;
+        }
+    }
 
     preferred
+}
+
+fn generated_rule_callers_reaching(
+    rules: &[Option<GeneratedParserRule>],
+    target_rules: &BTreeSet<usize>,
+) -> BTreeSet<usize> {
+    let mut reaching = target_rules.clone();
+    loop {
+        let mut changed = false;
+        for rule in rules.iter().flatten() {
+            if reaching.contains(&rule.rule_index)
+                || !generated_steps_call_any_rule(&rule.steps, &reaching)
+            {
+                continue;
+            }
+            changed |= reaching.insert(rule.rule_index);
+        }
+        if !changed {
+            return reaching;
+        }
+    }
+}
+
+fn generated_steps_call_any_rule(
+    steps: &[GeneratedParserStep],
+    rule_indices: &BTreeSet<usize>,
+) -> bool {
+    steps.iter().any(|step| match step {
+        GeneratedParserStep::CallRule { rule_index, .. } => rule_indices.contains(rule_index),
+        GeneratedParserStep::Decision { alts, .. } => alts
+            .iter()
+            .any(|alt| generated_steps_call_any_rule(alt, rule_indices)),
+        GeneratedParserStep::StarLoop { body, .. }
+        | GeneratedParserStep::LeftRecursiveLoop { body, .. } => {
+            generated_steps_call_any_rule(body, rule_indices)
+        }
+        GeneratedParserStep::MatchToken { .. }
+        | GeneratedParserStep::MatchSet { .. }
+        | GeneratedParserStep::MatchNotSet { .. }
+        | GeneratedParserStep::MatchWildcard { .. }
+        | GeneratedParserStep::Precedence(_)
+        | GeneratedParserStep::Predicate { .. }
+        | GeneratedParserStep::Action { .. } => false,
+    })
 }
 
 fn generated_atn_preferred_chain_is_expensive(
@@ -2846,6 +2905,33 @@ fn require_all_parser_rules_generated(
         io::ErrorKind::InvalidData,
         format!(
             "generated parser did not emit {} rule(s): {}",
+            missing.len(),
+            missing.join(", ")
+        ),
+    ))
+}
+
+fn require_portable_local_rules_generated(
+    rules: &[Option<GeneratedParserRule>],
+    required: &BTreeSet<usize>,
+    data: &InterpData,
+) -> io::Result<()> {
+    let missing = required
+        .iter()
+        .filter(|rule_index| rules.get(**rule_index).is_none_or(Option::is_none))
+        .map(|rule_index| {
+            data.rule_names
+                .get(*rule_index)
+                .map_or_else(|| rule_index.to_string(), Clone::clone)
+        })
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return Ok(());
+    }
+    Err(io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "portable local semantics require {} generated parser rule(s): {}",
             missing.len(),
             missing.join(", ")
         ),
@@ -3815,7 +3901,11 @@ fn render_generated_rule_dispatch_with_rule_names(
     portable_locals: Option<PortableLocalStepRender<'_>>,
 ) -> String {
     let mut out = String::new();
-    let atn_preferred_rule_calls = generated_atn_preferred_rule_calls(rules, rule_names);
+    let force_generated_rules = portable_locals.map_or_else(BTreeSet::new, |portable| {
+        generated_rule_callers_reaching(rules, portable.required_generated_rules)
+    });
+    let atn_preferred_rule_calls =
+        generated_atn_preferred_rule_calls_excluding(rules, rule_names, &force_generated_rules);
     writeln!(
         out,
         "    #[allow(dead_code)]\n    fn parse_generated_rule(&mut self, rule_index: usize, precedence: i32, allow_fallback: bool) -> Option<Result<antlr4_runtime::ParseTree, GeneratedRuleError>> {{"
@@ -5749,17 +5839,20 @@ struct PortableLocalData {
     inline_actions: BTreeMap<usize, String>,
     /// Parser predicate coordinate -> generated boolean expression.
     predicates: BTreeMap<(usize, usize), (String, Option<String>)>,
+    /// Rules whose local state has no equivalent interpreted representation.
+    required_generated_rules: BTreeSet<usize>,
 }
 
 impl PortableLocalData {
     fn has_semantics(&self) -> bool {
-        !self.inline_actions.is_empty() || !self.predicates.is_empty()
+        !self.required_generated_rules.is_empty()
     }
 
     fn step_render(&self) -> Option<PortableLocalStepRender<'_>> {
         self.has_semantics().then_some(PortableLocalStepRender {
             declarations: &self.declarations,
             predicates: &self.predicates,
+            required_generated_rules: &self.required_generated_rules,
         })
     }
 }
@@ -5852,6 +5945,7 @@ fn build_portable_local_data(
         }
         out.inline_actions
             .insert(state, format!("{local} = {value};"));
+        out.required_generated_rules.insert(slot.rule_index);
     }
 
     let coordinates = lexer_predicate_transitions(data)?;
@@ -5898,6 +5992,7 @@ fn build_portable_local_data(
                 predicate_fail_message(source, block.after_brace),
             ),
         );
+        out.required_generated_rules.insert(rule_index);
     }
 
     Ok(out)
@@ -6939,6 +7034,11 @@ fn render_parser_with_options(
         },
         (has_action_dispatch || has_predicate_dispatch || portable_local_data.has_semantics())
             && !options.embedded,
+    )?;
+    require_portable_local_rules_generated(
+        &generated_rules,
+        &portable_local_data.required_generated_rules,
+        data,
     )?;
     if options.require_generated_parser || options.embedded {
         // Embedded actions only run on the generated path, so every rule must
@@ -8843,42 +8943,65 @@ fn literal_rule_arg_calls(
     data: &InterpData,
     grammar_source: &str,
 ) -> Vec<(usize, RuleArgTemplate)> {
+    let rule_indices = data
+        .rule_names
+        .iter()
+        .enumerate()
+        .map(|(index, name)| (name.as_str(), index))
+        .collect::<BTreeMap<_, _>>();
     let mut calls = Vec::new();
-    for (rule_index, rule_name) in data.rule_names.iter().enumerate() {
-        let pattern = format!("{rule_name}[");
-        let mut offset = 0;
-        while let Some(start) = grammar_source[offset..]
-            .find(&pattern)
-            .map(|index| offset + index)
-        {
-            let value_start = start + pattern.len();
-            let Some(value_stop) = grammar_source[value_start..]
-                .find(']')
-                .map(|index| value_start + index)
-            else {
-                break;
-            };
-            if start == 0
-                || grammar_source[..start]
-                    .chars()
-                    .next_back()
-                    .is_none_or(|ch| !(ch == '_' || ch.is_ascii_alphanumeric()))
-            {
-                let value = grammar_source[value_start..value_stop].trim();
-                if let Ok(value) = value.parse::<i64>() {
-                    calls.push((start, rule_index, RuleArgTemplate::Literal(value)));
-                } else if matches!(value, "true" | "false") {
-                    calls.push((
-                        start,
-                        rule_index,
-                        RuleArgTemplate::Literal(i64::from(value == "true")),
-                    ));
-                } else if value == r#"<VarRef("i")>"# {
-                    calls.push((start, rule_index, RuleArgTemplate::InheritLocal));
-                }
-            }
-            offset = value_stop + 1;
+    let mut cursor = templates::GrammarSourceCursor::new(grammar_source, 0);
+    while let Some((start, ch)) = cursor.next_significant() {
+        if ch == '{' {
+            cursor.seek(
+                matching_action_brace(grammar_source, start + 1)
+                    .map_or(start + 1, |close| close + 1),
+            );
+            continue;
         }
+        if ch != '_' && !ch.is_ascii_alphanumeric() {
+            continue;
+        }
+        let mut name_stop = start + ch.len_utf8();
+        while grammar_source
+            .as_bytes()
+            .get(name_stop)
+            .is_some_and(|byte| *byte == b'_' || byte.is_ascii_alphanumeric())
+        {
+            name_stop += 1;
+        }
+        cursor.seek(name_stop);
+        let Some(&rule_index) = rule_indices.get(&grammar_source[start..name_stop]) else {
+            continue;
+        };
+        let value_open = templates::skip_ascii_whitespace(grammar_source, name_stop);
+        if grammar_source.as_bytes().get(value_open) != Some(&b'[') {
+            continue;
+        }
+        let value_start = value_open + 1;
+        let Some(value_stop) = grammar_source[value_start..]
+            .find(']')
+            .map(|index| value_start + index)
+        else {
+            break;
+        };
+        let value = grammar_source[value_start..value_stop].trim();
+        let template = value.parse::<i64>().map_or_else(
+            |_| {
+                if matches!(value, "true" | "false") {
+                    Some(RuleArgTemplate::Literal(i64::from(value == "true")))
+                } else if value == r#"<VarRef("i")>"# {
+                    Some(RuleArgTemplate::InheritLocal)
+                } else {
+                    None
+                }
+            },
+            |value| Some(RuleArgTemplate::Literal(value)),
+        );
+        if let Some(template) = template {
+            calls.push((start, rule_index, template));
+        }
+        cursor.seek(value_stop + 1);
     }
     calls.sort_by_key(|(start, _, _)| *start);
     calls
@@ -10709,6 +10832,16 @@ atn:
             generated_atn_preferred_rule_calls(&rules, &[]),
             vec![true; ATN_PREFERRED_LEADING_CALL_CHAIN_MIN]
         );
+        let required = BTreeSet::from([ATN_PREFERRED_LEADING_CALL_CHAIN_MIN - 1]);
+        assert_eq!(
+            generated_atn_preferred_rule_calls_excluding(
+                &rules,
+                &[],
+                &generated_rule_callers_reaching(&rules, &required),
+            ),
+            vec![false; ATN_PREFERRED_LEADING_CALL_CHAIN_MIN],
+            "portable-local owners and generated callers must stay on the generated path"
+        );
 
         rules.truncate(ATN_PREFERRED_LEADING_CALL_CHAIN_MIN - 1);
         assert_eq!(
@@ -11051,6 +11184,25 @@ atn:
                 (1, RuleArgTemplate::Literal(1)),
                 (1, RuleArgTemplate::Literal(0)),
             ]
+        );
+    }
+
+    #[test]
+    fn boolean_literal_rule_arguments_ignore_comments_literals_and_actions() {
+        let data = InterpData {
+            rule_names: vec!["s".to_owned(), "flag".to_owned()],
+            ..InterpData::default()
+        };
+
+        assert_eq!(
+            literal_rule_arg_calls(
+                &data,
+                "parser grammar T;\n\
+                 s : /* flag[true] */ flag[false] 'flag[true]' \"flag[false]\" \
+                     { flag[true] } ;\n\
+                 flag[boolean enabled] : ;"
+            ),
+            [(1, RuleArgTemplate::Literal(0))]
         );
     }
 
@@ -11468,6 +11620,22 @@ s : ;
         assert_eq!(
             error.to_string(),
             "generated parser did not emit 1 rule(s): s"
+        );
+    }
+
+    #[test]
+    fn portable_local_semantics_reject_missing_generated_owner() {
+        let error = require_portable_local_rules_generated(
+            &[None],
+            &BTreeSet::from([0]),
+            &minimal_parser_data(),
+        )
+        .expect_err("portable local semantics cannot use interpreted fallback");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            error.to_string(),
+            "portable local semantics require 1 generated parser rule(s): s"
         );
     }
 
@@ -13912,6 +14080,7 @@ ID : [a-z]+ ;\n";
             portable.declarations,
             [vec!["let mut __antlr_local_seen = false;".to_owned()]]
         );
+        assert_eq!(portable.required_generated_rules, BTreeSet::from([0]));
         assert_eq!(
             portable.inline_actions.get(&0).map(String::as_str),
             Some("__antlr_local_seen = true;")

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2401,7 +2401,7 @@ impl EmbeddedStepRender<'_> {
 #[derive(Clone, Copy)]
 struct PortableLocalStepRender<'a> {
     declarations: &'a [Vec<String>],
-    predicates: &'a BTreeMap<(usize, usize), String>,
+    predicates: &'a BTreeMap<(usize, usize), (String, Option<String>)>,
 }
 
 #[derive(Clone, Copy)]
@@ -4351,17 +4351,25 @@ fn render_generated_step(
             rule_index,
             pred_index,
         } => {
-            if let Some(condition) = render_context
+            if let Some((condition, message)) = render_context
                 .portable_locals
                 .and_then(|portable| portable.predicates.get(&(*rule_index, *pred_index)))
             {
                 writeln!(out, "{pad}if !({condition}) {{")
                     .expect("writing to a string cannot fail");
-                writeln!(
-                    out,
-                    "{pad}    return Err(self.base.failed_predicate_error(\"semantic predicate\"));"
-                )
-                .expect("writing to a string cannot fail");
+                match message {
+                    Some(message) => writeln!(
+                        out,
+                        "{pad}    return Err(self.base.failed_predicate_option_error({rule_index}, \"{}\".to_owned()));",
+                        rust_string(message)
+                    )
+                    .expect("writing to a string cannot fail"),
+                    None => writeln!(
+                        out,
+                        "{pad}    return Err(self.base.failed_predicate_error(\"semantic predicate\"));"
+                    )
+                    .expect("writing to a string cannot fail"),
+                }
                 writeln!(out, "{pad}}}").expect("writing to a string cannot fail");
                 return;
             }
@@ -4945,9 +4953,9 @@ fn semantic_alt_candidate_condition_with_la(
     }
     conditions.extend(leading_predicates(steps).into_iter().map(
         |(rule_index, pred_index)| {
-            if let Some(condition) = portable.and_then(|portable| {
-                portable.predicates.get(&(rule_index, pred_index))
-            }) {
+            if let Some((condition, _)) =
+                portable.and_then(|portable| portable.predicates.get(&(rule_index, pred_index)))
+            {
                 return format!("({condition})");
             }
             embedded.map_or_else(
@@ -5402,7 +5410,6 @@ fn render_generated_left_recursive_loop(
             "{pad}        Err(_) => return Err(self.base.no_viable_alternative_error(__decision_start)),"
         )
         .expect("writing to a string cannot fail");
-        writeln!(out, "{pad}    }};").expect("writing to a string cannot fail");
     } else {
         writeln!(
             out,
@@ -5741,17 +5748,19 @@ struct PortableLocalData {
     /// ATN action source state -> generated assignment.
     inline_actions: BTreeMap<usize, String>,
     /// Parser predicate coordinate -> generated boolean expression.
-    predicates: BTreeMap<(usize, usize), String>,
+    predicates: BTreeMap<(usize, usize), (String, Option<String>)>,
 }
 
 impl PortableLocalData {
+    fn has_semantics(&self) -> bool {
+        !self.inline_actions.is_empty() || !self.predicates.is_empty()
+    }
+
     fn step_render(&self) -> Option<PortableLocalStepRender<'_>> {
-        (!self.inline_actions.is_empty() || !self.predicates.is_empty()).then_some(
-            PortableLocalStepRender {
-                declarations: &self.declarations,
-                predicates: &self.predicates,
-            },
-        )
+        self.has_semantics().then_some(PortableLocalStepRender {
+            declarations: &self.declarations,
+            predicates: &self.predicates,
+        })
     }
 }
 
@@ -5882,7 +5891,13 @@ fn build_portable_local_data(
         } else {
             local.clone()
         };
-        out.predicates.insert((rule_index, pred_index), expression);
+        out.predicates.insert(
+            (rule_index, pred_index),
+            (
+                expression,
+                predicate_fail_message(source, block.after_brace),
+            ),
+        );
     }
 
     Ok(out)
@@ -6922,7 +6937,8 @@ fn render_parser_with_options(
             all: &predicate_coordinates,
             generated: &generated_predicate_coordinates,
         },
-        false,
+        (has_action_dispatch || has_predicate_dispatch || portable_local_data.has_semantics())
+            && !options.embedded,
     )?;
     if options.require_generated_parser || options.embedded {
         // Embedded actions only run on the generated path, so every rule must
@@ -13133,7 +13149,7 @@ ID: [a-z]+ { customJava(); };
 
     const PORTABLE_BOOL_GRAMMAR: &str = "parser grammar S;\n\
 s locals [boolean seen=false]\n\
-    : { $seen = true; } {$seen}? A\n\
+    : { $seen = true; } {$seen}?<fail='not seen'> A\n\
     ;\n";
 
     const PREDICATE_GRAMMAR: &str = "parser grammar S;\ns : {isTypeName()}? A ;\n";
@@ -13901,8 +13917,11 @@ ID : [a-z]+ ;\n";
             Some("__antlr_local_seen = true;")
         );
         assert_eq!(
-            portable.predicates.get(&(0, 0)).map(String::as_str),
-            Some("__antlr_local_seen")
+            portable
+                .predicates
+                .get(&(0, 0))
+                .map(|(condition, message)| (condition.as_str(), message.as_deref())),
+            Some(("__antlr_local_seen", Some("not seen")))
         );
 
         let module = render_parser("SParser", &data, Some(PORTABLE_BOOL_GRAMMAR))
@@ -13910,6 +13929,7 @@ ID : [a-z]+ ;\n";
         assert!(module.contains("let mut __antlr_local_seen = false;"));
         assert!(module.contains("__antlr_local_seen = true;"));
         assert!(module.contains("if !(__antlr_local_seen) {"));
+        assert!(module.contains("failed_predicate_option_error(0, \"not seen\".to_owned())"));
 
         let entries = collect_parser_semantics(
             &data,

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2652,6 +2652,54 @@ fn generated_rule_callers_reaching(
     }
 }
 
+fn parser_rule_callers_reaching(
+    data: &InterpData,
+    target_rules: &BTreeSet<usize>,
+) -> io::Result<BTreeSet<usize>> {
+    if target_rules.is_empty() {
+        return Ok(BTreeSet::new());
+    }
+    let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
+        .deserialize()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    Ok(atn_rule_callers_reaching(
+        &atn,
+        target_rules,
+        data.rule_names.len(),
+    ))
+}
+
+fn atn_rule_callers_reaching(
+    atn: &Atn,
+    target_rules: &BTreeSet<usize>,
+    rule_count: usize,
+) -> BTreeSet<usize> {
+    let mut reaching = target_rules.clone();
+    loop {
+        let mut changed = false;
+        for state in atn.states() {
+            let Some(caller_rule) = state.rule_index.filter(|index| *index < rule_count) else {
+                continue;
+            };
+            if reaching.contains(&caller_rule) {
+                continue;
+            }
+            let calls_reaching_rule = state.transitions.iter().any(|transition| {
+                matches!(
+                    transition,
+                    Transition::Rule { rule_index, .. } if reaching.contains(rule_index)
+                )
+            });
+            if calls_reaching_rule {
+                changed |= reaching.insert(caller_rule);
+            }
+        }
+        if !changed {
+            return reaching;
+        }
+    }
+}
+
 fn generated_steps_call_any_rule(
     steps: &[GeneratedParserStep],
     rule_indices: &BTreeSet<usize>,
@@ -6938,10 +6986,12 @@ fn render_parser_with_options(
     } else {
         grammar_source
     };
-    let portable_local_data = template_grammar_source
+    let mut portable_local_data = template_grammar_source
         .map(|source| build_portable_local_data(data, source, patterns))
         .transpose()?
         .unwrap_or_default();
+    portable_local_data.required_generated_rules =
+        parser_rule_callers_reaching(data, &portable_local_data.required_generated_rules)?;
     // A per-coordinate `assume-*` override is a documented no-op fallback; it
     // must not fall through to `parser_action_hook`, which would fail loud under
     // the Error policy or run a user side effect for a coordinate the manifest
@@ -11636,6 +11686,36 @@ s : ;
         assert_eq!(
             error.to_string(),
             "portable local semantics require 1 generated parser rule(s): s"
+        );
+    }
+
+    #[test]
+    fn portable_local_semantics_reject_missing_generated_caller() {
+        let required = atn_rule_callers_reaching(&entry_candidate_atn(), &BTreeSet::from([1]), 4);
+        assert_eq!(required, BTreeSet::from([0, 1, 2]));
+
+        let rules = vec![
+            None,
+            Some(test_rule(1, Vec::new())),
+            Some(test_rule(2, Vec::new())),
+            Some(test_rule(3, Vec::new())),
+        ];
+        let data = InterpData {
+            rule_names: vec![
+                "firstEntry".to_owned(),
+                "child".to_owned(),
+                "secondEntry".to_owned(),
+                "recursive".to_owned(),
+            ],
+            ..InterpData::default()
+        };
+        let error = require_portable_local_rules_generated(&rules, &required, &data)
+            .expect_err("interpreted callers cannot bypass generated local state");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert_eq!(
+            error.to_string(),
+            "portable local semantics require 1 generated parser rule(s): firstEntry"
         );
     }
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -12105,6 +12105,55 @@ s : ;
     }
 
     #[test]
+    fn generated_loop_filters_portable_local_predicate() {
+        let body = vec![
+            GeneratedParserStep::Predicate {
+                rule_index: 1,
+                pred_index: 0,
+            },
+            mt(3, 4),
+        ];
+        let declarations = vec![vec!["let mut __antlr_local_seen = false;".to_owned()]];
+        let predicates = BTreeMap::from([((1, 0), ("__antlr_local_seen".to_owned(), None))]);
+        let required_generated_rules = BTreeSet::from([1]);
+        let mut rendered = String::new();
+
+        render_generated_star_loop(
+            &mut rendered,
+            StarLoopRender {
+                state: 1,
+                decision: 0,
+                alts: (1, 2),
+                track_alt_number: false,
+                allow_semantic_context: true,
+                force_context: false,
+                plus_loop: false,
+                fast_path: None,
+                body: &body,
+            },
+            0,
+            GeneratedStepRenderContext {
+                embedded: None,
+                portable_locals: Some(PortableLocalStepRender {
+                    declarations: &declarations,
+                    predicates: &predicates,
+                    required_generated_rules: &required_generated_rules,
+                }),
+                inline_action_statements: &BTreeMap::new(),
+                track_alt_numbers: false,
+                direct_generated_rule_calls: &[],
+                atn_preferred_rule_calls: &[],
+            },
+        );
+
+        assert!(rendered.contains("__semantic_la == 3 && (__antlr_local_seen)"));
+        assert!(!rendered.contains("parser_semantic_ir_predicate_matches"));
+        assert!(
+            rendered.contains("antlr4_runtime::ParserAtnPrediction { alt: 2, ..__prediction }")
+        );
+    }
+
+    #[test]
     fn generated_loop_filters_first_nested_predicated_decision() {
         let body = vec![GeneratedParserStep::Decision {
             state: 1,

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2401,6 +2401,7 @@ impl EmbeddedStepRender<'_> {
 #[derive(Clone, Copy)]
 struct PortableLocalStepRender<'a> {
     declarations: &'a [Vec<String>],
+    inline_actions: &'a BTreeMap<usize, String>,
     predicates: &'a BTreeMap<(usize, usize), (String, Option<String>)>,
     required_generated_rules: &'a BTreeSet<usize>,
 }
@@ -4938,7 +4939,7 @@ fn render_generated_semantic_prediction_filter(
 ) {
     let alt_has_predicates = alts
         .iter()
-        .map(|steps| !leading_predicates(steps).is_empty())
+        .map(|steps| !leading_predicates(steps, portable).is_empty())
         .collect::<Vec<_>>();
     if !alt_has_predicates
         .iter()
@@ -4970,7 +4971,7 @@ fn render_generated_semantic_prediction_filter(
         writeln!(out, "{pad}        {alt} if {condition} => Some({alt}),")
             .expect("writing to a string cannot fail");
         writeln!(out, "{pad}        {alt} => {{").expect("writing to a string cannot fail");
-        render_semantic_alt_search(out, pad, &alt_conditions, alts);
+        render_semantic_alt_search(out, pad, &alt_conditions, alts, portable);
         writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
     }
     writeln!(out, "{pad}        _ => Some(__prediction.alt),")
@@ -5002,6 +5003,7 @@ fn render_semantic_alt_search(
     pad: &str,
     alt_conditions: &[String],
     alts: &[Vec<GeneratedParserStep>],
+    portable: Option<PortableLocalStepRender<'_>>,
 ) {
     // The predicted alt's predicate failed; pick another alt whose candidate
     // condition holds. This runs in TWO passes so an alt whose viability is not
@@ -5023,7 +5025,7 @@ fn render_semantic_alt_search(
     // loop-entry and diagnostic paths keep their behavior.
     let unresolved = alts
         .iter()
-        .map(|steps| semantic_alt_guard_is_unresolved(steps))
+        .map(|steps| semantic_alt_guard_is_unresolved(steps, portable))
         .collect::<Vec<_>>();
     for (index, condition) in alt_conditions.iter().enumerate() {
         if unresolved.get(index).copied().unwrap_or(false) {
@@ -5093,7 +5095,7 @@ fn semantic_alt_candidate_condition_with_la(
     if let Some(lookahead) = leading_lookahead_condition(steps, la_symbol) {
         conditions.push(lookahead);
     }
-    conditions.extend(leading_predicates(steps).into_iter().map(
+    conditions.extend(leading_predicates(steps, portable).into_iter().map(
         |(rule_index, pred_index)| {
             if let Some((condition, _)) =
                 portable.and_then(|portable| portable.predicates.get(&(rule_index, pred_index)))
@@ -5130,8 +5132,11 @@ fn semantic_alt_candidate_condition_with_la(
 /// concrete matching lookahead. The search treats these as last-resort
 /// candidates instead. A genuine epsilon alt (no consuming step at all) is NOT
 /// unguarded in this sense — it legitimately matches anything.
-fn semantic_alt_guard_is_unresolved(steps: &[GeneratedParserStep]) -> bool {
-    if !leading_predicates(steps).is_empty() {
+fn semantic_alt_guard_is_unresolved(
+    steps: &[GeneratedParserStep],
+    portable: Option<PortableLocalStepRender<'_>>,
+) -> bool {
+    if !leading_predicates(steps, portable).is_empty() {
         return false;
     }
     if leading_lookahead_condition(steps, "__semantic_la").is_some() {
@@ -5150,7 +5155,10 @@ fn semantic_alt_guard_is_unresolved(steps: &[GeneratedParserStep]) -> bool {
     })
 }
 
-fn leading_predicates(steps: &[GeneratedParserStep]) -> Vec<(usize, usize)> {
+fn leading_predicates(
+    steps: &[GeneratedParserStep],
+    portable: Option<PortableLocalStepRender<'_>>,
+) -> Vec<(usize, usize)> {
     let mut predicates = Vec::new();
     for step in steps {
         match step {
@@ -5158,6 +5166,14 @@ fn leading_predicates(steps: &[GeneratedParserStep]) -> Vec<(usize, usize)> {
                 rule_index,
                 pred_index,
             } => predicates.push((*rule_index, *pred_index)),
+            // Portable assignments run only after the alternative is selected,
+            // so predicates after one are not prediction-visible.
+            GeneratedParserStep::Action { source_state, .. }
+                if portable
+                    .is_some_and(|portable| portable.inline_actions.contains_key(source_state)) =>
+            {
+                break;
+            }
             GeneratedParserStep::Action { .. } | GeneratedParserStep::Precedence(_) => {}
             GeneratedParserStep::MatchToken { .. }
             | GeneratedParserStep::MatchSet { .. }
@@ -5903,6 +5919,7 @@ impl PortableLocalData {
     fn step_render(&self) -> Option<PortableLocalStepRender<'_>> {
         self.has_semantics().then_some(PortableLocalStepRender {
             declarations: &self.declarations,
+            inline_actions: &self.inline_actions,
             predicates: &self.predicates,
             required_generated_rules: &self.required_generated_rules,
         })
@@ -12034,6 +12051,69 @@ s : ;
     }
 
     #[test]
+    fn generated_decision_does_not_hoist_portable_predicate_past_local_action() {
+        let alts = vec![
+            vec![
+                GeneratedParserStep::Action {
+                    source_state: 5,
+                    rule_index: 1,
+                },
+                GeneratedParserStep::Predicate {
+                    rule_index: 1,
+                    pred_index: 0,
+                },
+                mt(1, 2),
+            ],
+            vec![mt(1, 3)],
+        ];
+        let declarations = vec![
+            Vec::new(),
+            vec!["let mut __antlr_local_seen = false;".to_owned()],
+        ];
+        let inline_actions = BTreeMap::from([(5, "__antlr_local_seen = true;".to_owned())]);
+        let predicates = BTreeMap::from([((1, 0), ("__antlr_local_seen".to_owned(), None))]);
+        let required_generated_rules = BTreeSet::from([1]);
+        let mut rendered = String::new();
+
+        render_generated_decision(
+            &mut rendered,
+            DecisionRender {
+                state: 1,
+                decision: 0,
+                track_alt_number: false,
+                allow_semantic_context: true,
+                force_context: false,
+                fast_path: None,
+                alts: &alts,
+            },
+            0,
+            GeneratedStepRenderContext {
+                embedded: None,
+                portable_locals: Some(PortableLocalStepRender {
+                    declarations: &declarations,
+                    inline_actions: &inline_actions,
+                    predicates: &predicates,
+                    required_generated_rules: &required_generated_rules,
+                }),
+                inline_action_statements: &inline_actions,
+                track_alt_numbers: false,
+                direct_generated_rule_calls: &[],
+                atn_preferred_rule_calls: &[],
+            },
+        );
+
+        assert!(!rendered.contains("let __semantic_alt"));
+        assert!(!rendered.contains("__semantic_la == 1 && (__antlr_local_seen)"));
+        let assignment = rendered
+            .find("__antlr_local_seen = true;")
+            .expect("portable assignment is rendered in the committed alternative");
+        let predicate = rendered
+            .find("if !(__antlr_local_seen)")
+            .expect("portable predicate is evaluated in the committed alternative");
+        assert!(assignment < predicate);
+    }
+
+    #[test]
     fn generated_decision_records_adaptive_diagnostics() {
         let alts = vec![vec![mt(1, 4)], vec![mt(2, 5)]];
         let mut rendered = String::new();
@@ -12190,6 +12270,7 @@ s : ;
                 embedded: None,
                 portable_locals: Some(PortableLocalStepRender {
                     declarations: &declarations,
+                    inline_actions: &BTreeMap::new(),
                     predicates: &predicates,
                     required_generated_rules: &required_generated_rules,
                 }),
@@ -12308,18 +12389,19 @@ s : ;
             rule_index: 1,
             precedence: GeneratedRuleCallPrecedence::Literal(0),
         }];
-        assert!(semantic_alt_guard_is_unresolved(&rule_call));
+        assert!(semantic_alt_guard_is_unresolved(&rule_call, None));
         // A token-led alt is resolved (concrete lookahead), so NOT unresolved.
-        assert!(!semantic_alt_guard_is_unresolved(&[mt(7, 4)]));
+        assert!(!semantic_alt_guard_is_unresolved(&[mt(7, 4)], None));
         // A predicate-led alt is resolved (guarded by the predicate).
-        assert!(!semantic_alt_guard_is_unresolved(&[
-            GeneratedParserStep::Predicate {
+        assert!(!semantic_alt_guard_is_unresolved(
+            &[GeneratedParserStep::Predicate {
                 rule_index: 2,
                 pred_index: 0,
-            },
-        ]));
+            }],
+            None,
+        ));
         // A pure epsilon alt (no consuming step) legitimately matches; not unresolved.
-        assert!(!semantic_alt_guard_is_unresolved(&[]));
+        assert!(!semantic_alt_guard_is_unresolved(&[], None));
     }
 
     #[test]
@@ -12348,7 +12430,7 @@ s : ;
             .map(|steps| semantic_alt_candidate_condition(steps, None, None))
             .collect::<Vec<_>>();
         let mut rendered = String::new();
-        render_semantic_alt_search(&mut rendered, "", &alt_conditions, &alts);
+        render_semantic_alt_search(&mut rendered, "", &alt_conditions, &alts, None);
 
         // The resolved token alt 3 is emitted before the unresolved rule-call
         // alt 2 (which keeps its real `true` condition as a last-resort branch),
@@ -12399,7 +12481,7 @@ s : ;
             .map(|steps| semantic_alt_candidate_condition(steps, None, None))
             .collect::<Vec<_>>();
         let mut rendered = String::new();
-        render_semantic_alt_search(&mut rendered, "", &alt_conditions, &alts);
+        render_semantic_alt_search(&mut rendered, "", &alt_conditions, &alts, None);
 
         // The lone unresolved alt is reachable via its real condition, not disabled.
         assert!(

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -942,6 +942,10 @@ fn collect_parser_semantics(
     patterns: &SemPatternFile,
 ) -> io::Result<Vec<SemanticsEntry>> {
     let mut entries = Vec::new();
+    let portable_locals = grammar_source
+        .map(|source| build_portable_local_data(data, source, patterns))
+        .transpose()?
+        .unwrap_or_default();
 
     let predicate_coordinates = lexer_predicate_transitions(data)?;
     if !predicate_coordinates.is_empty() {
@@ -975,8 +979,18 @@ fn collect_parser_semantics(
                         Some(pred_index),
                         None,
                     )
-                    .unwrap_or_else(|| predicate_template_disposition(template, policy)),
-                template: template.map(|template| format!("{template:?}")),
+                    .unwrap_or_else(|| {
+                        if portable_locals.predicates.contains_key(coordinate) {
+                            SemanticsDisposition::Translated
+                        } else {
+                            predicate_template_disposition(template, policy)
+                        }
+                    }),
+                template: portable_locals
+                    .predicates
+                    .contains_key(coordinate)
+                    .then(|| "PortableBooleanLocal".to_owned())
+                    .or_else(|| template.map(|template| format!("{template:?}"))),
             });
         }
     }
@@ -1029,7 +1043,11 @@ fn collect_parser_semantics(
                         Some(*state),
                     )
                     .unwrap_or_else(|| {
-                        if synthetic_states.contains(state) || empty_action_states.contains(state) {
+                        if portable_locals.inline_actions.contains_key(state) {
+                            SemanticsDisposition::Translated
+                        } else if synthetic_states.contains(state)
+                            || empty_action_states.contains(state)
+                        {
                             // ANTLR-synthesized actions and authored empty action
                             // bodies are no-op states exempt from the error gate.
                             SemanticsDisposition::Synthetic
@@ -1037,7 +1055,10 @@ fn collect_parser_semantics(
                             policy.unknown_action_disposition()
                         }
                     }),
-                template: None,
+                template: portable_locals
+                    .inline_actions
+                    .contains_key(state)
+                    .then(|| "PortableBooleanLocal".to_owned()),
             });
         }
     }
@@ -2378,9 +2399,17 @@ impl EmbeddedStepRender<'_> {
 }
 
 #[derive(Clone, Copy)]
+struct PortableLocalStepRender<'a> {
+    declarations: &'a [Vec<String>],
+    predicates: &'a BTreeMap<(usize, usize), String>,
+}
+
+#[derive(Clone, Copy)]
 struct GeneratedStepRenderContext<'a> {
     /// `Some` in embedded mode: actions/predicates are verbatim Rust.
     embedded: Option<EmbeddedStepRender<'a>>,
+    /// Portable raw-grammar boolean locals translated without embedded mode.
+    portable_locals: Option<PortableLocalStepRender<'a>>,
     inline_action_statements: &'a BTreeMap<usize, String>,
     track_alt_numbers: bool,
     direct_generated_rule_calls: &'a [bool],
@@ -3771,9 +3800,11 @@ fn render_generated_rule_dispatch(
         inline_action_statements,
         track_alt_numbers,
         None,
+        None,
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_generated_rule_dispatch_with_rule_names(
     rules: &[Option<GeneratedParserRule>],
     direct_generated_rule_calls: &[bool],
@@ -3781,6 +3812,7 @@ fn render_generated_rule_dispatch_with_rule_names(
     inline_action_statements: &BTreeMap<usize, String>,
     track_alt_numbers: bool,
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable_locals: Option<PortableLocalStepRender<'_>>,
 ) -> String {
     let mut out = String::new();
     let atn_preferred_rule_calls = generated_atn_preferred_rule_calls(rules, rule_names);
@@ -3817,6 +3849,7 @@ fn render_generated_rule_dispatch_with_rule_names(
     writeln!(out, "    }}").expect("writing to a string cannot fail");
     let step_render_context = GeneratedStepRenderContext {
         embedded,
+        portable_locals,
         inline_action_statements,
         track_alt_numbers,
         direct_generated_rule_calls,
@@ -3847,6 +3880,23 @@ fn render_generated_rule_dispatch_with_rule_names(
         render_generated_rule_method(&mut out, rule, step_render_context);
     }
     out
+}
+
+fn render_portable_local_declarations(
+    out: &mut String,
+    rule_index: usize,
+    step_render_context: GeneratedStepRenderContext<'_>,
+) {
+    let Some(portable) = step_render_context.portable_locals else {
+        return;
+    };
+    let Some(declarations) = portable.declarations.get(rule_index) else {
+        return;
+    };
+    for declaration in declarations {
+        writeln!(out, "        #[allow(unused_mut)]\n        {declaration}")
+            .expect("writing to a string cannot fail");
+    }
 }
 
 /// Declares the embedded per-rule attrs local (`__attrs`) on rule entry.
@@ -3967,6 +4017,7 @@ fn render_generated_rule_method(
         "        let __rule_start = antlr4_runtime::IntStream::index(self.base.input());"
     )
     .expect("writing to a string cannot fail");
+    render_portable_local_declarations(out, index, step_render_context);
     render_embedded_attrs_local(out, index, step_render_context);
     render_embedded_init_entry(out, index, step_render_context);
     writeln!(out, "        let mut __consumed_eof = false;")
@@ -4102,6 +4153,7 @@ fn render_generated_left_recursive_rule_method(
         "        let __rule_start = antlr4_runtime::IntStream::index(self.base.input());"
     )
     .expect("writing to a string cannot fail");
+    render_portable_local_declarations(out, index, step_render_context);
     render_embedded_attrs_local(out, index, step_render_context);
     render_embedded_init_entry(out, index, step_render_context);
     writeln!(out, "        let mut __consumed_eof = false;")
@@ -4226,7 +4278,7 @@ fn render_generated_step(
                 .expect("writing to a string cannot fail");
             writeln!(
                 out,
-                "{pad}for __child in __match.into_children() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
+                "{pad}for __child in __match.into_child_iter() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
             )
             .expect("writing to a string cannot fail");
         }
@@ -4244,7 +4296,7 @@ fn render_generated_step(
                 .expect("writing to a string cannot fail");
             writeln!(
                 out,
-                "{pad}for __child in __match.into_children() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
+                "{pad}for __child in __match.into_child_iter() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
             )
             .expect("writing to a string cannot fail");
         }
@@ -4262,7 +4314,7 @@ fn render_generated_step(
                 .expect("writing to a string cannot fail");
             writeln!(
                 out,
-                "{pad}for __child in __match.into_children() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
+                "{pad}for __child in __match.into_child_iter() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
             )
             .expect("writing to a string cannot fail");
         }
@@ -4281,7 +4333,7 @@ fn render_generated_step(
                 .expect("writing to a string cannot fail");
             writeln!(
                 out,
-                "{pad}for __child in __match.into_children() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
+                "{pad}for __child in __match.into_child_iter() {{ self.base.add_parse_child(&mut __ctx, __child); }}"
             )
             .expect("writing to a string cannot fail");
         }
@@ -4299,6 +4351,20 @@ fn render_generated_step(
             rule_index,
             pred_index,
         } => {
+            if let Some(condition) = render_context
+                .portable_locals
+                .and_then(|portable| portable.predicates.get(&(*rule_index, *pred_index)))
+            {
+                writeln!(out, "{pad}if !({condition}) {{")
+                    .expect("writing to a string cannot fail");
+                writeln!(
+                    out,
+                    "{pad}    return Err(self.base.failed_predicate_error(\"semantic predicate\"));"
+                )
+                .expect("writing to a string cannot fail");
+                writeln!(out, "{pad}}}").expect("writing to a string cannot fail");
+                return;
+            }
             if let Some(embedded) = render_context.embedded {
                 let (condition, message) =
                     embedded_predicate_condition_and_message(&embedded, *rule_index, *pred_index);
@@ -4583,13 +4649,20 @@ fn render_generated_decision(
         }
     }
     if allow_semantic_context {
-        render_generated_semantic_prediction_filter(out, &pad, alts, render_context.embedded);
+        render_generated_semantic_prediction_filter(
+            out,
+            &pad,
+            alts,
+            render_context.embedded,
+            render_context.portable_locals,
+        );
         render_generated_decision_diagnostic_report(
             out,
             &pad,
             state,
             alts,
             render_context.embedded,
+            render_context.portable_locals,
         );
     } else {
         writeln!(
@@ -4671,10 +4744,13 @@ fn render_generated_decision_diagnostic_report(
     state: usize,
     alts: &[Vec<GeneratedParserStep>],
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable: Option<PortableLocalStepRender<'_>>,
 ) {
     let alt_conditions = alts
         .iter()
-        .map(|steps| semantic_alt_candidate_condition_with_la(steps, "__diagnostic_la", embedded))
+        .map(|steps| {
+            semantic_alt_candidate_condition_with_la(steps, "__diagnostic_la", embedded, portable)
+        })
         .collect::<Vec<_>>();
     if alt_conditions
         .iter()
@@ -4708,6 +4784,7 @@ fn render_generated_semantic_prediction_filter(
     pad: &str,
     alts: &[Vec<GeneratedParserStep>],
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable: Option<PortableLocalStepRender<'_>>,
 ) {
     let alt_has_predicates = alts
         .iter()
@@ -4721,7 +4798,7 @@ fn render_generated_semantic_prediction_filter(
     }
     let alt_conditions = alts
         .iter()
-        .map(|steps| semantic_alt_candidate_condition(steps, embedded))
+        .map(|steps| semantic_alt_candidate_condition(steps, embedded, portable))
         .collect::<Vec<_>>();
     writeln!(
         out,
@@ -4843,14 +4920,16 @@ fn embedded_predicate_condition_and_message(
 fn semantic_alt_candidate_condition(
     steps: &[GeneratedParserStep],
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable: Option<PortableLocalStepRender<'_>>,
 ) -> String {
-    semantic_alt_candidate_condition_with_la(steps, "__semantic_la", embedded)
+    semantic_alt_candidate_condition_with_la(steps, "__semantic_la", embedded, portable)
 }
 
 fn semantic_alt_candidate_condition_with_la(
     steps: &[GeneratedParserStep],
     la_symbol: &str,
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable: Option<PortableLocalStepRender<'_>>,
 ) -> String {
     // Order matters: the lookahead guard comes FIRST so `&&` short-circuits on it
     // before any predicate hook runs. Otherwise, searching alternatives in a
@@ -4866,6 +4945,11 @@ fn semantic_alt_candidate_condition_with_la(
     }
     conditions.extend(leading_predicates(steps).into_iter().map(
         |(rule_index, pred_index)| {
+            if let Some(condition) = portable.and_then(|portable| {
+                portable.predicates.get(&(rule_index, pred_index))
+            }) {
+                return format!("({condition})");
+            }
             embedded.map_or_else(
                 || {
                     format!(
@@ -5201,6 +5285,7 @@ fn render_generated_star_loop(
         exit_alt,
         body,
         render_context.embedded,
+        render_context.portable_locals,
     );
     writeln!(
         out,
@@ -5259,62 +5344,125 @@ fn render_generated_left_recursive_loop(
         "{pad}    let __decision_start = antlr4_runtime::IntStream::index(self.base.input());"
     )
     .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}    let __prediction_precedence = if __precedence <= 0 {{ 0 }} else {{ __precedence as usize }};"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(out, "{pad}    let __prediction = match {{").expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        let __prediction_context = self.base.prediction_context(atn());"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        __simulator.set_exact_ambig_detection(self.base.prediction_mode() == antlr4_runtime::PredictionMode::LlExactAmbigDetection);"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context)"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(out, "{pad}    }} {{").expect("writing to a string cannot fail");
-    writeln!(out, "{pad}        Ok(__prediction) => __prediction,")
+    if render_context.embedded.is_some() {
+        writeln!(
+            out,
+            "{pad}    let __prediction_precedence = if __precedence <= 0 {{ 0 }} else {{ __precedence as usize }};"
+        )
         .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        Err(antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ .. }}) if self.base.left_recursive_loop_enter_matches(atn(), {state}, __precedence) => {{"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}            antlr4_runtime::ParserAtnPrediction {{ alt: {enter_alt}, requires_full_context: true, has_semantic_context: true, diagnostic: None }}"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        Err(antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ .. }}) => {{"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}            antlr4_runtime::ParserAtnPrediction {{ alt: {exit_alt}, requires_full_context: true, has_semantic_context: false, diagnostic: None }}"
-    )
-    .expect("writing to a string cannot fail");
-    writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
-    writeln!(
-        out,
-        "{pad}        Err(_) => return Err(self.base.no_viable_alternative_error(__decision_start)),"
-    )
-    .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}    let __prediction = match {{")
+            .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        let __prediction_context = self.base.prediction_context(atn());"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        __simulator.set_exact_ambig_detection(self.base.prediction_mode() == antlr4_runtime::PredictionMode::LlExactAmbigDetection);"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context)"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}    }} {{").expect("writing to a string cannot fail");
+        writeln!(out, "{pad}        Ok(__prediction) => __prediction,")
+            .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        Err(antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ .. }}) if self.base.left_recursive_loop_enter_matches(atn(), {state}, __precedence) => {{"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            antlr4_runtime::ParserAtnPrediction {{ alt: {enter_alt}, requires_full_context: true, has_semantic_context: true, diagnostic: None }}"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        Err(antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ .. }}) => {{"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            antlr4_runtime::ParserAtnPrediction {{ alt: {exit_alt}, requires_full_context: true, has_semantic_context: false, diagnostic: None }}"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        Err(_) => return Err(self.base.no_viable_alternative_error(__decision_start)),"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}    }};").expect("writing to a string cannot fail");
+    } else {
+        writeln!(
+            out,
+            "{pad}    let __prediction = match self.base.left_recursive_loop_enter_prediction(atn(), {state}, __precedence) {{"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        Some(true) => antlr4_runtime::ParserAtnPrediction {{ alt: {enter_alt}, requires_full_context: false, has_semantic_context: true, diagnostic: None }},"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}        Some(false) => antlr4_runtime::ParserAtnPrediction {{ alt: {exit_alt}, requires_full_context: false, has_semantic_context: false, diagnostic: None }},"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}        None => {{").expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            let __prediction_precedence = if __precedence <= 0 {{ 0 }} else {{ __precedence as usize }};"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            let __prediction_context = self.base.prediction_context(atn());"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            __simulator.set_exact_ambig_detection(self.base.prediction_mode() == antlr4_runtime::PredictionMode::LlExactAmbigDetection);"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}            __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context)"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}                .map_err(|__error| match __error {{"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}                    antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ index, .. }} => self.base.no_viable_alternative_error_at(__decision_start, index),"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(
+            out,
+            "{pad}                    _ => self.base.no_viable_alternative_error(__decision_start),"
+        )
+        .expect("writing to a string cannot fail");
+        writeln!(out, "{pad}                }})?").expect("writing to a string cannot fail");
+        writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
+    }
     writeln!(out, "{pad}    }};").expect("writing to a string cannot fail");
     render_generated_loop_semantic_prediction_filter(
         out,
@@ -5323,6 +5471,7 @@ fn render_generated_left_recursive_loop(
         exit_alt,
         body,
         render_context.embedded,
+        render_context.portable_locals,
     );
     writeln!(
         out,
@@ -5365,6 +5514,7 @@ fn render_generated_left_recursive_loop(
     writeln!(out, "{pad}}}").expect("writing to a string cannot fail");
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render_generated_loop_semantic_prediction_filter(
     out: &mut String,
     pad: &str,
@@ -5372,8 +5522,9 @@ fn render_generated_loop_semantic_prediction_filter(
     exit_alt: usize,
     body: &[GeneratedParserStep],
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable: Option<PortableLocalStepRender<'_>>,
 ) {
-    let Some(condition) = loop_entry_condition(body, embedded) else {
+    let Some(condition) = loop_entry_condition(body, embedded, portable) else {
         return;
     };
     writeln!(
@@ -5400,11 +5551,12 @@ fn render_generated_loop_semantic_prediction_filter(
 fn loop_entry_condition(
     body: &[GeneratedParserStep],
     embedded: Option<EmbeddedStepRender<'_>>,
+    portable: Option<PortableLocalStepRender<'_>>,
 ) -> Option<String> {
     let step = body.first()?;
     match step {
         GeneratedParserStep::Predicate { .. } | GeneratedParserStep::Precedence(_) => {
-            Some(semantic_alt_candidate_condition(body, embedded))
+            Some(semantic_alt_candidate_condition(body, embedded, portable))
         }
         GeneratedParserStep::Decision { alts, .. } => {
             if !alts.iter().any(|alt| steps_contain_predicate(alt)) {
@@ -5412,7 +5564,12 @@ fn loop_entry_condition(
             }
             Some(
                 alts.iter()
-                    .map(|alt| format!("({})", semantic_alt_candidate_condition(alt, embedded)))
+                    .map(|alt| {
+                        format!(
+                            "({})",
+                            semantic_alt_candidate_condition(alt, embedded, portable)
+                        )
+                    })
                     .collect::<Vec<_>>()
                     .join(" || "),
             )
@@ -5573,6 +5730,162 @@ struct EmbeddedParserData {
     adaptive_decisions: BTreeSet<usize>,
     /// Tool LOOK(1) dispatch intervals for LL(1)-disjoint decisions.
     ll1_decision_arms: BTreeMap<usize, Vec<Vec<(i32, i32)>>>,
+}
+
+/// Raw grammar-local booleans whose actions and predicates are portable
+/// without executing target-language code.
+#[derive(Debug, Default)]
+struct PortableLocalData {
+    /// Rule index -> generated local variable declarations.
+    declarations: Vec<Vec<String>>,
+    /// ATN action source state -> generated assignment.
+    inline_actions: BTreeMap<usize, String>,
+    /// Parser predicate coordinate -> generated boolean expression.
+    predicates: BTreeMap<(usize, usize), String>,
+}
+
+impl PortableLocalData {
+    fn step_render(&self) -> Option<PortableLocalStepRender<'_>> {
+        (!self.inline_actions.is_empty() || !self.predicates.is_empty()).then_some(
+            PortableLocalStepRender {
+                declarations: &self.declarations,
+                predicates: &self.predicates,
+            },
+        )
+    }
+}
+
+fn portable_local_name(name: &str) -> String {
+    format!("__antlr_local_{name}")
+}
+
+fn parse_portable_bool_assignment(body: &str) -> Option<(&str, bool)> {
+    let body = body.trim();
+    let body = body.strip_suffix(';').unwrap_or(body);
+    let (target, value) = body.split_once('=')?;
+    let target = target.trim().strip_prefix('$')?;
+    let value = match value.trim() {
+        "true" => true,
+        "false" => false,
+        _ => return None,
+    };
+    (!target.is_empty()
+        && target
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric()))
+    .then_some((target, value))
+}
+
+fn parse_portable_bool_predicate(body: &str) -> Option<(&str, bool)> {
+    let body = body.trim();
+    let (body, negated) = body
+        .strip_prefix('!')
+        .map_or((body, false), |body| (body.trim(), true));
+    let name = body.strip_prefix('$')?.trim();
+    (!name.is_empty()
+        && name
+            .chars()
+            .all(|ch| ch == '_' || ch.is_ascii_alphanumeric()))
+    .then_some((name, negated))
+}
+
+fn build_portable_local_data(
+    data: &InterpData,
+    source: &str,
+    patterns: &SemPatternFile,
+) -> io::Result<PortableLocalData> {
+    let model = embedded::parse_embedded_rules_model(source, &data.rule_names);
+    let mut out = PortableLocalData {
+        declarations: vec![Vec::new(); data.rule_names.len()],
+        ..PortableLocalData::default()
+    };
+    let mut local_names = Vec::with_capacity(data.rule_names.len());
+    for (rule_index, rule) in model.rules.iter().enumerate() {
+        let mut names = BTreeMap::new();
+        for attr in rule.attrs.iter().filter(|attr| attr.ty == "bool") {
+            let initial = if rule.local_names.contains(&attr.name) {
+                "false"
+            } else if rule.arg_names.first() == Some(&attr.name) {
+                "__precedence != 0"
+            } else {
+                continue;
+            };
+            let local = portable_local_name(&attr.name);
+            out.declarations[rule_index].push(format!("let mut {local} = {initial};"));
+            names.insert(attr.name.clone(), local);
+        }
+        local_names.push(names);
+    }
+
+    let action_slots = parser_action_source_block_slots(source, &data.rule_names);
+    for (state, slot) in
+        assign_states_to_parser_action_slots_with_model(data, &model, action_slots)?
+    {
+        let Some((name, value)) = parse_portable_bool_assignment(&slot.body) else {
+            continue;
+        };
+        let Some(local) = local_names
+            .get(slot.rule_index)
+            .and_then(|names| names.get(name))
+        else {
+            continue;
+        };
+        if patterns
+            .coordinate_disposition(
+                SemanticsKind::ParserAction,
+                data.rule_names.get(slot.rule_index).map(String::as_str),
+                None,
+                Some(state),
+            )
+            .is_some()
+        {
+            continue;
+        }
+        out.inline_actions
+            .insert(state, format!("{local} = {value};"));
+    }
+
+    let coordinates = lexer_predicate_transitions(data)?;
+    let mut predicate_index = 0;
+    let mut offset = 0;
+    while let Some(block) = next_predicate_action_block(source, offset) {
+        offset = block.after_brace;
+        if !predicate_block_included(source, block.open_brace, &data.rule_names) {
+            continue;
+        }
+        let Some(&(rule_index, pred_index)) = coordinates.get(predicate_index) else {
+            break;
+        };
+        predicate_index += 1;
+        let Some((name, negated)) = parse_portable_bool_predicate(block.body) else {
+            continue;
+        };
+        let Some(local) = local_names
+            .get(rule_index)
+            .and_then(|names| names.get(name))
+        else {
+            continue;
+        };
+        if patterns
+            .coordinate_disposition(
+                SemanticsKind::ParserPredicate,
+                data.rule_names.get(rule_index).map(String::as_str),
+                Some(pred_index),
+                None,
+            )
+            .is_some()
+        {
+            continue;
+        }
+        let expression = if negated {
+            format!("!{local}")
+        } else {
+            local.clone()
+        };
+        out.predicates.insert((rule_index, pred_index), expression);
+    }
+
+    Ok(out)
 }
 
 /// LOOK(1) of one decision alternative, plus whether the walk crossed a
@@ -6515,6 +6828,10 @@ fn render_parser_with_options(
     } else {
         grammar_source
     };
+    let portable_local_data = template_grammar_source
+        .map(|source| build_portable_local_data(data, source, patterns))
+        .transpose()?
+        .unwrap_or_default();
     // A per-coordinate `assume-*` override is a documented no-op fallback; it
     // must not fall through to `parser_action_hook`, which would fail loud under
     // the Error policy or run a user side effect for a coordinate the manifest
@@ -6542,9 +6859,10 @@ fn render_parser_with_options(
     )?;
     let rule_args = template_grammar_source
         .map_or_else(|| Ok(Vec::new()), |grammar| parser_rule_args(data, grammar))?;
-    let inline_action_statements = embedded_data
-        .as_ref()
-        .map_or_else(BTreeMap::new, |embedded| embedded.inline_actions.clone());
+    let inline_action_statements = embedded_data.as_ref().map_or_else(
+        || portable_local_data.inline_actions.clone(),
+        |embedded| embedded.inline_actions.clone(),
+    );
     let inline_action_states = inline_action_statements
         .keys()
         .copied()
@@ -6552,7 +6870,7 @@ fn render_parser_with_options(
     let action_states = parser_action_states(data)?
         .into_iter()
         .collect::<BTreeSet<_>>();
-    let generated_action_states = if options.embedded {
+    let mut generated_action_states = if options.embedded {
         action_states.clone()
     } else {
         // Synthetic actions and explicit assume-* overrides are no-op states.
@@ -6564,6 +6882,7 @@ fn render_parser_with_options(
             .copied()
             .collect()
     };
+    generated_action_states.extend(portable_local_data.inline_actions.keys().copied());
     // Under a non-default unknown-coordinate policy every predicate transition
     // must reach the interpreter (which applies the policy), so the coordinate
     // inventory is read from the ATN even without grammar source.
@@ -6575,7 +6894,7 @@ fn render_parser_with_options(
         }
         .into_iter()
         .collect::<BTreeSet<_>>();
-    let generated_predicate_coordinates = if options.embedded {
+    let mut generated_predicate_coordinates = if options.embedded {
         predicate_coordinates.clone()
     } else {
         predicates
@@ -6585,6 +6904,7 @@ fn render_parser_with_options(
             })
             .collect::<BTreeSet<_>>()
     };
+    generated_predicate_coordinates.extend(portable_local_data.predicates.keys().copied());
     let has_action_dispatch = !action_states.is_empty();
     let has_predicate_dispatch = !predicates.is_empty();
     let track_alt_numbers = grammar_source.is_some_and(uses_alt_number_contexts);
@@ -6602,7 +6922,7 @@ fn render_parser_with_options(
             all: &predicate_coordinates,
             generated: &generated_predicate_coordinates,
         },
-        (has_action_dispatch || has_predicate_dispatch) && !options.embedded,
+        false,
     )?;
     if options.require_generated_parser || options.embedded {
         // Embedded actions only run on the generated path, so every rule must
@@ -6620,6 +6940,7 @@ fn render_parser_with_options(
         &inline_action_statements,
         track_alt_numbers,
         embedded_step_render,
+        portable_local_data.step_render(),
     );
     // A non-default policy must reach the interpreter through the emitted
     // runtime options, so its literal forces the options-carrying call shape.
@@ -8530,6 +8851,12 @@ fn literal_rule_arg_calls(
                 let value = grammar_source[value_start..value_stop].trim();
                 if let Ok(value) = value.parse::<i64>() {
                     calls.push((start, rule_index, RuleArgTemplate::Literal(value)));
+                } else if matches!(value, "true" | "false") {
+                    calls.push((
+                        start,
+                        rule_index,
+                        RuleArgTemplate::Literal(i64::from(value == "true")),
+                    ));
                 } else if value == r#"<VarRef("i")>"# {
                     calls.push((start, rule_index, RuleArgTemplate::InheritLocal));
                 }
@@ -10283,11 +10610,15 @@ atn:
         assert!(rendered.contains("parse_rule_precedence_from_generated(0, 3)"));
         assert!(rendered.contains("precpred(_ctx, 2)"));
         assert!(
+            rendered.contains(
+                "let __prediction = match self.base.left_recursive_loop_enter_prediction(atn(), 2, __precedence)"
+            )
+        );
+        assert!(rendered.contains("Some(true) => antlr4_runtime::ParserAtnPrediction"));
+        assert!(
             rendered
                 .contains("adaptive_predict_stream_info_with_context(0, __prediction_precedence")
         );
-        assert!(rendered.contains("left_recursive_loop_enter_matches(atn(), 2, __precedence)"));
-        assert!(rendered.contains("ParserAtnSimulatorError::NoViableAlt { .. }"));
     }
 
     #[test]
@@ -10317,6 +10648,32 @@ atn:
         assert!(rules[0].is_none());
         assert!(rules[1].is_none());
         assert!(rules[2].is_some());
+    }
+
+    #[test]
+    fn generated_parent_keeps_interpreted_child_call() {
+        let rules = vec![
+            Some(GeneratedParserRule {
+                rule_index: 0,
+                entry_state: 0,
+                left_recursive: false,
+                steps: vec![GeneratedParserStep::CallRule {
+                    source_state: 4,
+                    rule_index: 1,
+                    precedence: GeneratedRuleCallPrecedence::Literal(0),
+                }],
+            }),
+            None,
+        ];
+
+        let rendered =
+            render_generated_rule_dispatch(&rules, &[true, false], &BTreeMap::new(), false);
+
+        assert!(rendered.contains(
+            "0 => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
+        ));
+        assert!(rendered.contains("self.parse_rule_precedence_from_generated(1, 0)"));
+        assert!(!rendered.contains("parse_generated_rule_1_dispatch"));
     }
 
     #[test]
@@ -10426,6 +10783,7 @@ atn:
             &BTreeMap::new(),
             true,
             None,
+            None,
         );
 
         // ATN-preferred children route through `parse_rule_precedence_from_generated`:
@@ -10461,6 +10819,7 @@ atn:
             &rule_names,
             &BTreeMap::new(),
             true,
+            None,
             None,
         );
 
@@ -10661,6 +11020,25 @@ atn:
     }
 
     #[test]
+    fn parses_boolean_literal_rule_arguments() {
+        let data = InterpData {
+            rule_names: vec!["s".to_owned(), "flag".to_owned()],
+            ..InterpData::default()
+        };
+
+        assert_eq!(
+            literal_rule_arg_calls(
+                &data,
+                "parser grammar T;\ns : flag[true] flag[false] ;\nflag[boolean enabled] : ;"
+            ),
+            [
+                (1, RuleArgTemplate::Literal(1)),
+                (1, RuleArgTemplate::Literal(0)),
+            ]
+        );
+    }
+
+    #[test]
     fn compiles_synthetic_noop_action_transitions_as_epsilon() {
         let action = Transition::Action {
             target: 8,
@@ -10793,6 +11171,7 @@ atn:
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -10824,6 +11203,7 @@ atn:
             2,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls,
@@ -11264,6 +11644,7 @@ s : ;
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -11311,6 +11692,7 @@ s : ;
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -11352,6 +11734,7 @@ s : ;
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -11394,6 +11777,7 @@ s : ;
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -11438,6 +11822,7 @@ s : ;
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -11494,6 +11879,7 @@ s : ;
             0,
             GeneratedStepRenderContext {
                 embedded: None,
+                portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 direct_generated_rule_calls: &[],
@@ -11529,7 +11915,7 @@ s : ;
             },
             mt(7, 4),
         ];
-        let condition = semantic_alt_candidate_condition(&steps, None);
+        let condition = semantic_alt_candidate_condition(&steps, None, None);
         let la_at = condition
             .find("__semantic_la == 7")
             .expect("condition includes the leading lookahead guard");
@@ -11592,7 +11978,7 @@ s : ;
         ];
         let alt_conditions = alts
             .iter()
-            .map(|steps| semantic_alt_candidate_condition(steps, None))
+            .map(|steps| semantic_alt_candidate_condition(steps, None, None))
             .collect::<Vec<_>>();
         let mut rendered = String::new();
         render_semantic_alt_search(&mut rendered, "", &alt_conditions, &alts);
@@ -11643,7 +12029,7 @@ s : ;
         ];
         let alt_conditions = alts
             .iter()
-            .map(|steps| semantic_alt_candidate_condition(steps, None))
+            .map(|steps| semantic_alt_candidate_condition(steps, None, None))
             .collect::<Vec<_>>();
         let mut rendered = String::new();
         render_semantic_alt_search(&mut rendered, "", &alt_conditions, &alts);
@@ -12714,6 +13100,42 @@ ID: [a-z]+ { customJava(); };
         }
     }
 
+    /// Parser `.interp` fixture for
+    /// `s locals [boolean seen=false] : {$seen=true;} {$seen}? A ;`.
+    fn portable_bool_parser_data() -> InterpData {
+        InterpData {
+            literal_names: vec![None, Some("'a'".to_owned())],
+            symbolic_names: vec![None, Some("A".to_owned())],
+            rule_names: vec!["s".to_owned()],
+            channel_names: vec!["DEFAULT_TOKEN_CHANNEL".to_owned()],
+            mode_names: vec!["DEFAULT_MODE".to_owned()],
+            atn: vec![
+                4, 1, 1, // version, parser grammar, max token type
+                4, // states
+                2, 0, // state 0: rule start/action source
+                1, 0, // state 1: predicate source
+                1, 0, // state 2: token source
+                7, 0, // state 3: rule stop
+                0, // non-greedy states
+                0, // precedence states
+                1, // rules
+                0, // rule 0 start
+                0, // modes
+                0, // sets
+                3, // transitions
+                0, 1, 6, 0, 0, 0, // action rule 0 action 0
+                1, 2, 4, 0, 0, 0, // predicate rule 0 pred 0
+                2, 3, 5, 1, 0, 0, // atom A
+                0, // decisions
+            ],
+        }
+    }
+
+    const PORTABLE_BOOL_GRAMMAR: &str = "parser grammar S;\n\
+s locals [boolean seen=false]\n\
+    : { $seen = true; } {$seen}? A\n\
+    ;\n";
+
     const PREDICATE_GRAMMAR: &str = "parser grammar S;\ns : {isTypeName()}? A ;\n";
 
     #[test]
@@ -13461,6 +13883,54 @@ ID : [a-z]+ ;\n";
         assert!(manifest.contains("\"disposition\": \"assume-true\""));
         assert!(manifest.contains("\"body\": \"isTypeName()\""));
         assert!(manifest.contains("\"line\": 2"));
+    }
+
+    #[test]
+    fn translates_portable_boolean_local_semantics() {
+        let data = portable_bool_parser_data();
+        let portable =
+            build_portable_local_data(&data, PORTABLE_BOOL_GRAMMAR, &SemPatternFile::default())
+                .expect("portable local semantics should build");
+
+        assert_eq!(
+            portable.declarations,
+            [vec!["let mut __antlr_local_seen = false;".to_owned()]]
+        );
+        assert_eq!(
+            portable.inline_actions.get(&0).map(String::as_str),
+            Some("__antlr_local_seen = true;")
+        );
+        assert_eq!(
+            portable.predicates.get(&(0, 0)).map(String::as_str),
+            Some("__antlr_local_seen")
+        );
+
+        let module = render_parser("SParser", &data, Some(PORTABLE_BOOL_GRAMMAR))
+            .expect("portable grammar should render");
+        assert!(module.contains("let mut __antlr_local_seen = false;"));
+        assert!(module.contains("__antlr_local_seen = true;"));
+        assert!(module.contains("if !(__antlr_local_seen) {"));
+
+        let entries = collect_parser_semantics(
+            &data,
+            Some(PORTABLE_BOOL_GRAMMAR),
+            SemUnknownPolicy::Error,
+            &SemPatternFile::default(),
+        )
+        .expect("portable coordinates should be inventoried");
+        assert_eq!(entries.len(), 2);
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.disposition == SemanticsDisposition::Translated)
+        );
+        assert!(
+            entries
+                .iter()
+                .all(|entry| entry.template.as_deref() == Some("PortableBooleanLocal"))
+        );
+        enforce_sem_unknown(SemUnknownPolicy::Error, &entries)
+            .expect("portable coordinates satisfy strict semantics");
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5607,25 +5607,25 @@ fn render_generated_left_recursive_loop(
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}            __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context)"
+            "{pad}            match __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context) {{"
         )
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}                .map_err(|__error| match __error {{"
+            "{pad}                Ok(__prediction) => __prediction,"
         )
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}                    antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ index, .. }} => self.base.no_viable_alternative_error_at(__decision_start, index),"
+            "{pad}                Err(antlr4_runtime::ParserAtnSimulatorError::NoViableAlt {{ .. }}) => antlr4_runtime::ParserAtnPrediction {{ alt: {exit_alt}, requires_full_context: true, has_semantic_context: false, diagnostic: None }},"
         )
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}                    _ => self.base.no_viable_alternative_error(__decision_start),"
+            "{pad}                Err(_) => return Err(self.base.no_viable_alternative_error(__decision_start)),"
         )
         .expect("writing to a string cannot fail");
-        writeln!(out, "{pad}                }})?").expect("writing to a string cannot fail");
+        writeln!(out, "{pad}            }}").expect("writing to a string cannot fail");
         writeln!(out, "{pad}        }}").expect("writing to a string cannot fail");
     }
     writeln!(out, "{pad}    }};").expect("writing to a string cannot fail");
@@ -10829,6 +10829,9 @@ atn:
             rendered
                 .contains("adaptive_predict_stream_info_with_context(0, __prediction_precedence")
         );
+        assert!(rendered.contains(
+            "Err(antlr4_runtime::ParserAtnSimulatorError::NoViableAlt { .. }) => antlr4_runtime::ParserAtnPrediction { alt: 2, requires_full_context: true, has_semantic_context: false, diagnostic: None }"
+        ));
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -187,9 +187,27 @@ fn parse_attr_decls(clause: &str) -> Vec<AttrDecl> {
 /// explicit `false` / zero initializers would only prevent the declaration
 /// parser from recognizing otherwise portable ANTLR rule locals.
 fn strip_default_initializer(part: &str) -> &str {
-    let Some((declaration, value)) = part.rsplit_once('=') else {
+    let Some(index) = part
+        .as_bytes()
+        .iter()
+        .enumerate()
+        .find_map(|(index, byte)| {
+            if *byte != b'='
+                || part.as_bytes().get(index + 1) == Some(&b'=')
+                || part
+                    .as_bytes()
+                    .get(index.wrapping_sub(1))
+                    .is_some_and(|byte| matches!(*byte, b'!' | b'<' | b'>' | b'='))
+            {
+                return None;
+            }
+            Some(index)
+        })
+    else {
         return part;
     };
+    let (declaration, value) = part.split_at(index);
+    let value = &value[1..];
     matches!(value.trim(), "false" | "0")
         .then_some(declaration.trim_end())
         .unwrap_or(part)
@@ -1252,6 +1270,24 @@ mod tests {
                 },
             ]
         );
+        assert_eq!(model.rules[0].local_names, ["seen", "count"]);
+    }
+
+    #[test]
+    fn preserves_non_default_local_comparison_initializers() {
+        assert_eq!(
+            strip_default_initializer("boolean seen = other == false"),
+            "boolean seen = other == false"
+        );
+        assert_eq!(
+            strip_default_initializer("int count = other == 0"),
+            "int count = other == 0"
+        );
+        assert_eq!(
+            strip_default_initializer("boolean seen=false"),
+            "boolean seen"
+        );
+        assert_eq!(strip_default_initializer("int count = 0"), "int count");
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -75,6 +75,8 @@ pub(crate) struct RuleModel {
     /// Args, returns and locals, flattened (names are unique per rule in the
     /// runtime testsuite corpus).
     pub(crate) attrs: Vec<AttrDecl>,
+    /// Names declared specifically by the rule's `locals [...]` clause.
+    pub(crate) local_names: Vec<String>,
     /// Names of the attrs that come from the `[...]` args clause, in order —
     /// call sites initialize these positionally (`a[2]`).
     pub(crate) arg_names: Vec<String>,
@@ -160,7 +162,7 @@ fn map_attr_type(raw: &str) -> String {
 fn parse_attr_decls(clause: &str) -> Vec<AttrDecl> {
     let mut decls = Vec::new();
     for part in split_top_level(clause, ',') {
-        let part = part.trim();
+        let part = strip_default_initializer(part.trim());
         if part.is_empty() {
             continue;
         }
@@ -177,6 +179,20 @@ fn parse_attr_decls(clause: &str) -> Vec<AttrDecl> {
         }
     }
     decls
+}
+
+/// Removes a raw grammar initializer when it is the type's Rust `Default`.
+///
+/// Embedded attrs are initialized through `Default::default()`, so retaining
+/// explicit `false` / zero initializers would only prevent the declaration
+/// parser from recognizing otherwise portable ANTLR rule locals.
+fn strip_default_initializer(part: &str) -> &str {
+    let Some((declaration, value)) = part.rsplit_once('=') else {
+        return part;
+    };
+    matches!(value.trim(), "false" | "0")
+        .then_some(declaration.trim_end())
+        .unwrap_or(part)
 }
 
 /// Splits `name: type`, tolerating generic types containing `:` (`Vec<T>` has
@@ -446,7 +462,12 @@ fn parse_rule_header_clauses(
             let clause = &header[offset + 1..close];
             let decls = parse_attr_decls(clause);
             match pending_keyword.take() {
-                Some("returns" | "locals") => rule.attrs.extend(decls),
+                Some("locals") => {
+                    rule.local_names
+                        .extend(decls.iter().map(|decl| decl.name.clone()));
+                    rule.attrs.extend(decls);
+                }
+                Some("returns") => rule.attrs.extend(decls),
                 _ => {
                     for decl in &decls {
                         rule.arg_names.push(decl.name.clone());
@@ -1209,6 +1230,28 @@ mod tests {
         assert_eq!(m.rules[1].alts[0].refs.len(), 2);
         assert_eq!(m.rules[1].alts[0].refs[0].label.as_deref(), Some("a"));
         assert_eq!(m.rules[1].alts[0].refs[1].label.as_deref(), Some("b"));
+    }
+
+    #[test]
+    fn parses_raw_default_valued_rule_locals() {
+        let model = parse_embedded_rules_model(
+            "parser grammar T;\ns locals [boolean seen=false, int count = 0] : ;",
+            &["s".to_owned()],
+        );
+
+        assert_eq!(
+            model.rules[0].attrs,
+            [
+                AttrDecl {
+                    name: "seen".to_owned(),
+                    ty: "bool".to_owned(),
+                },
+                AttrDecl {
+                    name: "count".to_owned(),
+                    ty: "i32".to_owned(),
+                },
+            ]
+        );
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -984,6 +984,17 @@ struct CachedPredictionContext {
 }
 
 #[derive(Debug)]
+struct LeftRecursiveCallerOverlap {
+    atn_key: SharedAtnCacheKey,
+    state_number: usize,
+    symbol: i32,
+    context: Rc<PredictionContext>,
+    overlaps: bool,
+}
+
+const LEFT_RECURSIVE_CALLER_OVERLAP_CACHE_SIZE: usize = 16;
+
+#[derive(Debug)]
 pub struct BaseParser<S, H = NoSemanticHooks> {
     input: CommonTokenStream<S>,
     data: RecognizerData,
@@ -1000,6 +1011,8 @@ pub struct BaseParser<S, H = NoSemanticHooks> {
     rule_context_stack: Vec<RuleContextFrame>,
     rule_context_version: usize,
     prediction_context_cache: Option<CachedPredictionContext>,
+    left_recursive_caller_overlap_cache:
+        [Option<LeftRecursiveCallerOverlap>; LEFT_RECURSIVE_CALLER_OVERLAP_CACHE_SIZE],
     pending_invoking_states: Vec<isize>,
     precedence_stack: Vec<i32>,
     /// Predicate side effects are observable in a few target-template tests;
@@ -1734,6 +1747,8 @@ type DecisionLookaheadCache = FxHashMap<usize, Rc<DecisionLookahead>>;
 struct SharedAtnCache {
     first_set: FirstSetCache,
     decision_lookahead: DecisionLookaheadCache,
+    left_recursive_operator_lookahead: FxHashMap<(usize, i32), Rc<TokenBitSet>>,
+    state_before_stop_lookahead: FxHashMap<(usize, usize), Rc<StateBeforeStopLookahead>>,
     state_expected_tokens: FxHashMap<usize, Rc<TokenBitSet>>,
     rule_stop_reach: FxHashMap<usize, bool>,
     observable_action_transitions: Option<bool>,
@@ -2278,6 +2293,105 @@ fn state_can_reach_symbol_with_precedence(
     })
 }
 
+fn left_recursive_operator_lookahead(
+    atn: &Atn,
+    state_number: usize,
+    precedence: i32,
+) -> TokenBitSet {
+    let Some(state) = atn.state(state_number) else {
+        return TokenBitSet::default();
+    };
+    let mut symbols = TokenBitSet::default();
+    for transition in &state.transitions {
+        let target = transition.target();
+        if atn
+            .state(target)
+            .is_some_and(|state| state.kind == AtnStateKind::LoopEnd)
+        {
+            continue;
+        }
+        for symbol in 1..=atn.max_token_type() {
+            if state_can_reach_symbol_with_precedence(
+                atn,
+                target,
+                symbol,
+                precedence,
+                &mut BTreeSet::new(),
+            ) {
+                symbols.insert(symbol);
+            }
+        }
+    }
+    symbols
+}
+
+#[derive(Debug, Default)]
+struct StateBeforeStopLookahead {
+    symbols: TokenBitSet,
+    reaches_stop: bool,
+}
+
+fn state_before_stop_lookahead(
+    atn: &Atn,
+    state_number: usize,
+    stop_state_number: usize,
+) -> Rc<StateBeforeStopLookahead> {
+    with_shared_atn_caches(atn, |cache| {
+        let key = (state_number, stop_state_number);
+        if let Some(cached) = cache.state_before_stop_lookahead.get(&key) {
+            return Rc::clone(cached);
+        }
+        let mut lookahead = StateBeforeStopLookahead::default();
+        state_before_stop_lookahead_inner(
+            atn,
+            state_number,
+            stop_state_number,
+            &mut BTreeSet::new(),
+            &mut lookahead,
+        );
+        let lookahead = Rc::new(lookahead);
+        cache
+            .state_before_stop_lookahead
+            .insert(key, Rc::clone(&lookahead));
+        lookahead
+    })
+}
+
+fn state_before_stop_lookahead_inner(
+    atn: &Atn,
+    state_number: usize,
+    stop_state_number: usize,
+    visited: &mut BTreeSet<usize>,
+    lookahead: &mut StateBeforeStopLookahead,
+) {
+    if state_number == stop_state_number {
+        lookahead.reaches_stop = true;
+        return;
+    }
+    if !visited.insert(state_number) {
+        return;
+    }
+    let Some(state) = atn.state(state_number) else {
+        return;
+    };
+    for transition in &state.transitions {
+        if transition.is_epsilon() {
+            state_before_stop_lookahead_inner(
+                atn,
+                transition.target(),
+                stop_state_number,
+                visited,
+                lookahead,
+            );
+        } else {
+            lookahead.symbols.extend_iter(transition_expected_symbols(
+                transition,
+                atn.max_token_type(),
+            ));
+        }
+    }
+}
+
 fn context_can_match_symbol_before_state(
     atn: &Atn,
     context: &PredictionContext,
@@ -2286,54 +2400,22 @@ fn context_can_match_symbol_before_state(
 ) -> bool {
     (0..context.len()).any(|index| {
         context.return_state(index).is_some_and(|return_state| {
+            if return_state == EMPTY_RETURN_STATE {
+                return false;
+            }
             let parent = context
                 .parent(index)
                 .unwrap_or_else(PredictionContext::empty);
-            state_or_parent_can_match_symbol_before_state(
-                atn,
-                return_state,
-                &parent,
-                stop_state_number,
-                symbol,
-                &mut BTreeSet::new(),
-            )
+            let lookahead = state_before_stop_lookahead(atn, return_state, stop_state_number);
+            lookahead.symbols.contains(symbol)
+                || (lookahead.reaches_stop
+                    && context_can_match_symbol_before_state(
+                        atn,
+                        &parent,
+                        stop_state_number,
+                        symbol,
+                    ))
         })
-    })
-}
-
-fn state_or_parent_can_match_symbol_before_state(
-    atn: &Atn,
-    state_number: usize,
-    parent: &Rc<PredictionContext>,
-    stop_state_number: usize,
-    symbol: i32,
-    visited: &mut BTreeSet<usize>,
-) -> bool {
-    if state_number == EMPTY_RETURN_STATE {
-        return false;
-    }
-    if state_number == stop_state_number {
-        return context_can_match_symbol_before_state(atn, parent, stop_state_number, symbol);
-    }
-    if !visited.insert(state_number) {
-        return false;
-    }
-    let Some(state) = atn.state(state_number) else {
-        return false;
-    };
-    state.transitions.iter().any(|transition| {
-        if transition.matches(symbol, 1, atn.max_token_type()) {
-            return true;
-        }
-        transition.is_epsilon()
-            && state_or_parent_can_match_symbol_before_state(
-                atn,
-                transition.target(),
-                parent,
-                stop_state_number,
-                symbol,
-                visited,
-            )
     })
 }
 
@@ -3154,6 +3236,7 @@ where
             rule_context_stack: Vec::new(),
             rule_context_version: 0,
             prediction_context_cache: None,
+            left_recursive_caller_overlap_cache: std::array::from_fn(|_| None),
             pending_invoking_states: Vec::new(),
             precedence_stack: vec![0],
             invoked_predicates: Vec::new(),
@@ -4037,30 +4120,56 @@ where
         if symbol == TOKEN_EOF {
             return Some(false);
         }
-        let Some(state) = atn.state(state_number) else {
-            return Some(false);
-        };
-        let operator_matches = state.transitions.iter().any(|transition| {
-            let target = transition.target();
-            if atn
-                .state(target)
-                .is_some_and(|state| state.kind == AtnStateKind::LoopEnd)
-            {
-                return false;
+        let operator_lookahead = with_shared_atn_caches(atn, |cache| {
+            let key = (state_number, precedence);
+            if let Some(cached) = cache.left_recursive_operator_lookahead.get(&key) {
+                return Rc::clone(cached);
             }
-            state_can_reach_symbol_with_precedence(
+            let lookahead = Rc::new(left_recursive_operator_lookahead(
                 atn,
-                target,
-                symbol,
+                state_number,
                 precedence,
-                &mut BTreeSet::new(),
-            )
+            ));
+            cache
+                .left_recursive_operator_lookahead
+                .insert(key, Rc::clone(&lookahead));
+            lookahead
         });
-        if !operator_matches {
+        if !operator_lookahead.contains(symbol) {
             return Some(false);
         }
         let context = self.prediction_context(atn);
-        if context_can_match_symbol_before_state(atn, &context, state_number, symbol) {
+        let atn_key = SharedAtnCacheKey::for_atn(atn);
+        let cached_overlap = self
+            .left_recursive_caller_overlap_cache
+            .iter()
+            .flatten()
+            .find(|entry| {
+                entry.atn_key == atn_key
+                    && entry.state_number == state_number
+                    && entry.symbol == symbol
+                    && entry.context == context
+            })
+            .map(|entry| entry.overlaps);
+        let caller_overlaps = cached_overlap.unwrap_or_else(|| {
+            let overlaps =
+                context_can_match_symbol_before_state(atn, &context, state_number, symbol);
+            if let Some(slot) = self
+                .left_recursive_caller_overlap_cache
+                .iter_mut()
+                .find(|slot| slot.is_none())
+            {
+                *slot = Some(LeftRecursiveCallerOverlap {
+                    atn_key,
+                    state_number,
+                    symbol,
+                    context: Rc::clone(&context),
+                    overlaps,
+                });
+            }
+            overlaps
+        });
+        if caller_overlaps {
             return None;
         }
         Some(true)
@@ -9955,34 +10064,31 @@ mod tests {
 
     #[test]
     fn left_recursive_loop_defers_overlapping_caller_lookahead() {
+        let overlapping_atn = left_recursive_loop_with_caller_follow_atn(1);
+        let unambiguous_atn = left_recursive_loop_with_caller_follow_atn(2);
+
         let mut overlapping = parser_inside_left_recursive_callee(1);
         assert_eq!(
-            overlapping.left_recursive_loop_enter_prediction(
-                &left_recursive_loop_with_caller_follow_atn(1),
-                4,
-                0,
-            ),
+            overlapping.left_recursive_loop_enter_prediction(&overlapping_atn, 4, 0),
             None
         );
 
         let mut unambiguous_enter = parser_inside_left_recursive_callee(1);
         assert_eq!(
-            unambiguous_enter.left_recursive_loop_enter_prediction(
-                &left_recursive_loop_with_caller_follow_atn(2),
-                4,
-                0,
-            ),
+            unambiguous_enter.left_recursive_loop_enter_prediction(&unambiguous_atn, 4, 0),
             Some(true)
         );
 
         let mut unambiguous_exit = parser_inside_left_recursive_callee(2);
         assert_eq!(
-            unambiguous_exit.left_recursive_loop_enter_prediction(
-                &left_recursive_loop_with_caller_follow_atn(2),
-                4,
-                0,
-            ),
+            unambiguous_exit.left_recursive_loop_enter_prediction(&unambiguous_atn, 4, 0),
             Some(false)
+        );
+
+        assert_eq!(
+            overlapping.left_recursive_loop_enter_prediction(&unambiguous_atn, 4, 0),
+            Some(true),
+            "overlap results must not leak across ATNs"
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2275,44 +2275,51 @@ struct OperatorReachabilityRequest {
     predicate_dependent: bool,
 }
 
-struct PredicateFreeNullableCtx<'a> {
-    first_set_cache: &'a mut FirstSetCache,
-    cache: FxHashMap<(usize, usize, i32), bool>,
-    in_progress: BTreeSet<(usize, usize, i32)>,
+struct NullablePrecedenceCtx {
+    cache: FxHashMap<(usize, usize, i32, bool), bool>,
+    in_progress: BTreeSet<(usize, usize, i32, bool)>,
     hit_cycle: bool,
 }
 
-fn state_is_predicate_free_nullable(
+fn state_is_nullable_with_precedence(
     atn: &Atn,
     state_number: usize,
     stop_state_number: usize,
     precedence: i32,
-    ctx: &mut PredicateFreeNullableCtx<'_>,
+    allow_predicates: bool,
+    ctx: &mut NullablePrecedenceCtx,
 ) -> bool {
     let saved_hit_cycle = ctx.hit_cycle;
     ctx.hit_cycle = false;
-    let nullable = state_is_predicate_free_nullable_cached(
+    let nullable = state_is_nullable_with_precedence_cached(
         atn,
         state_number,
         stop_state_number,
         precedence,
+        allow_predicates,
         ctx,
     );
     ctx.hit_cycle = saved_hit_cycle;
     nullable
 }
 
-fn state_is_predicate_free_nullable_cached(
+fn state_is_nullable_with_precedence_cached(
     atn: &Atn,
     state_number: usize,
     stop_state_number: usize,
     precedence: i32,
-    ctx: &mut PredicateFreeNullableCtx<'_>,
+    allow_predicates: bool,
+    ctx: &mut NullablePrecedenceCtx,
 ) -> bool {
     if state_number == stop_state_number {
         return true;
     }
-    let key = (state_number, stop_state_number, precedence);
+    let key = (
+        state_number,
+        stop_state_number,
+        precedence,
+        allow_predicates,
+    );
     if let Some(cached) = ctx.cache.get(&key) {
         return *cached;
     }
@@ -2328,40 +2335,56 @@ fn state_is_predicate_free_nullable_cached(
                 target,
                 rule_index,
                 follow_state,
-                ..
+                precedence: rule_precedence,
             } => {
                 let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
                     return false;
                 };
-                rule_first_set(atn, *target, child_stop, ctx.first_set_cache).nullable
-                    && state_is_predicate_free_nullable_cached(
-                        atn, *target, child_stop, precedence, ctx,
-                    )
-                    && state_is_predicate_free_nullable_cached(
-                        atn,
-                        *follow_state,
-                        stop_state_number,
-                        precedence,
-                        ctx,
-                    )
+                state_is_nullable_with_precedence_cached(
+                    atn,
+                    *target,
+                    child_stop,
+                    *rule_precedence,
+                    allow_predicates,
+                    ctx,
+                ) && state_is_nullable_with_precedence_cached(
+                    atn,
+                    *follow_state,
+                    stop_state_number,
+                    precedence,
+                    allow_predicates,
+                    ctx,
+                )
             }
             Transition::Epsilon { target } | Transition::Action { target, .. } => {
-                state_is_predicate_free_nullable_cached(
+                state_is_nullable_with_precedence_cached(
                     atn,
                     *target,
                     stop_state_number,
                     precedence,
+                    allow_predicates,
+                    ctx,
+                )
+            }
+            Transition::Predicate { target, .. } if allow_predicates => {
+                state_is_nullable_with_precedence_cached(
+                    atn,
+                    *target,
+                    stop_state_number,
+                    precedence,
+                    allow_predicates,
                     ctx,
                 )
             }
             Transition::Precedence {
                 target,
                 precedence: transition_precedence,
-            } if *transition_precedence >= precedence => state_is_predicate_free_nullable_cached(
+            } if *transition_precedence >= precedence => state_is_nullable_with_precedence_cached(
                 atn,
                 *target,
                 stop_state_number,
                 precedence,
+                allow_predicates,
                 ctx,
             ),
             Transition::Atom { .. }
@@ -2385,10 +2408,14 @@ fn state_can_reach_symbol_with_precedence(
     atn: &Atn,
     state_number: usize,
     request: OperatorReachabilityRequest,
-    nullable_ctx: &mut PredicateFreeNullableCtx<'_>,
-    visited: &mut BTreeSet<(usize, bool)>,
+    nullable_ctx: &mut NullablePrecedenceCtx,
+    visited: &mut BTreeSet<(usize, i32, bool)>,
 ) -> OperatorSymbolReachability {
-    if !visited.insert((state_number, request.predicate_dependent)) {
+    if !visited.insert((
+        state_number,
+        request.precedence,
+        request.predicate_dependent,
+    )) {
         return OperatorSymbolReachability::None;
     }
     let Some(state) = atn.state(state_number) else {
@@ -2408,12 +2435,15 @@ fn state_can_reach_symbol_with_precedence(
                 target,
                 rule_index,
                 follow_state,
-                ..
+                precedence: rule_precedence,
             } => {
                 let mut result = state_can_reach_symbol_with_precedence(
                     atn,
                     *target,
-                    request,
+                    OperatorReachabilityRequest {
+                        precedence: *rule_precedence,
+                        ..request
+                    },
                     nullable_ctx,
                     visited,
                 );
@@ -2423,13 +2453,21 @@ fn state_can_reach_symbol_with_precedence(
                 let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
                     continue;
                 };
-                if rule_first_set(atn, *target, child_stop, nullable_ctx.first_set_cache).nullable {
+                if state_is_nullable_with_precedence(
+                    atn,
+                    *target,
+                    child_stop,
+                    *rule_precedence,
+                    true,
+                    nullable_ctx,
+                ) {
                     let child_predicate_dependent = request.predicate_dependent
-                        || !state_is_predicate_free_nullable(
+                        || !state_is_nullable_with_precedence(
                             atn,
                             *target,
                             child_stop,
-                            request.precedence,
+                            *rule_precedence,
+                            false,
                             nullable_ctx,
                         );
                     result = result.max(state_can_reach_symbol_with_precedence(
@@ -2487,14 +2525,12 @@ fn left_recursive_operator_lookahead(
     atn: &Atn,
     state_number: usize,
     precedence: i32,
-    first_set_cache: &mut FirstSetCache,
 ) -> LeftRecursiveOperatorLookahead {
     let Some(state) = atn.state(state_number) else {
         return LeftRecursiveOperatorLookahead::default();
     };
     let mut lookahead = LeftRecursiveOperatorLookahead::default();
-    let mut nullable_ctx = PredicateFreeNullableCtx {
-        first_set_cache,
+    let mut nullable_ctx = NullablePrecedenceCtx {
         cache: FxHashMap::default(),
         in_progress: BTreeSet::new(),
         hit_cycle: false,
@@ -2535,7 +2571,7 @@ fn left_recursive_operator_lookahead(
 #[derive(Debug, Default)]
 struct StateBeforeStopLookahead {
     symbols: TokenBitSet,
-    reaches_rule_stop: bool,
+    reaches_context_boundary: bool,
 }
 
 fn state_before_stop_lookahead(
@@ -2574,6 +2610,7 @@ fn state_before_stop_lookahead_inner(
     lookahead: &mut StateBeforeStopLookahead,
 ) {
     if state_number == stop_state_number {
+        lookahead.reaches_context_boundary = true;
         return;
     }
     if !visited.insert(state_number) {
@@ -2583,7 +2620,7 @@ fn state_before_stop_lookahead_inner(
         return;
     };
     if state.kind == AtnStateKind::RuleStop {
-        lookahead.reaches_rule_stop = true;
+        lookahead.reaches_context_boundary = true;
         return;
     }
     for transition in &state.transitions {
@@ -2653,7 +2690,7 @@ fn context_can_match_symbol_before_state(
                 .unwrap_or_else(PredictionContext::empty);
             let lookahead = state_before_stop_lookahead(atn, return_state, stop_state_number);
             lookahead.symbols.contains(symbol)
-                || (lookahead.reaches_rule_stop
+                || (lookahead.reaches_context_boundary
                     && context_can_match_symbol_before_state(
                         atn,
                         &parent,
@@ -4374,7 +4411,6 @@ where
                 atn,
                 state_number,
                 precedence,
-                &mut cache.first_set,
             ));
             cache
                 .left_recursive_operator_lookahead
@@ -10326,6 +10362,7 @@ mod tests {
             (6, AtnStateKind::RuleStop, 0),
             (7, AtnStateKind::RuleStart, 1),
             (8, AtnStateKind::RuleStop, 1),
+            (9, AtnStateKind::Basic, 1),
         ] {
             let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
             if state == 0 {
@@ -10347,7 +10384,7 @@ mod tests {
             .expect("precedence predicate")
             .add_transition(Transition::Precedence {
                 target: 3,
-                precedence: 1,
+                precedence: 3,
             });
         atn.state_mut(3)
             .expect("nullable operator prefix")
@@ -10367,6 +10404,12 @@ mod tests {
             .expect("loop exit")
             .add_transition(Transition::Epsilon { target: 6 });
         atn.state_mut(7)
+            .expect("nullable operator prefix")
+            .add_transition(Transition::Precedence {
+                target: 9,
+                precedence: 1,
+            });
+        atn.state_mut(9)
             .expect("nullable operator prefix")
             .add_transition(Transition::Epsilon { target: 8 });
         atn
@@ -10587,6 +10630,84 @@ mod tests {
         atn
     }
 
+    fn left_recursive_loop_with_recursive_operand_return_atn(caller_symbol: i32) -> Atn {
+        let mut atn = Atn::new(AtnType::Parser, 2);
+        for (state, kind, rule) in [
+            (0, AtnStateKind::RuleStart, 0),
+            (1, AtnStateKind::Basic, 0),
+            (2, AtnStateKind::Basic, 0),
+            (3, AtnStateKind::RuleStop, 0),
+            (4, AtnStateKind::RuleStart, 1),
+            (5, AtnStateKind::StarLoopEntry, 1),
+            (6, AtnStateKind::Basic, 1),
+            (7, AtnStateKind::Basic, 1),
+            (8, AtnStateKind::Basic, 1),
+            (9, AtnStateKind::Basic, 1),
+            (10, AtnStateKind::LoopEnd, 1),
+            (11, AtnStateKind::RuleStop, 1),
+        ] {
+            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            if state == 4 {
+                atn_state.left_recursive_rule = true;
+            } else if state == 5 {
+                atn_state.precedence_rule_decision = true;
+            }
+            atn.add_state(atn_state);
+        }
+        atn.set_rule_to_start_state(vec![0, 4]);
+        atn.set_rule_to_stop_state(vec![3, 11]);
+        atn.state_mut(0)
+            .expect("caller start")
+            .add_transition(Transition::Epsilon { target: 1 });
+        atn.state_mut(1)
+            .expect("caller invocation")
+            .add_transition(Transition::Rule {
+                target: 4,
+                rule_index: 1,
+                follow_state: 2,
+                precedence: 0,
+            });
+        atn.state_mut(2)
+            .expect("caller follow")
+            .add_transition(Transition::Atom {
+                target: 3,
+                label: caller_symbol,
+            });
+        atn.state_mut(5)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 6 });
+        atn.state_mut(5)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 10 });
+        atn.state_mut(6)
+            .expect("precedence predicate")
+            .add_transition(Transition::Precedence {
+                target: 7,
+                precedence: 1,
+            });
+        atn.state_mut(7)
+            .expect("operator token")
+            .add_transition(Transition::Atom {
+                target: 8,
+                label: 1,
+            });
+        atn.state_mut(8)
+            .expect("recursive operand")
+            .add_transition(Transition::Rule {
+                target: 4,
+                rule_index: 1,
+                follow_state: 9,
+                precedence: 2,
+            });
+        atn.state_mut(9)
+            .expect("recursive operand follow")
+            .add_transition(Transition::Epsilon { target: 5 });
+        atn.state_mut(10)
+            .expect("loop exit")
+            .add_transition(Transition::Epsilon { target: 11 });
+        atn
+    }
+
     #[test]
     fn left_recursive_loop_defers_overlapping_caller_lookahead() {
         let overlapping_atn = left_recursive_loop_with_caller_follow_atn(1);
@@ -10637,6 +10758,11 @@ mod tests {
             parser.left_recursive_loop_enter_prediction(&atn, 1, 0),
             Some(true),
             "cached operator lookahead must preserve the nullable prefix return path"
+        );
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 1, 2),
+            Some(true),
+            "the nullable child must use its rule-call precedence, not the caller precedence"
         );
     }
 
@@ -10714,6 +10840,40 @@ mod tests {
             parser.left_recursive_loop_enter_prediction(&atn, 9, 0),
             None,
             "the caller-overlap cache must not retain a false negative"
+        );
+    }
+
+    #[test]
+    fn left_recursive_loop_defers_after_recursive_operand_returns_to_loop() {
+        let atn = left_recursive_loop_with_recursive_operand_return_atn(1);
+        let mut parser = mini_parser(vec![
+            CommonToken::new(1).with_text("lookahead"),
+            CommonToken::eof("parser-test", 1, 1, 1),
+        ]);
+        parser.rule_context_stack = vec![
+            RuleContextFrame {
+                rule_index: 0,
+                invoking_state: -1,
+            },
+            RuleContextFrame {
+                rule_index: 1,
+                invoking_state: 1,
+            },
+            RuleContextFrame {
+                rule_index: 1,
+                invoking_state: 8,
+            },
+        ];
+
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 5, 0),
+            None,
+            "a recursive operand return must preserve its parent caller context"
+        );
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 5, 0),
+            None,
+            "the caller-overlap cache must preserve the loop-boundary return"
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2328,7 +2328,7 @@ fn left_recursive_operator_lookahead(
 #[derive(Debug, Default)]
 struct StateBeforeStopLookahead {
     symbols: TokenBitSet,
-    reaches_stop: bool,
+    reaches_rule_stop: bool,
 }
 
 fn state_before_stop_lookahead(
@@ -2347,6 +2347,7 @@ fn state_before_stop_lookahead(
             state_number,
             stop_state_number,
             &mut BTreeSet::new(),
+            &mut cache.first_set,
             &mut lookahead,
         );
         let lookahead = Rc::new(lookahead);
@@ -2362,10 +2363,10 @@ fn state_before_stop_lookahead_inner(
     state_number: usize,
     stop_state_number: usize,
     visited: &mut BTreeSet<usize>,
+    first_set_cache: &mut FirstSetCache,
     lookahead: &mut StateBeforeStopLookahead,
 ) {
     if state_number == stop_state_number {
-        lookahead.reaches_stop = true;
         return;
     }
     if !visited.insert(state_number) {
@@ -2374,20 +2375,57 @@ fn state_before_stop_lookahead_inner(
     let Some(state) = atn.state(state_number) else {
         return;
     };
+    if state.kind == AtnStateKind::RuleStop {
+        lookahead.reaches_rule_stop = true;
+        return;
+    }
     for transition in &state.transitions {
-        if transition.is_epsilon() {
-            state_before_stop_lookahead_inner(
-                atn,
-                transition.target(),
-                stop_state_number,
-                visited,
-                lookahead,
-            );
-        } else {
-            lookahead.symbols.extend_iter(transition_expected_symbols(
-                transition,
-                atn.max_token_type(),
-            ));
+        match transition {
+            Transition::Epsilon { target }
+            | Transition::Action { target, .. }
+            | Transition::Predicate { target, .. }
+            | Transition::Precedence { target, .. } => {
+                state_before_stop_lookahead_inner(
+                    atn,
+                    *target,
+                    stop_state_number,
+                    visited,
+                    first_set_cache,
+                    lookahead,
+                );
+            }
+            Transition::Rule {
+                target,
+                rule_index,
+                follow_state,
+                ..
+            } => {
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                    continue;
+                };
+                let child = rule_first_set(atn, *target, child_stop, first_set_cache);
+                lookahead.symbols.extend_from(&child.symbols);
+                if child.nullable {
+                    state_before_stop_lookahead_inner(
+                        atn,
+                        *follow_state,
+                        stop_state_number,
+                        visited,
+                        first_set_cache,
+                        lookahead,
+                    );
+                }
+            }
+            Transition::Atom { .. }
+            | Transition::Range { .. }
+            | Transition::Set { .. }
+            | Transition::NotSet { .. }
+            | Transition::Wildcard { .. } => {
+                lookahead.symbols.extend_iter(transition_expected_symbols(
+                    transition,
+                    atn.max_token_type(),
+                ));
+            }
         }
     }
 }
@@ -2408,7 +2446,7 @@ fn context_can_match_symbol_before_state(
                 .unwrap_or_else(PredictionContext::empty);
             let lookahead = state_before_stop_lookahead(atn, return_state, stop_state_number);
             lookahead.symbols.contains(symbol)
-                || (lookahead.reaches_stop
+                || (lookahead.reaches_rule_stop
                     && context_can_match_symbol_before_state(
                         atn,
                         &parent,
@@ -10062,6 +10100,168 @@ mod tests {
         parser
     }
 
+    fn left_recursive_loop_with_nullable_follow_call_atn(caller_symbol: i32) -> Atn {
+        let mut atn = Atn::new(AtnType::Parser, 2);
+        for (state, kind, rule) in [
+            (0, AtnStateKind::RuleStart, 0),
+            (1, AtnStateKind::Basic, 0),
+            (2, AtnStateKind::Basic, 0),
+            (3, AtnStateKind::Basic, 0),
+            (4, AtnStateKind::RuleStop, 0),
+            (5, AtnStateKind::RuleStart, 1),
+            (6, AtnStateKind::StarLoopEntry, 1),
+            (7, AtnStateKind::Basic, 1),
+            (8, AtnStateKind::Basic, 1),
+            (9, AtnStateKind::LoopEnd, 1),
+            (10, AtnStateKind::RuleStop, 1),
+            (11, AtnStateKind::RuleStart, 2),
+            (12, AtnStateKind::RuleStop, 2),
+        ] {
+            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            if state == 5 {
+                atn_state.left_recursive_rule = true;
+            } else if state == 6 {
+                atn_state.precedence_rule_decision = true;
+            }
+            atn.add_state(atn_state);
+        }
+        atn.set_rule_to_start_state(vec![0, 5, 11]);
+        atn.set_rule_to_stop_state(vec![4, 10, 12]);
+        atn.state_mut(0)
+            .expect("caller start")
+            .add_transition(Transition::Epsilon { target: 1 });
+        atn.state_mut(1)
+            .expect("caller invoking state")
+            .add_transition(Transition::Rule {
+                target: 5,
+                rule_index: 1,
+                follow_state: 2,
+                precedence: 0,
+            });
+        atn.state_mut(2)
+            .expect("nullable child invocation")
+            .add_transition(Transition::Rule {
+                target: 11,
+                rule_index: 2,
+                follow_state: 3,
+                precedence: 0,
+            });
+        atn.state_mut(3)
+            .expect("caller follow")
+            .add_transition(Transition::Atom {
+                target: 4,
+                label: caller_symbol,
+            });
+        atn.state_mut(6)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 7 });
+        atn.state_mut(6)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 9 });
+        atn.state_mut(7)
+            .expect("precedence predicate")
+            .add_transition(Transition::Precedence {
+                target: 8,
+                precedence: 1,
+            });
+        atn.state_mut(8)
+            .expect("operator token")
+            .add_transition(Transition::Atom {
+                target: 6,
+                label: 1,
+            });
+        atn.state_mut(9)
+            .expect("loop exit")
+            .add_transition(Transition::Epsilon { target: 10 });
+        atn.state_mut(11)
+            .expect("nullable child")
+            .add_transition(Transition::Epsilon { target: 12 });
+        atn
+    }
+
+    fn left_recursive_loop_with_nullable_parent_return_atn(caller_symbol: i32) -> Atn {
+        let mut atn = Atn::new(AtnType::Parser, 2);
+        for (state, kind, rule) in [
+            (0, AtnStateKind::RuleStart, 0),
+            (1, AtnStateKind::Basic, 0),
+            (2, AtnStateKind::Basic, 0),
+            (3, AtnStateKind::RuleStop, 0),
+            (4, AtnStateKind::RuleStart, 1),
+            (5, AtnStateKind::Basic, 1),
+            (6, AtnStateKind::Basic, 1),
+            (7, AtnStateKind::RuleStop, 1),
+            (8, AtnStateKind::RuleStart, 2),
+            (9, AtnStateKind::StarLoopEntry, 2),
+            (10, AtnStateKind::Basic, 2),
+            (11, AtnStateKind::Basic, 2),
+            (12, AtnStateKind::LoopEnd, 2),
+            (13, AtnStateKind::RuleStop, 2),
+        ] {
+            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            if state == 8 {
+                atn_state.left_recursive_rule = true;
+            } else if state == 9 {
+                atn_state.precedence_rule_decision = true;
+            }
+            atn.add_state(atn_state);
+        }
+        atn.set_rule_to_start_state(vec![0, 4, 8]);
+        atn.set_rule_to_stop_state(vec![3, 7, 13]);
+        atn.state_mut(0)
+            .expect("parent start")
+            .add_transition(Transition::Epsilon { target: 1 });
+        atn.state_mut(1)
+            .expect("parent invocation")
+            .add_transition(Transition::Rule {
+                target: 4,
+                rule_index: 1,
+                follow_state: 2,
+                precedence: 0,
+            });
+        atn.state_mut(2)
+            .expect("parent follow")
+            .add_transition(Transition::Atom {
+                target: 3,
+                label: caller_symbol,
+            });
+        atn.state_mut(4)
+            .expect("caller start")
+            .add_transition(Transition::Epsilon { target: 5 });
+        atn.state_mut(5)
+            .expect("caller invocation")
+            .add_transition(Transition::Rule {
+                target: 8,
+                rule_index: 2,
+                follow_state: 6,
+                precedence: 0,
+            });
+        atn.state_mut(6)
+            .expect("nullable caller return")
+            .add_transition(Transition::Epsilon { target: 7 });
+        atn.state_mut(9)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 10 });
+        atn.state_mut(9)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 12 });
+        atn.state_mut(10)
+            .expect("precedence predicate")
+            .add_transition(Transition::Precedence {
+                target: 11,
+                precedence: 1,
+            });
+        atn.state_mut(11)
+            .expect("operator token")
+            .add_transition(Transition::Atom {
+                target: 9,
+                label: 1,
+            });
+        atn.state_mut(12)
+            .expect("loop exit")
+            .add_transition(Transition::Epsilon { target: 13 });
+        atn
+    }
+
     #[test]
     fn left_recursive_loop_defers_overlapping_caller_lookahead() {
         let overlapping_atn = left_recursive_loop_with_caller_follow_atn(1);
@@ -10089,6 +10289,56 @@ mod tests {
             overlapping.left_recursive_loop_enter_prediction(&unambiguous_atn, 4, 0),
             Some(true),
             "overlap results must not leak across ATNs"
+        );
+    }
+
+    #[test]
+    fn left_recursive_loop_defers_through_nullable_caller_rule_call() {
+        let atn = left_recursive_loop_with_nullable_follow_call_atn(1);
+        let mut parser = parser_inside_left_recursive_callee(1);
+
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 6, 0),
+            None
+        );
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 6, 0),
+            None,
+            "the cached overlap must preserve the nullable child return path"
+        );
+    }
+
+    #[test]
+    fn left_recursive_loop_defers_through_nullable_parent_return() {
+        let atn = left_recursive_loop_with_nullable_parent_return_atn(1);
+        let mut parser = mini_parser(vec![
+            CommonToken::new(1).with_text("lookahead"),
+            CommonToken::eof("parser-test", 1, 1, 1),
+        ]);
+        parser.rule_context_stack = vec![
+            RuleContextFrame {
+                rule_index: 0,
+                invoking_state: -1,
+            },
+            RuleContextFrame {
+                rule_index: 1,
+                invoking_state: 1,
+            },
+            RuleContextFrame {
+                rule_index: 2,
+                invoking_state: 5,
+            },
+        ];
+
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 9, 0),
+            None,
+            "a nullable caller must unwind to its parent's consuming follow path"
+        );
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 9, 0),
+            None,
+            "the caller-overlap cache must not retain a false negative"
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2259,6 +2259,7 @@ fn state_can_reach_symbol_with_precedence(
     state_number: usize,
     symbol: i32,
     precedence: i32,
+    first_set_cache: &mut FirstSetCache,
     visited: &mut BTreeSet<usize>,
 ) -> bool {
     if !visited.insert(state_number) {
@@ -2267,36 +2268,82 @@ fn state_can_reach_symbol_with_precedence(
     let Some(state) = atn.state(state_number) else {
         return false;
     };
-    state.transitions.iter().any(|transition| {
+    for transition in &state.transitions {
         if transition.matches(symbol, 1, atn.max_token_type()) {
             return true;
         }
-        if !transition.is_epsilon() {
-            return false;
-        }
-        if matches!(
-            transition,
-            Transition::Precedence {
-                precedence: transition_precedence,
+        match transition {
+            Transition::Rule {
+                target,
+                rule_index,
+                follow_state,
                 ..
-            } if *transition_precedence < precedence
-        ) {
-            return false;
+            } => {
+                if state_can_reach_symbol_with_precedence(
+                    atn,
+                    *target,
+                    symbol,
+                    precedence,
+                    first_set_cache,
+                    visited,
+                ) {
+                    return true;
+                }
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                    continue;
+                };
+                if rule_first_set(atn, *target, child_stop, first_set_cache).nullable
+                    && state_can_reach_symbol_with_precedence(
+                        atn,
+                        *follow_state,
+                        symbol,
+                        precedence,
+                        first_set_cache,
+                        visited,
+                    )
+                {
+                    return true;
+                }
+            }
+            Transition::Epsilon { target }
+            | Transition::Action { target, .. }
+            | Transition::Predicate { target, .. }
+            | Transition::Precedence { target, .. } => {
+                if matches!(
+                    transition,
+                    Transition::Precedence {
+                        precedence: transition_precedence,
+                        ..
+                    } if *transition_precedence < precedence
+                ) {
+                    continue;
+                }
+                if state_can_reach_symbol_with_precedence(
+                    atn,
+                    *target,
+                    symbol,
+                    precedence,
+                    first_set_cache,
+                    visited,
+                ) {
+                    return true;
+                }
+            }
+            Transition::Atom { .. }
+            | Transition::Range { .. }
+            | Transition::Set { .. }
+            | Transition::NotSet { .. }
+            | Transition::Wildcard { .. } => {}
         }
-        state_can_reach_symbol_with_precedence(
-            atn,
-            transition.target(),
-            symbol,
-            precedence,
-            visited,
-        )
-    })
+    }
+    false
 }
 
 fn left_recursive_operator_lookahead(
     atn: &Atn,
     state_number: usize,
     precedence: i32,
+    first_set_cache: &mut FirstSetCache,
 ) -> TokenBitSet {
     let Some(state) = atn.state(state_number) else {
         return TokenBitSet::default();
@@ -2316,6 +2363,7 @@ fn left_recursive_operator_lookahead(
                 target,
                 symbol,
                 precedence,
+                first_set_cache,
                 &mut BTreeSet::new(),
             ) {
                 symbols.insert(symbol);
@@ -4167,6 +4215,7 @@ where
                 atn,
                 state_number,
                 precedence,
+                &mut cache.first_set,
             ));
             cache
                 .left_recursive_operator_lookahead
@@ -10100,6 +10149,64 @@ mod tests {
         parser
     }
 
+    fn left_recursive_loop_with_nullable_operator_prefix_atn() -> Atn {
+        let mut atn = Atn::new(AtnType::Parser, 2);
+        for (state, kind, rule) in [
+            (0, AtnStateKind::RuleStart, 0),
+            (1, AtnStateKind::StarLoopEntry, 0),
+            (2, AtnStateKind::Basic, 0),
+            (3, AtnStateKind::Basic, 0),
+            (4, AtnStateKind::Basic, 0),
+            (5, AtnStateKind::LoopEnd, 0),
+            (6, AtnStateKind::RuleStop, 0),
+            (7, AtnStateKind::RuleStart, 1),
+            (8, AtnStateKind::RuleStop, 1),
+        ] {
+            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            if state == 0 {
+                atn_state.left_recursive_rule = true;
+            } else if state == 1 {
+                atn_state.precedence_rule_decision = true;
+            }
+            atn.add_state(atn_state);
+        }
+        atn.set_rule_to_start_state(vec![0, 7]);
+        atn.set_rule_to_stop_state(vec![6, 8]);
+        atn.state_mut(1)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 2 });
+        atn.state_mut(1)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 5 });
+        atn.state_mut(2)
+            .expect("precedence predicate")
+            .add_transition(Transition::Precedence {
+                target: 3,
+                precedence: 1,
+            });
+        atn.state_mut(3)
+            .expect("nullable operator prefix")
+            .add_transition(Transition::Rule {
+                target: 7,
+                rule_index: 1,
+                follow_state: 4,
+                precedence: 0,
+            });
+        atn.state_mut(4)
+            .expect("operator token")
+            .add_transition(Transition::Atom {
+                target: 1,
+                label: 1,
+            });
+        atn.state_mut(5)
+            .expect("loop exit")
+            .add_transition(Transition::Epsilon { target: 6 });
+        atn.state_mut(7)
+            .expect("nullable operator prefix")
+            .add_transition(Transition::Epsilon { target: 8 });
+        atn
+    }
+
     fn left_recursive_loop_with_nullable_follow_call_atn(caller_symbol: i32) -> Atn {
         let mut atn = Atn::new(AtnType::Parser, 2);
         for (state, kind, rule) in [
@@ -10289,6 +10396,29 @@ mod tests {
             overlapping.left_recursive_loop_enter_prediction(&unambiguous_atn, 4, 0),
             Some(true),
             "overlap results must not leak across ATNs"
+        );
+    }
+
+    #[test]
+    fn left_recursive_loop_enters_after_nullable_operator_prefix() {
+        let atn = left_recursive_loop_with_nullable_operator_prefix_atn();
+        let mut parser = mini_parser(vec![
+            CommonToken::new(1).with_text("operator"),
+            CommonToken::eof("parser-test", 1, 1, 1),
+        ]);
+        parser.rule_context_stack = vec![RuleContextFrame {
+            rule_index: 0,
+            invoking_state: -1,
+        }];
+
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 1, 0),
+            Some(true)
+        );
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 1, 0),
+            Some(true),
+            "cached operator lookahead must preserve the nullable prefix return path"
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1743,11 +1743,17 @@ type FirstSetCache = FxHashMap<(usize, usize), Rc<FirstSet>>;
 // is stable, which is what we hash on.
 type DecisionLookaheadCache = FxHashMap<usize, Rc<DecisionLookahead>>;
 
+#[derive(Debug, Default)]
+struct LeftRecursiveOperatorLookahead {
+    unconditional_symbols: TokenBitSet,
+    predicate_dependent_symbols: TokenBitSet,
+}
+
 #[derive(Default)]
 struct SharedAtnCache {
     first_set: FirstSetCache,
     decision_lookahead: DecisionLookaheadCache,
-    left_recursive_operator_lookahead: FxHashMap<(usize, i32), Rc<TokenBitSet>>,
+    left_recursive_operator_lookahead: FxHashMap<(usize, i32), Rc<LeftRecursiveOperatorLookahead>>,
     state_before_stop_lookahead: FxHashMap<(usize, usize), Rc<StateBeforeStopLookahead>>,
     state_expected_tokens: FxHashMap<usize, Rc<TokenBitSet>>,
     rule_stop_reach: FxHashMap<usize, bool>,
@@ -2254,89 +2260,227 @@ fn state_sync_symbols_inner(
     }
 }
 
-fn state_can_reach_symbol_with_precedence(
-    atn: &Atn,
-    state_number: usize,
+#[derive(Clone, Copy, Debug, Default, Eq, Ord, PartialEq, PartialOrd)]
+enum OperatorSymbolReachability {
+    #[default]
+    None,
+    PredicateDependent,
+    Unconditional,
+}
+
+#[derive(Clone, Copy)]
+struct OperatorReachabilityRequest {
     symbol: i32,
     precedence: i32,
-    first_set_cache: &mut FirstSetCache,
-    visited: &mut BTreeSet<usize>,
+    predicate_dependent: bool,
+}
+
+struct PredicateFreeNullableCtx<'a> {
+    first_set_cache: &'a mut FirstSetCache,
+    cache: FxHashMap<(usize, usize, i32), bool>,
+    in_progress: BTreeSet<(usize, usize, i32)>,
+    hit_cycle: bool,
+}
+
+fn state_is_predicate_free_nullable(
+    atn: &Atn,
+    state_number: usize,
+    stop_state_number: usize,
+    precedence: i32,
+    ctx: &mut PredicateFreeNullableCtx<'_>,
 ) -> bool {
-    if !visited.insert(state_number) {
+    let saved_hit_cycle = ctx.hit_cycle;
+    ctx.hit_cycle = false;
+    let nullable = state_is_predicate_free_nullable_cached(
+        atn,
+        state_number,
+        stop_state_number,
+        precedence,
+        ctx,
+    );
+    ctx.hit_cycle = saved_hit_cycle;
+    nullable
+}
+
+fn state_is_predicate_free_nullable_cached(
+    atn: &Atn,
+    state_number: usize,
+    stop_state_number: usize,
+    precedence: i32,
+    ctx: &mut PredicateFreeNullableCtx<'_>,
+) -> bool {
+    if state_number == stop_state_number {
+        return true;
+    }
+    let key = (state_number, stop_state_number, precedence);
+    if let Some(cached) = ctx.cache.get(&key) {
+        return *cached;
+    }
+    if !ctx.in_progress.insert(key) {
+        ctx.hit_cycle = true;
         return false;
     }
-    let Some(state) = atn.state(state_number) else {
-        return false;
-    };
-    for transition in &state.transitions {
-        if transition.matches(symbol, 1, atn.max_token_type()) {
-            return true;
-        }
-        match transition {
+    let saved_hit_cycle = ctx.hit_cycle;
+    ctx.hit_cycle = false;
+    let nullable = atn.state(state_number).is_some_and(|state| {
+        state.transitions.iter().any(|transition| match transition {
             Transition::Rule {
                 target,
                 rule_index,
                 follow_state,
                 ..
             } => {
-                if state_can_reach_symbol_with_precedence(
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                    return false;
+                };
+                rule_first_set(atn, *target, child_stop, ctx.first_set_cache).nullable
+                    && state_is_predicate_free_nullable_cached(
+                        atn, *target, child_stop, precedence, ctx,
+                    )
+                    && state_is_predicate_free_nullable_cached(
+                        atn,
+                        *follow_state,
+                        stop_state_number,
+                        precedence,
+                        ctx,
+                    )
+            }
+            Transition::Epsilon { target } | Transition::Action { target, .. } => {
+                state_is_predicate_free_nullable_cached(
                     atn,
                     *target,
-                    symbol,
+                    stop_state_number,
                     precedence,
-                    first_set_cache,
+                    ctx,
+                )
+            }
+            Transition::Precedence {
+                target,
+                precedence: transition_precedence,
+            } if *transition_precedence >= precedence => state_is_predicate_free_nullable_cached(
+                atn,
+                *target,
+                stop_state_number,
+                precedence,
+                ctx,
+            ),
+            Transition::Atom { .. }
+            | Transition::Range { .. }
+            | Transition::Set { .. }
+            | Transition::NotSet { .. }
+            | Transition::Wildcard { .. }
+            | Transition::Predicate { .. }
+            | Transition::Precedence { .. } => false,
+        })
+    });
+    ctx.in_progress.remove(&key);
+    if !ctx.hit_cycle {
+        ctx.cache.insert(key, nullable);
+    }
+    ctx.hit_cycle = saved_hit_cycle || ctx.hit_cycle;
+    nullable
+}
+
+fn state_can_reach_symbol_with_precedence(
+    atn: &Atn,
+    state_number: usize,
+    request: OperatorReachabilityRequest,
+    nullable_ctx: &mut PredicateFreeNullableCtx<'_>,
+    visited: &mut BTreeSet<(usize, bool)>,
+) -> OperatorSymbolReachability {
+    if !visited.insert((state_number, request.predicate_dependent)) {
+        return OperatorSymbolReachability::None;
+    }
+    let Some(state) = atn.state(state_number) else {
+        return OperatorSymbolReachability::None;
+    };
+    let mut reachability = OperatorSymbolReachability::None;
+    for transition in &state.transitions {
+        if transition.matches(request.symbol, 1, atn.max_token_type()) {
+            if request.predicate_dependent {
+                reachability = OperatorSymbolReachability::PredicateDependent;
+                continue;
+            }
+            return OperatorSymbolReachability::Unconditional;
+        }
+        let transition_reachability = match transition {
+            Transition::Rule {
+                target,
+                rule_index,
+                follow_state,
+                ..
+            } => {
+                let mut result = state_can_reach_symbol_with_precedence(
+                    atn,
+                    *target,
+                    request,
+                    nullable_ctx,
                     visited,
-                ) {
-                    return true;
+                );
+                if result == OperatorSymbolReachability::Unconditional {
+                    return result;
                 }
                 let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
                     continue;
                 };
-                if rule_first_set(atn, *target, child_stop, first_set_cache).nullable
-                    && state_can_reach_symbol_with_precedence(
+                if rule_first_set(atn, *target, child_stop, nullable_ctx.first_set_cache).nullable {
+                    let child_predicate_dependent = request.predicate_dependent
+                        || !state_is_predicate_free_nullable(
+                            atn,
+                            *target,
+                            child_stop,
+                            request.precedence,
+                            nullable_ctx,
+                        );
+                    result = result.max(state_can_reach_symbol_with_precedence(
                         atn,
                         *follow_state,
-                        symbol,
-                        precedence,
-                        first_set_cache,
+                        OperatorReachabilityRequest {
+                            predicate_dependent: child_predicate_dependent,
+                            ..request
+                        },
+                        nullable_ctx,
                         visited,
-                    )
-                {
-                    return true;
+                    ));
                 }
+                result
             }
             Transition::Epsilon { target }
             | Transition::Action { target, .. }
-            | Transition::Predicate { target, .. }
             | Transition::Precedence { target, .. } => {
                 if matches!(
                     transition,
                     Transition::Precedence {
                         precedence: transition_precedence,
                         ..
-                    } if *transition_precedence < precedence
+                    } if *transition_precedence < request.precedence
                 ) {
                     continue;
                 }
-                if state_can_reach_symbol_with_precedence(
-                    atn,
-                    *target,
-                    symbol,
-                    precedence,
-                    first_set_cache,
-                    visited,
-                ) {
-                    return true;
-                }
+                state_can_reach_symbol_with_precedence(atn, *target, request, nullable_ctx, visited)
             }
+            Transition::Predicate { target, .. } => state_can_reach_symbol_with_precedence(
+                atn,
+                *target,
+                OperatorReachabilityRequest {
+                    predicate_dependent: true,
+                    ..request
+                },
+                nullable_ctx,
+                visited,
+            ),
             Transition::Atom { .. }
             | Transition::Range { .. }
             | Transition::Set { .. }
             | Transition::NotSet { .. }
-            | Transition::Wildcard { .. } => {}
+            | Transition::Wildcard { .. } => OperatorSymbolReachability::None,
+        };
+        if transition_reachability == OperatorSymbolReachability::Unconditional {
+            return transition_reachability;
         }
+        reachability = reachability.max(transition_reachability);
     }
-    false
+    reachability
 }
 
 fn left_recursive_operator_lookahead(
@@ -2344,11 +2488,17 @@ fn left_recursive_operator_lookahead(
     state_number: usize,
     precedence: i32,
     first_set_cache: &mut FirstSetCache,
-) -> TokenBitSet {
+) -> LeftRecursiveOperatorLookahead {
     let Some(state) = atn.state(state_number) else {
-        return TokenBitSet::default();
+        return LeftRecursiveOperatorLookahead::default();
     };
-    let mut symbols = TokenBitSet::default();
+    let mut lookahead = LeftRecursiveOperatorLookahead::default();
+    let mut nullable_ctx = PredicateFreeNullableCtx {
+        first_set_cache,
+        cache: FxHashMap::default(),
+        in_progress: BTreeSet::new(),
+        hit_cycle: false,
+    };
     for transition in &state.transitions {
         let target = transition.target();
         if atn
@@ -2358,19 +2508,28 @@ fn left_recursive_operator_lookahead(
             continue;
         }
         for symbol in 1..=atn.max_token_type() {
-            if state_can_reach_symbol_with_precedence(
+            match state_can_reach_symbol_with_precedence(
                 atn,
                 target,
-                symbol,
-                precedence,
-                first_set_cache,
+                OperatorReachabilityRequest {
+                    symbol,
+                    precedence,
+                    predicate_dependent: false,
+                },
+                &mut nullable_ctx,
                 &mut BTreeSet::new(),
             ) {
-                symbols.insert(symbol);
+                OperatorSymbolReachability::Unconditional => {
+                    lookahead.unconditional_symbols.insert(symbol);
+                }
+                OperatorSymbolReachability::PredicateDependent => {
+                    lookahead.predicate_dependent_symbols.insert(symbol);
+                }
+                OperatorSymbolReachability::None => {}
             }
         }
     }
-    symbols
+    lookahead
 }
 
 #[derive(Debug, Default)]
@@ -4194,8 +4353,8 @@ where
     /// Predicts a generated left-recursive loop from one-token lookahead.
     ///
     /// `Some(true)` enters the operator alternative, `Some(false)` exits, and
-    /// `None` means the caller can consume the same symbol so full-context
-    /// adaptive prediction must break the ambiguity.
+    /// `None` means caller overlap or an unresolved semantic predicate requires
+    /// full-context adaptive prediction.
     pub fn left_recursive_loop_enter_prediction(
         &mut self,
         atn: &Atn,
@@ -4222,7 +4381,13 @@ where
                 .insert(key, Rc::clone(&lookahead));
             lookahead
         });
-        if !operator_lookahead.contains(symbol) {
+        if !operator_lookahead.unconditional_symbols.contains(symbol) {
+            if operator_lookahead
+                .predicate_dependent_symbols
+                .contains(symbol)
+            {
+                return None;
+            }
             return Some(false);
         }
         let context = self.prediction_context(atn);
@@ -10207,6 +10372,59 @@ mod tests {
         atn
     }
 
+    fn left_recursive_loop_with_predicate_guarded_operator_atn() -> Atn {
+        let mut atn = Atn::new(AtnType::Parser, 2);
+        for (state, kind) in [
+            (0, AtnStateKind::RuleStart),
+            (1, AtnStateKind::StarLoopEntry),
+            (2, AtnStateKind::Basic),
+            (3, AtnStateKind::Basic),
+            (4, AtnStateKind::Basic),
+            (5, AtnStateKind::LoopEnd),
+            (6, AtnStateKind::RuleStop),
+        ] {
+            let mut atn_state = AtnState::new(state, kind).with_rule_index(0);
+            if state == 0 {
+                atn_state.left_recursive_rule = true;
+            } else if state == 1 {
+                atn_state.precedence_rule_decision = true;
+            }
+            atn.add_state(atn_state);
+        }
+        atn.set_rule_to_start_state(vec![0]);
+        atn.set_rule_to_stop_state(vec![6]);
+        atn.state_mut(1)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 2 });
+        atn.state_mut(1)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 5 });
+        atn.state_mut(2)
+            .expect("precedence predicate")
+            .add_transition(Transition::Precedence {
+                target: 3,
+                precedence: 1,
+            });
+        atn.state_mut(3)
+            .expect("semantic predicate")
+            .add_transition(Transition::Predicate {
+                target: 4,
+                rule_index: 0,
+                pred_index: 0,
+                context_dependent: false,
+            });
+        atn.state_mut(4)
+            .expect("operator token")
+            .add_transition(Transition::Atom {
+                target: 1,
+                label: 1,
+            });
+        atn.state_mut(5)
+            .expect("loop exit")
+            .add_transition(Transition::Epsilon { target: 6 });
+        atn
+    }
+
     fn left_recursive_loop_with_nullable_follow_call_atn(caller_symbol: i32) -> Atn {
         let mut atn = Atn::new(AtnType::Parser, 2);
         for (state, kind, rule) in [
@@ -10419,6 +10637,33 @@ mod tests {
             parser.left_recursive_loop_enter_prediction(&atn, 1, 0),
             Some(true),
             "cached operator lookahead must preserve the nullable prefix return path"
+        );
+    }
+
+    #[test]
+    fn left_recursive_loop_defers_predicate_guarded_operator() {
+        let atn = left_recursive_loop_with_predicate_guarded_operator_atn();
+        let mut parser = mini_parser_with_hooks(
+            vec![
+                CommonToken::new(1).with_text("operator"),
+                CommonToken::eof("parser-test", 1, 1, 1),
+            ],
+            RejectingPredicateHooks::default(),
+        );
+        parser.rule_context_stack = vec![RuleContextFrame {
+            rule_index: 0,
+            invoking_state: -1,
+        }];
+
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 1, 0),
+            None,
+            "a false predicate must be evaluated before entering the operator alternative"
+        );
+        assert_eq!(
+            parser.left_recursive_loop_enter_prediction(&atn, 1, 0),
+            None,
+            "cached predicate-dependent lookahead must keep deferring"
         );
     }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3048,8 +3048,29 @@ where
 /// truly matched, matching ANTLR's `matchedEOF` semantics.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct GeneratedMatch {
-    children: Vec<ParseTree>,
+    children: GeneratedMatchChildren,
     consumed_eof: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum GeneratedMatchChildren {
+    One(ParseTree),
+    Many(Vec<ParseTree>),
+}
+
+struct GeneratedMatchChildrenIntoIter {
+    one: Option<ParseTree>,
+    many: Option<std::vec::IntoIter<ParseTree>>,
+}
+
+impl Iterator for GeneratedMatchChildrenIntoIter {
+    type Item = ParseTree;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.one
+            .take()
+            .or_else(|| self.many.as_mut().and_then(Iterator::next))
+    }
 }
 
 impl GeneratedMatch {
@@ -3058,14 +3079,34 @@ impl GeneratedMatch {
     /// error node).
     #[must_use]
     pub fn children(&self) -> &[ParseTree] {
-        &self.children
+        match &self.children {
+            GeneratedMatchChildren::One(child) => std::slice::from_ref(child),
+            GeneratedMatchChildren::Many(children) => children,
+        }
     }
 
     /// Consumes the result, returning the children for appending to the rule
     /// context.
     #[must_use]
     pub fn into_children(self) -> Vec<ParseTree> {
-        self.children
+        match self.children {
+            GeneratedMatchChildren::One(child) => vec![child],
+            GeneratedMatchChildren::Many(children) => children,
+        }
+    }
+
+    /// Consumes the match without allocating for the common single-child case.
+    pub fn into_child_iter(self) -> impl Iterator<Item = ParseTree> {
+        match self.children {
+            GeneratedMatchChildren::One(child) => GeneratedMatchChildrenIntoIter {
+                one: Some(child),
+                many: None,
+            },
+            GeneratedMatchChildren::Many(children) => GeneratedMatchChildrenIntoIter {
+                one: None,
+                many: Some(children.into_iter()),
+            },
+        }
     }
 
     /// Whether a real EOF terminal was consumed by this match.
@@ -3460,7 +3501,9 @@ where
             let consumed_eof = current.token_type() == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Terminal(TerminalNode::from_ref(current))],
+                children: GeneratedMatchChildren::One(ParseTree::Terminal(TerminalNode::from_ref(
+                    current,
+                ))),
                 consumed_eof,
             });
         }
@@ -3494,7 +3537,9 @@ where
             let consumed_eof = current.token_type() == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Terminal(TerminalNode::from_ref(current))],
+                children: GeneratedMatchChildren::One(ParseTree::Terminal(TerminalNode::from_ref(
+                    current,
+                ))),
                 consumed_eof,
             });
         }
@@ -3531,7 +3576,9 @@ where
             let consumed_eof = current.token_type() == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Terminal(TerminalNode::from_ref(current))],
+                children: GeneratedMatchChildren::One(ParseTree::Terminal(TerminalNode::from_ref(
+                    current,
+                ))),
                 consumed_eof,
             });
         }
@@ -3585,10 +3632,10 @@ where
             self.consume();
             self.consume();
             return Ok(GeneratedMatch {
-                children: vec![
+                children: GeneratedMatchChildren::Many(vec![
                     ParseTree::Error(ErrorNode::new(current)),
                     ParseTree::Terminal(TerminalNode::new(next)),
-                ],
+                ]),
                 consumed_eof,
             });
         }
@@ -3631,7 +3678,7 @@ where
             // EOF. Reporting consumed_eof=false here is what keeps `finish_rule`
             // from recording EOF as the rule stop on this recovery path.
             return Ok(GeneratedMatch {
-                children: vec![ParseTree::Error(ErrorNode::new(token))],
+                children: GeneratedMatchChildren::One(ParseTree::Error(ErrorNode::new(token))),
                 consumed_eof: false,
             });
         }
@@ -3975,28 +4022,25 @@ where
         self.exit_rule();
     }
 
-    /// Checks whether a generated left-recursive loop has an operator
-    /// alternative that can start at the current token under the active
-    /// precedence. The operator block still performs adaptive prediction; this
-    /// guard only decides whether the loop should enter or exit.
-    pub fn left_recursive_loop_enter_matches(
+    /// Predicts a generated left-recursive loop from one-token lookahead.
+    ///
+    /// `Some(true)` enters the operator alternative, `Some(false)` exits, and
+    /// `None` means the caller can consume the same symbol so full-context
+    /// adaptive prediction must break the ambiguity.
+    pub fn left_recursive_loop_enter_prediction(
         &mut self,
         atn: &Atn,
         state_number: usize,
         precedence: i32,
-    ) -> bool {
+    ) -> Option<bool> {
         let symbol = self.la(1);
         if symbol == TOKEN_EOF {
-            return false;
+            return Some(false);
         }
         let Some(state) = atn.state(state_number) else {
-            return false;
+            return Some(false);
         };
-        let context = self.prediction_context(atn);
-        if context_can_match_symbol_before_state(atn, &context, state_number, symbol) {
-            return false;
-        }
-        state.transitions.iter().any(|transition| {
+        let operator_matches = state.transitions.iter().any(|transition| {
             let target = transition.target();
             if atn
                 .state(target)
@@ -4011,7 +4055,26 @@ where
                 precedence,
                 &mut BTreeSet::new(),
             )
-        })
+        });
+        if !operator_matches {
+            return Some(false);
+        }
+        let context = self.prediction_context(atn);
+        if context_can_match_symbol_before_state(atn, &context, state_number, symbol) {
+            return None;
+        }
+        Some(true)
+    }
+
+    /// Checks whether a generated left-recursive loop can unambiguously enter
+    /// its operator alternative from one-token lookahead.
+    pub fn left_recursive_loop_enter_matches(
+        &mut self,
+        atn: &Atn,
+        state_number: usize,
+        precedence: i32,
+    ) -> bool {
+        self.left_recursive_loop_enter_prediction(atn, state_number, precedence) == Some(true)
     }
 
     /// Implements generated `precpred(_ctx, k)` checks.
@@ -9816,6 +9879,113 @@ mod tests {
         )
     }
 
+    fn left_recursive_loop_with_caller_follow_atn(caller_symbol: i32) -> Atn {
+        let mut atn = Atn::new(AtnType::Parser, 2);
+        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
+        atn.add_state(AtnState::new(1, AtnStateKind::Basic).with_rule_index(0));
+        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
+        let mut callee_start = AtnState::new(3, AtnStateKind::RuleStart).with_rule_index(1);
+        callee_start.left_recursive_rule = true;
+        atn.add_state(callee_start);
+        let mut loop_entry = AtnState::new(4, AtnStateKind::StarLoopEntry).with_rule_index(1);
+        loop_entry.precedence_rule_decision = true;
+        atn.add_state(loop_entry);
+        atn.add_state(AtnState::new(5, AtnStateKind::Basic).with_rule_index(1));
+        atn.add_state(AtnState::new(6, AtnStateKind::Basic).with_rule_index(1));
+        atn.add_state(AtnState::new(7, AtnStateKind::LoopEnd).with_rule_index(1));
+        atn.add_state(AtnState::new(8, AtnStateKind::RuleStop).with_rule_index(1));
+        atn.add_state(AtnState::new(9, AtnStateKind::RuleStop).with_rule_index(0));
+        atn.set_rule_to_start_state(vec![0, 3]);
+        atn.set_rule_to_stop_state(vec![9, 8]);
+        atn.state_mut(1)
+            .expect("caller invoking state")
+            .add_transition(Transition::Rule {
+                target: 3,
+                rule_index: 1,
+                follow_state: 2,
+                precedence: 0,
+            });
+        atn.state_mut(2)
+            .expect("caller follow")
+            .add_transition(Transition::Atom {
+                target: 9,
+                label: caller_symbol,
+            });
+        atn.state_mut(4)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 5 });
+        atn.state_mut(4)
+            .expect("precedence loop")
+            .add_transition(Transition::Epsilon { target: 7 });
+        atn.state_mut(5)
+            .expect("precedence predicate")
+            .add_transition(Transition::Precedence {
+                target: 6,
+                precedence: 1,
+            });
+        atn.state_mut(6)
+            .expect("operator token")
+            .add_transition(Transition::Atom {
+                target: 4,
+                label: 1,
+            });
+        atn.state_mut(7)
+            .expect("loop exit")
+            .add_transition(Transition::Epsilon { target: 8 });
+        atn
+    }
+
+    fn parser_inside_left_recursive_callee(symbol: i32) -> BaseParser<Source> {
+        let mut parser = mini_parser(vec![
+            CommonToken::new(symbol).with_text("lookahead"),
+            CommonToken::eof("parser-test", 1, 1, 1),
+        ]);
+        parser.rule_context_stack = vec![
+            RuleContextFrame {
+                rule_index: 0,
+                invoking_state: -1,
+            },
+            RuleContextFrame {
+                rule_index: 1,
+                invoking_state: 1,
+            },
+        ];
+        parser
+    }
+
+    #[test]
+    fn left_recursive_loop_defers_overlapping_caller_lookahead() {
+        let mut overlapping = parser_inside_left_recursive_callee(1);
+        assert_eq!(
+            overlapping.left_recursive_loop_enter_prediction(
+                &left_recursive_loop_with_caller_follow_atn(1),
+                4,
+                0,
+            ),
+            None
+        );
+
+        let mut unambiguous_enter = parser_inside_left_recursive_callee(1);
+        assert_eq!(
+            unambiguous_enter.left_recursive_loop_enter_prediction(
+                &left_recursive_loop_with_caller_follow_atn(2),
+                4,
+                0,
+            ),
+            Some(true)
+        );
+
+        let mut unambiguous_exit = parser_inside_left_recursive_callee(2);
+        assert_eq!(
+            unambiguous_exit.left_recursive_loop_enter_prediction(
+                &left_recursive_loop_with_caller_follow_atn(2),
+                4,
+                0,
+            ),
+            Some(false)
+        );
+    }
+
     fn token_then_eof_atn() -> Atn {
         AtnDeserializer::new(&SerializedAtn::from_i32(&[
             4, 1, 2, // version, parser, max token type
@@ -10570,6 +10740,13 @@ mod tests {
 
         assert_eq!(node.children().len(), 1);
         assert_eq!(node.children()[0].text(), "<missing 'Y'>");
+        assert_eq!(
+            node.clone()
+                .into_child_iter()
+                .map(|child| child.text())
+                .collect::<Vec<_>>(),
+            ["<missing 'Y'>"]
+        );
         // Single-token insertion synthesizes a missing token and consumes nothing,
         // so no EOF terminal is consumed even though lookahead is EOF.
         assert!(!node.consumed_eof());
@@ -10616,7 +10793,48 @@ mod tests {
         assert!(matches!(node.children()[0], ParseTree::Error(_)));
         assert_eq!(node.children()[0].text(), "z");
         assert_eq!(node.children()[1].text(), "y");
+        assert_eq!(
+            node.into_child_iter()
+                .map(|child| child.text())
+                .collect::<Vec<_>>(),
+            ["z", "y"]
+        );
         assert_eq!(parser.number_of_syntax_errors(), 1);
+    }
+
+    #[test]
+    fn generated_match_token_iterates_single_success_without_a_children_vec() {
+        let atn = generated_match_recovery_atn();
+        let data = RecognizerData::new(
+            "Mini.g4",
+            Vocabulary::new(
+                [None, Some("'X'"), Some("'Y'")],
+                [None, Some("X"), Some("Y")],
+                [None::<&str>, None, None],
+            ),
+        );
+        let mut parser = BaseParser::new(
+            CommonTokenStream::new(Source {
+                tokens: vec![
+                    CommonToken::new(2).with_text("y"),
+                    CommonToken::eof("parser-test", 1, 1, 1),
+                ],
+                index: 0,
+            }),
+            data,
+        );
+
+        let node = parser
+            .match_token_recovering(2, 5, &atn)
+            .expect("generated match should consume the expected token");
+
+        assert_eq!(
+            node.into_child_iter()
+                .map(|child| child.text())
+                .collect::<Vec<_>>(),
+            ["y"]
+        );
+        assert_eq!(parser.number_of_syntax_errors(), 0);
     }
 
     #[test]


### PR DESCRIPTION
Closes #76

## What changed

- Translate portable ANTLR boolean locals, assignments, predicates, failure messages, and literal boolean rule arguments into generated Rust.
- Require generated implementations for rules that own translated local semantics, and keep their generated caller chains off ATN-preferred fallback.
- Predict generated left-recursive loop entry from lookahead, with full-context adaptive fallback when the caller can consume the same token.
- Treat `NoViableAlt` from left-recursive loop fallback prediction as the normal loop-exit alternative.
- Cache operator and caller-follow lookahead per ATN, preserving nullable rule-call returns, nullable operator prefixes, and parent prediction-context unwinding.
- Store the common single-child `GeneratedMatch` result inline instead of allocating a `Vec` for every successful token match.
- Update README benchmark ratios from a fresh Kotlin, C#, Java, and Trino SQL sweep.

All runtime and codegen behavior remains grammar-agnostic; there are no Solidity-specific rule names or workarounds.

## Root cause

The Solidity grammar's portable local predicates prevented complete strict generated-parser coverage. Once generated, expression-heavy left-recursive rules still paid for adaptive ATN simulation at every operator boundary, and every normal token match allocated a one-element children vector. The first optimization exposed repeated caller-follow graph walks in other left-recursive grammars, so those pure ATN results now live in the shared grammar cache rather than being recomputed per parse.

## Correctness

Strict generation emits all 93 Solidity parser rules. The semantic manifest contains 60 translated and 2 synthetic coordinates with none unsupported. Parse trees are byte-identical to the Go ANTLR runtime for Ownable, ERC20, ERC721, and Governor, including the caller-follow ambiguity around `new string[]` that requires full-context fallback.

## Solidity performance

Same official Solidity grammar, same OpenZeppelin fixture classes, full CST enabled, release builds with five warmups and 30 measured iterations per process on Apple M3 Pro. The table is the third complete round on commit `3c3607f`:

| Fixture | Bytes | Rust median | Go median | Go / Rust |
|---|---:|---:|---:|---:|
| Ownable | 3,102 | 300 us | 882 us | 2.94x |
| ERC20 | 10,798 | 872 us | 2,495 us | 2.86x |
| ERC721 | 16,102 | 1,329 us | 4,292 us | 3.23x |
| Governor | 31,931 | 2,336 us | 7,531 us | 3.22x |

Across three complete rounds on the final head, every fixture remained above 2x; the worst observed ratio was 2.60x.

Governor scaling on the same final head:

| Bytes | Rust median | Go median | Go / Rust |
|---:|---:|---:|---:|
| 31,931 | 2,325 us | 7,488 us | 3.22x |
| 63,862 | 4,928 us | 17,155 us | 3.48x |
| 127,724 | 9,794 us | 31,498 us | 3.22x |
| 255,448 | 19,909 us | 61,187 us | 3.07x |

Governor allocation profile improves from the issue baseline of 189,489 allocations / 42.0 MB allocated / 17.6 MB peak live to 65,107 / 18.77 MB / 5.60 MB.

Artifact sizes:

- Generated Rust parser + lexer source: 1,594,757 bytes
- Stripped Rust benchmark binary: 2,137,464 bytes
- Go benchmark binary built with `-ldflags='-s -w'`: 4,150,706 bytes

## Cross-language benchmark

Same-machine `origin/main` and final PR runs used 10 measured iterations after two warmups. The 17-fixture comparator passed with a 1.15x maximum-regression threshold. Go/Rust ratios use the README's warm-minimum metric.

| Language | Fixtures | Rust vs Go geometric mean | Rust time vs main |
|---|---:|---:|---:|
| Kotlin | 4 | 17.60x | -1.2% |
| C# | 4 | 1.72x | -2.2% |
| Java | 4 | 2.65x | -23.3% |
| Trino SQL | 5 | 2.27x | -46.7% |

README uses the lower-variance paired sweep values: 18.5x Kotlin, 1.7x C#, 2.5x Java, and 2.2x Trino SQL.

## Validation

- `cargo fmt --check`
- `cargo test --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` (`356 passed, 0 failed, 1 skipped`)
- `tools/parse-bench/compare.py` on same-protocol `origin/main` vs final head (`17` results passed at `1.15x`)
- Strict Solidity regeneration with `--require-generated-parser`
- Byte-for-byte Rust/Go Solidity tree comparison on all four fixtures
- Three final-head 30-iteration four-fixture benchmark rounds plus Governor 1x/2x/4x/8x scaling