### PR TITLE
store buffered tokens once by TokenId

### DIFF
--- a/.conformance-review/Rust.test.stg
+++ b/.conformance-review/Rust.test.stg
@@ -55,7 +55,7 @@ Not(v) ::= "!<v>"
 // target that renders a real assertion receives uncompilable Java syntax.
 Assert(s) ::= ""
 
-Cast(t,v) ::= "(<v>).downcast_ref::\<<t>>().unwrap()"
+Cast(t,v) ::= "(<v>).downcast_ref::\<<t>>(self.base.token_store()).unwrap()"
 
 // Rust has no `&str + &str` operator, and descriptors chain Append/AppendStr
 // with bare string literals on the left (`"(" + $ID.text + …` in Java terms),
@@ -110,7 +110,7 @@ BuildParseTrees() ::= "self.set_build_parse_trees(true);"
 
 BailErrorStrategy() ::= <%self.set_error_handler(BailErrorStrategy::new());%>
 
-ToStringTree(s) ::= <%<s>.to_string_tree(Some(self))%>
+ToStringTree(s) ::= <%<s>.to_string_tree(Some(self), self.base.token_store())%>
 
 Column() ::= "self.char_position_in_line()"
 
@@ -280,7 +280,7 @@ impl TListener for LeafListener {
 
 WalkListener(s) ::= <<
 let mut listener = LeafListener::default();
-ParseTreeWalker::walk(&mut listener, <s>);
+ParseTreeWalker::walk(&mut listener, <s>, self.base.token_store());
 >>
 
 // Java needs a custom context superclass because its default RuleContext does

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Buffered tokens now live once in a compact `TokenStore` and are addressed by
   `TokenId`; public access uses borrowing `TokenView` values.
+- `CommonTokenStream` owns its `TokenStore` directly, parse-tree nodes store
+  only `TokenId`, and token-dependent tree APIs take `&TokenStore`.
+- Generated `parse()` helpers return `ParsedFile<R>` so completed trees retain
+  ownership of their canonical token store.
 - `CommonToken`, `TokenRef`, and token factories are removed. `TokenSource`
   implementations write directly to `TokenSink`.
 - Generated lexers and parsers must be regenerated with the matching

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased
+
+### Breaking
+
+- Buffered tokens now live once in a compact `TokenStore` and are addressed by
+  `TokenId`; public access uses borrowing `TokenView` values.
+- `CommonToken`, `TokenRef`, and token factories are removed. `TokenSource`
+  implementations write directly to `TokenSink`.
+- Generated lexers and parsers must be regenerated with the matching
+  `antlr4-rust-gen` release.

--- a/README.md
+++ b/README.md
@@ -442,10 +442,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | ~18.5× faster           |
-| Java     | 4        | ~2.5× faster            |
+| Kotlin   | 4        | ~18.6× faster           |
+| Java     | 4        | ~2.7× faster            |
 | C#       | 4        | ~1.7× faster            |
-| Trino SQL| 5        | ~2.2× faster            |
+| Trino SQL| 5        | ~2.5× faster            |
 
 Rust is faster than Go on average in all four language groups, with
 Kotlin leading dramatically (expression-ladder memoization in the generated

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ use generated::json_lexer::JsonLexer;
 fn main() -> Result<(), antlr4_runtime::AntlrError> {
     let parsed = json::parse(r#"{"a":1}"#, JsonLexer::new, Json::json)?;
 
-    println!("{}", parsed.tree.text(&parsed.tokens));
+    println!("{}", parsed.tree().text(parsed.tokens()));
     Ok(())
 }
 ```
@@ -208,10 +208,10 @@ otherwise token text is stored explicitly in the sparse side pool.
 
 `CommonTokenStream` owns its `TokenStore` directly. Parse-tree nodes contain
 only `TokenId` values, so token-dependent tree methods take `&TokenStore`.
-Generated `parse()` returns `ParsedFile<R>`, which owns both `tokens` and the
-entry-rule result in `tree`. Direct rule calls can resolve their returned tree
-through `parser.token_store()` while the parser is alive, or consume the parser
-with `into_token_store()`.
+Generated `parse()` returns `ParsedFile<R>`, which owns both the token store and
+entry-rule result. Access them through `tokens()` and `tree()`. Direct rule calls
+can resolve their returned tree through `parser.token_store()` while the parser
+is alive, or consume the parser with `into_token_store()`.
 
 Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
 numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);

--- a/README.md
+++ b/README.md
@@ -190,6 +190,25 @@ grammar's documentation. Calling the wrong rule can still recover and return a
 parse tree with error nodes, so check parser diagnostics when adding a new input
 form.
 
+## Token API Migration
+
+The compact token store is a breaking runtime/generator change. Regenerate all
+generated lexers and parsers with the matching `antlr4-rust-gen`; code generated
+against the pointer-owned token API does not compile against this runtime.
+
+`CommonToken`, `TokenRef`, and token factories are removed. Custom token sources
+now append a `TokenSpec` directly to the supplied `TokenSink` and return its
+`TokenId`. Buffered-token consumers use borrowing `TokenView` values from
+`get`, `lt`, or the `tokens()` iterator. Custom `CharStream` implementations
+should provide `source_text()` when the complete UTF-8 input can be shared;
+otherwise token text is stored explicitly in the sparse side pool.
+
+Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
+numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);
+`u32::MAX` is reserved for ANTLR's synthetic `-1` boundary. All conversions are
+checked. Use `CommonTokenStream::try_new` or `try_with_channel` to handle limit
+errors; `new` and `with_channel` panic with the same error.
+
 ## Technical Notes
 
 - Pure Rust runtime implementation.
@@ -206,7 +225,8 @@ The runtime contains:
 
 - `IntStream` and `CharStream`
 - UTF-8 input as Unicode scalar values
-- `Token`, `CommonToken`, token factories, and `TokenSource`
+- compact `TokenId`/`TokenView` access, `TokenSource`, and one canonical
+  `TokenStore`
 - buffered, channel-aware `CommonTokenStream`
 - `Vocabulary`
 - recognizer metadata and error listener plumbing

--- a/README.md
+++ b/README.md
@@ -130,15 +130,15 @@ use generated::json::{self, Json};
 use generated::json_lexer::JsonLexer;
 
 fn main() -> Result<(), antlr4_runtime::AntlrError> {
-    let tree = json::parse(r#"{"a":1}"#, JsonLexer::new, Json::json)?;
+    let parsed = json::parse(r#"{"a":1}"#, JsonLexer::new, Json::json)?;
 
-    println!("{}", tree.text());
+    println!("{}", parsed.tree.text(&parsed.tokens));
     Ok(())
 }
 ```
 
 Use `parse_with_parser` when you want the compact setup path and also need the
-parser afterward for diagnostics or the owned token stream:
+parser afterward for diagnostics:
 
 ```rust
 use antlr4_runtime::Parser;
@@ -148,11 +148,14 @@ use generated::json_lexer::JsonLexer;
 fn main() -> Result<(), antlr4_runtime::AntlrError> {
     let output = json::parse_with_parser(r#"{"a":1}"#, JsonLexer::new, Json::json)?;
     let syntax_errors = output.parser.number_of_syntax_errors();
-    let tree = output.result;
-    let tokens = output.parser.into_token_stream();
+    let json::JsonParseOutput {
+        result: tree,
+        parser,
+    } = output;
+    let tokens = parser.into_token_store();
 
-    println!("{} errors across {} tokens", syntax_errors, tokens.tokens().len());
-    println!("{}", tree.text());
+    println!("{} errors across {} tokens", syntax_errors, tokens.len());
+    println!("{}", tree.text(&tokens));
     Ok(())
 }
 ```
@@ -171,7 +174,7 @@ fn main() -> Result<(), antlr4_runtime::AntlrError> {
     let mut parser = Json::new(tokens);
     let tree = parser.json()?;
 
-    println!("{}", tree.text());
+    println!("{}", tree.text(parser.token_store()));
     Ok(())
 }
 ```
@@ -203,6 +206,13 @@ now append a `TokenSpec` directly to the supplied `TokenSink` and return its
 should provide `source_text()` when the complete UTF-8 input can be shared;
 otherwise token text is stored explicitly in the sparse side pool.
 
+`CommonTokenStream` owns its `TokenStore` directly. Parse-tree nodes contain
+only `TokenId` values, so token-dependent tree methods take `&TokenStore`.
+Generated `parse()` returns `ParsedFile<R>`, which owns both `tokens` and the
+entry-rule result in `tree`. Direct rule calls can resolve their returned tree
+through `parser.token_store()` while the parser is alive, or consume the parser
+with `into_token_store()`.
+
 Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
 numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);
 `u32::MAX` is reserved for ANTLR's synthetic `-1` boundary. All conversions are
@@ -216,8 +226,8 @@ errors; `new` and `with_channel` panic with the same error.
 - Supports ANTLR serialized ATN deserialization.
 - Supports lexer and parser execution through generated Rust wrappers.
 - Supports real split lexer/parser grammars, including Kotlin smoke builds.
-- Passes every upstream ANTLR runtime-testsuite descriptor discovered by the
-  harness: `357 passed, 0 failed, 0 skipped, 357 run`.
+- Passes every supported upstream ANTLR runtime-testsuite descriptor discovered
+  by the harness: `356 passed, 0 failed, 1 skipped, 356 run`.
 - Licensed under BSD-3-Clause for compatibility with ANTLR's runtime licensing
   pattern and downstream open-source applications.
 

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -13,7 +13,7 @@ use crate::lexer::{
 };
 use crate::parser::{SemanticHooks, UnknownSemanticPolicy};
 use crate::prediction::PredictionFxHasher;
-use crate::token::{CommonToken, DEFAULT_CHANNEL, INVALID_TOKEN_TYPE, TokenFactory};
+use crate::token::{DEFAULT_CHANNEL, INVALID_TOKEN_TYPE, TokenId, TokenSink, TokenStoreError};
 
 #[allow(clippy::disallowed_types)]
 type FxHashSet<K> = HashSet<K, BuildHasherDefault<PredictionFxHasher>>;
@@ -86,10 +86,9 @@ impl LexerActionResult {
 
     /// Applies one deserialized lexer action to this token emission result and
     /// to the lexer mode stack when the action changes modes.
-    fn apply<I, F>(&mut self, action: &LexerAction, lexer: &mut BaseLexer<I, F>)
+    fn apply<I>(&mut self, action: &LexerAction, lexer: &mut BaseLexer<I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         match action {
             LexerAction::Channel(channel) => self.channel = *channel,
@@ -123,12 +122,15 @@ struct ClosureState {
 /// actions collected on the accepted path are applied after the input cursor is
 /// moved to the accepted token boundary, so mode changes and token type/channel
 /// rewrites happen at the same point generated ANTLR lexers perform them.
-pub fn next_token<I, F>(lexer: &mut BaseLexer<I, F>, atn: &Atn) -> CommonToken
+pub fn next_token<I>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
+    atn: &Atn,
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
 {
-    next_token_with_cache(lexer, atn, |_, _| {}, |_, _| true, |_, _, _| {})
+    next_token_with_cache(lexer, sink, atn, |_, _| {}, |_, _| true, |_, _, _| {})
 }
 
 /// Runs one lexer-token match and invokes `custom_action` for embedded
@@ -137,17 +139,17 @@ where
 /// The callback receives the base lexer plus the serialized custom-action
 /// coordinates. It is used by generated lexers to replay target templates while
 /// keeping all ATN path exploration in the shared runtime.
-pub fn next_token_with_actions<I, F, A>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_with_actions<I, A>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     custom_action: A,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
 {
-    next_token_with_hooks(lexer, atn, custom_action, |_, _| true, |_, _, _| {})
+    next_token_with_hooks(lexer, sink, atn, custom_action, |_, _| true, |_, _, _| {})
 }
 
 /// Runs one lexer-token match and lets generated code adjust the final accept
@@ -156,37 +158,38 @@ where
 /// ANTLR target templates such as `PositionAdjustingLexer` use this to accept
 /// a long disambiguating token path but emit only the prefix, leaving the
 /// remaining characters for the next token.
-pub fn next_token_with_accept_adjuster<I, F, E>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_with_accept_adjuster<I, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     accept_adjuster: E,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
-    next_token_with_hooks(lexer, atn, |_, _| {}, |_, _| true, accept_adjuster)
+    next_token_with_hooks(lexer, sink, atn, |_, _| {}, |_, _| true, accept_adjuster)
 }
 
 /// Runs one lexer-token match with grammar-specific actions and predicates.
 ///
 /// Predicates are evaluated during ATN closure construction so non-viable
 /// paths are rejected before longest-match and lexer-rule priority selection.
-pub fn next_token_with_actions_and_predicates<I, F, A, P>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_with_actions_and_predicates<I, A, P>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     mut custom_action: A,
     mut semantic_predicate: P,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
 {
     next_token_with_hooks(
         lexer,
+        sink,
         atn,
         &mut custom_action,
         &mut semantic_predicate,
@@ -199,22 +202,23 @@ where
 /// Custom actions and predicates correspond to serialized ATN edges. The
 /// accept adjuster runs after lexer commands but before `emit`, matching target
 /// runtimes that override emission to split a longest-match token.
-pub fn next_token_with_hooks<I, F, A, P, E>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_with_hooks<I, A, P, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     mut custom_action: A,
     mut semantic_predicate: P,
     mut accept_adjuster: E,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     next_token_with_hooks_impl(
         lexer,
+        sink,
         atn,
         &mut custom_action,
         &mut semantic_predicate,
@@ -231,14 +235,13 @@ where
 /// Both `next_token_*_with_semantic_hooks` entry points wire the interpreter's
 /// action callback to this, so the `RefCell` borrow + [`LexerSemCtx`] plumbing
 /// lives in one place instead of being copied per entry point.
-fn dispatch_lexer_action_hook<I, F, H>(
+fn dispatch_lexer_action_hook<I, H>(
     hooks: &RefCell<&mut H>,
-    lexer: &mut BaseLexer<I, F>,
+    lexer: &mut BaseLexer<I>,
     action: LexerCustomAction,
 ) -> bool
 where
     I: CharStream,
-    F: TokenFactory,
     H: SemanticHooks,
 {
     let Ok(rule_index) = usize::try_from(action.rule_index()) else {
@@ -258,14 +261,13 @@ where
 /// Dispatches one lexer semantic predicate to a shared [`SemanticHooks`]
 /// object, defaulting unknown coordinates to `true` (the historical closure
 /// default) when the hook declines with `None`.
-fn dispatch_lexer_predicate_hook<I, F, H>(
+fn dispatch_lexer_predicate_hook<I, H>(
     hooks: &RefCell<&mut H>,
-    lexer: &BaseLexer<I, F>,
+    lexer: &BaseLexer<I>,
     predicate: LexerPredicate,
 ) -> Option<bool>
 where
     I: CharStream,
-    F: TokenFactory,
     H: SemanticHooks,
 {
     let mut ctx = LexerSemCtx::new(
@@ -285,19 +287,20 @@ where
 /// Unknown lexer predicates default to `true` when the hook returns `None`,
 /// matching the existing closure default; callers that need fail-loud behavior
 /// can implement the hook to record and reject coordinates explicitly.
-pub fn next_token_with_semantic_hooks<I, F, H>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_with_semantic_hooks<I, H>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     hooks: &mut H,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
     H: SemanticHooks,
 {
     let hooks = RefCell::new(hooks);
     let token = next_token_with_hooks(
         lexer,
+        sink,
         atn,
         |lexer, action| {
             let _ = dispatch_lexer_action_hook(&hooks, lexer, action);
@@ -305,8 +308,12 @@ where
         |lexer, predicate| dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true),
         |_, _, _| {},
     );
-    hooks.borrow_mut().lexer_token_emitted(&token);
-    token
+    let token = token?;
+    hooks.borrow_mut().lexer_token_emitted(
+        sink.view(token)
+            .expect("lexer hook token should be present in its sink"),
+    );
+    Ok(token)
 }
 
 /// Runs one lexer-token match against an ahead-of-time compiled lexer DFA.
@@ -314,17 +321,18 @@ where
 /// Tokens starting in a compiled mode are matched by walking static tables;
 /// modes the compiler left dynamic fall back to cached ATN interpretation per
 /// token, so behavior always matches [`next_token`].
-pub fn next_token_compiled<I, F>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_compiled<I>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     dfa: &CompiledLexerDfa,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
 {
     next_token_with_hooks_impl(
         lexer,
+        sink,
         atn,
         &mut |_, _| {},
         &mut |_, _| true,
@@ -341,23 +349,25 @@ where
 /// Compiled modes never contain semantic predicates, so hook grammars still
 /// take the table walk for their static modes; predicate-bearing modes re-run
 /// the ATN interpreter exactly like [`next_token_with_hooks`].
-pub fn next_token_compiled_with_hooks<I, F, A, P, E>(
-    lexer: &mut BaseLexer<I, F>,
+#[allow(clippy::too_many_arguments)]
+pub fn next_token_compiled_with_hooks<I, A, P, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     dfa: &CompiledLexerDfa,
     mut custom_action: A,
     mut semantic_predicate: P,
     mut accept_adjuster: E,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     next_token_with_hooks_impl(
         lexer,
+        sink,
         atn,
         &mut custom_action,
         &mut semantic_predicate,
@@ -371,20 +381,21 @@ where
 
 /// Runs one compiled-DFA lexer-token match with a shared [`SemanticHooks`]
 /// object for dynamic predicate/action modes.
-pub fn next_token_compiled_with_semantic_hooks<I, F, H>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_compiled_with_semantic_hooks<I, H>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     dfa: &CompiledLexerDfa,
     hooks: &mut H,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
     H: SemanticHooks,
 {
     let hooks = RefCell::new(hooks);
     let token = next_token_compiled_with_hooks(
         lexer,
+        sink,
         atn,
         dfa,
         |lexer, action| {
@@ -393,8 +404,12 @@ where
         |lexer, predicate| dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true),
         |_, _, _| {},
     );
-    hooks.borrow_mut().lexer_token_emitted(&token);
-    token
+    let token = token?;
+    hooks.borrow_mut().lexer_token_emitted(
+        sink.view(token)
+            .expect("lexer hook token should be present in its sink"),
+    );
+    Ok(token)
 }
 
 /// Runs one interpreted lexer-token match by composing generated translations
@@ -405,26 +420,27 @@ where
 /// `Some` owns the coordinate; `None` falls through to
 /// [`SemanticHooks::lexer_sempred`] and finally the selected unknown policy.
 #[allow(clippy::too_many_arguments)]
-pub fn next_token_with_semantic_dispatch<I, F, H, A, P, E>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_with_semantic_dispatch<I, H, A, P, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     hooks: &mut H,
     mut generated_action: A,
     mut generated_predicate: P,
     unknown_policy: UnknownSemanticPolicy,
     accept_adjuster: E,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
     H: SemanticHooks,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction) -> bool,
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> Option<bool>,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction) -> bool,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> Option<bool>,
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     let hooks = RefCell::new(hooks);
     let token = next_token_with_hooks(
         lexer,
+        sink,
         atn,
         |lexer, action| {
             if !generated_action(lexer, action)
@@ -456,14 +472,19 @@ where
         },
         accept_adjuster,
     );
-    hooks.borrow_mut().lexer_token_emitted(&token);
-    token
+    let token = token?;
+    hooks.borrow_mut().lexer_token_emitted(
+        sink.view(token)
+            .expect("lexer hook token should be present in its sink"),
+    );
+    Ok(token)
 }
 
 /// Compiled-DFA counterpart of [`next_token_with_semantic_dispatch`].
 #[allow(clippy::too_many_arguments)]
-pub fn next_token_compiled_with_semantic_dispatch<I, F, H, A, P, E>(
-    lexer: &mut BaseLexer<I, F>,
+pub fn next_token_compiled_with_semantic_dispatch<I, H, A, P, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     dfa: &CompiledLexerDfa,
     hooks: &mut H,
@@ -471,18 +492,18 @@ pub fn next_token_compiled_with_semantic_dispatch<I, F, H, A, P, E>(
     mut generated_predicate: P,
     unknown_policy: UnknownSemanticPolicy,
     accept_adjuster: E,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
     H: SemanticHooks,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction) -> bool,
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> Option<bool>,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction) -> bool,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> Option<bool>,
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     let hooks = RefCell::new(hooks);
     let token = next_token_compiled_with_hooks(
         lexer,
+        sink,
         atn,
         dfa,
         |lexer, action| {
@@ -515,26 +536,31 @@ where
         },
         accept_adjuster,
     );
-    hooks.borrow_mut().lexer_token_emitted(&token);
-    token
+    let token = token?;
+    hooks.borrow_mut().lexer_token_emitted(
+        sink.view(token)
+            .expect("lexer hook token should be present in its sink"),
+    );
+    Ok(token)
 }
 
-fn next_token_with_cache<I, F, A, P, E>(
-    lexer: &mut BaseLexer<I, F>,
+fn next_token_with_cache<I, A, P, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     mut custom_action: A,
     mut semantic_predicate: P,
     mut accept_adjuster: E,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     next_token_with_hooks_impl(
         lexer,
+        sink,
         atn,
         &mut custom_action,
         &mut semantic_predicate,
@@ -558,8 +584,8 @@ struct LexerMatchStrategy<'a> {
 }
 
 /// Dispatches one token match to the strategy's backend.
-fn match_token_with_strategy<I, F, P>(
-    lexer: &mut BaseLexer<I, F>,
+fn match_token_with_strategy<I, P>(
+    lexer: &mut BaseLexer<I>,
     atn: &Atn,
     mode: i32,
     start: usize,
@@ -568,8 +594,7 @@ fn match_token_with_strategy<I, F, P>(
 ) -> MatchResult
 where
     I: CharStream,
-    F: TokenFactory,
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
 {
     if let Some(dfa) = strategy.compiled
         && !lexer.force_interpreted()
@@ -585,25 +610,26 @@ where
     }
 }
 
-fn next_token_with_hooks_impl<I, F, A, P, E>(
-    lexer: &mut BaseLexer<I, F>,
+#[allow(clippy::too_many_arguments)]
+fn next_token_with_hooks_impl<I, A, P, E>(
+    lexer: &mut BaseLexer<I>,
+    sink: &mut TokenSink<'_>,
     atn: &Atn,
     custom_action: &mut A,
     semantic_predicate: &mut P,
     accept_adjuster: &mut E,
     strategy: LexerMatchStrategy<'_>,
-) -> CommonToken
+) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
-    F: TokenFactory,
-    A: FnMut(&mut BaseLexer<I, F>, LexerCustomAction),
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
-    E: FnMut(&mut BaseLexer<I, F>, i32, usize),
+    A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
+    E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     let mut continuing_more = false;
     loop {
         if lexer.hit_eof() {
-            return lexer.eof_token();
+            return lexer.eof_token(sink);
         }
 
         if !continuing_more {
@@ -619,7 +645,7 @@ where
                 lexer.input_mut().seek(start);
                 if lexer.input_mut().la(1) == EOF {
                     lexer.set_hit_eof(true);
-                    return lexer.eof_token();
+                    return lexer.eof_token(sink);
                 }
                 record_token_recognition_error(lexer, start, stop);
                 while lexer.input().index() < stop {
@@ -681,7 +707,7 @@ where
         } else {
             None
         };
-        return lexer.emit_with_stop(result.token_type, result.channel, stop, text);
+        return lexer.emit_with_stop(sink, result.token_type, result.channel, stop, text);
     }
 }
 
@@ -713,8 +739,8 @@ pub(super) fn lexer_action_belongs_to_accept(
 /// This is intentionally an ATN simulation, not generated Rust code for each
 /// rule. The generated lexer carries the serialized ATN and this interpreter
 /// supplies matching semantics shared by all generated grammars.
-fn match_token<I, F, P>(
-    lexer: &mut BaseLexer<I, F>,
+fn match_token<I, P>(
+    lexer: &mut BaseLexer<I>,
     atn: &Atn,
     mode: i32,
     start: usize,
@@ -722,8 +748,7 @@ fn match_token<I, F, P>(
 ) -> MatchResult
 where
     I: CharStream,
-    F: TokenFactory,
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
 {
     let Some(mode_index) = usize::try_from(mode).ok() else {
         return MatchResult::NoViableAlt { stop: start };
@@ -817,8 +842,8 @@ where
     )
 }
 
-fn match_token_cached<I, F, P>(
-    lexer: &mut BaseLexer<I, F>,
+fn match_token_cached<I, P>(
+    lexer: &mut BaseLexer<I>,
     atn: &Atn,
     mode: i32,
     start: usize,
@@ -826,8 +851,7 @@ fn match_token_cached<I, F, P>(
 ) -> MatchResult
 where
     I: CharStream,
-    F: TokenFactory,
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
 {
     let Some((mut dfa_state, mode_start_has_semantic_context)) =
         cached_mode_start_state(lexer, atn, mode, start, semantic_predicate)
@@ -957,15 +981,14 @@ const MAX_COMPILED_EOF_EDGES: u32 = 8;
 /// character the walk looked at, exactly like `match_token`. Reaching an
 /// escape edge (semantic predicate, recursive lexer rule, state budget)
 /// returns `None`, and the caller re-matches the token with the interpreter.
-fn match_token_compiled<I, F>(
-    lexer: &mut BaseLexer<I, F>,
+fn match_token_compiled<I>(
+    lexer: &mut BaseLexer<I>,
     dfa: &CompiledLexerDfa,
     start_state: u16,
     start: usize,
 ) -> Option<MatchResult>
 where
     I: CharStream,
-    F: TokenFactory,
 {
     let mut state = start_state;
     let mut position = start;
@@ -1035,8 +1058,8 @@ fn record_compiled_accept(
     });
 }
 
-fn cached_mode_start_state<I, F, P>(
-    lexer: &BaseLexer<I, F>,
+fn cached_mode_start_state<I, P>(
+    lexer: &BaseLexer<I>,
     atn: &Atn,
     mode: i32,
     start: usize,
@@ -1044,8 +1067,7 @@ fn cached_mode_start_state<I, F, P>(
 ) -> Option<(usize, bool)>
 where
     I: CharStream,
-    F: TokenFactory,
-    P: FnMut(&BaseLexer<I, F>, LexerPredicate) -> bool,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
 {
     if let Some(state) = lexer.cached_lexer_mode_start(mode) {
         return Some((state, false));
@@ -1081,8 +1103,8 @@ where
     Some((state, start_closure.has_semantic_context))
 }
 
-fn cache_dfa_state<I, F>(
-    lexer: &BaseLexer<I, F>,
+fn cache_dfa_state<I>(
+    lexer: &BaseLexer<I>,
     atn: &Atn,
     active: &[LexerConfig],
     has_semantic_context: bool,
@@ -1091,7 +1113,6 @@ fn cache_dfa_state<I, F>(
 ) -> usize
 where
     I: CharStream,
-    F: TokenFactory,
 {
     let state = lexer.lexer_dfa_state(
         lexer_dfa_key(active, token_start),
@@ -1432,10 +1453,9 @@ pub(super) fn set_config_state(atn: &Atn, config: &mut LexerConfig, state_number
 }
 
 /// Buffers ANTLR's default diagnostic for one unmatchable input span.
-fn record_token_recognition_error<I, F>(lexer: &BaseLexer<I, F>, start: usize, stop: usize)
+fn record_token_recognition_error<I>(lexer: &BaseLexer<I>, start: usize, stop: usize)
 where
     I: CharStream,
-    F: TokenFactory,
 {
     let stop = stop.saturating_sub(1);
     let text = display_error_text(&lexer.input().text(TextInterval::new(start, stop)));
@@ -1463,10 +1483,9 @@ fn display_error_text(text: &str) -> String {
 ///
 /// The interpreter explores many paths at different input offsets, so it seeks
 /// the shared input stream before each lookahead instead of cloning the stream.
-fn symbol_at<I, F>(lexer: &mut BaseLexer<I, F>, position: usize) -> i32
+fn symbol_at<I>(lexer: &mut BaseLexer<I>, position: usize) -> i32
 where
     I: CharStream,
-    F: TokenFactory,
 {
     lexer.input_mut().seek(position);
     lexer.input_mut().la(1)
@@ -1479,8 +1498,29 @@ mod tests {
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
     use crate::char_stream::InputStream;
     use crate::recognizer::RecognizerData;
-    use crate::token::{TOKEN_EOF, Token};
+    use crate::token::{TOKEN_EOF, Token, TokenStore};
     use crate::vocabulary::Vocabulary;
+
+    #[derive(Debug)]
+    struct TokenSnapshot {
+        token_type: i32,
+        start: usize,
+        stop: usize,
+        text: String,
+    }
+
+    fn lex_one<I: CharStream>(lexer: &mut BaseLexer<I>, atn: &Atn) -> TokenSnapshot {
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = next_token(lexer, &mut sink, atn).expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
+        TokenSnapshot {
+            token_type: token.token_type(),
+            start: token.start(),
+            stop: token.stop(),
+            text: token.text().to_owned(),
+        }
+    }
 
     #[test]
     fn predicate_sensitive_lexer_state_is_not_replay_cached() {
@@ -1581,10 +1621,10 @@ mod tests {
         );
         let mut lexer = BaseLexer::new(InputStream::new(" ab"), data);
 
-        let token = next_token(&mut lexer, &atn);
-        assert_eq!(token.token_type(), 1);
-        assert_eq!(token.text(), "ab");
-        assert_eq!(next_token(&mut lexer, &atn).token_type(), TOKEN_EOF);
+        let token = lex_one(&mut lexer, &atn);
+        assert_eq!(token.token_type, 1);
+        assert_eq!(token.text, "ab");
+        assert_eq!(lex_one(&mut lexer, &atn).token_type, TOKEN_EOF);
     }
 
     #[test]
@@ -1624,10 +1664,10 @@ mod tests {
         );
         let mut lexer = BaseLexer::new(InputStream::new("ab"), data);
 
-        let token = next_token(&mut lexer, &atn);
-        assert_eq!(token.token_type(), 1);
-        assert_eq!(token.start(), 0);
-        assert_eq!(token.stop(), 1);
-        assert_eq!(token.text(), "ab");
+        let token = lex_one(&mut lexer, &atn);
+        assert_eq!(token.token_type, 1);
+        assert_eq!(token.start, 0);
+        assert_eq!(token.stop, 1);
+        assert_eq!(token.text, "ab");
     }
 }

--- a/src/atn/lexer_dfa.rs
+++ b/src/atn/lexer_dfa.rs
@@ -917,8 +917,40 @@ mod tests {
     use crate::char_stream::InputStream;
     use crate::lexer::BaseLexer;
     use crate::recognizer::RecognizerData;
-    use crate::token::{TOKEN_EOF, Token};
+    use crate::token::{TOKEN_EOF, Token, TokenSink, TokenStore};
     use crate::vocabulary::Vocabulary;
+
+    #[derive(Debug, Eq, PartialEq)]
+    struct TokenSnapshot {
+        token_type: i32,
+        text: String,
+    }
+
+    fn compiled_token(
+        lexer: &mut BaseLexer<InputStream>,
+        atn: &Atn,
+        dfa: &CompiledLexerDfa,
+    ) -> TokenSnapshot {
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = next_token_compiled(lexer, &mut sink, atn, dfa).expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
+        TokenSnapshot {
+            token_type: token.token_type(),
+            text: token.text().to_owned(),
+        }
+    }
+
+    fn interpreted_token(lexer: &mut BaseLexer<InputStream>, atn: &Atn) -> TokenSnapshot {
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = next_token(lexer, &mut sink, atn).expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
+        TokenSnapshot {
+            token_type: token.token_type(),
+            text: token.text().to_owned(),
+        }
+    }
 
     fn recognizer_data() -> RecognizerData {
         RecognizerData::new(
@@ -1019,13 +1051,10 @@ mod tests {
         assert!(dfa.mode_start(0).is_some());
 
         let mut lexer = BaseLexer::new(InputStream::new(" ab"), recognizer_data());
-        let token = next_token_compiled(&mut lexer, &atn, &dfa);
-        assert_eq!(token.token_type(), 1);
-        assert_eq!(token.text(), "ab");
-        assert_eq!(
-            next_token_compiled(&mut lexer, &atn, &dfa).token_type(),
-            TOKEN_EOF
-        );
+        let token = compiled_token(&mut lexer, &atn, &dfa);
+        assert_eq!(token.token_type, 1);
+        assert_eq!(token.text, "ab");
+        assert_eq!(compiled_token(&mut lexer, &atn, &dfa).token_type, TOKEN_EOF);
     }
 
     #[test]
@@ -1037,14 +1066,19 @@ mod tests {
         assert!(dfa.mode_start(0).is_some());
 
         let mut lexer = BaseLexer::new(InputStream::new(" ab"), recognizer_data());
-        let token = next_token_compiled_with_hooks(
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = next_token_compiled_with_hooks(
             &mut lexer,
+            &mut sink,
             &atn,
             &dfa,
             |_, _| {},
             |_, _| true,
             |_, _, _| {},
-        );
+        )
+        .expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
         assert_eq!(token.token_type(), 1);
         assert_eq!(token.text(), "ab");
     }
@@ -1056,13 +1090,10 @@ mod tests {
         assert!(dfa.mode_start(0).is_some());
 
         let mut lexer = BaseLexer::new(InputStream::new("ĀĂ"), recognizer_data());
-        let token = next_token_compiled(&mut lexer, &atn, &dfa);
-        assert_eq!(token.token_type(), 1);
-        assert_eq!(token.text(), "ĀĂ");
-        assert_eq!(
-            next_token_compiled(&mut lexer, &atn, &dfa).token_type(),
-            TOKEN_EOF
-        );
+        let token = compiled_token(&mut lexer, &atn, &dfa);
+        assert_eq!(token.token_type, 1);
+        assert_eq!(token.text, "ĀĂ");
+        assert_eq!(compiled_token(&mut lexer, &atn, &dfa).token_type, TOKEN_EOF);
     }
 
     #[test]
@@ -1073,11 +1104,10 @@ mod tests {
         let mut compiled = BaseLexer::new(InputStream::new("zĀ"), recognizer_data());
         let mut interpreted = BaseLexer::new(InputStream::new("zĀ"), recognizer_data());
         loop {
-            let compiled_token = next_token_compiled(&mut compiled, &atn, &dfa);
-            let interpreted_token = next_token(&mut interpreted, &atn);
-            assert_eq!(compiled_token.token_type(), interpreted_token.token_type());
-            assert_eq!(compiled_token.text(), interpreted_token.text());
-            if compiled_token.token_type() == TOKEN_EOF {
+            let compiled_token = compiled_token(&mut compiled, &atn, &dfa);
+            let interpreted_token = interpreted_token(&mut interpreted, &atn);
+            assert_eq!(compiled_token, interpreted_token);
+            if compiled_token.token_type == TOKEN_EOF {
                 break;
             }
         }
@@ -1106,9 +1136,9 @@ mod tests {
         assert_eq!(restored.serialize(), stream);
 
         let mut lexer = BaseLexer::new(InputStream::new(" ab"), recognizer_data());
-        let token = next_token_compiled(&mut lexer, &atn, &restored);
-        assert_eq!(token.token_type(), 1);
-        assert_eq!(token.text(), "ab");
+        let token = compiled_token(&mut lexer, &atn, &restored);
+        assert_eq!(token.token_type, 1);
+        assert_eq!(token.text, "ab");
 
         // A stream from a different runtime version is rejected, not trusted.
         let mut wrong_tag = stream;
@@ -1139,8 +1169,8 @@ mod tests {
 
         let mut lexer = BaseLexer::new(InputStream::new("ab"), recognizer_data());
         lexer.set_force_interpreted(true);
-        let token = next_token_compiled(&mut lexer, &atn, &dfa);
-        assert_eq!(token.token_type(), 1);
+        let token = compiled_token(&mut lexer, &atn, &dfa);
+        assert_eq!(token.token_type, 1);
         // The interpreter path records the learned-DFA trace; the compiled
         // walk does not.
         assert!(!lexer.lexer_dfa_string().is_empty());

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -1990,14 +1990,14 @@ fn render_lexer(
             "|_, _, _| {}"
         };
         format!(
-            "antlr4_runtime::atn::lexer::next_token_compiled_with_semantic_dispatch(&mut self.base, atn(), lexer_dfa(), &mut self.hooks, {action}, {predicate}, {lexer_unknown_policy}, {adjuster})"
+            "antlr4_runtime::atn::lexer::next_token_compiled_with_semantic_dispatch(&mut self.base, sink, atn(), lexer_dfa(), &mut self.hooks, {action}, {predicate}, {lexer_unknown_policy}, {adjuster})"
         )
     } else if !has_action_dispatch
         && !has_predicate_dispatch
         && !adjusts_accept_position
         && !unknown_predicates_assume_false
     {
-        "antlr4_runtime::atn::lexer::next_token_compiled(&mut self.base, atn(), lexer_dfa())"
+        "antlr4_runtime::atn::lexer::next_token_compiled(&mut self.base, sink, atn(), lexer_dfa())"
             .to_owned()
     } else {
         let action = if has_action_dispatch {
@@ -2018,7 +2018,7 @@ fn render_lexer(
             "|_, _, _| {}"
         };
         format!(
-            "antlr4_runtime::atn::lexer::next_token_compiled_with_hooks(&mut self.base, atn(), lexer_dfa(), {action}, {predicate}, {adjuster})"
+            "antlr4_runtime::atn::lexer::next_token_compiled_with_hooks(&mut self.base, sink, atn(), lexer_dfa(), {action}, {predicate}, {adjuster})"
         )
     };
     let generated_header = GENERATED_MODULE_HEADER;
@@ -2027,7 +2027,7 @@ fn render_lexer(
     Ok(format!(
         r#"{generated_header}use antlr4_runtime::char_stream::CharStream;
 use antlr4_runtime::recognizer::RecognizerData;
-use antlr4_runtime::token::{{CommonToken, TokenSource}};
+use antlr4_runtime::token::{{TokenId, TokenSink, TokenSource, TokenStoreError}};
 use antlr4_runtime::atn::Atn;
 use antlr4_runtime::atn::lexer_dfa::CompiledLexerDfa;
 use antlr4_runtime::atn::serialized::AtnDeserializer;
@@ -2158,13 +2158,14 @@ where
     I: CharStream,
     H: antlr4_runtime::SemanticHooks,
 {{
-    fn next_token(&mut self) -> CommonToken {{
+    fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {{
         {next_token_call}
     }}
 
     fn line(&self) -> usize {{ self.base.line() }}
     fn column(&self) -> usize {{ self.base.column() }}
     fn source_name(&self) -> &str {{ self.base.source_name() }}
+    fn source_text(&self) -> Option<std::rc::Rc<str>> {{ self.base.source_text() }}
     fn drain_errors(&mut self) -> Vec<antlr4_runtime::token::TokenSourceError> {{
         self.base.drain_errors()
     }}
@@ -9688,7 +9689,7 @@ fn render_lexer_typed_hook_adapter(type_name: &str, mappings: &[LexerTypedHookMa
             let separator = if arguments.is_empty() { "" } else { ", " };
             let result = if *predicate { " -> bool" } else { "" };
             format!(
-                "    fn {method}<I, F>(&mut self, ctx: &mut antlr4_runtime::LexerSemCtx<'_, I, F>{separator}{arguments}){result}\n    where\n        I: antlr4_runtime::CharStream,\n        F: antlr4_runtime::TokenFactory;"
+                "    fn {method}<I>(&mut self, ctx: &mut antlr4_runtime::LexerSemCtx<'_, I>{separator}{arguments}){result}\n    where\n        I: antlr4_runtime::CharStream;"
             )
         })
         .collect::<Vec<_>>()
@@ -9731,7 +9732,7 @@ fn render_lexer_typed_hook_adapter(type_name: &str, mappings: &[LexerTypedHookMa
         r#"pub trait {trait_name}: Sized {{
 {method_decls}
 
-    fn token_emitted(&mut self, _token: &antlr4_runtime::CommonToken) {{}}
+    fn token_emitted(&mut self, _token: antlr4_runtime::TokenView<'_>) {{}}
 }}
 
 #[derive(Clone, Debug, Default)]
@@ -9745,10 +9746,9 @@ impl<T> antlr4_runtime::SemanticHooks for {adapter_name}<T>
 where
     T: {trait_name},
 {{
-    fn lexer_sempred<I, F>(&mut self, ctx: &mut antlr4_runtime::LexerSemCtx<'_, I, F>, rule_index: usize, pred_index: usize) -> Option<bool>
+    fn lexer_sempred<I>(&mut self, ctx: &mut antlr4_runtime::LexerSemCtx<'_, I>, rule_index: usize, pred_index: usize) -> Option<bool>
     where
         I: antlr4_runtime::CharStream,
-        F: antlr4_runtime::TokenFactory,
     {{
         match (rule_index, pred_index) {{
 {predicate_arms}
@@ -9756,10 +9756,9 @@ where
         }}
     }}
 
-    fn lexer_action<I, F>(&mut self, ctx: &mut antlr4_runtime::LexerSemCtx<'_, I, F>, action: antlr4_runtime::LexerCustomAction) -> bool
+    fn lexer_action<I>(&mut self, ctx: &mut antlr4_runtime::LexerSemCtx<'_, I>, action: antlr4_runtime::LexerCustomAction) -> bool
     where
         I: antlr4_runtime::CharStream,
-        F: antlr4_runtime::TokenFactory,
     {{
         let Ok(rule_index) = usize::try_from(action.rule_index()) else {{ return false; }};
         let Ok(action_index) = usize::try_from(action.action_index()) else {{ return false; }};
@@ -9769,7 +9768,7 @@ where
         }}
     }}
 
-    fn lexer_token_emitted(&mut self, token: &antlr4_runtime::CommonToken) {{
+    fn lexer_token_emitted(&mut self, token: antlr4_runtime::TokenView<'_>) {{
         self.0.token_emitted(token);
     }}
 }}
@@ -14740,7 +14739,7 @@ ID : [a-z]+ ;\n";
             "override renders a failing arm"
         );
         assert!(module.contains("run_predicate"));
-        assert!(!module.contains("next_token_compiled(&mut self.base, atn(), lexer_dfa())"));
+        assert!(!module.contains("next_token_compiled(&mut self.base, sink, atn(), lexer_dfa())"));
     }
 
     #[test]
@@ -14859,7 +14858,15 @@ ID : [a-z]+ ;\n";
         )
         .expect("lexer should render");
 
-        assert!(module.contains("next_token_compiled(&mut self.base, atn(), lexer_dfa())"));
+        assert!(module.contains("next_token_compiled(&mut self.base, sink, atn(), lexer_dfa())"));
+        assert!(module.contains(
+            "fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError>"
+        ));
+        assert!(module.contains(
+            "fn source_text(&self) -> Option<std::rc::Rc<str>> { self.base.source_text() }"
+        ));
+        assert!(!module.contains("CommonToken"));
+        assert!(!module.contains("TokenFactory"));
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5822,7 +5822,12 @@ fn render_parser(
     )
 }
 
-const GENERATED_PARSER_RESERVED_RULE_METHODS: &[&str] = &["token_stream", "into_token_stream"];
+const GENERATED_PARSER_RESERVED_RULE_METHODS: &[&str] = &[
+    "token_stream",
+    "token_store",
+    "into_token_stream",
+    "into_token_store",
+];
 
 fn parser_public_rule_method_names(rule_names: &[String]) -> Vec<String> {
     let mut used = GENERATED_PARSER_RESERVED_RULE_METHODS
@@ -6532,7 +6537,7 @@ fn embedded_rule_call_args(
 ///   alternative) with positional child accessors (`ctx.e(0)` /
 ///   `ctx.e_all()`, `ctx.INT(0)` / `ctx.INT_all()`), `child_count()`,
 ///   `start()`, public attribute fields, and a `FromRuleContext` impl backing
-///   `$ctx.downcast_ref::<XContext>()`;
+///   `$ctx.downcast_ref::<XContext>(tokens)`;
 /// * the `<Grammar>Listener` trait with defaulted `enter_/exit_<rule>` (and
 ///   per-labeled-alternative) callbacks plus `visit_terminal`;
 /// * a module-local `ParseTreeWalker` whose bridge dispatches the runtime
@@ -6557,6 +6562,37 @@ fn render_embedded_context_types(
             i32::try_from(token_type).ok().map(|ty| (name.clone(), ty))
         })
         .collect();
+
+    out.push_str(
+        r#"#[allow(dead_code)]
+#[derive(Clone)]
+pub struct TerminalNode<'a> {
+    __node: RuntimeTerminalNode,
+    __tokens: &'a antlr4_runtime::TokenStore,
+}
+
+#[allow(dead_code)]
+impl<'a> TerminalNode<'a> {
+    fn new(node: RuntimeTerminalNode, tokens: &'a antlr4_runtime::TokenStore) -> Self {
+        Self {
+            __node: node,
+            __tokens: tokens,
+        }
+    }
+
+    pub fn symbol(&self) -> antlr4_runtime::TokenView<'a> {
+        self.__node.symbol(self.__tokens)
+    }
+}
+
+impl std::fmt::Display for TerminalNode<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.__node.text(self.__tokens))
+    }
+}
+
+"#,
+    );
 
     // (struct name, rule index, alt label) — one per rule plus one per
     // labeled alternative.
@@ -6585,16 +6621,16 @@ fn render_embedded_context_types(
         }
         let _ = writeln!(
             out,
-            "#[allow(non_camel_case_types, dead_code)]\n#[derive(Clone)]\npub struct {view_name} {{\n    __node: ParserRuleContext,\n    __chain: Vec<isize>,\n{fields}}}\n"
+            "#[allow(non_camel_case_types, dead_code)]\n#[derive(Clone)]\npub struct {view_name}<'a> {{\n    __node: ParserRuleContext,\n    __tokens: &'a antlr4_runtime::TokenStore,\n    __chain: Vec<isize>,\n{fields}}}\n"
         );
         let _ = writeln!(
             out,
-            "impl FromRuleContext for {view_name} {{\n    fn from_rule_context(context: &ParserRuleContext) -> Option<Self> {{\n        if context.rule_index() != {rule_index} {{ return None; }}\n        Some(Self::__from_node_with_chain(context, Vec::new()))\n    }}\n}}\n"
+            "impl<'a> FromRuleContext<'a> for {view_name}<'a> {{\n    fn from_rule_context(context: &ParserRuleContext, tokens: &'a antlr4_runtime::TokenStore) -> Option<Self> {{\n        if context.rule_index() != {rule_index} {{ return None; }}\n        Some(Self::__from_node_with_chain(context, tokens, Vec::new()))\n    }}\n}}\n"
         );
         let mut accessors = String::new();
         let _ = writeln!(
             accessors,
-            "    fn __from_node_with_chain(node: &ParserRuleContext, mut chain: Vec<isize>) -> Self {{\n        chain.insert(0, node.invoking_state());\n        let __default = {attrs_struct}::default();\n        let __attrs = node.generated_attrs::<{attrs_struct}>().unwrap_or(&__default);\n        Self {{\n            __node: node.clone(),\n            __chain: chain,\n{field_inits}        }}\n    }}\n"
+            "    fn __from_node_with_chain(node: &ParserRuleContext, tokens: &'a antlr4_runtime::TokenStore, mut chain: Vec<isize>) -> Self {{\n        chain.insert(0, node.invoking_state());\n        let __default = {attrs_struct}::default();\n        let __attrs = node.generated_attrs::<{attrs_struct}>().unwrap_or(&__default);\n        Self {{\n            __node: node.clone(),\n            __tokens: tokens,\n            __chain: chain,\n{field_inits}        }}\n    }}\n"
         );
         // A grammar rule claiming a built-in helper's name (`start`,
         // `child_count`) takes the accessor slot; the built-in yields.
@@ -6613,7 +6649,7 @@ fn render_embedded_context_types(
         if !rule_claims("start") {
             let _ = writeln!(
                 accessors,
-                "    pub fn start(&self) -> __GeneratedTokenView {{ __GeneratedTokenView {{ text: self.__node.start().map(|token| token.text().to_owned()).unwrap_or_default() }} }}"
+                "    pub fn start(&self) -> __GeneratedTokenView {{ __GeneratedTokenView {{ text: self.__node.start(self.__tokens).map(|token| token.text().to_owned()).unwrap_or_default() }} }}"
             );
         }
         for (child_index, child) in model.rules.iter().enumerate() {
@@ -6621,24 +6657,24 @@ fn render_embedded_context_types(
             let child_view = format!("{}Context", rust_type_name(&child.name));
             let _ = writeln!(
                 accessors,
-                "    pub fn {method}(&self, index: usize) -> Rc<{child_view}> {{ let node = self.__node.child_rules({child_index}).nth(index).expect(\"missing rule child\"); Rc::new({child_view}::__from_node_with_chain(node, self.__chain.clone())) }}\n    pub fn {method}_all(&self) -> Vec<Rc<{child_view}>> {{ self.__node.child_rules({child_index}).map(|node| Rc::new({child_view}::__from_node_with_chain(node, self.__chain.clone()))).collect() }}"
+                "    pub fn {method}(&self, index: usize) -> Rc<{child_view}<'a>> {{ let node = self.__node.child_rules({child_index}).nth(index).expect(\"missing rule child\"); Rc::new({child_view}::__from_node_with_chain(node, self.__tokens, self.__chain.clone())) }}\n    pub fn {method}_all(&self) -> Vec<Rc<{child_view}<'a>>> {{ self.__node.child_rules({child_index}).map(|node| Rc::new({child_view}::__from_node_with_chain(node, self.__tokens, self.__chain.clone()))).collect() }}"
             );
         }
         for (token_name, token_type) in &token_accessors {
             let _ = writeln!(
                 accessors,
-                "    #[allow(non_snake_case)]\n    pub fn {token_name}(&self, index: usize) -> Rc<TerminalNode> {{ Rc::new(self.__node.child_tokens({token_type}).nth(index).expect(\"missing token child\").clone()) }}\n    #[allow(non_snake_case)]\n    pub fn {token_name}_all(&self) -> Vec<Rc<TerminalNode>> {{ self.__node.child_tokens({token_type}).cloned().map(Rc::new).collect() }}"
+                "    #[allow(non_snake_case)]\n    pub fn {token_name}(&self, index: usize) -> Rc<TerminalNode<'a>> {{ let node = self.__node.child_tokens({token_type}, self.__tokens).nth(index).expect(\"missing token child\"); Rc::new(TerminalNode::new(node.clone(), self.__tokens)) }}\n    #[allow(non_snake_case)]\n    pub fn {token_name}_all(&self) -> Vec<Rc<TerminalNode<'a>>> {{ self.__node.child_tokens({token_type}, self.__tokens).map(|node| Rc::new(TerminalNode::new(node.clone(), self.__tokens))).collect() }}"
             );
         }
         let _ = writeln!(
             out,
-            "#[allow(dead_code, clippy::all)]\nimpl {view_name} {{\n{accessors}}}\n"
+            "#[allow(dead_code, clippy::all)]\nimpl<'a> {view_name}<'a> {{\n{accessors}}}\n"
         );
         // Java's RuleContext.toString(): bracketed invoking-state chain from
         // this context to the root, the root's sentinel excluded.
         let _ = writeln!(
             out,
-            "impl std::fmt::Display for {view_name} {{\n    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{\n        let chain: Vec<String> = self.__chain.iter().take(self.__chain.len().saturating_sub(1)).map(|state| state.to_string()).collect();\n        write!(f, \"[{{}}]\", chain.join(\" \"))\n    }}\n}}\n"
+            "impl std::fmt::Display for {view_name}<'_> {{\n    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{\n        let chain: Vec<String> = self.__chain.iter().take(self.__chain.len().saturating_sub(1)).map(|state| state.to_string()).collect();\n        write!(f, \"[{{}}]\", chain.join(\" \"))\n    }}\n}}\n"
         );
     }
 
@@ -6695,7 +6731,7 @@ fn render_embedded_context_types(
             if !has_labels {
                 let (method, view) = &names[0];
                 return format!(
-                    "                self.0.{phase}_{method}(&{view}::__from_node_with_chain(context, self.1.clone()));\n"
+                    "                self.0.{phase}_{method}(&{view}::__from_node_with_chain(context, tokens, self.1.clone()));\n"
                 );
             }
             let mut out = String::new();
@@ -6713,7 +6749,7 @@ fn render_embedded_context_types(
                     let primary_view = format!("{}Context", rust_type_name(primary));
                     let _ = writeln!(
                         out,
-                        "                if context.child_rule_trees({rule_index}).next().is_some() {{ self.0.{phase}_{op_method}(&{op_view}::__from_node_with_chain(context, self.1.clone())); }} else {{ self.0.{phase}_{primary_method}(&{primary_view}::__from_node_with_chain(context, self.1.clone())); }}"
+                        "                if context.child_rule_trees({rule_index}).next().is_some() {{ self.0.{phase}_{op_method}(&{op_view}::__from_node_with_chain(context, tokens, self.1.clone())); }} else {{ self.0.{phase}_{primary_method}(&{primary_view}::__from_node_with_chain(context, tokens, self.1.clone())); }}"
                     );
                 }
                 _ => {
@@ -6722,7 +6758,7 @@ fn render_embedded_context_types(
                     let (method, view) = &names[0];
                     let _ = writeln!(
                         out,
-                        "                self.0.{phase}_{method}(&{view}::__from_node_with_chain(context, self.1.clone()));"
+                        "                self.0.{phase}_{method}(&{view}::__from_node_with_chain(context, tokens, self.1.clone()));"
                     );
                 }
             }
@@ -6745,14 +6781,15 @@ fn render_embedded_context_types(
     );
 
     // Bridge + module-local walker (shadows the runtime walker so rendered
-    // `ParseTreeWalker::walk(&mut listener, tree)` dispatches typed callbacks).
+    // `ParseTreeWalker::walk(&mut listener, tree, tokens)` dispatches typed
+    // callbacks.
     let _ = writeln!(
         out,
         r#"#[allow(dead_code)]
 struct __ListenerBridge<'a, T: {listener_trait}>(&'a mut T, Vec<isize>);
 
 impl<T: {listener_trait}> antlr4_runtime::ParseTreeListener for __ListenerBridge<'_, T> {{
-    fn enter_every_rule(&mut self, context: &ParserRuleContext) -> Result<(), antlr4_runtime::AntlrError> {{
+    fn enter_every_rule(&mut self, context: &ParserRuleContext, tokens: &antlr4_runtime::TokenStore) -> Result<(), antlr4_runtime::AntlrError> {{
         self.1.insert(0, context.invoking_state());
         match context.rule_index() {{
 {enter_arms}            _ => {{}}
@@ -6760,7 +6797,7 @@ impl<T: {listener_trait}> antlr4_runtime::ParseTreeListener for __ListenerBridge
         Ok(())
     }}
 
-    fn exit_every_rule(&mut self, context: &ParserRuleContext) -> Result<(), antlr4_runtime::AntlrError> {{
+    fn exit_every_rule(&mut self, context: &ParserRuleContext, tokens: &antlr4_runtime::TokenStore) -> Result<(), antlr4_runtime::AntlrError> {{
         match context.rule_index() {{
 {exit_arms}            _ => {{}}
         }}
@@ -6770,8 +6807,8 @@ impl<T: {listener_trait}> antlr4_runtime::ParseTreeListener for __ListenerBridge
         Ok(())
     }}
 
-    fn visit_terminal(&mut self, node: &TerminalNode) -> Result<(), antlr4_runtime::AntlrError> {{
-        self.0.visit_terminal(node);
+    fn visit_terminal(&mut self, node: &RuntimeTerminalNode, tokens: &antlr4_runtime::TokenStore) -> Result<(), antlr4_runtime::AntlrError> {{
+        self.0.visit_terminal(&TerminalNode::new(node.clone(), tokens));
         Ok(())
     }}
 }}
@@ -6781,9 +6818,9 @@ pub struct ParseTreeWalker;
 
 #[allow(dead_code)]
 impl ParseTreeWalker {{
-    pub fn walk<T: {listener_trait}>(listener: &mut T, tree: &antlr4_runtime::ParseTree) {{
+    pub fn walk<T: {listener_trait}>(listener: &mut T, tree: &antlr4_runtime::ParseTree, tokens: &antlr4_runtime::TokenStore) {{
         let mut bridge = __ListenerBridge(listener, Vec::new());
-        let _ = antlr4_runtime::ParseTreeWalker::walk(&mut bridge, tree);
+        let _ = antlr4_runtime::ParseTreeWalker::walk(&mut bridge, tree, tokens);
     }}
 }}
 "#
@@ -7205,7 +7242,7 @@ fn render_parser_with_options(
     let generated_footer = GENERATED_MODULE_FOOTER;
 
     let embedded_imports = if options.embedded {
-        "#[allow(unused_imports)]\nuse std::io::Write as _;\n#[allow(unused_imports)]\nuse std::rc::Rc;\n#[allow(unused_imports)]\nuse antlr4_runtime::{{java_style_list, PredictionMode, BailErrorStrategy, TerminalNode, ParserRuleContext, FromRuleContext, Token as _}};\n"
+        "#[allow(unused_imports)]\nuse std::io::Write as _;\n#[allow(unused_imports)]\nuse std::rc::Rc;\n#[allow(unused_imports)]\nuse antlr4_runtime::{{java_style_list, PredictionMode, BailErrorStrategy, TerminalNode as RuntimeTerminalNode, ParserRuleContext, FromRuleContext, Token as _}};\n"
     } else {
         ""
     };
@@ -7307,8 +7344,18 @@ where
     }}
 
     #[must_use]
+    pub const fn token_store(&self) -> &antlr4_runtime::TokenStore {{
+        self.base.token_store()
+    }}
+
+    #[must_use]
     pub fn into_token_stream(self) -> CommonTokenStream<L> {{
         self.base.into_token_stream()
+    }}
+
+    #[must_use]
+    pub fn into_token_store(self) -> antlr4_runtime::TokenStore {{
+        self.base.into_token_store()
     }}
 
     #[allow(dead_code)]
@@ -10265,15 +10312,18 @@ where
 /// Pass the generated lexer constructor and a parser entry rule, for example
 /// `parse(src, MyGrammarLexer::new, {type_name}::file)`.
 ///
-/// Use [`parse_with_parser`] instead when the caller needs parser diagnostics
-/// or the parser-owned token stream after the entry rule runs.
+/// The returned [`antlr4_runtime::ParsedFile`] owns both the entry-rule result
+/// and the canonical token store referenced by any parse tree in that result.
+/// Use [`parse_with_parser`] instead when the caller also needs parser
+/// diagnostics after the entry rule runs.
 pub fn parse<L: TokenSource, R>(
     input: impl AsRef<str>,
     lexer: impl FnOnce(antlr4_runtime::InputStream) -> L,
     entry: impl FnOnce(&mut {type_name}<L>) -> Result<R, antlr4_runtime::AntlrError>,
-) -> Result<R, antlr4_runtime::AntlrError>
+) -> Result<antlr4_runtime::ParsedFile<R>, antlr4_runtime::AntlrError>
 {{
-    parse_with_parser(input, lexer, entry).map(|output| output.result)
+    let {output_type_name} {{ result, parser }} = parse_with_parser(input, lexer, entry)?;
+    Ok(antlr4_runtime::ParsedFile::new(parser.into_token_store(), result))
 }}
 
 /// Parses UTF-8 text like [`parse`] while returning the parser after the entry
@@ -11814,8 +11864,12 @@ s : ;
         assert!(rendered.contains("let tokens = CommonTokenStream::new(lexer);"));
         assert!(rendered.contains("let result = entry(&mut parser)?;"));
         assert!(rendered.contains("Ok(TParserParseOutput { result, parser })"));
+        assert!(rendered.contains(
+            "let TParserParseOutput { result, parser } = parse_with_parser(input, lexer, entry)?;"
+        ));
         assert!(
-            rendered.contains("parse_with_parser(input, lexer, entry).map(|output| output.result)")
+            rendered
+                .contains("Ok(antlr4_runtime::ParsedFile::new(parser.into_token_store(), result))")
         );
         assert!(rendered.contains("pub fn new(input: CommonTokenStream<L>) -> Self"));
         assert!(
@@ -11857,6 +11911,12 @@ s : ;
         assert!(rendered.contains("self.base.token_stream()"));
         assert!(rendered.contains("pub fn into_token_stream(self) -> CommonTokenStream<L>"));
         assert!(rendered.contains("self.base.into_token_stream()"));
+        assert!(
+            rendered.contains("pub const fn token_store(&self) -> &antlr4_runtime::TokenStore")
+        );
+        assert!(rendered.contains("self.base.token_store()"));
+        assert!(rendered.contains("pub fn into_token_store(self) -> antlr4_runtime::TokenStore"));
+        assert!(rendered.contains("self.base.into_token_store()"));
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -998,7 +998,9 @@ fn translate_reference(
         ("text", None) => return Ok(text_expression(ctx)),
         ("_p", None) => return Ok("__precedence".to_owned()),
         ("parser", None) => return Ok("self".to_owned()),
-        ("start", None) => return Ok("__ctx.start()".to_owned()),
+        ("start", None) => {
+            return Ok("__ctx.start(self.base.token_store())".to_owned());
+        }
         _ => {}
     }
     let rule = ctx.rule();
@@ -1101,7 +1103,7 @@ fn translate_element_read(
         }
         if let Some(token_type) = ctx.token_types.get(&element.target) {
             return Ok(format!(
-                "__ctx.child_tokens({token_type}).collect::<Vec<_>>()"
+                "__ctx.child_tokens({token_type}, self.base.token_store()).collect::<Vec<_>>()"
             ));
         }
     }
@@ -1112,11 +1114,11 @@ fn translate_element_read(
         // `Token.toString()`), which is the same rendering as start/stop.
         return match suffix {
             None | Some("stop" | "start") => Ok(
-                "__ctx.terminal_children().last().map(|__t| __t.symbol().to_string()).unwrap_or_default()"
+                "__ctx.terminal_children().last().map(|__t| __t.symbol(self.base.token_store()).to_string()).unwrap_or_default()"
                     .to_owned(),
             ),
             Some("text") => Ok(
-                "__ctx.terminal_children().last().map(antlr4_runtime::TerminalNode::text).unwrap_or_default()"
+                "__ctx.terminal_children().last().map(|__t| __t.text(self.base.token_store()).to_owned()).unwrap_or_default()"
                     .to_owned(),
             ),
             _ => Err(io::Error::new(
@@ -1136,13 +1138,13 @@ fn translate_element_read(
                 "__ctx.child_rule_trees({rule_index}).{pick}.expect(\"labeled rule child\")"
             )),
             Some("text") => Ok(format!(
-                "__ctx.child_rules({rule_index}).{pick}.map(antlr4_runtime::ParserRuleContext::text).unwrap_or_default()"
+                "__ctx.child_rules({rule_index}).{pick}.map(|__c| __c.text(self.base.token_store())).unwrap_or_default()"
             )),
             Some("start") => Ok(format!(
-                "__ctx.child_rules({rule_index}).{pick}.and_then(|__c| __c.start()).map(|__t| __t.to_string()).unwrap_or_default()"
+                "__ctx.child_rules({rule_index}).{pick}.and_then(|__c| __c.start(self.base.token_store())).map(|__t| __t.to_string()).unwrap_or_default()"
             )),
             Some("stop") => Ok(format!(
-                "__ctx.child_rules({rule_index}).{pick}.and_then(|__c| __c.stop()).map(|__t| __t.to_string()).unwrap_or_default()"
+                "__ctx.child_rules({rule_index}).{pick}.and_then(|__c| __c.stop(self.base.token_store())).map(|__t| __t.to_string()).unwrap_or_default()"
             )),
             Some(attr) => {
                 let target_rule = &ctx.model.rules[rule_index];
@@ -1171,16 +1173,16 @@ fn translate_element_read(
         };
         return match suffix {
             Some("text") => Ok(format!(
-                "__ctx.child_tokens({token_type}).{pick}.map(antlr4_runtime::TerminalNode::text).unwrap_or_default()"
+                "__ctx.child_tokens({token_type}, self.base.token_store()).{pick}.map(|__t| __t.text(self.base.token_store()).to_owned()).unwrap_or_default()"
             )),
             Some("int") => Ok(format!(
-                "__ctx.child_tokens({token_type}).{pick}.map(|__t| __t.text().parse::<i32>().unwrap_or_default()).unwrap_or_default()"
+                "__ctx.child_tokens({token_type}, self.base.token_store()).{pick}.map(|__t| __t.text(self.base.token_store()).parse::<i32>().unwrap_or_default()).unwrap_or_default()"
             )),
             Some("line") => Ok(format!(
-                "__ctx.child_tokens({token_type}).{pick}.map(|__t| __t.symbol().line()).unwrap_or_default()"
+                "__ctx.child_tokens({token_type}, self.base.token_store()).{pick}.map(|__t| __t.symbol(self.base.token_store()).line()).unwrap_or_default()"
             )),
             None | Some("stop" | "start") => Ok(format!(
-                "__ctx.child_tokens({token_type}).{pick}.map(|__t| __t.symbol().to_string()).unwrap_or_default()"
+                "__ctx.child_tokens({token_type}, self.base.token_store()).{pick}.map(|__t| __t.symbol(self.base.token_store()).to_string()).unwrap_or_default()"
             )),
             Some(other) => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
@@ -1325,7 +1327,10 @@ mod tests {
         };
         let translated = translate_body("$v = $INT.int;", &ctx).expect("translates");
         assert!(translated.starts_with("__attrs.v = "), "{translated}");
-        assert!(translated.contains("child_tokens(1)"), "{translated}");
+        assert!(
+            translated.contains("child_tokens(1, self.base.token_store())"),
+            "{translated}"
+        );
 
         let parent_ctx = TranslationCtx {
             model: &m,

--- a/src/char_stream.rs
+++ b/src/char_stream.rs
@@ -24,6 +24,20 @@ impl TextInterval {
 pub trait CharStream: IntStream {
     fn text(&self, interval: TextInterval) -> String;
 
+    /// Returns the complete backing UTF-8 source when it can be shared with a
+    /// token store.
+    ///
+    /// Implementations that return `None` remain supported, but their token
+    /// text is copied into the store's sparse explicit-text pool.
+    fn source_text(&self) -> Option<Rc<str>> {
+        None
+    }
+
+    fn byte_interval(&self, interval: TextInterval) -> Option<(usize, usize)> {
+        self.text_source_interval(interval)
+            .map(|(_, start, stop)| (start, stop))
+    }
+
     fn text_source_interval(&self, _interval: TextInterval) -> Option<(Rc<str>, usize, usize)> {
         None
     }
@@ -175,6 +189,22 @@ impl CharStream for InputStream {
 
         let (start_byte, stop_byte) = self.data.byte_bounds(&self.source, start, stop)?;
         Some((Rc::clone(&self.source), start_byte, stop_byte))
+    }
+
+    fn source_text(&self) -> Option<Rc<str>> {
+        Some(Rc::clone(&self.source))
+    }
+
+    fn byte_interval(&self, interval: TextInterval) -> Option<(usize, usize)> {
+        let len = self.data.len(&self.source);
+        if interval.is_empty() || len == 0 {
+            return None;
+        }
+        let start = interval.start.min(len);
+        let stop = interval.stop.min(len.saturating_sub(1));
+        (start <= stop)
+            .then(|| self.data.byte_bounds(&self.source, start, stop))
+            .flatten()
     }
 }
 

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -8,7 +8,7 @@ use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
 use crate::prediction::PredictionFxHasher;
 use crate::recognizer::{Recognizer, RecognizerData};
-use crate::token::{CommonToken, CommonTokenFactory, TokenFactory, TokenSourceError, TokenSpec};
+use crate::token::{TokenId, TokenSink, TokenSourceError, TokenSpec, TokenStoreError};
 
 #[allow(clippy::disallowed_types)]
 type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<PredictionFxHasher>>;
@@ -98,21 +98,19 @@ impl LexerPredicate {
 /// committed path and gets a mutable borrow so a hook can change lexer state
 /// (mode stack), matching the closure-based `custom_action` API.
 #[derive(Debug)]
-enum LexerRef<'a, I, F>
+enum LexerRef<'a, I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
-    Shared(&'a BaseLexer<I, F>),
-    Mut(&'a mut BaseLexer<I, F>),
+    Shared(&'a BaseLexer<I>),
+    Mut(&'a mut BaseLexer<I>),
 }
 
-impl<I, F> LexerRef<'_, I, F>
+impl<I> LexerRef<'_, I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
-    const fn get(&self) -> &BaseLexer<I, F> {
+    const fn get(&self) -> &BaseLexer<I> {
         match self {
             LexerRef::Shared(lexer) => lexer,
             LexerRef::Mut(lexer) => lexer,
@@ -122,24 +120,22 @@ where
 
 /// Runtime view passed to lexer semantic hooks.
 #[derive(Debug)]
-pub struct LexerSemCtx<'a, I, F = CommonTokenFactory>
+pub struct LexerSemCtx<'a, I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
-    lexer: LexerRef<'a, I, F>,
+    lexer: LexerRef<'a, I>,
     rule_index: usize,
     coordinate_index: usize,
     position: usize,
 }
 
-impl<'a, I, F> LexerSemCtx<'a, I, F>
+impl<'a, I> LexerSemCtx<'a, I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
     pub(crate) const fn new(
-        lexer: &'a BaseLexer<I, F>,
+        lexer: &'a BaseLexer<I>,
         rule_index: usize,
         coordinate_index: usize,
         position: usize,
@@ -155,7 +151,7 @@ where
     /// Builds a context with a mutable lexer borrow, for a custom-action hook
     /// that may change lexer state (mode stack). See [`Self::push_mode`] etc.
     pub(crate) const fn new_mut(
-        lexer: &'a mut BaseLexer<I, F>,
+        lexer: &'a mut BaseLexer<I>,
         rule_index: usize,
         coordinate_index: usize,
         position: usize,
@@ -263,10 +259,10 @@ pub trait Lexer: Recognizer {
 }
 
 #[derive(Clone, Debug)]
-pub struct BaseLexer<I, F = CommonTokenFactory> {
+pub struct BaseLexer<I> {
     input: I,
     data: RecognizerData,
-    factory: F,
+    has_source_text: bool,
     mode: i32,
     mode_stack: Vec<i32>,
     token_start: usize,
@@ -412,23 +408,12 @@ impl<I> BaseLexer<I>
 where
     I: CharStream,
 {
-    /// Creates a lexer base using `CommonTokenFactory`.
     pub fn new(input: I, data: RecognizerData) -> Self {
-        Self::with_factory(input, data, CommonTokenFactory)
-    }
-}
-
-impl<I, F> BaseLexer<I, F>
-where
-    I: CharStream,
-    F: TokenFactory,
-{
-    /// Creates a lexer base with a custom token factory.
-    pub fn with_factory(input: I, data: RecognizerData, factory: F) -> Self {
+        let has_source_text = input.source_text().is_some();
         Self {
             input,
             data,
-            factory,
+            has_source_text,
             mode: DEFAULT_MODE,
             mode_stack: Vec::new(),
             token_start: 0,
@@ -537,9 +522,15 @@ where
     /// the base lexer captures the matched source interval so downstream token
     /// streams and parse trees can render token text without retaining a source
     /// pair object.
-    pub fn emit(&self, token_type: i32, channel: i32, text: Option<String>) -> CommonToken {
+    pub fn emit(
+        &self,
+        sink: &mut TokenSink<'_>,
+        token_type: i32,
+        channel: i32,
+        text: Option<String>,
+    ) -> Result<TokenId, TokenStoreError> {
         let stop = self.input.index().checked_sub(1).unwrap_or(usize::MAX);
-        self.emit_with_stop(token_type, channel, stop, text)
+        self.emit_with_stop(sink, token_type, channel, stop, text)
     }
 
     /// Builds a token with an explicit stop index.
@@ -549,11 +540,12 @@ where
     /// `usize::MAX` to represent ANTLR's `-1` stop index at empty input.
     pub fn emit_with_stop(
         &self,
+        sink: &mut TokenSink<'_>,
         token_type: i32,
         channel: i32,
         stop: usize,
         text: Option<String>,
-    ) -> CommonToken {
+    ) -> Result<TokenId, TokenStoreError> {
         let text = text.or_else(|| {
             if stop == usize::MAX {
                 Some("<EOF>".to_owned())
@@ -561,46 +553,36 @@ where
                 None
             }
         });
-        let source_interval = if text.is_none() && stop != usize::MAX && self.token_start <= stop {
+        let source_interval = if self.has_source_text
+            && text.is_none()
+            && stop != usize::MAX
+            && self.token_start <= stop
+        {
             self.input
-                .text_source_interval(TextInterval::new(self.token_start, stop))
+                .byte_interval(TextInterval::new(self.token_start, stop))
         } else {
             None
         };
-        let source_text = source_interval
-            .as_ref()
-            .and_then(|(input, start_byte, stop_byte)| {
-                Some(crate::token::TokenSourceText {
-                    input: Rc::clone(input),
-                    start_byte: u32::try_from(*start_byte).ok()?,
-                    stop_byte: u32::try_from(*stop_byte).ok()?,
-                })
-            });
-        let source_byte_span = source_text
-            .as_ref()
-            .map(|source_text| (source_text.start_byte, source_text.stop_byte));
         let text = text.or_else(|| {
-            source_text
+            source_interval
                 .is_none()
                 .then(|| self.input.text(TextInterval::new(self.token_start, stop)))
         });
-        let mut token = self.factory.create(TokenSpec {
+        let (start_byte, stop_byte) = source_interval
+            .or_else(|| self.token_byte_span(stop))
+            .unwrap_or((self.token_start, self.token_start));
+        sink.push(TokenSpec {
             token_type,
             channel,
             start: self.token_start,
             stop,
+            start_byte,
+            stop_byte,
             line: self.token_start_line,
             column: self.token_start_column,
             text,
-            source_text,
-            source_name: self.input.source_name(),
-        });
-        if let Some((start_byte, stop_byte)) =
-            source_byte_span.or_else(|| self.token_byte_span(stop))
-        {
-            token = token.with_byte_span(start_byte, stop_byte);
-        }
-        token
+            source_backed: source_interval.is_some(),
+        })
     }
 
     /// Returns the current token text from the token start through the input
@@ -646,52 +628,45 @@ where
     }
 
     /// Builds the synthetic EOF token at the current input cursor.
-    pub fn eof_token(&self) -> CommonToken {
-        let token = CommonToken::eof(
-            self.input.source_name(),
+    pub fn eof_token(&self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {
+        let byte_offset = self.eof_byte_offset().unwrap_or_else(|| self.input.index());
+        sink.push(TokenSpec::eof(
             self.input.index(),
+            byte_offset,
             self.line,
             self.column,
-        );
-        match self.eof_byte_offset() {
-            Some(byte_offset) => token.with_byte_span(byte_offset, byte_offset),
-            None => token,
-        }
+        ))
     }
 
-    fn eof_byte_offset(&self) -> Option<u32> {
+    fn eof_byte_offset(&self) -> Option<usize> {
         self.byte_offset_at(self.input.index())
     }
 
-    fn token_byte_span(&self, stop: usize) -> Option<(u32, u32)> {
+    fn token_byte_span(&self, stop: usize) -> Option<(usize, usize)> {
         if stop != usize::MAX && self.token_start <= stop {
-            let (_, start_byte, stop_byte) = self
+            let (start_byte, stop_byte) = self
                 .input
-                .text_source_interval(TextInterval::new(self.token_start, stop))?;
-            return Some((
-                u32::try_from(start_byte).ok()?,
-                u32::try_from(stop_byte).ok()?,
-            ));
+                .byte_interval(TextInterval::new(self.token_start, stop))?;
+            return Some((start_byte, stop_byte));
         }
         let byte_offset = self.byte_offset_at(self.token_start)?;
         Some((byte_offset, byte_offset))
     }
 
-    fn byte_offset_at(&self, index: usize) -> Option<u32> {
+    fn byte_offset_at(&self, index: usize) -> Option<usize> {
         let byte_offset = if index == 0 {
             0
         } else {
             let previous = TextInterval::new(index - 1, index - 1);
-            self.input.text_source_interval(previous)?.2
+            self.input.byte_interval(previous)?.1
         };
-        u32::try_from(byte_offset).ok()
+        Some(byte_offset)
     }
 }
 
-impl<I, F> Recognizer for BaseLexer<I, F>
+impl<I> Recognizer for BaseLexer<I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
     fn data(&self) -> &RecognizerData {
         &self.data
@@ -702,10 +677,9 @@ where
     }
 }
 
-impl<I, F> Lexer for BaseLexer<I, F>
+impl<I> Lexer for BaseLexer<I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
     fn mode(&self) -> i32 {
         self.mode
@@ -727,10 +701,9 @@ where
     }
 }
 
-impl<I, F> BaseLexer<I, F>
+impl<I> BaseLexer<I>
 where
     I: CharStream,
-    F: TokenFactory,
 {
     pub const fn line(&self) -> usize {
         self.line
@@ -742,6 +715,10 @@ where
 
     pub fn source_name(&self) -> &str {
         self.input.source_name()
+    }
+
+    pub fn source_text(&self) -> Option<Rc<str>> {
+        self.input.source_text()
     }
 
     pub const fn hit_eof(&self) -> bool {
@@ -933,9 +910,49 @@ fn lexer_dfa_edge_label(symbol: i32) -> Option<String> {
 mod tests {
     use super::*;
     use crate::char_stream::InputStream;
+    use crate::int_stream::IntStream;
     use crate::recognizer::RecognizerData;
-    use crate::token::{DEFAULT_CHANNEL, Token};
+    use crate::token::{DEFAULT_CHANNEL, Token, TokenStore};
     use crate::vocabulary::Vocabulary;
+
+    #[derive(Clone, Debug)]
+    struct UnsharedInput(InputStream);
+
+    impl IntStream for UnsharedInput {
+        fn consume(&mut self) {
+            self.0.consume();
+        }
+
+        fn la(&mut self, offset: isize) -> i32 {
+            self.0.la(offset)
+        }
+
+        fn index(&self) -> usize {
+            self.0.index()
+        }
+
+        fn seek(&mut self, index: usize) {
+            self.0.seek(index);
+        }
+
+        fn size(&self) -> usize {
+            self.0.size()
+        }
+
+        fn source_name(&self) -> &str {
+            self.0.source_name()
+        }
+    }
+
+    impl CharStream for UnsharedInput {
+        fn text(&self, interval: TextInterval) -> String {
+            self.0.text(interval)
+        }
+
+        fn byte_interval(&self, interval: TextInterval) -> Option<(usize, usize)> {
+            self.0.byte_interval(interval)
+        }
+    }
 
     #[test]
     fn eof_token_uses_utf8_byte_offset_after_non_ascii_input() {
@@ -950,7 +967,10 @@ mod tests {
         let mut lexer = BaseLexer::new(InputStream::new("β"), data);
         lexer.consume_char();
 
-        let token = lexer.eof_token();
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = lexer.eof_token(&mut sink).expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
 
         assert_eq!(token.start(), 1);
         assert_eq!(token.stop(), 0);
@@ -972,7 +992,12 @@ mod tests {
         lexer.consume_char();
         lexer.begin_token();
 
-        let token = lexer.emit_with_stop(1, DEFAULT_CHANNEL, 0, Some("<EOF>".to_owned()));
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = lexer
+            .emit_with_stop(&mut sink, 1, DEFAULT_CHANNEL, 0, Some("<EOF>".to_owned()))
+            .expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
 
         assert_eq!(token.start(), 1);
         assert_eq!(token.stop(), 0);
@@ -994,10 +1019,40 @@ mod tests {
         lexer.begin_token();
         lexer.consume_char();
 
-        let token = lexer.emit(1, DEFAULT_CHANNEL, None);
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = lexer
+            .emit(&mut sink, 1, DEFAULT_CHANNEL, None)
+            .expect("test token should fit");
+        let token = sink.view(id).expect("emitted token should exist");
 
         assert_eq!(token.start(), 0);
         assert_eq!(token.stop(), 0);
+        assert_eq!(token.text(), "β");
+        assert_eq!(token.byte_span(), 0..2);
+    }
+
+    #[test]
+    fn emit_falls_back_to_explicit_text_without_shareable_source() {
+        let data = RecognizerData::new(
+            "T",
+            Vocabulary::new(
+                std::iter::empty::<Option<&str>>(),
+                std::iter::empty::<Option<&str>>(),
+                std::iter::empty::<Option<&str>>(),
+            ),
+        );
+        let mut lexer = BaseLexer::new(UnsharedInput(InputStream::new("β")), data);
+        lexer.begin_token();
+        lexer.consume_char();
+
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = lexer
+            .emit(&mut sink, 1, DEFAULT_CHANNEL, None)
+            .expect("unshared input should emit explicit token text");
+        let token = sink.view(id).expect("emitted token should exist");
+
         assert_eq!(token.text(), "β");
         assert_eq!(token.byte_span(), 0..2);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@ pub use token::{
 pub use token_stream::CommonTokenStream;
 pub use tree::{
     ErrorNode, FromRuleContext, GeneratedAttrs, ParseTree, ParseTreeDescendants, ParseTreeListener,
-    ParseTreeWalker, ParserRuleContext, RuleNode, TerminalNode,
+    ParseTreeWalker, ParsedFile, ParserRuleContext, RuleNode, TerminalNode,
 };
 pub use vocabulary::Vocabulary;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,8 +38,9 @@ pub use prediction::{
 };
 pub use recognizer::{Recognizer, RecognizerData};
 pub use token::{
-    CommonToken, CommonTokenFactory, DEFAULT_CHANNEL, HIDDEN_CHANNEL, INVALID_TOKEN_TYPE,
-    TOKEN_EOF, Token, TokenChannel, TokenFactory, TokenSource,
+    DEFAULT_CHANNEL, HIDDEN_CHANNEL, INVALID_TOKEN_TYPE, MAX_TOKEN_OFFSET, TOKEN_EOF, Token,
+    TokenChannel, TokenId, TokenSink, TokenSource, TokenSpec, TokenStore, TokenStoreError,
+    TokenView,
 };
 pub use token_stream::CommonTokenStream;
 pub use tree::{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -3291,7 +3291,7 @@ where
         self.context.and_then(|context| {
             context.children().iter().find_map(|child| match child {
                 ParseTree::Rule(rule) if rule.context().rule_index() == rule_index => {
-                    Some(child.text())
+                    Some(child.text(self.input.token_store()))
                 }
                 ParseTree::Rule(_) | ParseTree::Terminal(_) | ParseTree::Error(_) => None,
             })
@@ -3597,10 +3597,22 @@ where
         &self.input
     }
 
+    /// Returns the canonical token store referenced by parse trees.
+    #[must_use]
+    pub const fn token_store(&self) -> &crate::token::TokenStore {
+        self.input.token_store()
+    }
+
     /// Consumes this parser and returns its token stream.
     #[must_use]
     pub fn into_token_stream(self) -> CommonTokenStream<S> {
         self.input
+    }
+
+    /// Consumes this parser and returns its canonical token store.
+    #[must_use]
+    pub fn into_token_store(self) -> crate::token::TokenStore {
+        self.input.into_token_store()
     }
 
     /// Returns the number of parser syntax errors recorded by committed parse
@@ -3823,29 +3835,27 @@ where
     }
 
     fn token_type_for_id(&self, id: TokenId) -> i32 {
-        self.input
-            .token_view(id)
-            .map_or(TOKEN_EOF, |token| token.token_type())
+        self.input.token_store().token_type(id).unwrap_or(TOKEN_EOF)
     }
 
-    fn terminal_tree(&self, id: TokenId) -> ParseTree {
-        ParseTree::Terminal(TerminalNode::from_id(id, self.input.token_store_handle()))
+    const fn terminal_tree(&self, id: TokenId) -> ParseTree {
+        ParseTree::Terminal(TerminalNode::from_id(id))
     }
 
-    fn error_tree(&self, id: TokenId) -> ParseTree {
-        ParseTree::Error(ErrorNode::from_id(id, self.input.token_store_handle()))
+    const fn error_tree(&self, id: TokenId) -> ParseTree {
+        ParseTree::Error(ErrorNode::from_id(id))
     }
 
-    fn set_context_start(&self, context: &mut ParserRuleContext, id: TokenId) {
-        context.set_start_id(id, self.input.token_store_handle());
+    const fn set_context_start(&self, context: &mut ParserRuleContext, id: TokenId) {
+        context.set_start_id(id);
     }
 
-    fn set_context_stop(&self, context: &mut ParserRuleContext, id: TokenId) {
-        context.set_stop_id(id, self.input.token_store_handle());
+    const fn set_context_stop(&self, context: &mut ParserRuleContext, id: TokenId) {
+        context.set_stop_id(id);
     }
 
     fn insert_synthetic_token(
-        &self,
+        &mut self,
         token_type: i32,
         text: String,
         line: usize,
@@ -4397,7 +4407,6 @@ where
         let start = current.start_id();
         let mut replacement = ParserRuleContext::new(rule_index, invoking_state);
         if start.is_some() {
-            replacement.set_store_from_context(current);
             replacement.set_start_from_context(current);
         }
         let previous = std::mem::replace(current, replacement);
@@ -8384,8 +8393,8 @@ where
         current_index: usize,
     ) -> Option<usize> {
         if let ParseTree::Rule(rule) = tree {
-            if let Some(stop) = rule.context().stop() {
-                return Some(stop.token_id().index());
+            if let Some(stop) = rule.context().stop_id() {
+                return Some(stop.index());
             }
         }
         self.after_action_stop_index(current_index)
@@ -8401,14 +8410,14 @@ where
     /// pre-rule cursor still points at. Falls back to `fallback_index` only when
     /// the tree carries no rule start.
     #[must_use]
-    pub fn after_action_start_index_for_tree(
+    pub const fn after_action_start_index_for_tree(
         &self,
         tree: &ParseTree,
         fallback_index: usize,
     ) -> usize {
         if let ParseTree::Rule(rule) = tree {
-            if let Some(start) = rule.context().start() {
-                return start.token_id().index();
+            if let Some(start) = rule.context().start_id() {
+                return start.index();
             }
         }
         fallback_index
@@ -8703,7 +8712,7 @@ where
                 .and_then(|context| {
                     context.children().iter().find_map(|child| match child {
                         ParseTree::Rule(rule) if rule.context().rule_index() == *rule_index => {
-                            Some(child.text())
+                            Some(child.text(self.input.token_store()))
                         }
                         ParseTree::Rule(_) | ParseTree::Terminal(_) | ParseTree::Error(_) => None,
                     })
@@ -10210,10 +10219,7 @@ mod tests {
         ParserAtnPredictionDiagnostic, ParserAtnPredictionDiagnosticKind, ParserAtnSimulator,
     };
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
-    use crate::token::{
-        HIDDEN_CHANNEL, Token, TokenId, TokenSink, TokenSpec, TokenStore, TokenStoreError,
-        TokenStoreHandle,
-    };
+    use crate::token::{HIDDEN_CHANNEL, Token, TokenId, TokenSink, TokenSpec, TokenStoreError};
     use crate::token_stream::CommonTokenStream;
     use crate::vocabulary::Vocabulary;
 
@@ -10335,10 +10341,8 @@ mod tests {
         }
     }
 
-    fn test_terminal(token: TestToken) -> TerminalNode {
-        let store = TokenStoreHandle::new(TokenStore::new(None, token.source_name.as_str()));
-        let id = store.push(token.spec).expect("test token should fit");
-        TerminalNode::from_id(id, store)
+    fn test_terminal(token: &TestToken) -> TerminalNode {
+        TerminalNode::from_id(token.id)
     }
 
     #[derive(Debug)]
@@ -11542,10 +11546,8 @@ mod tests {
             Vocabulary::new([None, Some("'x'")], [None, Some("X")], [None::<&str>, None]),
         );
         let mut parser = BaseParser::new(CommonTokenStream::new(source), data);
-        assert_eq!(
-            parser.match_token(1).expect("token 1 should match").text(),
-            "x"
-        );
+        let matched = parser.match_token(1).expect("token 1 should match");
+        assert_eq!(matched.text(parser.token_store()), "x");
         assert!(parser.match_token(1).is_err());
     }
 
@@ -11556,13 +11558,10 @@ mod tests {
             TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
-        assert_eq!(
-            parser
-                .match_set(&[(1, 1), (3, 4)])
-                .expect("token set should match")
-                .text(),
-            "x"
-        );
+        let matched = parser
+            .match_set(&[(1, 1), (3, 4)])
+            .expect("token set should match");
+        assert_eq!(matched.text(parser.token_store()), "x");
         assert!(parser.match_not_set(&[(1, 1)], 1, 4).is_err());
     }
 
@@ -11634,11 +11633,14 @@ mod tests {
 
     #[test]
     fn parser_predicates_support_context_child_text_checks() {
-        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![
+            TestToken::new(1).with_text("var"),
+            TestToken::eof("parser-test", 1, 1, 1),
+        ]);
         let mut context = ParserRuleContext::new(1, 0);
         let mut child_context = ParserRuleContext::new(2, 0);
         child_context.add_child(ParseTree::Terminal(test_terminal(
-            TestToken::new(1).with_text("var"),
+            &TestToken::new(1).with_text("var"),
         )));
         context.add_child(ParseTree::Rule(RuleNode::new(child_context)));
         let predicates = [(
@@ -11749,11 +11751,14 @@ mod tests {
             .expect("generated match should insert missing token");
 
         assert_eq!(node.children().len(), 1);
-        assert_eq!(node.children()[0].text(), "<missing 'Y'>");
+        assert_eq!(
+            node.children()[0].text(parser.token_store()),
+            "<missing 'Y'>"
+        );
         assert_eq!(
             node.clone()
                 .into_child_iter()
-                .map(|child| child.text())
+                .map(|child| child.text(parser.token_store()))
                 .collect::<Vec<_>>(),
             ["<missing 'Y'>"]
         );
@@ -11801,11 +11806,11 @@ mod tests {
 
         assert_eq!(node.children().len(), 2);
         assert!(matches!(node.children()[0], ParseTree::Error(_)));
-        assert_eq!(node.children()[0].text(), "z");
-        assert_eq!(node.children()[1].text(), "y");
+        assert_eq!(node.children()[0].text(parser.token_store()), "z");
+        assert_eq!(node.children()[1].text(parser.token_store()), "y");
         assert_eq!(
             node.into_child_iter()
-                .map(|child| child.text())
+                .map(|child| child.text(parser.token_store()))
                 .collect::<Vec<_>>(),
             ["z", "y"]
         );
@@ -11840,7 +11845,7 @@ mod tests {
 
         assert_eq!(
             node.into_child_iter()
-                .map(|child| child.text())
+                .map(|child| child.text(parser.token_store()))
                 .collect::<Vec<_>>(),
             ["y"]
         );
@@ -12039,7 +12044,11 @@ mod tests {
         // A single `<missing ...>` error node is inserted; EOF is not consumed.
         assert_eq!(node.children().len(), 1);
         assert!(!node.consumed_eof());
-        assert!(node.children()[0].text().starts_with("<missing"));
+        assert!(
+            node.children()[0]
+                .text(parser.token_store())
+                .starts_with("<missing")
+        );
         assert_eq!(parser.la(1), TOKEN_EOF);
         assert_eq!(
             parser.generated_parser_diagnostics,
@@ -12089,7 +12098,10 @@ mod tests {
         let tree = parser.finish_rule(child, false);
 
         assert_eq!(parser.la(1), TOKEN_EOF);
-        assert_eq!(tree.to_string_tree_with_names(&["s", "a"]), "(a z)");
+        assert_eq!(
+            tree.to_string_tree_with_names(&["s", "a"], parser.token_store()),
+            "(a z)"
+        );
         assert_eq!(parser.number_of_syntax_errors(), 1);
         assert_eq!(
             parser.generated_parser_diagnostics,
@@ -12217,7 +12229,8 @@ mod tests {
             TestToken::new(1).with_text("x"),
             TestToken::eof("parser-test", 1, 1, 1),
         ]);
-        assert_eq!(parser.match_wildcard().expect("wildcard").text(), "x");
+        let matched = parser.match_wildcard().expect("wildcard");
+        assert_eq!(matched.text(parser.token_store()), "x");
         assert!(parser.match_wildcard().is_err());
     }
 
@@ -12233,7 +12246,7 @@ mod tests {
         parser.set_build_parse_trees(false);
         let mut ctx = ParserRuleContext::new(0, 0);
         assert!(!ctx.has_matched_child());
-        parser.add_parse_child(&mut ctx, ParseTree::Terminal(test_terminal(token.clone())));
+        parser.add_parse_child(&mut ctx, ParseTree::Terminal(test_terminal(&token)));
         // Tree building is off, so no child is stored...
         assert!(ctx.children().is_empty());
         // ...but the match is recorded, so the context is no longer "empty".
@@ -12242,7 +12255,7 @@ mod tests {
         // With tree building on, the child is stored and the match is recorded.
         parser.set_build_parse_trees(true);
         let mut ctx = ParserRuleContext::new(0, 0);
-        parser.add_parse_child(&mut ctx, ParseTree::Terminal(test_terminal(token)));
+        parser.add_parse_child(&mut ctx, ParseTree::Terminal(test_terminal(&token)));
         assert_eq!(ctx.children().len(), 1);
         assert!(ctx.has_matched_child());
     }
@@ -12258,10 +12271,10 @@ mod tests {
         let tree = parser
             .parse_atn_rule(&atn, 0)
             .expect("artificial parser rule should parse");
-        assert_eq!(tree.text(), "x<EOF>");
+        assert_eq!(tree.text(parser.token_store()), "x<EOF>");
         assert_eq!(parser.number_of_syntax_errors(), 0);
         assert_eq!(
-            tree.first_rule_stop(0)
+            tree.first_rule_stop(0, parser.token_store())
                 .expect("rule should stop at EOF")
                 .token_type(),
             TOKEN_EOF
@@ -12276,7 +12289,7 @@ mod tests {
             .expect("runtime-option parser rule should parse");
         assert!(actions.is_empty());
         assert_eq!(
-            tree.first_rule_stop(0)
+            tree.first_rule_stop(0, parser.token_store())
                 .expect("rule should stop at EOF")
                 .token_type(),
             TOKEN_EOF
@@ -12295,7 +12308,7 @@ mod tests {
             .parse_atn_rule_with_runtime_options(&atn, 0, ParserRuntimeOptions::default())
             .expect("no-op parser action should not force action replay");
 
-        assert_eq!(tree.text(), "x<EOF>");
+        assert_eq!(tree.text(parser.token_store()), "x<EOF>");
         assert!(
             actions.is_empty(),
             "action_index=None transitions are ANTLR metadata, not replay actions"
@@ -12314,7 +12327,7 @@ mod tests {
         let tree = parser
             .parse_atn_rule(&atn, 0)
             .expect("artificial parser rule should parse");
-        assert_eq!(tree.text(), "x<EOF>");
+        assert_eq!(tree.text(parser.token_store()), "x<EOF>");
 
         let stream = parser.token_stream();
         let source_index_after_parse = stream.token_source().index;
@@ -12350,7 +12363,7 @@ mod tests {
 
         assert_eq!(parser.number_of_syntax_errors(), 1);
         assert_eq!(
-            tree.first_error_token()
+            tree.first_error_token(parser.token_store())
                 .expect("recovery should embed an error token")
                 .text(),
             "y"
@@ -12386,7 +12399,7 @@ mod tests {
             .parse_atn_rule_adaptive_or_fallback(&atn, &mut simulator, 0)
             .expect("direct adaptive rule should parse");
 
-        assert_eq!(tree.text(), "y");
+        assert_eq!(tree.text(parser.token_store()), "y");
         assert_eq!(parser.input.index(), 1);
     }
 
@@ -12404,7 +12417,7 @@ mod tests {
             .parse_atn_rule_adaptive_or_fallback(&atn, &mut simulator, 0)
             .expect("fallback recognizer should parse");
 
-        assert_eq!(tree.text(), "xy");
+        assert_eq!(tree.text(parser.token_store()), "xy");
         assert_eq!(parser.input.index(), 2);
     }
 
@@ -12421,7 +12434,7 @@ mod tests {
             .parse_atn_rule_with_runtime_options(&atn, 0, ParserRuntimeOptions::default())
             .expect("unknown predicate should pass under the default policy");
 
-        assert_eq!(tree.text(), "xy");
+        assert_eq!(tree.text(parser.token_store()), "xy");
         assert_eq!(parser.number_of_syntax_errors(), 0);
     }
 
@@ -12633,7 +12646,7 @@ mod tests {
             )
             .expect("hook supplies the missing predicate result");
 
-        assert_eq!(tree.text(), "xy");
+        assert_eq!(tree.text(parser.token_store()), "xy");
         assert_eq!(
             parser.semantic_hooks.predicates,
             vec![(1, 0, 0, Some("y".to_owned()))]
@@ -12738,7 +12751,7 @@ mod tests {
             )
             .expect("a predicate covered by the table is not an unknown coordinate");
 
-        assert_eq!(tree.text(), "xy");
+        assert_eq!(tree.text(parser.token_store()), "xy");
     }
 
     /// Hooks that decline (`None`) must fall through to the configured policy
@@ -12790,7 +12803,7 @@ mod tests {
             )
             .expect("a declined SemIR hook must pass under assume-true");
 
-        assert_eq!(tree.text(), "xy");
+        assert_eq!(tree.text(parser.token_store()), "xy");
     }
 
     #[test]
@@ -12913,7 +12926,7 @@ mod tests {
         };
         assert_eq!(
             rule.context()
-                .start()
+                .start(parser.token_store())
                 .expect("rule should have a start token")
                 .token_type(),
             1

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,7 +83,7 @@ use crate::prediction::{EMPTY_RETURN_STATE, PredictionContext};
 use crate::recognizer::{Recognizer, RecognizerData};
 use crate::semir::{self, AStmt, ArithOp, CmpOp, ExprId, HookId, PExpr, SemIr, StmtId};
 use crate::token::{
-    CommonToken, TOKEN_EOF, Token, TokenFactory, TokenRef, TokenSource, TokenSourceError,
+    TOKEN_EOF, Token, TokenId, TokenSource, TokenSourceError, TokenSpec, TokenView,
 };
 use crate::token_stream::CommonTokenStream;
 use crate::tree::{ErrorNode, ParseTree, ParserRuleContext, RuleNode, TerminalNode};
@@ -383,13 +383,13 @@ where
     }
 
     /// Token at one-based lookahead/lookbehind offset.
-    pub fn lt(&mut self, offset: isize) -> Option<&CommonToken> {
+    pub fn lt(&self, offset: isize) -> Option<TokenView<'_>> {
         self.input.lt(offset)
     }
 
-    /// Token text at one-based lookahead/lookbehind offset.
-    pub fn token_text(&mut self, offset: isize) -> Option<&str> {
-        self.lt(offset).and_then(Token::text)
+    /// Borrowing token view for text inspection at a one-based offset.
+    pub fn token_text(&self, offset: isize) -> Option<TokenView<'_>> {
+        self.lt(offset)
     }
 
     /// Token at an absolute buffered index, including hidden/custom channels.
@@ -398,7 +398,7 @@ where
     /// filter and does not move its cursor. It is intended for semantic helpers
     /// such as automatic-semicolon-insertion checks that inspect trivia
     /// immediately before the current visible token.
-    pub fn token_at(&mut self, index: usize) -> Option<&CommonToken> {
+    pub fn token_at(&self, index: usize) -> Option<TokenView<'_>> {
         self.input.get(index)
     }
 
@@ -442,7 +442,7 @@ where
     /// tokens (and the EOF marker) are excluded rather than blindly subtracting
     /// one, which could point at hidden whitespace. `CommonTokenStream::text`
     /// itself guards `start > stop`, so an empty interval yields `""`.
-    pub fn action_text(&mut self) -> String {
+    pub fn action_text(&self) -> String {
         let Some(action) = self.action else {
             return String::new();
         };
@@ -501,15 +501,14 @@ pub trait SemanticHooks {
         false
     }
 
-    fn lexer_sempred<I, F>(
+    fn lexer_sempred<I>(
         &mut self,
-        ctx: &mut LexerSemCtx<'_, I, F>,
+        ctx: &mut LexerSemCtx<'_, I>,
         rule_index: usize,
         pred_index: usize,
     ) -> Option<bool>
     where
         I: CharStream,
-        F: TokenFactory,
     {
         let _ = (ctx, rule_index, pred_index);
         None
@@ -524,14 +523,9 @@ pub trait SemanticHooks {
     /// closure-based `custom_action` API. (The speculative predicate context in
     /// [`Self::lexer_sempred`] is a shared borrow, so those mutators are inert
     /// there.)
-    fn lexer_action<I, F>(
-        &mut self,
-        ctx: &mut LexerSemCtx<'_, I, F>,
-        action: LexerCustomAction,
-    ) -> bool
+    fn lexer_action<I>(&mut self, ctx: &mut LexerSemCtx<'_, I>, action: LexerCustomAction) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         let _ = (ctx, action);
         false
@@ -543,7 +537,7 @@ pub trait SemanticHooks {
     ///
     /// Hidden and custom-channel tokens are included. `skip` and intermediate
     /// `more` matches do not produce callbacks.
-    fn lexer_token_emitted(&mut self, token: &CommonToken) {
+    fn lexer_token_emitted(&mut self, token: TokenView<'_>) {
         let _ = token;
     }
 }
@@ -2798,11 +2792,16 @@ struct ParserTableSemCtx<'a> {
 }
 
 impl semir::PredContext for ParserTableSemCtx<'_> {
+    type TokenText<'a>
+        = &'a str
+    where
+        Self: 'a;
+
     fn la(&mut self, _offset: isize) -> i64 {
         i64::from(TOKEN_EOF)
     }
 
-    fn token_text(&mut self, _offset: isize) -> Option<&str> {
+    fn token_text(&mut self, _offset: isize) -> Option<Self::TokenText<'_>> {
         None
     }
 
@@ -3265,19 +3264,24 @@ where
     S: TokenSource,
     H: SemanticHooks,
 {
+    type TokenText<'a>
+        = TokenView<'a>
+    where
+        Self: 'a;
+
     fn la(&mut self, offset: isize) -> i64 {
         i64::from(self.input.la(offset))
     }
 
-    fn token_text(&mut self, offset: isize) -> Option<&str> {
-        self.input.lt(offset).and_then(Token::text)
+    fn token_text(&mut self, offset: isize) -> Option<Self::TokenText<'_>> {
+        self.input.lt(offset)
     }
 
     fn token_index_adjacent(&mut self) -> bool {
-        let Some(first) = self.input.lt(-2).map(Token::token_index) else {
+        let Some(first) = self.input.lt_id(-2).map(TokenId::index) else {
             return false;
         };
-        let Some(second) = self.input.lt(-1).map(Token::token_index) else {
+        let Some(second) = self.input.lt_id(-1).map(TokenId::index) else {
             return false;
         };
         first + 1 == second
@@ -3682,18 +3686,18 @@ where
         if !self.reported_prediction_diagnostics.insert(key) {
             return;
         }
-        let start_token = self.token_at(start_index);
-        let stop_token = self.token_at(stop_index);
-        self.generated_parser_diagnostics.push(diagnostic_for_token(
-            start_token.as_ref(),
+        let start_diagnostic = diagnostic_for_token(
+            self.token_at(start_index),
             format!("reportAttemptingFullContext d={decision} ({rule_name}), input='{input}'"),
-        ));
-        self.generated_parser_diagnostics.push(diagnostic_for_token(
-            stop_token.as_ref(),
+        );
+        let stop_diagnostic = diagnostic_for_token(
+            self.token_at(stop_index),
             format!(
                 "reportAmbiguity d={decision} ({rule_name}): ambigAlts={{{alts}}}, input='{input}'"
             ),
-        ));
+        );
+        self.generated_parser_diagnostics.push(start_diagnostic);
+        self.generated_parser_diagnostics.push(stop_diagnostic);
     }
 
     /// Buffers ANTLR-style diagnostic-listener messages produced by generated
@@ -3751,14 +3755,13 @@ where
         if !self.reported_prediction_diagnostics.insert(key) {
             return;
         }
-        let attempt_token = self.token_at(diagnostic.sll_stop_index);
-        self.generated_parser_diagnostics.push(diagnostic_for_token(
-            attempt_token.as_ref(),
+        let attempt_diagnostic = diagnostic_for_token(
+            self.token_at(diagnostic.sll_stop_index),
             format!(
                 "reportAttemptingFullContext d={decision} ({rule_name}), input='{attempt_input}'"
             ),
-        ));
-        let result_token = self.token_at(diagnostic.ll_stop_index);
+        );
+        self.generated_parser_diagnostics.push(attempt_diagnostic);
         let message = match diagnostic.kind {
             ParserAtnPredictionDiagnosticKind::Ambiguity => {
                 // Java's DiagnosticErrorListener is exactOnly by default:
@@ -3778,11 +3781,12 @@ where
                 )
             }
         };
-        self.generated_parser_diagnostics
-            .push(diagnostic_for_token(result_token.as_ref(), message));
+        let result_diagnostic =
+            diagnostic_for_token(self.token_at(diagnostic.ll_stop_index), message);
+        self.generated_parser_diagnostics.push(result_diagnostic);
     }
 
-    pub fn la(&mut self, offset: isize) -> i32 {
+    pub fn la(&self, offset: isize) -> i32 {
         self.input.la_token(offset)
     }
 
@@ -3818,6 +3822,45 @@ where
         *value
     }
 
+    fn token_type_for_id(&self, id: TokenId) -> i32 {
+        self.input
+            .token_view(id)
+            .map_or(TOKEN_EOF, |token| token.token_type())
+    }
+
+    fn terminal_tree(&self, id: TokenId) -> ParseTree {
+        ParseTree::Terminal(TerminalNode::from_id(id, self.input.token_store_handle()))
+    }
+
+    fn error_tree(&self, id: TokenId) -> ParseTree {
+        ParseTree::Error(ErrorNode::from_id(id, self.input.token_store_handle()))
+    }
+
+    fn set_context_start(&self, context: &mut ParserRuleContext, id: TokenId) {
+        context.set_start_id(id, self.input.token_store_handle());
+    }
+
+    fn set_context_stop(&self, context: &mut ParserRuleContext, id: TokenId) {
+        context.set_stop_id(id, self.input.token_store_handle());
+    }
+
+    fn insert_synthetic_token(
+        &self,
+        token_type: i32,
+        text: String,
+        line: usize,
+        column: usize,
+    ) -> Result<TokenId, AntlrError> {
+        self.input
+            .insert(
+                TokenSpec::explicit(token_type, text)
+                    .with_span(usize::MAX, usize::MAX)
+                    .with_byte_span(0, 0)
+                    .with_position(line, column),
+            )
+            .map_err(|error| AntlrError::Unsupported(error.to_string()))
+    }
+
     /// Matches and consumes the current token when it has the expected token
     /// type.
     ///
@@ -3825,21 +3868,19 @@ where
     /// On mismatch the error carries vocabulary display names so diagnostics are
     /// stable across literal and symbolic token naming.
     pub fn match_token(&mut self, token_type: i32) -> Result<ParseTree, AntlrError> {
-        let current = self
-            .input
-            .lt_ref(1)
-            .ok_or_else(|| AntlrError::ParserError {
-                line: 0,
-                column: 0,
-                message: "missing current token".to_owned(),
-            })?;
-        if current.token_type() == token_type {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if current_type == token_type {
             self.consume();
-            Ok(ParseTree::Terminal(TerminalNode::from_ref(current)))
+            Ok(self.terminal_tree(current))
         } else {
             Err(AntlrError::MismatchedInput {
                 expected: self.vocabulary().display_name(token_type),
-                found: self.vocabulary().display_name(current.token_type()),
+                found: self.vocabulary().display_name(current_type),
             })
         }
     }
@@ -3853,34 +3894,26 @@ where
         follow_state: usize,
         atn: &Atn,
     ) -> Result<GeneratedMatch, AntlrError> {
-        let current = self
-            .input
-            .lt_ref(1)
-            .ok_or_else(|| AntlrError::ParserError {
-                line: 0,
-                column: 0,
-                message: "missing current token".to_owned(),
-            })?;
-        if current.token_type() == token_type {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if current_type == token_type {
             self.generated_sync_expected = None;
-            let consumed_eof = current.token_type() == TOKEN_EOF;
+            let consumed_eof = current_type == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: GeneratedMatchChildren::One(ParseTree::Terminal(TerminalNode::from_ref(
-                    current,
-                ))),
+                children: GeneratedMatchChildren::One(self.terminal_tree(current)),
                 consumed_eof,
             });
         }
         let mut expected_symbols = BTreeSet::new();
         expected_symbols.insert(token_type);
-        self.recover_generated_match(
-            current.as_ref().clone(),
-            &expected_symbols,
-            follow_state,
-            atn,
-            |symbol| symbol == token_type,
-        )
+        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
+            symbol == token_type
+        })
     }
 
     pub fn match_set_recovering(
@@ -3889,33 +3922,25 @@ where
         follow_state: usize,
         atn: &Atn,
     ) -> Result<GeneratedMatch, AntlrError> {
-        let current = self
-            .input
-            .lt_ref(1)
-            .ok_or_else(|| AntlrError::ParserError {
-                line: 0,
-                column: 0,
-                message: "missing current token".to_owned(),
-            })?;
-        if interval_set_contains(intervals, current.token_type()) {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if interval_set_contains(intervals, current_type) {
             self.generated_sync_expected = None;
-            let consumed_eof = current.token_type() == TOKEN_EOF;
+            let consumed_eof = current_type == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: GeneratedMatchChildren::One(ParseTree::Terminal(TerminalNode::from_ref(
-                    current,
-                ))),
+                children: GeneratedMatchChildren::One(self.terminal_tree(current)),
                 consumed_eof,
             });
         }
         let expected_symbols = interval_symbols(intervals);
-        self.recover_generated_match(
-            current.as_ref().clone(),
-            &expected_symbols,
-            follow_state,
-            atn,
-            |symbol| interval_set_contains(intervals, symbol),
-        )
+        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
+            interval_set_contains(intervals, symbol)
+        })
     }
 
     pub fn match_not_set_recovering(
@@ -3926,80 +3951,81 @@ where
         follow_state: usize,
         atn: &Atn,
     ) -> Result<GeneratedMatch, AntlrError> {
-        let current = self
-            .input
-            .lt_ref(1)
-            .ok_or_else(|| AntlrError::ParserError {
-                line: 0,
-                column: 0,
-                message: "missing current token".to_owned(),
-            })?;
-        if (min_vocabulary..=max_vocabulary).contains(&current.token_type())
-            && !interval_set_contains(intervals, current.token_type())
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if (min_vocabulary..=max_vocabulary).contains(&current_type)
+            && !interval_set_contains(intervals, current_type)
         {
             self.generated_sync_expected = None;
-            let consumed_eof = current.token_type() == TOKEN_EOF;
+            let consumed_eof = current_type == TOKEN_EOF;
             self.consume();
             return Ok(GeneratedMatch {
-                children: GeneratedMatchChildren::One(ParseTree::Terminal(TerminalNode::from_ref(
-                    current,
-                ))),
+                children: GeneratedMatchChildren::One(self.terminal_tree(current)),
                 consumed_eof,
             });
         }
         let expected_symbols =
             interval_complement_symbols(intervals, min_vocabulary, max_vocabulary);
-        self.recover_generated_match(
-            current.as_ref().clone(),
-            &expected_symbols,
-            follow_state,
-            atn,
-            |symbol| {
-                (min_vocabulary..=max_vocabulary).contains(&symbol)
-                    && !interval_set_contains(intervals, symbol)
-            },
-        )
+        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
+            (min_vocabulary..=max_vocabulary).contains(&symbol)
+                && !interval_set_contains(intervals, symbol)
+        })
     }
 
     fn recover_generated_match(
         &mut self,
-        current: CommonToken,
+        current: TokenId,
         expected_symbols: &BTreeSet<i32>,
         follow_state: usize,
         atn: &Atn,
         matches: impl Fn(i32) -> bool,
     ) -> Result<GeneratedMatch, AntlrError> {
         let expected_display = self.expected_symbols_display(expected_symbols);
+        let (current_type, current_line, current_column, current_display) = {
+            let token = self
+                .input
+                .token_view(current)
+                .expect("current token ID should be valid");
+            (
+                token.token_type(),
+                token.line(),
+                token.column(),
+                token_input_display(&token),
+            )
+        };
         if self.bail_on_error {
             return Err(AntlrError::ParserError {
-                line: current.line(),
-                column: current.column(),
-                message: format!(
-                    "mismatched input {} expecting {expected_display}",
-                    token_input_display(&current)
-                ),
+                line: current_line,
+                column: current_column,
+                message: format!("mismatched input {current_display} expecting {expected_display}"),
             });
         }
-        if current.token_type() != TOKEN_EOF
-            && let Some(next) = self.input.lt(2).cloned()
-            && matches(next.token_type())
+        if current_type != TOKEN_EOF
+            && let Some(next) = self.input.lt_id(2)
+            && matches(self.token_type_for_id(next))
         {
-            let message = format!(
-                "extraneous input {} expecting {expected_display}",
-                token_input_display(&current)
-            );
-            self.push_generated_parser_diagnostic(diagnostic_for_token(Some(&current), message));
+            let message =
+                format!("extraneous input {current_display} expecting {expected_display}");
+            self.push_generated_parser_diagnostic(ParserDiagnostic {
+                line: current_line,
+                column: current_column,
+                message,
+            });
             self.record_syntax_errors(1);
             self.generated_sync_expected = None;
             // Single-token deletion: skip `current`, then accept `next`. The
             // accepted token can be EOF only if it is a real EOF terminal.
-            let consumed_eof = next.token_type() == TOKEN_EOF;
+            let consumed_eof = self.token_type_for_id(next) == TOKEN_EOF;
             self.consume();
             self.consume();
             return Ok(GeneratedMatch {
                 children: GeneratedMatchChildren::Many(vec![
-                    ParseTree::Error(ErrorNode::new(current)),
-                    ParseTree::Terminal(TerminalNode::new(next)),
+                    self.error_tree(current),
+                    self.terminal_tree(next),
                 ]),
                 consumed_eof,
             });
@@ -4013,37 +4039,40 @@ where
         // `start: ID+;` on empty input — antlr#6 `InvalidEmptyInput`, which must
         // stay a `mismatched input` error). `follow_symbols` mixes both sources,
         // so consult the follow state's OWN expected set for the explicit case.
-        let follow_explicitly_expects_eof = current.token_type() == TOKEN_EOF
+        let follow_explicitly_expects_eof = current_type == TOKEN_EOF
             && self
                 .cached_state_expected_symbols(atn, follow_state)
                 .contains(&TOKEN_EOF);
-        if follow_symbols.contains(&current.token_type())
-            && (current.token_type() != TOKEN_EOF
+        if follow_symbols.contains(&current_type)
+            && (current_type != TOKEN_EOF
                 || self.rule_context_stack.len() > 1
                 || expected_symbols.is_empty()
                 || follow_explicitly_expects_eof)
         {
-            let message = format!(
-                "missing {expected_display} at {}",
-                token_input_display(&current)
-            );
-            self.push_generated_parser_diagnostic(diagnostic_for_token(Some(&current), message));
+            let message = format!("missing {expected_display} at {current_display}");
+            self.push_generated_parser_diagnostic(ParserDiagnostic {
+                line: current_line,
+                column: current_column,
+                message,
+            });
             self.record_syntax_errors(1);
             self.generated_sync_expected = None;
             let token_type = expected_symbols.iter().next().copied().unwrap_or(TOKEN_EOF);
             let mut missing_symbol = BTreeSet::new();
             missing_symbol.insert(token_type);
             let missing_display = self.expected_symbols_display(&missing_symbol);
-            let token = CommonToken::new(token_type)
-                .with_text(format!("<missing {missing_display}>"))
-                .with_span(usize::MAX, usize::MAX)
-                .with_position(current.line(), current.column());
+            let token = self.insert_synthetic_token(
+                token_type,
+                format!("<missing {missing_display}>"),
+                current_line,
+                current_column,
+            )?;
             // Single-token insertion synthesizes a missing token and consumes
             // nothing, so no EOF terminal is consumed even when the lookahead is
             // EOF. Reporting consumed_eof=false here is what keeps `finish_rule`
             // from recording EOF as the rule stop on this recovery path.
             return Ok(GeneratedMatch {
-                children: GeneratedMatchChildren::One(ParseTree::Error(ErrorNode::new(token))),
+                children: GeneratedMatchChildren::One(self.error_tree(token)),
                 consumed_eof: false,
             });
         }
@@ -4053,11 +4082,10 @@ where
         );
         let mismatch_expected_display = self.expected_symbols_display(&mismatch_expected);
         Err(AntlrError::ParserError {
-            line: current.line(),
-            column: current.column(),
+            line: current_line,
+            column: current_column,
             message: format!(
-                "mismatched input {} expecting {mismatch_expected_display}",
-                token_input_display(&current)
+                "mismatched input {current_display} expecting {mismatch_expected_display}"
             ),
         })
     }
@@ -4102,21 +4130,19 @@ where
         intervals: &[(i32, i32)],
         matches: impl FnOnce(i32) -> bool,
     ) -> Result<ParseTree, AntlrError> {
-        let current = self
-            .input
-            .lt_ref(1)
-            .ok_or_else(|| AntlrError::ParserError {
-                line: 0,
-                column: 0,
-                message: "missing current token".to_owned(),
-            })?;
-        if matches(current.token_type()) {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if matches(current_type) {
             self.consume();
-            Ok(ParseTree::Terminal(TerminalNode::from_ref(current)))
+            Ok(self.terminal_tree(current))
         } else {
             Err(AntlrError::MismatchedInput {
                 expected: self.interval_display(intervals),
-                found: self.vocabulary().display_name(current.token_type()),
+                found: self.vocabulary().display_name(current_type),
             })
         }
     }
@@ -4156,8 +4182,8 @@ where
         self.invalidate_prediction_context_cache();
         let start_index = self.current_visible_index();
         let mut context = ParserRuleContext::new(rule_index, invoking_state);
-        if let Some(token) = self.token_ref_at(start_index) {
-            context.set_start_ref(token);
+        if let Some(token) = self.token_id_at(start_index) {
+            self.set_context_start(&mut context, token);
         }
         context
     }
@@ -4237,8 +4263,8 @@ where
     /// Finishes a generated parser rule and returns its parse-tree node.
     pub fn finish_rule(&mut self, mut context: ParserRuleContext, consumed_eof: bool) -> ParseTree {
         let stop_index = self.rule_stop_token_index(self.input.index(), consumed_eof);
-        if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
-            context.set_stop_ref(token);
+        if let Some(token) = stop_index.and_then(|index| self.token_id_at(index)) {
+            self.set_context_stop(&mut context, token);
         }
         self.exit_rule();
         self.rule_node(context)
@@ -4265,11 +4291,11 @@ where
             if symbol == TOKEN_EOF || recovery_symbols.contains(&symbol) {
                 break;
             }
-            let Some(token) = self.input.lt(1).cloned() else {
+            let Some(token) = self.input.lt_id(1) else {
                 break;
             };
             self.consume();
-            self.add_parse_child(context, ParseTree::Error(ErrorNode::new(token)));
+            self.add_parse_child(context, self.error_tree(token));
         }
         self.record_syntax_errors(1);
     }
@@ -4285,7 +4311,7 @@ where
         self.generated_parser_diagnostics.push(diagnostic);
     }
 
-    fn generated_rule_error_diagnostic(&mut self, error: AntlrError) -> ParserDiagnostic {
+    fn generated_rule_error_diagnostic(&self, error: AntlrError) -> ParserDiagnostic {
         match error {
             AntlrError::ParserError {
                 line,
@@ -4324,8 +4350,8 @@ where
         consumed_eof: bool,
     ) -> ParseTree {
         let stop_index = self.rule_stop_token_index(self.input.index(), consumed_eof);
-        if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
-            context.set_stop_ref(token);
+        if let Some(token) = stop_index.and_then(|index| self.token_id_at(index)) {
+            self.set_context_stop(&mut context, token);
         }
         self.unroll_recursion_context();
         self.rule_node(context)
@@ -4363,15 +4389,16 @@ where
         self.set_state(state);
         if let Some(stop) = self
             .rule_stop_token_index(self.input.index(), false)
-            .and_then(|index| self.token_ref_at(index))
+            .and_then(|index| self.token_id_at(index))
         {
-            current.set_stop_ref(stop);
+            self.set_context_stop(current, stop);
         }
         let invoking_state = current.invoking_state();
-        let start = current.start_ref();
+        let start = current.start_id();
         let mut replacement = ParserRuleContext::new(rule_index, invoking_state);
-        if let Some(start) = start {
-            replacement.set_start_ref(start);
+        if start.is_some() {
+            replacement.set_store_from_context(current);
+            replacement.set_start_from_context(current);
         }
         let previous = std::mem::replace(current, replacement);
         if self.build_parse_trees {
@@ -4589,22 +4616,19 @@ where
 
     /// Matches any non-EOF token.
     pub fn match_wildcard(&mut self) -> Result<ParseTree, AntlrError> {
-        let current = self
-            .input
-            .lt_ref(1)
-            .ok_or_else(|| AntlrError::ParserError {
-                line: 0,
-                column: 0,
-                message: "missing current token".to_owned(),
-            })?;
-        if current.token_type() == TOKEN_EOF {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        if self.token_type_for_id(current) == TOKEN_EOF {
             return Err(AntlrError::MismatchedInput {
                 expected: "wildcard".to_owned(),
                 found: self.vocabulary().display_name(TOKEN_EOF),
             });
         }
         self.consume();
-        Ok(ParseTree::Terminal(TerminalNode::from_ref(current)))
+        Ok(self.terminal_tree(current))
     }
 
     /// Generated parser synchronization hook. The current interpreter owns
@@ -4725,7 +4749,7 @@ where
                     expected.contains(next_symbol)
                 };
                 if next_is_expected_stop {
-                    let current_token = self.input.lt(1).cloned();
+                    let current_token = self.input.lt(1);
                     let expected_symbols = expected.to_btree_set();
                     let message = format!(
                         "extraneous input {} expecting {}",
@@ -4735,15 +4759,15 @@ where
                         self.expected_symbols_display(&expected_symbols)
                     );
                     self.push_generated_parser_diagnostic(diagnostic_for_token(
-                        current_token.as_ref(),
+                        current_token,
                         message,
                     ));
                     self.record_syntax_errors(1);
                     let mut children = Vec::with_capacity(skipped.len());
                     for index in skipped {
-                        if let Some(token) = self.token_at(index) {
+                        if let Some(token) = self.token_id_at(index) {
                             self.consume();
-                            children.push(ParseTree::Error(ErrorNode::new(token)));
+                            children.push(self.error_tree(token));
                         }
                     }
                     return Ok(children);
@@ -4761,7 +4785,7 @@ where
             self.generated_sync_expected = Some(expected);
             return Ok(Vec::new());
         }
-        let current = self.input.lt(1).cloned();
+        let current = self.input.lt(1);
         let expected_symbols = expected.to_btree_set();
         Err(AntlrError::ParserError {
             line: current.as_ref().map(Token::line).unwrap_or_default(),
@@ -4910,7 +4934,7 @@ where
     }
 
     /// Builds a generated no-viable-alternative parser error.
-    pub fn no_viable_alternative_error(&mut self, start_index: usize) -> AntlrError {
+    pub fn no_viable_alternative_error(&self, start_index: usize) -> AntlrError {
         let error_index = self.input.index();
         self.no_viable_alternative_error_at(start_index, error_index)
     }
@@ -4920,7 +4944,7 @@ where
     /// before returning, so generated parsers have to pass the recorded index
     /// explicitly to preserve ANTLR's LL(k) diagnostic span.
     pub fn no_viable_alternative_error_at(
-        &mut self,
+        &self,
         start_index: usize,
         error_index: usize,
     ) -> AntlrError {
@@ -4933,8 +4957,8 @@ where
     }
 
     /// Builds a generated failed-predicate parser error.
-    pub fn failed_predicate_error(&mut self, message: impl Into<String>) -> AntlrError {
-        let current = self.input.lt(1).cloned();
+    pub fn failed_predicate_error(&self, message: impl Into<String>) -> AntlrError {
+        let current = self.input.lt(1);
         AntlrError::ParserError {
             line: current.as_ref().map(Token::line).unwrap_or_default(),
             column: current.as_ref().map(Token::column).unwrap_or_default(),
@@ -4945,11 +4969,11 @@ where
     /// Builds a generated parser error for a semantic predicate with ANTLR's
     /// `<fail='...'>` option.
     pub fn failed_predicate_option_error(
-        &mut self,
+        &self,
         rule_index: usize,
         message: impl Into<String>,
     ) -> AntlrError {
-        let current = self.input.lt(1).cloned();
+        let current = self.input.lt(1);
         let rule_name = self
             .rule_names()
             .get(rule_index)
@@ -5178,12 +5202,12 @@ where
                 0
             },
         );
-        if let Some(token) = self.token_ref_at(start_index) {
-            context.set_start_ref(token);
+        if let Some(token) = self.token_id_at(start_index) {
+            self.set_context_start(&mut context, token);
         }
         let stop_index = self.rule_stop_token_index(outcome.index, outcome.consumed_eof);
-        if let Some(token) = stop_index.and_then(|token_index| self.token_ref_at(token_index)) {
-            context.set_stop_ref(token);
+        if let Some(token) = stop_index.and_then(|token_index| self.token_id_at(token_index)) {
+            self.set_context_stop(&mut context, token);
         }
         if self.build_parse_trees {
             if outcome.nodes.has_left_recursive_boundary() {
@@ -5324,39 +5348,35 @@ where
             FastRecognizedNode::Token { index } => {
                 let token = self
                     .input
-                    .get_ref(*index)
+                    .get_id(*index)
                     .ok_or_else(|| AntlrError::ParserError {
                         line: 0,
                         column: 0,
                         message: format!("missing token at index {index}"),
                     })?;
-                Ok(ParseTree::Terminal(TerminalNode::from_ref(token)))
+                Ok(self.terminal_tree(token))
             }
             FastRecognizedNode::ErrorToken { index } => {
                 let token = self
                     .input
-                    .get_ref(*index)
+                    .get_id(*index)
                     .ok_or_else(|| AntlrError::ParserError {
                         line: 0,
                         column: 0,
                         message: format!("missing error token at index {index}"),
                     })?;
-                Ok(ParseTree::Error(ErrorNode::from_ref(token)))
+                Ok(self.error_tree(token))
             }
             FastRecognizedNode::MissingToken {
                 token_type,
                 at_index,
                 text,
             } => {
-                let current = self.token_at(*at_index);
-                let token = CommonToken::new(*token_type)
-                    .with_text(text.as_str())
-                    .with_span(usize::MAX, usize::MAX)
-                    .with_position(
-                        current.as_ref().map(Token::line).unwrap_or_default(),
-                        current.as_ref().map(Token::column).unwrap_or_default(),
-                    );
-                Ok(ParseTree::Error(ErrorNode::new(token)))
+                let (line, column) = self
+                    .token_at(*at_index)
+                    .map_or((0, 0), |token| (token.line(), token.column()));
+                let token = self.insert_synthetic_token(*token_type, text.clone(), line, column)?;
+                Ok(self.error_tree(token))
             }
             FastRecognizedNode::Rule {
                 rule_index,
@@ -5370,11 +5390,11 @@ where
                     *invoking_state,
                     children.len(),
                 );
-                if let Some(token) = self.token_ref_at(*start_index) {
-                    context.set_start_ref(token);
+                if let Some(token) = self.token_id_at(*start_index) {
+                    self.set_context_start(&mut context, token);
                 }
-                if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
-                    context.set_stop_ref(token);
+                if let Some(token) = stop_index.and_then(|index| self.token_id_at(index)) {
+                    self.set_context_stop(&mut context, token);
                 }
                 if children.has_left_recursive_boundary() {
                     let folded = fold_fast_left_recursive_boundaries(children.to_vec());
@@ -5413,11 +5433,11 @@ where
                     *invoking_state,
                     children.len(),
                 );
-                if let Some(token) = self.token_ref_at(*start_index) {
-                    context.set_start_ref(token);
+                if let Some(token) = self.token_id_at(*start_index) {
+                    self.set_context_start(&mut context, token);
                 }
-                if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
-                    context.set_stop_ref(token);
+                if let Some(token) = stop_index.and_then(|index| self.token_id_at(index)) {
+                    self.set_context_stop(&mut context, token);
                 }
                 if children.has_left_recursive_boundary() {
                     let folded = fold_fast_left_recursive_boundaries(children.to_vec());
@@ -5511,14 +5531,14 @@ where
             }
             let token = self
                 .input
-                .get_ref(index)
+                .get_id(index)
                 .ok_or_else(|| AntlrError::ParserError {
                     line: 0,
                     column: 0,
                     message: format!("missing token at index {index}"),
                 })?;
-            let is_eof = token.token_type() == TOKEN_EOF;
-            context.add_child(ParseTree::Terminal(TerminalNode::from_ref(token)));
+            let is_eof = self.token_type_for_id(token) == TOKEN_EOF;
+            context.add_child(self.terminal_tree(token));
             if is_eof {
                 return Ok(None);
             }
@@ -5740,11 +5760,11 @@ where
         for (name, value) in outcome.return_values {
             context.set_int_return(name, value);
         }
-        if let Some(token) = self.token_ref_at(start_index) {
-            context.set_start_ref(token);
+        if let Some(token) = self.token_id_at(start_index) {
+            self.set_context_start(&mut context, token);
         }
-        if let Some(token) = self.rule_stop_token_ref(outcome.index, outcome.consumed_eof) {
-            context.set_stop_ref(token);
+        if let Some(token) = self.rule_stop_token_id(outcome.index, outcome.consumed_eof) {
+            self.set_context_stop(&mut context, token);
         }
         if self.build_parse_trees {
             let nodes = fold_left_recursive_boundaries(outcome.nodes);
@@ -5788,7 +5808,7 @@ where
     ) -> AntlrError {
         let (index, message) = self.expected_error_message(rule_index, start_index, expected);
         self.input.seek(index);
-        let current = self.input.lt(1).cloned();
+        let current = self.input.lt(1);
         let line = current.as_ref().map(Token::line).unwrap_or_default();
         let column = current.as_ref().map(Token::column).unwrap_or_default();
         AntlrError::ParserError {
@@ -5810,7 +5830,7 @@ where
             .or_else(|| expected.no_viable.map(|no_viable| no_viable.error_index))
             .unwrap_or_else(|| self.input.index());
         self.input.seek(index);
-        let current = self.input.lt(1).cloned();
+        let current = self.input.lt(1);
         let message = if expected
             .no_viable
             .as_ref()
@@ -5864,7 +5884,7 @@ where
         expected: &ExpectedTokens,
     ) -> Option<RecognizeOutcome> {
         let (error_index, message) = self.expected_error_message(rule_index, start_index, expected);
-        let token = self.token_at(error_index);
+        let diagnostic = diagnostic_for_token(self.token_at(error_index), message);
         let mut next_index = error_index;
         loop {
             let symbol = self.token_type_at(next_index);
@@ -5889,7 +5909,7 @@ where
             alt_number: 0,
             member_values,
             return_values: BTreeMap::new(),
-            diagnostics: vec![diagnostic_for_token(token.as_ref(), message)],
+            diagnostics: vec![diagnostic],
             decisions: Vec::new(),
             actions: Vec::new(),
             nodes: vec![RecognizedNode::ErrorToken { index: error_index }],
@@ -5955,7 +5975,7 @@ where
                 .map_or_else(|| "'<EOF>'".to_owned(), token_input_display)
         );
         Some((
-            diagnostic_for_token(current.as_ref(), message),
+            diagnostic_for_token(current, message),
             next_index,
             next_symbol,
         ))
@@ -5983,7 +6003,7 @@ where
                 .map_or_else(|| "'<EOF>'".to_owned(), token_input_display),
             self.expected_symbols_display(expected_symbols)
         );
-        let diagnostic = diagnostic_for_token(current.as_ref(), message);
+        let diagnostic = diagnostic_for_token(current, message);
         let mut skipped = Vec::new();
         let mut cursor = index;
         loop {
@@ -6230,7 +6250,7 @@ where
         expected: &ExpectedTokens,
     ) -> Option<FastRecognizeOutcome> {
         let (error_index, message) = self.expected_error_message(rule_index, start_index, expected);
-        let token = self.token_at(error_index);
+        let diagnostic = diagnostic_for_token(self.token_at(error_index), message);
         let mut next_index = error_index;
         loop {
             let symbol = self.token_type_at(next_index);
@@ -6250,7 +6270,7 @@ where
             next_index = after;
         }
         let mut diagnostics = FastDiagnostics::new();
-        diagnostics.insert(0, diagnostic_for_token(token.as_ref(), message));
+        diagnostics.insert(0, diagnostic);
         let mut nodes = NodeList::new();
         if self.fast_token_nodes_enabled {
             nodes.prepend(Rc::new(FastRecognizedNode::ErrorToken {
@@ -7267,7 +7287,7 @@ where
     /// Stops the current rule at EOF after a nested failure, matching ANTLR's
     /// behavior of unwinding instead of inserting caller tokens at EOF.
     fn eof_consuming_failure_fallback(
-        &mut self,
+        &self,
         fallback: ConsumingFailureFallback<'_>,
         expected: &ExpectedTokens,
     ) -> Vec<RecognizeOutcome> {
@@ -8271,14 +8291,14 @@ where
         }
     }
 
-    /// Clones the visible token at an absolute token-stream index.
-    fn token_at(&mut self, index: usize) -> Option<CommonToken> {
-        self.input.get(index).cloned()
+    /// Borrows the visible token at an absolute token-stream index.
+    fn token_at(&self, index: usize) -> Option<TokenView<'_>> {
+        self.input.get(index)
     }
 
-    /// Clones the shared token handle at an absolute token-stream index.
-    fn token_ref_at(&mut self, index: usize) -> Option<TokenRef> {
-        self.input.get_ref(index)
+    /// Returns the compact token ID at an absolute token-stream index.
+    fn token_id_at(&self, index: usize) -> Option<TokenId> {
+        self.input.get_id(index)
     }
 
     /// Normalizes the current token-stream cursor to the next parser-visible
@@ -8311,7 +8331,7 @@ where
     /// from a visible-token index can point at whitespace. Parser intervals use
     /// this helper to stop at the previous visible token while preserving hidden
     /// text inside the rendered interval.
-    fn previous_token_index(&mut self, index: usize) -> Option<usize> {
+    fn previous_token_index(&self, index: usize) -> Option<usize> {
         self.input.previous_visible_token_index(index)
     }
 
@@ -8365,10 +8385,7 @@ where
     ) -> Option<usize> {
         if let ParseTree::Rule(rule) = tree {
             if let Some(stop) = rule.context().stop() {
-                let token_index = stop.token_index();
-                if token_index >= 0 {
-                    return Some(token_index.unsigned_abs());
-                }
+                return Some(stop.token_id().index());
             }
         }
         self.after_action_stop_index(current_index)
@@ -8391,10 +8408,7 @@ where
     ) -> usize {
         if let ParseTree::Rule(rule) = tree {
             if let Some(start) = rule.context().start() {
-                let token_index = start.token_index();
-                if token_index >= 0 {
-                    return token_index.unsigned_abs();
-                }
+                return start.token_id().index();
             }
         }
         fallback_index
@@ -8404,9 +8418,9 @@ where
     ///
     /// EOF transitions do not advance the token-stream cursor, so an EOF match
     /// must use the current token rather than the previous visible token.
-    fn rule_stop_token_ref(&mut self, index: usize, consumed_eof: bool) -> Option<TokenRef> {
+    fn rule_stop_token_id(&mut self, index: usize, consumed_eof: bool) -> Option<TokenId> {
         self.rule_stop_token_index(index, consumed_eof)
-            .and_then(|token_index| self.token_ref_at(token_index))
+            .and_then(|token_index| self.token_id_at(token_index))
     }
 
     /// Recovers from a semantic predicate with an ANTLR `<fail='...'>` option.
@@ -8669,17 +8683,18 @@ where
                 }
                 *value
             }
-            ParserPredicate::LookaheadTextEquals { offset, text } => {
-                self.input.lt(*offset).and_then(Token::text) == Some(*text)
-            }
+            ParserPredicate::LookaheadTextEquals { offset, text } => self
+                .input
+                .lt(*offset)
+                .is_some_and(|token| Token::text(&token) == Some(*text)),
             ParserPredicate::LookaheadNotEquals { offset, token_type } => {
                 self.la(*offset) != *token_type
             }
             ParserPredicate::TokenPairAdjacent => {
-                let Some(first) = self.input.lt(-2).map(Token::token_index) else {
+                let Some(first) = self.input.lt_id(-2).map(TokenId::index) else {
                     return false;
                 };
-                let Some(second) = self.input.lt(-1).map(Token::token_index) else {
+                let Some(second) = self.input.lt_id(-1).map(TokenId::index) else {
                     return false;
                 };
                 first + 1 == second
@@ -8776,11 +8791,7 @@ where
 
     /// Builds ANTLR's no-viable-alternative diagnostic for an ambiguous
     /// decision that failed after consuming a shared prefix.
-    fn no_viable_alternative(
-        &mut self,
-        start_index: usize,
-        error_index: usize,
-    ) -> ParserDiagnostic {
+    fn no_viable_alternative(&self, start_index: usize, error_index: usize) -> ParserDiagnostic {
         let text = display_input_text(&self.input.text(start_index, error_index));
         diagnostic_for_token(
             self.token_at(error_index).as_ref(),
@@ -8791,7 +8802,7 @@ where
     /// Selects the diagnostic for a failed consuming transition after all
     /// recovery repairs have been ruled out.
     fn recovery_failure_diagnostic(
-        &mut self,
+        &self,
         index: usize,
         decision_start_index: Option<usize>,
         expected_symbols: &BTreeSet<i32>,
@@ -8816,7 +8827,7 @@ where
     /// Builds the EOF diagnostic used when ANTLR unwinds a failed nested rule
     /// instead of inserting missing tokens in the caller.
     fn eof_rule_recovery_diagnostic(
-        &mut self,
+        &self,
         index: usize,
         expected_symbols: &BTreeSet<i32>,
         expected: &ExpectedTokens,
@@ -8843,7 +8854,7 @@ where
     ///
     /// ANTLR treats EOF as a range boundary rather than printable input text,
     /// even when an action interval explicitly stops at the EOF token.
-    pub fn text_interval(&mut self, start: usize, stop: Option<usize>) -> String {
+    pub fn text_interval(&self, start: usize, stop: Option<usize>) -> String {
         let Some(stop) = stop else {
             return String::new();
         };
@@ -8961,18 +8972,18 @@ where
         if !self.reported_prediction_diagnostics.insert(key) {
             return;
         }
-        let start_token = self.token_at(start_index);
-        let stop_token = self.token_at(stop_index);
-        self.prediction_diagnostics.push(diagnostic_for_token(
-            start_token.as_ref(),
+        let start_diagnostic = diagnostic_for_token(
+            self.token_at(start_index),
             format!("reportAttemptingFullContext d={decision} ({rule_name}), input='{input}'"),
-        ));
-        self.prediction_diagnostics.push(diagnostic_for_token(
-            stop_token.as_ref(),
+        );
+        let stop_diagnostic = diagnostic_for_token(
+            self.token_at(stop_index),
             format!(
                 "reportAmbiguity d={decision} ({rule_name}): ambigAlts={{{alts}}}, input='{input}'"
             ),
-        ));
+        );
+        self.prediction_diagnostics.push(start_diagnostic);
+        self.prediction_diagnostics.push(stop_diagnostic);
     }
 
     /// Formats the tokens expected from an ATN state using ANTLR display names.
@@ -9023,7 +9034,7 @@ where
     }
 
     /// Formats a buffered token in ANTLR's diagnostic token display form.
-    pub fn token_display_at(&mut self, index: usize) -> Option<String> {
+    pub fn token_display_at(&self, index: usize) -> Option<String> {
         self.token_at(index).map(|token| format!("{token}"))
     }
 
@@ -9037,39 +9048,35 @@ where
             RecognizedNode::Token { index } => {
                 let token = self
                     .input
-                    .get_ref(*index)
+                    .get_id(*index)
                     .ok_or_else(|| AntlrError::ParserError {
                         line: 0,
                         column: 0,
                         message: format!("missing token at index {index}"),
                     })?;
-                Ok(ParseTree::Terminal(TerminalNode::from_ref(token)))
+                Ok(self.terminal_tree(token))
             }
             RecognizedNode::ErrorToken { index } => {
                 let token = self
                     .input
-                    .get_ref(*index)
+                    .get_id(*index)
                     .ok_or_else(|| AntlrError::ParserError {
                         line: 0,
                         column: 0,
                         message: format!("missing error token at index {index}"),
                     })?;
-                Ok(ParseTree::Error(ErrorNode::from_ref(token)))
+                Ok(self.error_tree(token))
             }
             RecognizedNode::MissingToken {
                 token_type,
                 at_index,
                 text,
             } => {
-                let current = self.token_at(*at_index);
-                let token = CommonToken::new(*token_type)
-                    .with_text(text.as_str())
-                    .with_span(usize::MAX, usize::MAX)
-                    .with_position(
-                        current.as_ref().map(Token::line).unwrap_or_default(),
-                        current.as_ref().map(Token::column).unwrap_or_default(),
-                    );
-                Ok(ParseTree::Error(ErrorNode::new(token)))
+                let (line, column) = self
+                    .token_at(*at_index)
+                    .map_or((0, 0), |token| (token.line(), token.column()));
+                let token = self.insert_synthetic_token(*token_type, text.clone(), line, column)?;
+                Ok(self.error_tree(token))
             }
             RecognizedNode::Rule {
                 rule_index,
@@ -9087,11 +9094,11 @@ where
                 for (name, value) in return_values {
                     context.set_int_return(name.clone(), *value);
                 }
-                if let Some(token) = self.token_ref_at(*start_index) {
-                    context.set_start_ref(token);
+                if let Some(token) = self.token_id_at(*start_index) {
+                    self.set_context_start(&mut context, token);
                 }
-                if let Some(token) = stop_index.and_then(|index| self.token_ref_at(index)) {
-                    context.set_stop_ref(token);
+                if let Some(token) = stop_index.and_then(|index| self.token_id_at(index)) {
+                    self.set_context_stop(&mut context, token);
                 }
                 for child in children {
                     context.add_child(self.recognized_node_tree(child, track_alt_numbers)?);
@@ -9204,14 +9211,14 @@ where
                 0
             },
         );
-        if let Some(token) = self.parser.token_ref_at(start_index) {
-            context.set_start_ref(token);
+        if let Some(token) = self.parser.token_id_at(start_index) {
+            self.parser.set_context_start(&mut context, token);
         }
         let stop_index = self
             .parser
             .rule_stop_token_index(self.parser.input.index(), consumed_eof);
-        if let Some(token) = stop_index.and_then(|index| self.parser.token_ref_at(index)) {
-            context.set_stop_ref(token);
+        if let Some(token) = stop_index.and_then(|index| self.parser.token_id_at(index)) {
+            self.parser.set_context_stop(&mut context, token);
         }
         if self.parser.build_parse_trees {
             for child in children {
@@ -9349,7 +9356,7 @@ where
         let token = self
             .parser
             .input
-            .lt_ref(1)
+            .lt_id(1)
             .ok_or(DirectAdaptiveParseControl::Fallback(
                 DirectAdaptiveFallback::TokenMismatch,
             ))?;
@@ -9360,7 +9367,7 @@ where
         let child = self
             .parser
             .build_parse_trees
-            .then(|| ParseTree::Terminal(TerminalNode::from_ref(token)));
+            .then(|| self.parser.terminal_tree(token));
         Ok((matched_eof, child))
     }
 }
@@ -9588,10 +9595,11 @@ fn display_input_text(text: &str) -> String {
     out
 }
 
-fn diagnostic_for_token(token: Option<&impl Token>, message: String) -> ParserDiagnostic {
+fn diagnostic_for_token<T: Token>(token: Option<T>, message: String) -> ParserDiagnostic {
+    let (line, column) = token.map_or((0, 0), |token| (token.line(), token.column()));
     ParserDiagnostic {
-        line: token.map(Token::line).unwrap_or_default(),
-        column: token.map(Token::column).unwrap_or_default(),
+        line,
+        column,
         message,
     }
 }
@@ -10202,7 +10210,10 @@ mod tests {
         ParserAtnPredictionDiagnostic, ParserAtnPredictionDiagnosticKind, ParserAtnSimulator,
     };
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
-    use crate::token::{CommonToken, HIDDEN_CHANNEL, Token};
+    use crate::token::{
+        HIDDEN_CHANNEL, Token, TokenId, TokenSink, TokenSpec, TokenStore, TokenStoreError,
+        TokenStoreHandle,
+    };
     use crate::token_stream::CommonTokenStream;
     use crate::vocabulary::Vocabulary;
 
@@ -10222,21 +10233,129 @@ mod tests {
         assert_eq!(typed.finish(), bytewise.finish());
     }
 
+    #[derive(Clone, Debug)]
+    struct TestToken {
+        spec: TokenSpec,
+        id: TokenId,
+        source_name: String,
+    }
+
+    impl TestToken {
+        fn new(token_type: i32) -> Self {
+            Self {
+                spec: TokenSpec::explicit(token_type, ""),
+                id: TokenId::try_from(0).expect("zero token ID"),
+                source_name: String::new(),
+            }
+        }
+
+        fn eof(source_name: &str, index: usize, line: usize, column: usize) -> Self {
+            Self {
+                spec: TokenSpec::eof(index, index, line, column),
+                id: TokenId::try_from(0).expect("zero token ID"),
+                source_name: source_name.to_owned(),
+            }
+        }
+
+        fn with_text(mut self, text: impl Into<String>) -> Self {
+            self.spec.text = Some(text.into());
+            self
+        }
+
+        const fn with_channel(mut self, channel: i32) -> Self {
+            self.spec.channel = channel;
+            self
+        }
+
+        const fn with_span(mut self, start: usize, stop: usize) -> Self {
+            self.spec.start = start;
+            self.spec.stop = stop;
+            self.spec.start_byte = start;
+            self.spec.stop_byte = match stop.checked_add(1) {
+                Some(end) if end >= start => end,
+                Some(_) | None => start,
+            };
+            self
+        }
+
+        const fn with_position(mut self, line: usize, column: usize) -> Self {
+            self.spec.line = line;
+            self.spec.column = column;
+            self
+        }
+
+        fn set_token_index(&mut self, index: isize) {
+            self.id = TokenId::try_from(index.max(0).cast_unsigned()).expect("test token index");
+        }
+    }
+
+    impl Token for TestToken {
+        fn token_id(&self) -> TokenId {
+            self.id
+        }
+
+        fn token_type(&self) -> i32 {
+            self.spec.token_type
+        }
+
+        fn channel(&self) -> i32 {
+            self.spec.channel
+        }
+
+        fn start(&self) -> usize {
+            self.spec.start
+        }
+
+        fn stop(&self) -> usize {
+            self.spec.stop
+        }
+
+        fn line(&self) -> usize {
+            self.spec.line
+        }
+
+        fn column(&self) -> usize {
+            self.spec.column
+        }
+
+        fn text(&self) -> Option<&str> {
+            self.spec.text.as_deref()
+        }
+
+        fn source_name(&self) -> &str {
+            &self.source_name
+        }
+
+        fn start_byte(&self) -> usize {
+            self.spec.start_byte
+        }
+
+        fn stop_byte(&self) -> usize {
+            self.spec.stop_byte
+        }
+    }
+
+    fn test_terminal(token: TestToken) -> TerminalNode {
+        let store = TokenStoreHandle::new(TokenStore::new(None, token.source_name.as_str()));
+        let id = store.push(token.spec).expect("test token should fit");
+        TerminalNode::from_id(id, store)
+    }
+
     #[derive(Debug)]
     struct Source {
-        tokens: Vec<CommonToken>,
+        tokens: Vec<TestToken>,
         index: usize,
     }
 
     impl TokenSource for Source {
-        fn next_token(&mut self) -> CommonToken {
+        fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {
             let token = self
                 .tokens
                 .get(self.index)
                 .cloned()
-                .unwrap_or_else(|| CommonToken::eof("parser-test", self.index, 1, self.index));
+                .unwrap_or_else(|| TestToken::eof("parser-test", self.index, 1, self.index));
             self.index += 1;
-            token
+            sink.push(token.spec)
         }
 
         fn line(&self) -> usize {
@@ -10260,12 +10379,12 @@ mod tests {
         .with_rule_names(["s"])
     }
 
-    fn mini_parser(tokens: Vec<CommonToken>) -> BaseParser<Source> {
+    fn mini_parser(tokens: Vec<TestToken>) -> BaseParser<Source> {
         let data = mini_parser_data();
         BaseParser::new(CommonTokenStream::new(Source { tokens, index: 0 }), data)
     }
 
-    fn mini_parser_with_hooks<H>(tokens: Vec<CommonToken>, hooks: H) -> BaseParser<Source, H>
+    fn mini_parser_with_hooks<H>(tokens: Vec<TestToken>, hooks: H) -> BaseParser<Source, H>
     where
         H: SemanticHooks,
     {
@@ -10334,8 +10453,8 @@ mod tests {
 
     fn parser_inside_left_recursive_callee(symbol: i32) -> BaseParser<Source> {
         let mut parser = mini_parser(vec![
-            CommonToken::new(symbol).with_text("lookahead"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(symbol).with_text("lookahead"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         parser.rule_context_stack = vec![
             RuleContextFrame {
@@ -10742,8 +10861,8 @@ mod tests {
     fn left_recursive_loop_enters_after_nullable_operator_prefix() {
         let atn = left_recursive_loop_with_nullable_operator_prefix_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("operator"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("operator"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         parser.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
@@ -10771,8 +10890,8 @@ mod tests {
         let atn = left_recursive_loop_with_predicate_guarded_operator_atn();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("operator"),
-                CommonToken::eof("parser-test", 1, 1, 1),
+                TestToken::new(1).with_text("operator"),
+                TestToken::eof("parser-test", 1, 1, 1),
             ],
             RejectingPredicateHooks::default(),
         );
@@ -10813,8 +10932,8 @@ mod tests {
     fn left_recursive_loop_defers_through_nullable_parent_return() {
         let atn = left_recursive_loop_with_nullable_parent_return_atn(1);
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("lookahead"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("lookahead"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         parser.rule_context_stack = vec![
             RuleContextFrame {
@@ -10847,8 +10966,8 @@ mod tests {
     fn left_recursive_loop_defers_after_recursive_operand_returns_to_loop() {
         let atn = left_recursive_loop_with_recursive_operand_return_atn(1);
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("lookahead"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("lookahead"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         parser.rule_context_stack = vec![
             RuleContextFrame {
@@ -11037,9 +11156,9 @@ mod tests {
         let atn = optional_then_b_eof_atn();
 
         let mut single = mini_parser(vec![
-            CommonToken::new(3).with_text("c"),
-            CommonToken::new(2).with_text("b"),
-            CommonToken::eof("parser-test", 1, 2, 2),
+            TestToken::new(3).with_text("c"),
+            TestToken::new(2).with_text("b"),
+            TestToken::eof("parser-test", 1, 2, 2),
         ]);
         single.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
@@ -11055,10 +11174,10 @@ mod tests {
         assert_eq!(single.la(1), 2);
 
         let mut double = mini_parser(vec![
-            CommonToken::new(3).with_text("c"),
-            CommonToken::new(3).with_text("c"),
-            CommonToken::new(2).with_text("b"),
-            CommonToken::eof("parser-test", 1, 3, 3),
+            TestToken::new(3).with_text("c"),
+            TestToken::new(3).with_text("c"),
+            TestToken::new(2).with_text("b"),
+            TestToken::eof("parser-test", 1, 3, 3),
         ]);
         double.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
@@ -11160,7 +11279,7 @@ mod tests {
     #[test]
     fn runtime_options_default_exits_recovering_empty_plus_iteration() {
         let atn = plus_loop_with_recovering_body_atn();
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
 
         let error = parser
             .parse_atn_rule_with_runtime_options(&atn, 0, ParserRuntimeOptions::default())
@@ -11183,8 +11302,8 @@ mod tests {
         // EOF must be a valid scan-stop for this to fire.
         let atn = star_loop_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(2).with_text("c"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(2).with_text("c"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         parser.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
@@ -11211,9 +11330,9 @@ mod tests {
         // with no EOF). The scan must NOT multi-token-consume both `c`s here.
         let atn = star_loop_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(2).with_text("c"),
-            CommonToken::new(2).with_text("c"),
-            CommonToken::eof("parser-test", 1, 2, 2),
+            TestToken::new(2).with_text("c"),
+            TestToken::new(2).with_text("c"),
+            TestToken::eof("parser-test", 1, 2, 2),
         ]);
         parser.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
@@ -11244,9 +11363,9 @@ mod tests {
         // post-`a` state directly: `c c <EOF>` with loop_back = true.
         let atn = star_loop_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(2).with_text("c"),
-            CommonToken::new(2).with_text("c"),
-            CommonToken::eof("parser-test", 1, 2, 2),
+            TestToken::new(2).with_text("c"),
+            TestToken::new(2).with_text("c"),
+            TestToken::eof("parser-test", 1, 2, 2),
         ]);
         parser.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
@@ -11413,8 +11532,8 @@ mod tests {
     fn parser_matches_token_and_reports_mismatch() {
         let source = Source {
             tokens: vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::eof("parser-test", 1, 1, 1),
+                TestToken::new(1).with_text("x"),
+                TestToken::eof("parser-test", 1, 1, 1),
             ],
             index: 0,
         };
@@ -11433,8 +11552,8 @@ mod tests {
     #[test]
     fn parser_matches_token_sets() {
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         assert_eq!(
@@ -11449,7 +11568,7 @@ mod tests {
 
     #[test]
     fn generated_rule_api_tracks_state_and_precedence() {
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
 
         let context = parser.enter_rule(7, 2);
         assert_eq!(context.rule_index(), 2);
@@ -11487,9 +11606,9 @@ mod tests {
     #[test]
     fn parser_predicates_support_token_adjacency() {
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("=").with_span(0, 0),
-            CommonToken::new(1).with_text(">").with_span(1, 1),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("=").with_span(0, 0),
+            TestToken::new(1).with_text(">").with_span(1, 1),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
         parser.consume();
         parser.consume();
@@ -11499,13 +11618,13 @@ mod tests {
         assert!(parser.parser_semantic_predicate_matches(&predicates, 0, 0));
 
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("=").with_span(0, 0),
-            CommonToken::new(1)
+            TestToken::new(1).with_text("=").with_span(0, 0),
+            TestToken::new(1)
                 .with_text(" ")
                 .with_channel(HIDDEN_CHANNEL)
                 .with_span(1, 1),
-            CommonToken::new(1).with_text(">").with_span(2, 2),
-            CommonToken::eof("parser-test", 3, 1, 3),
+            TestToken::new(1).with_text(">").with_span(2, 2),
+            TestToken::eof("parser-test", 3, 1, 3),
         ]);
         parser.consume();
         parser.consume();
@@ -11515,11 +11634,11 @@ mod tests {
 
     #[test]
     fn parser_predicates_support_context_child_text_checks() {
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         let mut context = ParserRuleContext::new(1, 0);
         let mut child_context = ParserRuleContext::new(2, 0);
-        child_context.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(1).with_text("var"),
+        child_context.add_child(ParseTree::Terminal(test_terminal(
+            TestToken::new(1).with_text("var"),
         )));
         context.add_child(ParseTree::Rule(RuleNode::new(child_context)));
         let predicates = [(
@@ -11545,7 +11664,7 @@ mod tests {
     #[test]
     fn context_expected_symbols_walks_nullable_parent_contexts() {
         let atn = nested_nullable_context_atn();
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         parser.rule_context_stack = vec![
             RuleContextFrame {
                 rule_index: 0,
@@ -11570,7 +11689,7 @@ mod tests {
     #[test]
     fn prediction_context_reuses_cached_stack_until_rule_stack_changes() {
         let atn = nested_nullable_context_atn();
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         parser.rule_context_stack = vec![
             RuleContextFrame {
                 rule_index: 0,
@@ -11608,7 +11727,7 @@ mod tests {
         );
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
-                tokens: vec![CommonToken::eof("parser-test", 3, 1, 3)],
+                tokens: vec![TestToken::eof("parser-test", 3, 1, 3)],
                 index: 0,
             }),
             data,
@@ -11667,9 +11786,9 @@ mod tests {
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
                 tokens: vec![
-                    CommonToken::new(3).with_text("z"),
-                    CommonToken::new(2).with_text("y"),
-                    CommonToken::eof("parser-test", 3, 1, 3),
+                    TestToken::new(3).with_text("z"),
+                    TestToken::new(2).with_text("y"),
+                    TestToken::eof("parser-test", 3, 1, 3),
                 ],
                 index: 0,
             }),
@@ -11707,8 +11826,8 @@ mod tests {
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
                 tokens: vec![
-                    CommonToken::new(2).with_text("y"),
-                    CommonToken::eof("parser-test", 1, 1, 1),
+                    TestToken::new(2).with_text("y"),
+                    TestToken::eof("parser-test", 1, 1, 1),
                 ],
                 index: 0,
             }),
@@ -11741,7 +11860,7 @@ mod tests {
         );
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
-                tokens: vec![CommonToken::eof("parser-test", 3, 1, 3)],
+                tokens: vec![TestToken::eof("parser-test", 3, 1, 3)],
                 index: 0,
             }),
             data,
@@ -11784,15 +11903,15 @@ mod tests {
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
                 tokens: vec![
-                    CommonToken::new(1)
+                    TestToken::new(1)
                         .with_text("x")
                         .with_position(1, 0)
                         .with_span(0, 0),
-                    CommonToken::new(2)
+                    TestToken::new(2)
                         .with_text("y")
                         .with_position(1, 2)
                         .with_span(1, 1),
-                    CommonToken::eof("parser-test", 2, 1, 3),
+                    TestToken::eof("parser-test", 2, 1, 3),
                 ],
                 index: 0,
             }),
@@ -11864,7 +11983,7 @@ mod tests {
     #[test]
     fn generated_match_not_set_recovers_empty_complement_at_eof() {
         let atn = complement_set_atn();
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         parser.rule_context_stack = vec![RuleContextFrame {
             rule_index: 0,
             invoking_state: 0,
@@ -11903,7 +12022,7 @@ mod tests {
         );
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
-                tokens: vec![CommonToken::eof("parser-test", 1, 1, 1)],
+                tokens: vec![TestToken::eof("parser-test", 1, 1, 1)],
                 index: 0,
             }),
             data,
@@ -11946,8 +12065,8 @@ mod tests {
         let mut parser = BaseParser::new(
             CommonTokenStream::new(Source {
                 tokens: vec![
-                    CommonToken::new(3).with_text("z"),
-                    CommonToken::eof("parser-test", 1, 1, 1),
+                    TestToken::new(3).with_text("z"),
+                    TestToken::eof("parser-test", 1, 1, 1),
                 ],
                 index: 0,
             }),
@@ -12019,7 +12138,7 @@ mod tests {
             recovery_state: None,
         };
 
-        let mut sparse = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut sparse = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         for state_number in 0..(CLEAN_SINGLE_OUTCOME_MEMO_PROBE_LIMIT - 1) {
             assert!(sparse.should_memoize_single_outcome(&key(state_number)));
         }
@@ -12029,7 +12148,7 @@ mod tests {
             SingleOutcomeMemoMode::Sparse
         );
 
-        let mut promote = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
+        let mut promote = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         let repeated = key(1);
         for _ in 0..=CLEAN_SINGLE_OUTCOME_MEMO_REPEAT_LIMIT {
             assert!(promote.should_memoize_single_outcome(&repeated));
@@ -12064,7 +12183,7 @@ mod tests {
                 label: 2,
             });
 
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 0, 1, 0)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 0, 1, 0)]);
         parser.fast_recovery_enabled = false;
         let mut visiting = FxHashSet::default();
         let mut memo = FxHashMap::default();
@@ -12095,8 +12214,8 @@ mod tests {
     #[test]
     fn wildcard_matches_non_eof_only() {
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         assert_eq!(parser.match_wildcard().expect("wildcard").text(), "x");
         assert!(parser.match_wildcard().is_err());
@@ -12108,16 +12227,13 @@ mod tests {
         // matches, not parse-tree children: when `build_parse_trees(false)`,
         // `children` stays empty but `has_matched_child` must still flip so nested
         // recovery does not wrongly suppress single-token deletion.
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
-        let token = CommonToken::new(1).with_text("x");
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
+        let token = TestToken::new(1).with_text("x");
 
         parser.set_build_parse_trees(false);
         let mut ctx = ParserRuleContext::new(0, 0);
         assert!(!ctx.has_matched_child());
-        parser.add_parse_child(
-            &mut ctx,
-            ParseTree::Terminal(TerminalNode::new(token.clone())),
-        );
+        parser.add_parse_child(&mut ctx, ParseTree::Terminal(test_terminal(token.clone())));
         // Tree building is off, so no child is stored...
         assert!(ctx.children().is_empty());
         // ...but the match is recorded, so the context is no longer "empty".
@@ -12126,7 +12242,7 @@ mod tests {
         // With tree building on, the child is stored and the match is recorded.
         parser.set_build_parse_trees(true);
         let mut ctx = ParserRuleContext::new(0, 0);
-        parser.add_parse_child(&mut ctx, ParseTree::Terminal(TerminalNode::new(token)));
+        parser.add_parse_child(&mut ctx, ParseTree::Terminal(test_terminal(token)));
         assert_eq!(ctx.children().len(), 1);
         assert!(ctx.has_matched_child());
     }
@@ -12135,8 +12251,8 @@ mod tests {
     fn parser_interprets_simple_atn_rule() {
         let atn = token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         let tree = parser
@@ -12152,8 +12268,8 @@ mod tests {
         );
 
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
         let (tree, actions) = parser
             .parse_atn_rule_with_runtime_options(&atn, 0, ParserRuntimeOptions::default())
@@ -12171,8 +12287,8 @@ mod tests {
     fn runtime_options_default_ignores_noop_action_transitions() {
         let atn = noop_action_then_token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         let (tree, actions) = parser
@@ -12191,8 +12307,8 @@ mod tests {
     fn parser_exposes_buffered_token_stream_after_parse() {
         let atn = token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         let tree = parser
@@ -12202,26 +12318,30 @@ mod tests {
 
         let stream = parser.token_stream();
         let source_index_after_parse = stream.token_source().index;
-        let buffered = stream.tokens();
+        let buffered = stream.tokens().collect::<Vec<_>>();
         assert_eq!(buffered.len(), 2);
         assert_eq!(buffered[0].text(), "x");
-        assert_eq!(buffered[0].token_index(), 0);
+        assert_eq!(buffered[0].token_id().index(), 0);
         assert_eq!(buffered[1].token_type(), TOKEN_EOF);
         assert_eq!(stream.token_source().index, source_index_after_parse);
+        drop(buffered);
 
         let stream = parser.into_token_stream();
         assert_eq!(stream.token_source().index, source_index_after_parse);
-        assert_eq!(stream.tokens()[0].text(), "x");
-        assert_eq!(stream.tokens()[1].token_type(), TOKEN_EOF);
+        assert_eq!(stream.tokens().next().expect("first token").text(), "x");
+        assert_eq!(
+            stream.tokens().nth(1).expect("EOF token").token_type(),
+            TOKEN_EOF
+        );
     }
 
     #[test]
     fn parser_syntax_error_count_tracks_interpreted_recovery() {
         let atn = token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let tree = parser
@@ -12241,8 +12361,8 @@ mod tests {
     fn parser_syntax_error_count_tracks_failed_interpreted_parse() {
         let atn = token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         let error = parser
@@ -12258,8 +12378,8 @@ mod tests {
         let atn = two_alt_decision_atn();
         let mut simulator = ParserAtnSimulator::new(&atn);
         let mut parser = mini_parser(vec![
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         let tree = parser
@@ -12275,9 +12395,9 @@ mod tests {
         let atn = predicate_after_token_atn();
         let mut simulator = ParserAtnSimulator::new(&atn);
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let tree = parser
@@ -12292,9 +12412,9 @@ mod tests {
     fn unknown_predicate_policy_defaults_to_assume_true() {
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let (tree, _) = parser
@@ -12312,8 +12432,8 @@ mod tests {
         // not wipe the parent's recorded hit before the top-level surfaces it.
         let atn = token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         // Simulate the parent having recorded a fail-loud coordinate.
@@ -12338,9 +12458,9 @@ mod tests {
     fn unknown_predicate_policy_assume_false_kills_the_guarded_path() {
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let result = parser.parse_atn_rule_with_runtime_options(
@@ -12362,9 +12482,9 @@ mod tests {
     fn unknown_predicate_policy_error_names_the_coordinate() {
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let error = parser
@@ -12400,9 +12520,9 @@ mod tests {
         // clean parse surfaces no stale error.
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         parser
@@ -12447,7 +12567,7 @@ mod tests {
                 ctx.input_index(),
                 rule_index,
                 pred_index,
-                ctx.token_text(1).map(str::to_owned),
+                ctx.token_text(1).map(|token| token.text().to_owned()),
             ));
             Some(true)
         }
@@ -12484,7 +12604,7 @@ mod tests {
                 ctx.input_index(),
                 rule_index,
                 pred_index,
-                ctx.token_text(1).map(str::to_owned),
+                ctx.token_text(1).map(|token| token.text().to_owned()),
             ));
             Some(false)
         }
@@ -12495,9 +12615,9 @@ mod tests {
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::new(2).with_text("y"),
-                CommonToken::eof("parser-test", 2, 1, 2),
+                TestToken::new(1).with_text("x"),
+                TestToken::new(2).with_text("y"),
+                TestToken::eof("parser-test", 2, 1, 2),
             ],
             RecordingHooks::default(),
         );
@@ -12525,9 +12645,9 @@ mod tests {
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::new(2).with_text("y"),
-                CommonToken::eof("parser-test", 2, 1, 2),
+                TestToken::new(1).with_text("x"),
+                TestToken::new(2).with_text("y"),
+                TestToken::eof("parser-test", 2, 1, 2),
             ],
             RejectingPredicateHooks::default(),
         );
@@ -12550,8 +12670,8 @@ mod tests {
         let atn = token_then_eof_atn();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::eof("parser-test", 1, 1, 1),
+                TestToken::new(1).with_text("x"),
+                TestToken::eof("parser-test", 1, 1, 1),
             ],
             RecordingHooks::default(),
         );
@@ -12571,8 +12691,7 @@ mod tests {
         // An action offered to the hook that no hook handles (returns false)
         // must be recorded and surfaced as `AntlrError::Unsupported` under the
         // Error policy, so a `hook`-disposed action is not silently dropped.
-        let mut parser =
-            mini_parser_with_hooks(vec![CommonToken::eof("t", 0, 1, 0)], DecliningHooks);
+        let mut parser = mini_parser_with_hooks(vec![TestToken::eof("t", 0, 1, 0)], DecliningHooks);
         parser.set_unknown_predicate_policy(UnknownSemanticPolicy::Error);
         let tree = ParseTree::Rule(RuleNode::new(ParserRuleContext::new(0, -1)));
 
@@ -12592,7 +12711,7 @@ mod tests {
 
         // Under the default (assume-true) policy the same miss is not recorded.
         let mut lenient =
-            mini_parser_with_hooks(vec![CommonToken::eof("t", 0, 1, 0)], DecliningHooks);
+            mini_parser_with_hooks(vec![TestToken::eof("t", 0, 1, 0)], DecliningHooks);
         let tree = ParseTree::Rule(RuleNode::new(ParserRuleContext::new(0, -1)));
         assert!(!lenient.parser_action_hook(ParserAction::new(42, 0, 0, Some(0)), &tree));
         assert!(lenient.take_unknown_semantic_error().is_none());
@@ -12602,9 +12721,9 @@ mod tests {
     fn translated_predicate_is_unaffected_by_error_policy() {
         let atn = predicate_after_token_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::new(2).with_text("y"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::new(2).with_text("y"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let (tree, _) = parser
@@ -12652,9 +12771,9 @@ mod tests {
         let semantics = hook_predicate_semantics();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::new(2).with_text("y"),
-                CommonToken::eof("parser-test", 2, 1, 2),
+                TestToken::new(1).with_text("x"),
+                TestToken::new(2).with_text("y"),
+                TestToken::eof("parser-test", 2, 1, 2),
             ],
             DecliningHooks,
         );
@@ -12680,9 +12799,9 @@ mod tests {
         let semantics = hook_predicate_semantics();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::new(2).with_text("y"),
-                CommonToken::eof("parser-test", 2, 1, 2),
+                TestToken::new(1).with_text("x"),
+                TestToken::new(2).with_text("y"),
+                TestToken::eof("parser-test", 2, 1, 2),
             ],
             DecliningHooks,
         );
@@ -12709,9 +12828,9 @@ mod tests {
         let semantics = hook_predicate_semantics();
         let mut parser = mini_parser_with_hooks(
             vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::new(2).with_text("y"),
-                CommonToken::eof("parser-test", 2, 1, 2),
+                TestToken::new(1).with_text("x"),
+                TestToken::new(2).with_text("y"),
+                TestToken::eof("parser-test", 2, 1, 2),
             ],
             DecliningHooks,
         );
@@ -12748,7 +12867,7 @@ mod tests {
         let context = ParserRuleContext::new(0, -1);
 
         let mut assume_true =
-            mini_parser_with_hooks(vec![CommonToken::eof("t", 0, 1, 0)], DecliningHooks);
+            mini_parser_with_hooks(vec![TestToken::eof("t", 0, 1, 0)], DecliningHooks);
         assert!(
             assume_true.parser_semantic_ir_predicate_matches_with_context_and_local(
                 &semantics, 0, 0, &context, 0
@@ -12758,7 +12877,7 @@ mod tests {
         assert!(assume_true.take_unknown_semantic_error().is_none());
 
         let mut error_policy =
-            mini_parser_with_hooks(vec![CommonToken::eof("t", 0, 1, 0)], DecliningHooks);
+            mini_parser_with_hooks(vec![TestToken::eof("t", 0, 1, 0)], DecliningHooks);
         error_policy.set_unknown_predicate_policy(UnknownSemanticPolicy::Error);
         assert!(
             !error_policy.parser_semantic_ir_predicate_matches_with_context_and_local(
@@ -12779,11 +12898,11 @@ mod tests {
     fn parser_rule_start_skips_leading_hidden_tokens() {
         let atn = token_then_eof_atn();
         let mut parser = mini_parser(vec![
-            CommonToken::new(99)
+            TestToken::new(99)
                 .with_text(" ")
                 .with_channel(HIDDEN_CHANNEL),
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 2, 1, 2),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 2, 1, 2),
         ]);
 
         let tree = parser
@@ -12804,7 +12923,7 @@ mod tests {
     #[test]
     fn parser_action_after_eof_stops_at_eof_token() {
         let atn = eof_then_action_atn();
-        let mut parser = mini_parser(vec![CommonToken::eof("parser-test", 0, 1, 0)]);
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 0, 1, 0)]);
 
         let (_, actions) = parser
             .parse_atn_rule_with_runtime_options(&atn, 0, ParserRuntimeOptions::default())
@@ -12824,9 +12943,9 @@ mod tests {
         // called from `start: a EOF;`): after matching ID the cursor parks on EOF,
         // but the rule did not consume it. The @after stop must follow the rule
         // context's recorded stop (ID at index 0), not the cursor's EOF (index 1).
-        let mut id = CommonToken::new(1).with_text("x");
+        let mut id = TestToken::new(1).with_text("x");
         id.set_token_index(0);
-        let mut eof = CommonToken::eof("parser-test", 1, 1, 1);
+        let mut eof = TestToken::eof("parser-test", 1, 1, 1);
         eof.set_token_index(1);
         let mut parser = mini_parser(vec![id.clone(), eof]);
         // Advance the cursor onto EOF, as it would be after `a` matched ID.
@@ -12836,7 +12955,10 @@ mod tests {
         // Rule `a` matched only ID, so its context stop is the ID token (index 0),
         // exactly what finish_rule(consumed_eof = false) records.
         let mut ctx = ParserRuleContext::new(0, 0);
-        ctx.set_stop(id);
+        parser.set_context_stop(
+            &mut ctx,
+            parser.token_id_at(0).expect("ID token should be buffered"),
+        );
         let tree = ParseTree::Rule(RuleNode::new(ctx));
 
         let current_index = parser.input.index();
@@ -12855,13 +12977,22 @@ mod tests {
         // start (set by `enter_rule`) is the first visible token, not the raw cursor
         // that may still point at the hidden prefix. The @after start must follow
         // the context start so `$start`/`$text` excludes the hidden prefix.
-        let parser = mini_parser(vec![CommonToken::eof("parser-test", 1, 1, 1)]);
-        let mut id = CommonToken::new(1).with_text("x");
-        // The first visible token sits at stream index 2 (after two hidden tokens).
-        id.set_token_index(2);
+        let parser = mini_parser(vec![
+            TestToken::new(9)
+                .with_text(" ")
+                .with_channel(HIDDEN_CHANNEL),
+            TestToken::new(9)
+                .with_text(" ")
+                .with_channel(HIDDEN_CHANNEL),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 3, 1, 3),
+        ]);
 
         let mut ctx = ParserRuleContext::new(0, 0);
-        ctx.set_start(id);
+        parser.set_context_start(
+            &mut ctx,
+            parser.token_id_at(2).expect("ID token should be buffered"),
+        );
         let tree = ParseTree::Rule(RuleNode::new(ctx));
 
         // The raw fallback (pre-rule cursor) would be 0 (the hidden prefix)...
@@ -13079,12 +13210,12 @@ mod tests {
     #[test]
     fn caller_follow_token_info_treats_hidden_tokens_as_boundary_gaps() {
         let mut parser = mini_parser(vec![
-            CommonToken::new(5).with_text("\n"),
-            CommonToken::new(6)
+            TestToken::new(5).with_text("\n"),
+            TestToken::new(6)
                 .with_text("// comment\n")
                 .with_channel(HIDDEN_CHANNEL),
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 2, 0),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 2, 0),
         ]);
 
         assert_eq!(parser.caller_follow_token_info(0), (5, true, true));
@@ -13096,12 +13227,12 @@ mod tests {
     fn caller_follow_token_info_uses_stream_visible_channel() {
         let source = Source {
             tokens: vec![
-                CommonToken::new(5).with_text("\n").with_channel(2),
-                CommonToken::new(1).with_text("x").with_channel(2),
-                CommonToken::new(6)
+                TestToken::new(5).with_text("\n").with_channel(2),
+                TestToken::new(1).with_text("x").with_channel(2),
+                TestToken::new(6)
                     .with_text("// comment\n")
                     .with_channel(HIDDEN_CHANNEL),
-                CommonToken::eof("parser-test", 1, 2, 0),
+                TestToken::eof("parser-test", 1, 2, 0),
             ],
             index: 0,
         };
@@ -13132,8 +13263,8 @@ mod tests {
     fn parser_error_with_empty_expected_set_omits_empty_set_display() {
         let source = Source {
             tokens: vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::eof("parser-test", 1, 1, 1),
+                TestToken::new(1).with_text("x"),
+                TestToken::eof("parser-test", 1, 1, 1),
             ],
             index: 0,
         };
@@ -13157,8 +13288,8 @@ mod tests {
     fn eof_rule_stop_index_points_at_eof_token() {
         let source = Source {
             tokens: vec![
-                CommonToken::new(1).with_text("x"),
-                CommonToken::eof("parser-test", 1, 1, 1),
+                TestToken::new(1).with_text("x"),
+                TestToken::eof("parser-test", 1, 1, 1),
             ],
             index: 0,
         };
@@ -13175,8 +13306,8 @@ mod tests {
     #[test]
     fn generated_parser_action_uses_current_rule_stop_boundary() {
         let mut parser = mini_parser(vec![
-            CommonToken::new(1).with_text("x"),
-            CommonToken::eof("parser-test", 1, 1, 1),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
         ]);
 
         parser.match_token(1).expect("token should match");

--- a/src/semir.rs
+++ b/src/semir.rs
@@ -245,10 +245,14 @@ impl Value {
 /// Null). Lookahead methods take `&mut self` because token streams buffer
 /// lazily.
 pub trait PredContext {
+    type TokenText<'a>: AsRef<str>
+    where
+        Self: 'a;
+
     /// Token type (parser) or character (lexer) at the given lookahead.
     fn la(&mut self, offset: isize) -> i64;
     /// Text of the token at the given lookahead, if present.
-    fn token_text(&mut self, offset: isize) -> Option<&str>;
+    fn token_text(&mut self, offset: isize) -> Option<Self::TokenText<'_>>;
     /// Whether `LT(-2)` and `LT(-1)` are adjacent token-stream entries.
     fn token_index_adjacent(&mut self) -> bool;
     /// Text of the current context's first child with this rule index.
@@ -506,7 +510,9 @@ fn resolve_owned_text<C: PredContext>(
     ctx: &mut C,
 ) -> Option<String> {
     match source {
-        TextSource::Lookahead(offset) => ctx.token_text(offset).map(str::to_owned),
+        TextSource::Lookahead(offset) => {
+            ctx.token_text(offset).map(|text| text.as_ref().to_owned())
+        }
         other => resolve_static_text(ir, other, ctx).map(Cow::into_owned),
     }
 }
@@ -527,22 +533,21 @@ fn eval_text_cmp<C: PredContext>(
     };
     Value::Bool(match (left_source, right_source) {
         (TextSource::Lookahead(left), TextSource::Lookahead(right)) => {
-            // Two live lookahead borrows cannot coexist; own the left side.
-            // No current producer emits this shape, so the allocation is
-            // acceptable.
-            let left = ctx.token_text(left).map(str::to_owned);
+            // Holding the first token-text borrow would keep `ctx` borrowed,
+            // so own this unsupported producer shape's first operand.
+            let left = ctx.token_text(left).map(|text| text.as_ref().to_owned());
             let right = ctx.token_text(right);
-            cmp_texts(op, left.as_deref(), right)
+            cmp_texts(op, left.as_deref(), right.as_ref().map(AsRef::as_ref))
         }
         (TextSource::Lookahead(offset), other) => {
             let right = resolve_static_text(ir, other, ctx);
             let left = ctx.token_text(offset);
-            cmp_texts(op, left, right.as_deref())
+            cmp_texts(op, left.as_ref().map(AsRef::as_ref), right.as_deref())
         }
         (other, TextSource::Lookahead(offset)) => {
             let left = resolve_static_text(ir, other, ctx);
             let right = ctx.token_text(offset);
-            cmp_texts(op, left.as_deref(), right)
+            cmp_texts(op, left.as_deref(), right.as_ref().map(AsRef::as_ref))
         }
         (left, right) => {
             let left = resolve_static_text(ir, left, ctx);
@@ -615,12 +620,17 @@ mod tests {
     }
 
     impl PredContext for MockCtx {
+        type TokenText<'a>
+            = &'a str
+        where
+            Self: 'a;
+
         fn la(&mut self, offset: isize) -> i64 {
             self.la_calls += 1;
             self.lookup(offset).map_or(-1, |(token_type, _)| token_type)
         }
 
-        fn token_text(&mut self, offset: isize) -> Option<&str> {
+        fn token_text(&mut self, offset: isize) -> Option<Self::TokenText<'_>> {
             self.lookup(offset).and_then(|(_, text)| text)
         }
 

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,4 +1,5 @@
 use crate::char_stream::TextInterval;
+use std::cell::{Ref, RefCell};
 use std::fmt;
 use std::ops::Range;
 use std::rc::Rc;
@@ -7,6 +8,32 @@ pub const TOKEN_EOF: i32 = -1;
 pub const INVALID_TOKEN_TYPE: i32 = 0;
 pub const DEFAULT_CHANNEL: i32 = 0;
 pub const HIDDEN_CHANNEL: i32 = 1;
+
+/// Largest source or location offset accepted by the compact token store.
+///
+/// `u32::MAX` is reserved for ANTLR's synthetic `-1` source boundary.
+pub const MAX_TOKEN_OFFSET: usize = (u32::MAX - 1) as usize;
+
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TokenId(u32);
+
+impl TokenId {
+    #[must_use]
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl TryFrom<usize> for TokenId {
+    type Error = TokenStoreError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        u32::try_from(value)
+            .map(Self)
+            .map_err(|_| TokenStoreError::overflow("index", value, u32::MAX as usize))
+    }
+}
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum TokenChannel {
@@ -36,6 +63,7 @@ impl From<i32> for TokenChannel {
 }
 
 pub trait Token: fmt::Debug {
+    fn token_id(&self) -> TokenId;
     fn token_type(&self) -> i32;
     fn channel(&self) -> i32;
     /// Zero-based absolute start index measured in Unicode scalar values.
@@ -43,7 +71,6 @@ pub trait Token: fmt::Debug {
     /// Zero-based absolute inclusive stop index measured in Unicode scalar
     /// values.
     fn stop(&self) -> usize;
-    fn token_index(&self) -> isize;
     /// One-based source line where the token starts.
     fn line(&self) -> usize;
     /// Zero-based source column where the token starts, measured in Unicode
@@ -57,23 +84,10 @@ pub trait Token: fmt::Debug {
     }
 
     /// Zero-based absolute start offset measured in UTF-8 bytes.
-    ///
-    /// The default implementation treats the character index as a byte offset,
-    /// which is exact for ASCII and preserves compatibility for token
-    /// implementations that do not expose source byte bounds.
-    fn start_byte(&self) -> usize {
-        self.start()
-    }
+    fn start_byte(&self) -> usize;
 
     /// Zero-based exclusive end offset measured in UTF-8 bytes.
-    ///
-    /// Unlike [`Self::stop`], this is exclusive so
-    /// `token.start_byte()..token.stop_byte()` can slice the original UTF-8
-    /// source when the token carries source byte bounds. The default
-    /// implementation treats character indices as byte offsets.
-    fn stop_byte(&self) -> usize {
-        default_stop_byte(self.start(), self.stop())
-    }
+    fn stop_byte(&self) -> usize;
 
     /// Zero-based UTF-8 byte span for the token text.
     fn byte_span(&self) -> Range<usize> {
@@ -81,150 +95,101 @@ pub trait Token: fmt::Debug {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CommonToken {
-    token_type: i32,
-    channel: i32,
-    start: usize,
-    stop: usize,
-    token_index: isize,
-    line: usize,
-    column: usize,
-    text: Option<TokenText>,
-    byte_span: Option<TokenByteSpan>,
-    source_name: Rc<str>,
-}
+impl<T: Token + ?Sized> Token for &T {
+    fn token_id(&self) -> TokenId {
+        (**self).token_id()
+    }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-struct TokenByteSpan {
-    start_byte: u32,
-    stop_byte: u32,
-}
+    fn token_type(&self) -> i32 {
+        (**self).token_type()
+    }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-enum TokenText {
-    Explicit(Rc<str>),
-    Source {
-        input: Rc<str>,
-        start_byte: u32,
-        stop_byte: u32,
-    },
-}
+    fn channel(&self) -> i32 {
+        (**self).channel()
+    }
 
-impl TokenText {
-    fn as_str(&self) -> &str {
-        match self {
-            Self::Explicit(text) => text.as_ref(),
-            Self::Source {
-                input,
-                start_byte,
-                stop_byte,
-            } => &input[*start_byte as usize..*stop_byte as usize],
-        }
+    fn start(&self) -> usize {
+        (**self).start()
+    }
+
+    fn stop(&self) -> usize {
+        (**self).stop()
+    }
+
+    fn line(&self) -> usize {
+        (**self).line()
+    }
+
+    fn column(&self) -> usize {
+        (**self).column()
+    }
+
+    fn text(&self) -> Option<&str> {
+        (**self).text()
+    }
+
+    fn source_name(&self) -> &str {
+        (**self).source_name()
+    }
+
+    fn start_byte(&self) -> usize {
+        (**self).start_byte()
+    }
+
+    fn stop_byte(&self) -> usize {
+        (**self).stop_byte()
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TokenSourceText {
-    pub input: Rc<str>,
-    pub start_byte: u32,
-    pub stop_byte: u32,
-}
-
-#[derive(Debug)]
-pub struct TokenSpec<'a> {
+/// The fields emitted for one token.
+///
+/// This is transient sink input, not an owned token representation. Source
+/// text and the source name live once in [`TokenStore`].
+#[derive(Clone, Debug)]
+pub struct TokenSpec {
     pub token_type: i32,
     pub channel: i32,
     pub start: usize,
     pub stop: usize,
+    pub start_byte: usize,
+    pub stop_byte: usize,
     pub line: usize,
     pub column: usize,
     pub text: Option<String>,
-    pub source_text: Option<TokenSourceText>,
-    pub source_name: &'a str,
+    pub source_backed: bool,
 }
 
-impl CommonToken {
-    pub fn new(token_type: i32) -> Self {
+impl TokenSpec {
+    #[must_use]
+    pub fn explicit(token_type: i32, text: impl Into<String>) -> Self {
         Self {
             token_type,
             channel: DEFAULT_CHANNEL,
             start: 0,
             stop: 0,
-            token_index: -1,
+            start_byte: 0,
+            stop_byte: 1,
             line: 1,
             column: 0,
-            text: None,
-            byte_span: None,
-            source_name: Rc::from(""),
+            text: Some(text.into()),
+            source_backed: false,
         }
     }
 
-    pub fn eof(source_name: impl Into<Rc<str>>, index: usize, line: usize, column: usize) -> Self {
+    #[must_use]
+    pub fn eof(index: usize, byte_offset: usize, line: usize, column: usize) -> Self {
         Self {
             token_type: TOKEN_EOF,
             channel: DEFAULT_CHANNEL,
             start: index,
             stop: index.checked_sub(1).unwrap_or(usize::MAX),
-            token_index: -1,
+            start_byte: byte_offset,
+            stop_byte: byte_offset,
             line,
             column,
-            text: Some(TokenText::Explicit(Rc::from("<EOF>"))),
-            byte_span: None,
-            source_name: source_name.into(),
+            text: Some("<EOF>".to_owned()),
+            source_backed: false,
         }
-    }
-
-    #[must_use]
-    pub fn with_text(mut self, text: impl Into<Rc<str>>) -> Self {
-        self.text = Some(TokenText::Explicit(text.into()));
-        self
-    }
-
-    #[must_use]
-    pub fn with_source_text(mut self, input: Rc<str>, start_byte: u32, stop_byte: u32) -> Self {
-        debug_assert!(
-            start_byte <= stop_byte && stop_byte as usize <= input.len(),
-            "invalid token source-text bounds: start={start_byte}, stop={stop_byte}, len={}",
-            input.len()
-        );
-        self.text = Some(TokenText::Source {
-            input,
-            start_byte,
-            stop_byte,
-        });
-        self.byte_span = Some(TokenByteSpan {
-            start_byte,
-            stop_byte,
-        });
-        self
-    }
-
-    #[must_use]
-    pub(crate) fn with_byte_span(mut self, start_byte: u32, stop_byte: u32) -> Self {
-        debug_assert!(
-            start_byte <= stop_byte,
-            "invalid token byte span: start={start_byte}, stop={stop_byte}"
-        );
-        self.byte_span = Some(TokenByteSpan {
-            start_byte,
-            stop_byte,
-        });
-        self
-    }
-
-    #[must_use]
-    pub const fn with_span(mut self, start: usize, stop: usize) -> Self {
-        self.start = start;
-        self.stop = stop;
-        self
-    }
-
-    #[must_use]
-    pub const fn with_position(mut self, line: usize, column: usize) -> Self {
-        self.line = line;
-        self.column = column;
-        self
     }
 
     #[must_use]
@@ -234,116 +199,166 @@ impl CommonToken {
     }
 
     #[must_use]
-    pub fn with_source_name(mut self, source_name: impl Into<Rc<str>>) -> Self {
-        self.source_name = source_name.into();
+    pub const fn with_span(mut self, start: usize, stop: usize) -> Self {
+        self.start = start;
+        self.stop = stop;
+        self.start_byte = start;
+        self.stop_byte = default_stop_byte(start, stop);
         self
     }
 
-    pub const fn set_token_index(&mut self, token_index: isize) {
-        self.token_index = token_index;
+    #[must_use]
+    pub const fn with_byte_span(mut self, start_byte: usize, stop_byte: usize) -> Self {
+        self.start_byte = start_byte;
+        self.stop_byte = stop_byte;
+        self
     }
 
-    const fn source_byte_span(&self) -> Option<Range<usize>> {
-        match self.byte_span {
-            Some(TokenByteSpan {
-                start_byte,
-                stop_byte,
-            }) => Some(start_byte as usize..stop_byte as usize),
-            None => None,
+    #[must_use]
+    pub const fn with_position(mut self, line: usize, column: usize) -> Self {
+        self.line = line;
+        self.column = column;
+        self
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TokenStoreError {
+    field: &'static str,
+    value: usize,
+    limit: usize,
+}
+
+impl TokenStoreError {
+    const fn overflow(field: &'static str, value: usize, limit: usize) -> Self {
+        Self {
+            field,
+            value,
+            limit,
         }
     }
 }
 
-impl Token for CommonToken {
-    fn token_type(&self) -> i32 {
-        self.token_type
-    }
-
-    fn channel(&self) -> i32 {
-        self.channel
-    }
-
-    fn start(&self) -> usize {
-        self.start
-    }
-
-    fn stop(&self) -> usize {
-        self.stop
-    }
-
-    fn token_index(&self) -> isize {
-        self.token_index
-    }
-
-    fn line(&self) -> usize {
-        self.line
-    }
-
-    fn column(&self) -> usize {
-        self.column
-    }
-
-    fn text(&self) -> Option<&str> {
-        self.text.as_ref().map(TokenText::as_str)
-    }
-
-    fn source_name(&self) -> &str {
-        self.source_name.as_ref()
-    }
-
-    fn start_byte(&self) -> usize {
-        self.source_byte_span()
-            .map_or(self.start, |byte_span| byte_span.start)
-    }
-
-    fn stop_byte(&self) -> usize {
-        self.source_byte_span()
-            .map_or_else(|| default_stop_byte(self.start, self.stop), |span| span.end)
-    }
-}
-
-impl CommonToken {
-    /// The token's text, empty when unset — ANTLR's `getText()` shape, which
-    /// generated test actions print directly (`token.text()` in `{}`).
-    ///
-    /// This inherent method intentionally shadows the Option-returning
-    /// [`Token::text`] trait method on concrete `CommonToken` values; generic
-    /// code keeps the trait signature.
-    #[must_use]
-    pub fn text(&self) -> &str {
-        self.text.as_ref().map_or("", TokenText::as_str)
-    }
-}
-
-impl fmt::Display for CommonToken {
+impl fmt::Display for TokenStoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let text = Self::text(self);
-        let channel = if self.channel() == DEFAULT_CHANNEL {
-            String::new()
-        } else {
-            format!(",channel={}", self.channel())
-        };
         write!(
             f,
-            "[@{},{}:{}='{}',<{}>{},{}:{}]",
-            self.token_index(),
-            display_token_boundary(self.start()),
-            display_token_boundary(self.stop()),
-            display_text(text),
-            self.token_type(),
-            channel,
-            self.line(),
-            self.column()
+            "token {field} {value} exceeds the supported limit {limit}",
+            field = self.field,
+            value = self.value,
+            limit = self.limit
         )
     }
 }
 
-/// Formats synthetic-token boundaries with ANTLR's `-1` sentinel.
-fn display_token_boundary(value: usize) -> String {
-    if value == usize::MAX {
-        "-1".to_owned()
-    } else {
-        value.to_string()
+impl std::error::Error for TokenStoreError {}
+
+/// Canonical compact storage for every token associated with one token stream.
+#[derive(Debug)]
+pub struct TokenStore {
+    source: Option<Rc<str>>,
+    source_name: Rc<str>,
+    token_types: Vec<i32>,
+    channels: Vec<i32>,
+    scalar_starts: Vec<u32>,
+    scalar_stops: Vec<u32>,
+    byte_starts: Vec<u32>,
+    byte_stops: Vec<u32>,
+    lines: Vec<u32>,
+    columns: Vec<u32>,
+    source_backed: Vec<bool>,
+    explicit_text: Vec<(TokenId, Rc<str>)>,
+}
+
+impl TokenStore {
+    pub(crate) fn new(source: Option<Rc<str>>, source_name: impl Into<Rc<str>>) -> Self {
+        Self {
+            source,
+            source_name: source_name.into(),
+            token_types: Vec::new(),
+            channels: Vec::new(),
+            scalar_starts: Vec::new(),
+            scalar_stops: Vec::new(),
+            byte_starts: Vec::new(),
+            byte_stops: Vec::new(),
+            lines: Vec::new(),
+            columns: Vec::new(),
+            source_backed: Vec::new(),
+            explicit_text: Vec::new(),
+        }
+    }
+
+    #[must_use]
+    pub const fn len(&self) -> usize {
+        self.token_types.len()
+    }
+
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.token_types.is_empty()
+    }
+
+    fn push(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
+        let raw_id = u32::try_from(self.len())
+            .map_err(|_| TokenStoreError::overflow("count", self.len(), u32::MAX as usize))?;
+        let id = TokenId(raw_id);
+        let scalar_start = compact_boundary("start offset", spec.start)?;
+        let scalar_stop = compact_boundary("stop offset", spec.stop)?;
+        let byte_start = compact_offset("start byte", spec.start_byte)?;
+        let byte_stop = compact_offset("stop byte", spec.stop_byte)?;
+        let line = compact_offset("line", spec.line)?;
+        let column = compact_offset("column", spec.column)?;
+
+        if spec.source_backed {
+            let Some(source) = self.source.as_ref() else {
+                return Err(TokenStoreError::overflow("source text", 1, 0));
+            };
+            if spec.start_byte > spec.stop_byte || spec.stop_byte > source.len() {
+                return Err(TokenStoreError::overflow(
+                    "source byte span",
+                    spec.stop_byte,
+                    source.len(),
+                ));
+            }
+        }
+
+        self.token_types.push(spec.token_type);
+        self.channels.push(spec.channel);
+        self.scalar_starts.push(scalar_start);
+        self.scalar_stops.push(scalar_stop);
+        self.byte_starts.push(byte_start);
+        self.byte_stops.push(byte_stop);
+        self.lines.push(line);
+        self.columns.push(column);
+        self.source_backed.push(spec.source_backed);
+        if let Some(text) = spec.text {
+            self.explicit_text.push((id, Rc::from(text)));
+        }
+        Ok(id)
+    }
+
+    const fn contains(&self, id: TokenId) -> bool {
+        id.index() < self.len()
+    }
+
+    fn explicit_text(&self, id: TokenId) -> Option<&str> {
+        self.explicit_text
+            .binary_search_by_key(&id, |(token_id, _)| *token_id)
+            .ok()
+            .map(|index| self.explicit_text[index].1.as_ref())
+    }
+
+    fn text(&self, id: TokenId) -> Option<&str> {
+        if let Some(text) = self.explicit_text(id) {
+            return Some(text);
+        }
+        if !self.source_backed.get(id.index()).copied().unwrap_or(false) {
+            return None;
+        }
+        let source = self.source.as_deref()?;
+        let start = self.byte_starts[id.index()] as usize;
+        let stop = self.byte_stops[id.index()] as usize;
+        source.get(start..stop)
     }
 }
 
@@ -354,50 +369,228 @@ const fn default_stop_byte(start: usize, stop: usize) -> usize {
     }
 }
 
-/// Escapes token text the way ANTLR's token display format expects.
-///
-/// Debug escaping is close but not identical: ANTLR leaves ordinary
-/// backslashes and quotes unescaped, and only normalizes control characters
-/// that would otherwise disrupt the one-line token representation.
-fn display_text(text: &str) -> String {
-    let mut out = String::new();
-    for ch in text.chars() {
-        match ch {
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            other => out.push(other),
+const fn compact_boundary(field: &'static str, value: usize) -> Result<u32, TokenStoreError> {
+    if value == usize::MAX {
+        return Ok(u32::MAX);
+    }
+    compact_offset(field, value)
+}
+
+const fn compact_offset(field: &'static str, value: usize) -> Result<u32, TokenStoreError> {
+    if value > MAX_TOKEN_OFFSET {
+        return Err(TokenStoreError::overflow(field, value, MAX_TOKEN_OFFSET));
+    }
+    Ok(value as u32)
+}
+
+#[derive(Clone)]
+pub(crate) struct TokenStoreHandle(Rc<RefCell<TokenStore>>);
+
+impl TokenStoreHandle {
+    pub(crate) fn new(store: TokenStore) -> Self {
+        Self(Rc::new(RefCell::new(store)))
+    }
+
+    pub(crate) fn push(&self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
+        self.0.borrow_mut().push(spec)
+    }
+
+    pub(crate) fn view(&self, id: TokenId) -> Option<TokenView<'_>> {
+        let store = self.0.borrow();
+        store.contains(id).then_some(TokenView {
+            store: TokenStoreBorrow::Shared(store),
+            id,
+        })
+    }
+}
+
+impl fmt::Debug for TokenStoreHandle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenStoreHandle")
+            .field("tokens", &self.0.borrow().len())
+            .finish()
+    }
+}
+
+impl PartialEq for TokenStoreHandle {
+    fn eq(&self, other: &Self) -> bool {
+        Rc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for TokenStoreHandle {}
+
+enum TokenStoreBorrow<'a> {
+    Direct(&'a TokenStore),
+    Shared(Ref<'a, TokenStore>),
+}
+
+impl TokenStoreBorrow<'_> {
+    fn store(&self) -> &TokenStore {
+        match self {
+            Self::Direct(store) => store,
+            Self::Shared(store) => store,
         }
     }
-    out
 }
 
-pub type TokenRef = Rc<CommonToken>;
-
-pub trait TokenFactory {
-    fn create(&self, spec: TokenSpec<'_>) -> CommonToken;
-}
-
-#[derive(Clone, Debug, Default)]
-pub struct CommonTokenFactory;
-
-impl TokenFactory for CommonTokenFactory {
-    fn create(&self, spec: TokenSpec<'_>) -> CommonToken {
-        let mut token = CommonToken::new(spec.token_type)
-            .with_channel(spec.channel)
-            .with_span(spec.start, spec.stop)
-            .with_position(spec.line, spec.column)
-            .with_source_name(spec.source_name);
-        if let Some(text) = spec.text {
-            token = token.with_text(text);
-        } else if let Some(source_text) = spec.source_text {
-            token = token.with_source_text(
-                source_text.input,
-                source_text.start_byte,
-                source_text.stop_byte,
-            );
+impl Clone for TokenStoreBorrow<'_> {
+    fn clone(&self) -> Self {
+        match self {
+            Self::Direct(store) => Self::Direct(store),
+            Self::Shared(store) => Self::Shared(Ref::clone(store)),
         }
-        token
+    }
+}
+
+/// Borrowing public view of one canonical token-store record.
+#[derive(Clone)]
+pub struct TokenView<'a> {
+    store: TokenStoreBorrow<'a>,
+    id: TokenId,
+}
+
+impl TokenView<'_> {
+    fn store(&self) -> &TokenStore {
+        self.store.store()
+    }
+
+    /// The token's text, empty when no explicit or source-backed text exists.
+    #[must_use]
+    pub fn text(&self) -> &str {
+        self.store().text(self.id).unwrap_or("")
+    }
+}
+
+impl fmt::Debug for TokenView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TokenView")
+            .field("id", &self.id)
+            .field("token_type", &self.token_type())
+            .field("channel", &self.channel())
+            .field("text", &self.text())
+            .finish()
+    }
+}
+
+impl PartialEq for TokenView<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.id == other.id
+            && self.token_type() == other.token_type()
+            && self.channel() == other.channel()
+            && self.start() == other.start()
+            && self.stop() == other.stop()
+            && self.line() == other.line()
+            && self.column() == other.column()
+            && self.text() == other.text()
+            && self.source_name() == other.source_name()
+    }
+}
+
+impl Eq for TokenView<'_> {}
+
+impl Token for TokenView<'_> {
+    fn token_id(&self) -> TokenId {
+        self.id
+    }
+
+    fn token_type(&self) -> i32 {
+        self.store().token_types[self.id.index()]
+    }
+
+    fn channel(&self) -> i32 {
+        self.store().channels[self.id.index()]
+    }
+
+    fn start(&self) -> usize {
+        expand_boundary(self.store().scalar_starts[self.id.index()])
+    }
+
+    fn stop(&self) -> usize {
+        expand_boundary(self.store().scalar_stops[self.id.index()])
+    }
+
+    fn line(&self) -> usize {
+        self.store().lines[self.id.index()] as usize
+    }
+
+    fn column(&self) -> usize {
+        self.store().columns[self.id.index()] as usize
+    }
+
+    fn text(&self) -> Option<&str> {
+        self.store().text(self.id)
+    }
+
+    fn source_name(&self) -> &str {
+        self.store().source_name.as_ref()
+    }
+
+    fn start_byte(&self) -> usize {
+        self.store().byte_starts[self.id.index()] as usize
+    }
+
+    fn stop_byte(&self) -> usize {
+        self.store().byte_stops[self.id.index()] as usize
+    }
+}
+
+impl fmt::Display for TokenView<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let channel = if self.channel() == DEFAULT_CHANNEL {
+            String::new()
+        } else {
+            format!(",channel={}", self.channel())
+        };
+        write!(
+            f,
+            "[@{},{}:{}='{}',<{}>{},{}:{}]",
+            display_token_index(self),
+            display_token_boundary(self.start()),
+            display_token_boundary(self.stop()),
+            display_text(self.text()),
+            self.token_type(),
+            channel,
+            self.line(),
+            self.column()
+        )
+    }
+}
+
+impl AsRef<str> for TokenView<'_> {
+    fn as_ref(&self) -> &str {
+        self.text()
+    }
+}
+
+const fn expand_boundary(value: u32) -> usize {
+    if value == u32::MAX {
+        usize::MAX
+    } else {
+        value as usize
+    }
+}
+
+/// Mutable append-only view used by a token source.
+#[derive(Debug)]
+pub struct TokenSink<'a> {
+    store: &'a mut TokenStore,
+}
+
+impl<'a> TokenSink<'a> {
+    pub(crate) const fn new(store: &'a mut TokenStore) -> Self {
+        Self { store }
+    }
+
+    pub fn push(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
+        self.store.push(spec)
+    }
+
+    pub fn view(&self, id: TokenId) -> Option<TokenView<'_>> {
+        self.store.contains(id).then_some(TokenView {
+            store: TokenStoreBorrow::Direct(self.store),
+            id,
+        })
     }
 }
 
@@ -424,10 +617,16 @@ impl TokenSourceError {
 }
 
 pub trait TokenSource {
-    fn next_token(&mut self) -> CommonToken;
+    fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError>;
     fn line(&self) -> usize;
     fn column(&self) -> usize;
     fn source_name(&self) -> &str;
+
+    /// Returns the source buffer once for ownership by the token store.
+    fn source_text(&self) -> Option<Rc<str>> {
+        None
+    }
+
     /// Returns and clears diagnostics emitted while fetching tokens.
     fn drain_errors(&mut self) -> Vec<TokenSourceError> {
         Vec::new()
@@ -439,74 +638,108 @@ pub trait TokenSource {
     }
 }
 
+fn display_token_index(token: &impl Token) -> String {
+    if token.start() == usize::MAX && token.stop() == usize::MAX {
+        "-1".to_owned()
+    } else {
+        token.token_id().index().to_string()
+    }
+}
+
+/// Formats synthetic-token boundaries with ANTLR's `-1` sentinel.
+fn display_token_boundary(value: usize) -> String {
+    if value == usize::MAX {
+        "-1".to_owned()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Escapes token text the way ANTLR's token display format expects.
+fn display_text(text: &str) -> String {
+    let mut out = String::new();
+    for ch in text.chars() {
+        match ch {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            other => out.push(other),
+        }
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn common_token_display_matches_antlr_shape() {
-        let mut token = CommonToken::new(7)
-            .with_text("abc")
-            .with_span(2, 4)
-            .with_position(3, 9);
-        token.set_token_index(5);
-        assert_eq!(token.to_string(), "[@5,2:4='abc',<7>,3:9]");
+    fn one_token(spec: TokenSpec) -> TokenStoreHandle {
+        let handle = TokenStoreHandle::new(TokenStore::new(None, ""));
+        handle.push(spec).expect("test token should fit");
+        handle
     }
 
     #[test]
-    fn common_token_display_matches_antlr_escaping() {
-        let quote = CommonToken::new(1).with_text("\"");
-        assert_eq!(quote.to_string(), "[@-1,0:0='\"',<1>,1:0]");
-
-        let newline = CommonToken::new(1).with_text("\n");
-        assert_eq!(newline.to_string(), "[@-1,0:0='\\n',<1>,1:0]");
-
-        let backslash = CommonToken::new(1).with_text("\\");
-        assert_eq!(backslash.to_string(), "[@-1,0:0='\\',<1>,1:0]");
+    fn token_view_display_matches_antlr_shape() {
+        let handle = one_token(
+            TokenSpec::explicit(7, "abc")
+                .with_span(2, 4)
+                .with_position(3, 9),
+        );
+        assert_eq!(
+            handle.view(TokenId(0)).expect("token").to_string(),
+            "[@0,2:4='abc',<7>,3:9]"
+        );
     }
 
     #[test]
-    fn common_token_display_includes_non_default_channel() {
-        let token = CommonToken::new(2).with_text("b").with_channel(2);
-        assert_eq!(token.to_string(), "[@-1,0:0='b',<2>,channel=2,1:0]");
-    }
-
-    #[test]
-    fn eof_display_uses_antlr_empty_input_stop_index() {
-        let token = CommonToken::eof("", 0, 1, 0);
-        assert_eq!(token.to_string(), "[@-1,0:-1='<EOF>',<-1>,1:0]");
+    fn synthetic_token_display_uses_antlr_negative_index() {
+        let handle = one_token(
+            TokenSpec::explicit(7, "<missing X>")
+                .with_span(usize::MAX, usize::MAX)
+                .with_byte_span(0, 0)
+                .with_position(3, 9),
+        );
+        assert_eq!(
+            handle.view(TokenId(0)).expect("token").to_string(),
+            "[@-1,-1:-1='<missing X>',<7>,3:9]"
+        );
     }
 
     #[test]
     fn source_backed_token_exposes_utf8_byte_span() {
-        let source: Rc<str> = Rc::from("éβz");
-        let token = CommonToken::new(1)
-            .with_span(1, 1)
-            .with_source_text(source, 2, 4);
+        let mut store = TokenStore::new(Some(Rc::from("éβz")), "");
+        let id = store
+            .push(TokenSpec {
+                token_type: 1,
+                channel: DEFAULT_CHANNEL,
+                start: 1,
+                stop: 1,
+                start_byte: 2,
+                stop_byte: 4,
+                line: 1,
+                column: 1,
+                text: None,
+                source_backed: true,
+            })
+            .expect("token should fit");
+        let token = TokenView {
+            store: TokenStoreBorrow::Direct(&store),
+            id,
+        };
 
         assert_eq!(token.start(), 1);
         assert_eq!(token.stop(), 1);
-        assert_eq!(token.start_byte(), 2);
-        assert_eq!(token.stop_byte(), 4);
         assert_eq!(token.byte_span(), 2..4);
         assert_eq!(token.text(), "β");
     }
 
     #[test]
-    fn explicit_text_byte_span_falls_back_to_character_span() {
-        let token = CommonToken::new(1).with_text("β").with_span(3, 3);
-
-        assert_eq!(token.byte_span(), 3..4);
-    }
-
-    #[test]
-    fn explicit_text_can_carry_utf8_byte_span() {
-        let token = CommonToken::new(TOKEN_EOF)
-            .with_text("<EOF>")
-            .with_span(1, 0)
-            .with_byte_span(2, 2);
-
-        assert_eq!(token.text(), "<EOF>");
-        assert_eq!(token.byte_span(), 2..2);
+    fn overlarge_offset_is_rejected() {
+        let mut store = TokenStore::new(None, "");
+        let error = store
+            .push(TokenSpec::explicit(1, "x").with_span(MAX_TOKEN_OFFSET + 1, 0))
+            .expect_err("overlarge offsets must fail");
+        assert!(error.to_string().contains("supported limit"));
     }
 }

--- a/src/token.rs
+++ b/src/token.rs
@@ -222,35 +222,82 @@ impl TokenSpec {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TokenStoreError {
-    field: &'static str,
-    value: usize,
-    limit: usize,
-}
+pub struct TokenStoreError(TokenStoreErrorKind);
 
 impl TokenStoreError {
     const fn overflow(field: &'static str, value: usize, limit: usize) -> Self {
-        Self {
+        Self(TokenStoreErrorKind::Overflow {
             field,
             value,
             limit,
-        }
+        })
+    }
+
+    const fn invalid_source_boundary(offset: usize, source_len: usize) -> Self {
+        Self(TokenStoreErrorKind::InvalidSourceBoundary { offset, source_len })
+    }
+
+    pub(crate) const fn invalid_source_output(
+        expected_id: usize,
+        returned_id: usize,
+        appended: usize,
+    ) -> Self {
+        Self(TokenStoreErrorKind::InvalidSourceOutput {
+            expected_id,
+            returned_id,
+            appended,
+        })
     }
 }
 
 impl fmt::Display for TokenStoreError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "token {field} {value} exceeds the supported limit {limit}",
-            field = self.field,
-            value = self.value,
-            limit = self.limit
-        )
+        match self.0 {
+            TokenStoreErrorKind::Overflow {
+                field,
+                value,
+                limit,
+            } => write!(
+                f,
+                "token {field} {value} exceeds the supported limit {limit}"
+            ),
+            TokenStoreErrorKind::InvalidSourceBoundary { offset, source_len } => write!(
+                f,
+                "token source byte offset {offset} is not a UTF-8 character boundary \
+                 for source length {source_len}"
+            ),
+            TokenStoreErrorKind::InvalidSourceOutput {
+                expected_id,
+                returned_id,
+                appended,
+            } => write!(
+                f,
+                "token source must append exactly one token and return ID {expected_id}, \
+                 but appended {appended} and returned ID {returned_id}"
+            ),
+        }
     }
 }
 
 impl std::error::Error for TokenStoreError {}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum TokenStoreErrorKind {
+    Overflow {
+        field: &'static str,
+        value: usize,
+        limit: usize,
+    },
+    InvalidSourceBoundary {
+        offset: usize,
+        source_len: usize,
+    },
+    InvalidSourceOutput {
+        expected_id: usize,
+        returned_id: usize,
+        appended: usize,
+    },
+}
 
 /// Canonical compact storage for every token associated with one token stream.
 #[derive(Debug)]
@@ -315,6 +362,18 @@ impl TokenStore {
             if spec.start_byte > spec.stop_byte || spec.stop_byte > source.len() {
                 return Err(TokenStoreError::overflow(
                     "source byte span",
+                    spec.stop_byte,
+                    source.len(),
+                ));
+            }
+            if !source.is_char_boundary(spec.start_byte) {
+                return Err(TokenStoreError::invalid_source_boundary(
+                    spec.start_byte,
+                    source.len(),
+                ));
+            }
+            if !source.is_char_boundary(spec.stop_byte) {
+                return Err(TokenStoreError::invalid_source_boundary(
                     spec.stop_byte,
                     source.len(),
                 ));
@@ -591,6 +650,10 @@ impl<'a> TokenSink<'a> {
     pub fn view(&self, id: TokenId) -> Option<TokenView<'_>> {
         self.store.view(id)
     }
+
+    pub(crate) const fn token_count(&self) -> usize {
+        self.store.len()
+    }
 }
 
 /// A diagnostic buffered by a token source while it was producing tokens.
@@ -728,6 +791,30 @@ mod tests {
         assert_eq!(token.stop(), 1);
         assert_eq!(token.byte_span(), 2..4);
         assert_eq!(token.text(), "β");
+    }
+
+    #[test]
+    fn source_backed_token_rejects_non_utf8_boundaries() {
+        for (start_byte, stop_byte) in [(1, 2), (0, 1)] {
+            let mut store = TokenStore::new(Some(Rc::from("éz")), "");
+            let error = store
+                .push(TokenSpec {
+                    token_type: 1,
+                    channel: DEFAULT_CHANNEL,
+                    start: 0,
+                    stop: 0,
+                    start_byte,
+                    stop_byte,
+                    line: 1,
+                    column: 0,
+                    text: None,
+                    source_backed: true,
+                })
+                .expect_err("spans that split UTF-8 code points must fail");
+
+            assert!(error.to_string().contains("UTF-8 character boundary"));
+            assert!(store.is_empty());
+        }
     }
 
     #[test]

--- a/src/token.rs
+++ b/src/token.rs
@@ -1,5 +1,4 @@
 use crate::char_stream::TextInterval;
-use std::cell::{Ref, RefCell};
 use std::fmt;
 use std::ops::Range;
 use std::rc::Rc;
@@ -298,7 +297,7 @@ impl TokenStore {
         self.token_types.is_empty()
     }
 
-    fn push(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
+    pub(crate) fn push(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
         let raw_id = u32::try_from(self.len())
             .map_err(|_| TokenStoreError::overflow("count", self.len(), u32::MAX as usize))?;
         let id = TokenId(raw_id);
@@ -341,6 +340,70 @@ impl TokenStore {
         id.index() < self.len()
     }
 
+    /// Returns a borrowing view of one token record.
+    #[must_use]
+    pub fn view(&self, id: TokenId) -> Option<TokenView<'_>> {
+        self.contains(id).then_some(TokenView { store: self, id })
+    }
+
+    /// Returns the token type for `id`.
+    #[must_use]
+    pub fn token_type(&self, id: TokenId) -> Option<i32> {
+        self.token_types.get(id.index()).copied()
+    }
+
+    /// Returns the token channel for `id`.
+    #[must_use]
+    pub fn channel(&self, id: TokenId) -> Option<i32> {
+        self.channels.get(id.index()).copied()
+    }
+
+    /// Returns the token's zero-based scalar start offset.
+    #[must_use]
+    pub fn start(&self, id: TokenId) -> Option<usize> {
+        self.scalar_starts
+            .get(id.index())
+            .copied()
+            .map(expand_boundary)
+    }
+
+    /// Returns the token's zero-based inclusive scalar stop offset.
+    #[must_use]
+    pub fn stop(&self, id: TokenId) -> Option<usize> {
+        self.scalar_stops
+            .get(id.index())
+            .copied()
+            .map(expand_boundary)
+    }
+
+    /// Returns the token's one-based source line.
+    #[must_use]
+    pub fn line(&self, id: TokenId) -> Option<usize> {
+        self.lines.get(id.index()).map(|line| *line as usize)
+    }
+
+    /// Returns the token's zero-based source column.
+    #[must_use]
+    pub fn column(&self, id: TokenId) -> Option<usize> {
+        self.columns.get(id.index()).map(|column| *column as usize)
+    }
+
+    /// Returns the token's zero-based UTF-8 byte start offset.
+    #[must_use]
+    pub fn start_byte(&self, id: TokenId) -> Option<usize> {
+        self.byte_starts
+            .get(id.index())
+            .map(|offset| *offset as usize)
+    }
+
+    /// Returns the token's zero-based exclusive UTF-8 byte stop offset.
+    #[must_use]
+    pub fn stop_byte(&self, id: TokenId) -> Option<usize> {
+        self.byte_stops
+            .get(id.index())
+            .map(|offset| *offset as usize)
+    }
+
     fn explicit_text(&self, id: TokenId) -> Option<&str> {
         self.explicit_text
             .binary_search_by_key(&id, |(token_id, _)| *token_id)
@@ -348,7 +411,9 @@ impl TokenStore {
             .map(|index| self.explicit_text[index].1.as_ref())
     }
 
-    fn text(&self, id: TokenId) -> Option<&str> {
+    /// Returns explicit or source-backed text for `id`.
+    #[must_use]
+    pub fn text(&self, id: TokenId) -> Option<&str> {
         if let Some(text) = self.explicit_text(id) {
             return Some(text);
         }
@@ -383,82 +448,18 @@ const fn compact_offset(field: &'static str, value: usize) -> Result<u32, TokenS
     Ok(value as u32)
 }
 
-#[derive(Clone)]
-pub(crate) struct TokenStoreHandle(Rc<RefCell<TokenStore>>);
-
-impl TokenStoreHandle {
-    pub(crate) fn new(store: TokenStore) -> Self {
-        Self(Rc::new(RefCell::new(store)))
-    }
-
-    pub(crate) fn push(&self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
-        self.0.borrow_mut().push(spec)
-    }
-
-    pub(crate) fn view(&self, id: TokenId) -> Option<TokenView<'_>> {
-        let store = self.0.borrow();
-        store.contains(id).then_some(TokenView {
-            store: TokenStoreBorrow::Shared(store),
-            id,
-        })
-    }
-}
-
-impl fmt::Debug for TokenStoreHandle {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("TokenStoreHandle")
-            .field("tokens", &self.0.borrow().len())
-            .finish()
-    }
-}
-
-impl PartialEq for TokenStoreHandle {
-    fn eq(&self, other: &Self) -> bool {
-        Rc::ptr_eq(&self.0, &other.0)
-    }
-}
-
-impl Eq for TokenStoreHandle {}
-
-enum TokenStoreBorrow<'a> {
-    Direct(&'a TokenStore),
-    Shared(Ref<'a, TokenStore>),
-}
-
-impl TokenStoreBorrow<'_> {
-    fn store(&self) -> &TokenStore {
-        match self {
-            Self::Direct(store) => store,
-            Self::Shared(store) => store,
-        }
-    }
-}
-
-impl Clone for TokenStoreBorrow<'_> {
-    fn clone(&self) -> Self {
-        match self {
-            Self::Direct(store) => Self::Direct(store),
-            Self::Shared(store) => Self::Shared(Ref::clone(store)),
-        }
-    }
-}
-
 /// Borrowing public view of one canonical token-store record.
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct TokenView<'a> {
-    store: TokenStoreBorrow<'a>,
+    store: &'a TokenStore,
     id: TokenId,
 }
 
 impl TokenView<'_> {
-    fn store(&self) -> &TokenStore {
-        self.store.store()
-    }
-
     /// The token's text, empty when no explicit or source-backed text exists.
     #[must_use]
     pub fn text(&self) -> &str {
-        self.store().text(self.id).unwrap_or("")
+        self.store.text(self.id).unwrap_or("")
     }
 }
 
@@ -495,43 +496,43 @@ impl Token for TokenView<'_> {
     }
 
     fn token_type(&self) -> i32 {
-        self.store().token_types[self.id.index()]
+        self.store.token_types[self.id.index()]
     }
 
     fn channel(&self) -> i32 {
-        self.store().channels[self.id.index()]
+        self.store.channels[self.id.index()]
     }
 
     fn start(&self) -> usize {
-        expand_boundary(self.store().scalar_starts[self.id.index()])
+        expand_boundary(self.store.scalar_starts[self.id.index()])
     }
 
     fn stop(&self) -> usize {
-        expand_boundary(self.store().scalar_stops[self.id.index()])
+        expand_boundary(self.store.scalar_stops[self.id.index()])
     }
 
     fn line(&self) -> usize {
-        self.store().lines[self.id.index()] as usize
+        self.store.lines[self.id.index()] as usize
     }
 
     fn column(&self) -> usize {
-        self.store().columns[self.id.index()] as usize
+        self.store.columns[self.id.index()] as usize
     }
 
     fn text(&self) -> Option<&str> {
-        self.store().text(self.id)
+        self.store.text(self.id)
     }
 
     fn source_name(&self) -> &str {
-        self.store().source_name.as_ref()
+        self.store.source_name.as_ref()
     }
 
     fn start_byte(&self) -> usize {
-        self.store().byte_starts[self.id.index()] as usize
+        self.store.byte_starts[self.id.index()] as usize
     }
 
     fn stop_byte(&self) -> usize {
-        self.store().byte_stops[self.id.index()] as usize
+        self.store.byte_stops[self.id.index()] as usize
     }
 }
 
@@ -587,10 +588,7 @@ impl<'a> TokenSink<'a> {
     }
 
     pub fn view(&self, id: TokenId) -> Option<TokenView<'_>> {
-        self.store.contains(id).then_some(TokenView {
-            store: TokenStoreBorrow::Direct(self.store),
-            id,
-        })
+        self.store.view(id)
     }
 }
 
@@ -673,35 +671,35 @@ fn display_text(text: &str) -> String {
 mod tests {
     use super::*;
 
-    fn one_token(spec: TokenSpec) -> TokenStoreHandle {
-        let handle = TokenStoreHandle::new(TokenStore::new(None, ""));
-        handle.push(spec).expect("test token should fit");
-        handle
+    fn one_token(spec: TokenSpec) -> TokenStore {
+        let mut store = TokenStore::new(None, "");
+        store.push(spec).expect("test token should fit");
+        store
     }
 
     #[test]
     fn token_view_display_matches_antlr_shape() {
-        let handle = one_token(
+        let store = one_token(
             TokenSpec::explicit(7, "abc")
                 .with_span(2, 4)
                 .with_position(3, 9),
         );
         assert_eq!(
-            handle.view(TokenId(0)).expect("token").to_string(),
+            store.view(TokenId(0)).expect("token").to_string(),
             "[@0,2:4='abc',<7>,3:9]"
         );
     }
 
     #[test]
     fn synthetic_token_display_uses_antlr_negative_index() {
-        let handle = one_token(
+        let store = one_token(
             TokenSpec::explicit(7, "<missing X>")
                 .with_span(usize::MAX, usize::MAX)
                 .with_byte_span(0, 0)
                 .with_position(3, 9),
         );
         assert_eq!(
-            handle.view(TokenId(0)).expect("token").to_string(),
+            store.view(TokenId(0)).expect("token").to_string(),
             "[@-1,-1:-1='<missing X>',<7>,3:9]"
         );
     }
@@ -723,10 +721,7 @@ mod tests {
                 source_backed: true,
             })
             .expect("token should fit");
-        let token = TokenView {
-            store: TokenStoreBorrow::Direct(&store),
-            id,
-        };
+        let token = TokenView { store: &store, id };
 
         assert_eq!(token.start(), 1);
         assert_eq!(token.stop(), 1);

--- a/src/token.rs
+++ b/src/token.rs
@@ -455,10 +455,11 @@ pub struct TokenView<'a> {
     id: TokenId,
 }
 
-impl TokenView<'_> {
+impl<'a> TokenView<'a> {
     /// The token's text, empty when no explicit or source-backed text exists.
     #[must_use]
-    pub fn text(&self) -> &str {
+    #[allow(clippy::trivially_copy_pass_by_ref)]
+    pub fn text(&self) -> &'a str {
         self.store.text(self.id).unwrap_or("")
     }
 }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,9 +1,16 @@
 use crate::int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
+use std::cell::Cell;
 
 use crate::token::{
     DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenId, TokenSink, TokenSource, TokenSourceError,
     TokenSpec, TokenStore, TokenStoreError, TokenView,
 };
+
+#[derive(Debug)]
+struct BufferedSourceError {
+    token_index: usize,
+    error: TokenSourceError,
+}
 
 #[derive(Debug)]
 pub struct CommonTokenStream<S> {
@@ -13,7 +20,8 @@ pub struct CommonTokenStream<S> {
     next_visible_after: Vec<usize>,
     cursor: usize,
     channel: i32,
-    source_errors: Vec<TokenSourceError>,
+    requested_token_count: Cell<usize>,
+    source_errors: Vec<BufferedSourceError>,
 }
 
 const UNKNOWN_NEXT_VISIBLE: usize = usize::MAX;
@@ -49,7 +57,12 @@ where
         loop {
             let mut sink = TokenSink::new(&mut store);
             let id = source.next_token(&mut sink)?;
-            source_errors.extend(source.drain_errors());
+            source_errors.extend(source.drain_errors().into_iter().map(|error| {
+                BufferedSourceError {
+                    token_index: id.index(),
+                    error,
+                }
+            }));
             let token = sink
                 .view(id)
                 .expect("token source returned an ID it did not emit");
@@ -65,28 +78,29 @@ where
             next_visible_after: vec![UNKNOWN_NEXT_VISIBLE; source_token_count],
             cursor: 0,
             channel,
+            requested_token_count: Cell::new(0),
             source_errors,
         };
         stream.cursor = stream.adjust_seek_index(0);
+        stream.requested_token_count.set(0);
         Ok(stream)
     }
 
     /// Idempotent eager-buffering operation. Construction already buffers
     /// through EOF so the store can be shared with CST nodes.
     pub fn fill(&mut self) {
+        self.note_requested_count(self.source_token_count);
         self.cursor = self.adjust_seek_index(self.cursor);
     }
 
     /// Returns a borrowing view of the token at an absolute buffered index.
     pub fn get(&self, index: usize) -> Option<TokenView<'_>> {
-        (index < self.source_token_count)
-            .then(|| TokenId::try_from(index).ok())
-            .flatten()
-            .and_then(|id| self.store.view(id))
+        self.get_id(index).and_then(|id| self.store.view(id))
     }
 
     /// Returns the compact ID at an absolute buffered index.
     pub fn get_id(&self, index: usize) -> Option<TokenId> {
+        self.note_requested_count(index.saturating_add(1));
         (index < self.source_token_count)
             .then(|| TokenId::try_from(index).ok())
             .flatten()
@@ -141,7 +155,8 @@ where
     }
 
     /// Iterates borrowing views of the original buffered token sequence.
-    pub const fn tokens(&self) -> TokenIter<'_> {
+    pub fn tokens(&self) -> TokenIter<'_> {
+        self.note_requested_count(self.source_token_count);
         TokenIter {
             store: &self.store,
             next: 0,
@@ -171,6 +186,14 @@ where
 
     pub(crate) fn insert(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
         self.store.push(spec)
+    }
+
+    fn note_requested_count(&self, count: usize) {
+        self.requested_token_count.set(
+            self.requested_token_count
+                .get()
+                .max(count.min(self.source_token_count)),
+        );
     }
 
     /// Moves a raw token index to the next token visible on this stream's
@@ -312,7 +335,7 @@ where
         (start..=stop.min(self.source_token_count.saturating_sub(1)))
             .filter_map(|index| self.get(index))
             .take_while(|token| token.token_type() != TOKEN_EOF)
-            .map(|token| token.text().to_owned())
+            .map(|token| token.text())
             .collect()
     }
 
@@ -320,13 +343,20 @@ where
     pub fn text_all(&self) -> String {
         self.tokens()
             .filter(|token| token.token_type() != TOKEN_EOF)
-            .map(|token| token.text().to_owned())
+            .map(|token| token.text())
             .collect()
     }
 
-    /// Returns and clears diagnostics emitted by the underlying token source.
+    /// Returns and clears diagnostics emitted while producing requested tokens.
     pub fn drain_source_errors(&mut self) -> Vec<TokenSourceError> {
-        std::mem::take(&mut self.source_errors)
+        let requested = self.requested_token_count.get();
+        let ready = self
+            .source_errors
+            .partition_point(|buffered| buffered.token_index < requested);
+        self.source_errors
+            .drain(..ready)
+            .map(|buffered| buffered.error)
+            .collect()
     }
 
     pub const fn is_filled(&self) -> bool {
@@ -407,6 +437,43 @@ mod tests {
         }
     }
 
+    #[derive(Debug)]
+    struct ErrorTokenSource {
+        tokens: VecDeque<(TokenSpec, Vec<TokenSourceError>)>,
+        pending_errors: Vec<TokenSourceError>,
+        index: usize,
+    }
+
+    impl TokenSource for ErrorTokenSource {
+        fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {
+            let (spec, errors) = self.tokens.pop_front().unwrap_or_else(|| {
+                (
+                    TokenSpec::eof(self.index, self.index, 1, self.index),
+                    Vec::new(),
+                )
+            });
+            self.index += 1;
+            self.pending_errors = errors;
+            sink.push(spec)
+        }
+
+        fn line(&self) -> usize {
+            1
+        }
+
+        fn column(&self) -> usize {
+            self.index
+        }
+
+        fn source_name(&self) -> &'static str {
+            "errors"
+        }
+
+        fn drain_errors(&mut self) -> Vec<TokenSourceError> {
+            std::mem::take(&mut self.pending_errors)
+        }
+    }
+
     fn source(tokens: Vec<TokenSpec>) -> VecTokenSource {
         VecTokenSource {
             tokens: tokens.into(),
@@ -441,6 +508,39 @@ mod tests {
             TokenSpec::eof(1, 1, 1, 1),
         ]));
         assert_eq!(stream.text(10, 12), "");
+    }
+
+    #[test]
+    fn text_concatenates_borrowed_token_text() {
+        let stream = CommonTokenStream::new(source(vec![
+            TokenSpec::explicit(1, "a"),
+            TokenSpec::explicit(2, "b"),
+            TokenSpec::eof(2, 2, 1, 2),
+        ]));
+        assert_eq!(stream.text(0, 1), "ab");
+        assert_eq!(stream.text_all(), "ab");
+    }
+
+    #[test]
+    fn source_errors_remain_hidden_until_their_token_is_requested() {
+        let suffix_error = TokenSourceError::new(1, 4, "token recognition error at: '@'");
+        let mut stream = CommonTokenStream::new(ErrorTokenSource {
+            tokens: [
+                (TokenSpec::explicit(1, "x"), Vec::new()),
+                (TokenSpec::explicit(2, "y"), Vec::new()),
+                (TokenSpec::eof(3, 3, 1, 3), vec![suffix_error.clone()]),
+            ]
+            .into(),
+            pending_errors: Vec::new(),
+            index: 0,
+        });
+
+        assert!(stream.drain_source_errors().is_empty());
+        assert_eq!(stream.token_type_at_index(1), 2);
+        assert!(stream.drain_source_errors().is_empty());
+
+        assert_eq!(stream.token_type_at_index(2), TOKEN_EOF);
+        assert_eq!(stream.drain_source_errors(), vec![suffix_error]);
     }
 
     #[test]

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,18 +1,17 @@
 use crate::int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
-use std::rc::Rc;
 
 use crate::token::{
-    CommonToken, DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenRef, TokenSource, TokenSourceError,
+    DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenId, TokenSink, TokenSource, TokenSourceError,
+    TokenSpec, TokenStore, TokenStoreError, TokenStoreHandle, TokenView,
 };
 
 #[derive(Debug)]
 pub struct CommonTokenStream<S> {
     source: S,
-    tokens: Vec<TokenRef>,
-    public_tokens: Vec<CommonToken>,
+    store: TokenStoreHandle,
+    source_token_count: usize,
     next_visible_after: Vec<usize>,
     cursor: usize,
-    fetched_eof: bool,
     channel: i32,
     source_errors: Vec<TokenSourceError>,
 }
@@ -23,49 +22,85 @@ impl<S> CommonTokenStream<S>
 where
     S: TokenSource,
 {
-    /// Creates a token stream that filters lookahead to the default channel.
-    pub const fn new(source: S) -> Self {
-        Self::with_channel(source, DEFAULT_CHANNEL)
+    /// Creates and fills a token stream that filters lookahead to the default
+    /// channel.
+    ///
+    /// Use [`Self::try_new`] when token/source limit errors should be handled
+    /// instead of reported as a construction panic.
+    pub fn new(source: S) -> Self {
+        Self::try_new(source).unwrap_or_else(|error| panic!("failed to buffer tokens: {error}"))
     }
 
-    /// Creates a token stream whose `LT/LA` operations see only `channel`.
-    pub const fn with_channel(source: S, channel: i32) -> Self {
-        Self {
+    pub fn try_new(source: S) -> Result<Self, TokenStoreError> {
+        Self::try_with_channel(source, DEFAULT_CHANNEL)
+    }
+
+    /// Creates and fills a token stream whose `LT/LA` operations see only
+    /// `channel`.
+    pub fn with_channel(source: S, channel: i32) -> Self {
+        Self::try_with_channel(source, channel)
+            .unwrap_or_else(|error| panic!("failed to buffer tokens: {error}"))
+    }
+
+    pub fn try_with_channel(mut source: S, channel: i32) -> Result<Self, TokenStoreError> {
+        let source_name = source.source_name().to_owned();
+        let mut store = TokenStore::new(source.source_text(), source_name);
+        let mut source_errors = Vec::new();
+        loop {
+            let mut sink = TokenSink::new(&mut store);
+            let id = source.next_token(&mut sink)?;
+            source_errors.extend(source.drain_errors());
+            let token = sink
+                .view(id)
+                .expect("token source returned an ID it did not emit");
+            if token.token_type() == TOKEN_EOF {
+                break;
+            }
+        }
+        let source_token_count = store.len();
+        let store = TokenStoreHandle::new(store);
+        let mut stream = Self {
             source,
-            tokens: Vec::new(),
-            public_tokens: Vec::new(),
-            next_visible_after: Vec::new(),
+            store,
+            source_token_count,
+            next_visible_after: vec![UNKNOWN_NEXT_VISIBLE; source_token_count],
             cursor: 0,
-            fetched_eof: false,
             channel,
-            source_errors: Vec::new(),
-        }
+            source_errors,
+        };
+        stream.cursor = stream.adjust_seek_index(0);
+        Ok(stream)
     }
 
-    /// Reads tokens from the source until EOF is buffered.
+    /// Idempotent eager-buffering operation. Construction already buffers
+    /// through EOF so the store can be shared with CST nodes.
     pub fn fill(&mut self) {
-        while !self.fetched_eof {
-            self.fetch_one();
-        }
         self.cursor = self.adjust_seek_index(self.cursor);
     }
 
-    /// Returns the token at an absolute buffered index, fetching from the source
-    /// as needed.
-    pub fn get(&mut self, index: usize) -> Option<&CommonToken> {
-        self.sync(index);
-        self.tokens.get(index).map(Rc::as_ref)
+    /// Returns a borrowing view of the token at an absolute buffered index.
+    pub fn get(&self, index: usize) -> Option<TokenView<'_>> {
+        (index < self.source_token_count)
+            .then(|| TokenId::try_from(index).ok())
+            .flatten()
+            .and_then(|id| self.store.view(id))
     }
 
-    /// Returns a shared reference-counted token at an absolute buffered index.
-    pub fn get_ref(&mut self, index: usize) -> Option<TokenRef> {
-        self.sync(index);
-        self.tokens.get(index).map(Rc::clone)
+    /// Returns the compact ID at an absolute buffered index.
+    pub fn get_id(&self, index: usize) -> Option<TokenId> {
+        (index < self.source_token_count)
+            .then(|| TokenId::try_from(index).ok())
+            .flatten()
     }
 
     /// Returns the token at one-based lookahead/lookbehind offset, skipping
     /// tokens outside the configured channel for positive offsets.
-    pub fn lt(&mut self, offset: isize) -> Option<&CommonToken> {
+    pub fn lt(&self, offset: isize) -> Option<TokenView<'_>> {
+        self.lt_id(offset).and_then(|id| self.store.view(id))
+    }
+
+    /// Returns the compact token ID at one-based lookahead/lookbehind offset.
+    pub fn lt_id(&self, offset: isize) -> Option<TokenId> {
         if offset == 0 {
             return None;
         }
@@ -73,7 +108,7 @@ where
             return offset
                 .checked_neg()
                 .map(isize::cast_unsigned)
-                .and_then(|offset| self.lb(offset));
+                .and_then(|offset| self.lb_id(offset));
         }
 
         let mut index = self.next_token_on_channel(self.cursor, self.channel);
@@ -82,34 +117,14 @@ where
             index = self.next_token_on_channel(index + 1, self.channel);
             remaining -= 1;
         }
-        self.sync(index);
-        self.tokens.get(index).map(Rc::as_ref)
+        self.get_id(index)
     }
 
-    /// Returns the token at one-based lookahead/lookbehind offset as a shared
-    /// reference-counted token.
-    pub fn lt_ref(&mut self, offset: isize) -> Option<TokenRef> {
-        if offset == 0 {
-            return None;
-        }
-        if offset < 0 {
-            return offset
-                .checked_neg()
-                .map(isize::cast_unsigned)
-                .and_then(|offset| self.lb_ref(offset));
-        }
-
-        let mut index = self.next_token_on_channel(self.cursor, self.channel);
-        let mut remaining = offset;
-        while remaining > 1 {
-            index = self.next_token_on_channel(index + 1, self.channel);
-            remaining -= 1;
-        }
-        self.sync(index);
-        self.tokens.get(index).map(Rc::clone)
+    pub fn lb(&self, offset: usize) -> Option<TokenView<'_>> {
+        self.lb_id(offset).and_then(|id| self.store.view(id))
     }
 
-    pub fn lb(&self, offset: usize) -> Option<&CommonToken> {
+    fn lb_id(&self, offset: usize) -> Option<TokenId> {
         if offset == 0 || self.cursor == 0 {
             return None;
         }
@@ -119,75 +134,51 @@ where
             index = self.previous_token_on_channel(index, self.channel)?;
             remaining -= 1;
         }
-        self.tokens.get(index).map(Rc::as_ref)
-    }
-
-    fn lb_ref(&self, offset: usize) -> Option<TokenRef> {
-        if offset == 0 || self.cursor == 0 {
-            return None;
-        }
-        let mut index = self.cursor;
-        let mut remaining = offset;
-        while remaining > 0 {
-            index = self.previous_token_on_channel(index, self.channel)?;
-            remaining -= 1;
-        }
-        self.tokens.get(index).map(Rc::clone)
+        self.get_id(index)
     }
 
     pub const fn token_source(&self) -> &S {
         &self.source
     }
 
-    pub fn tokens(&self) -> &[CommonToken] {
-        &self.public_tokens
-    }
-
-    /// Ensures the buffer contains `index`, unless EOF has already been fetched.
-    fn sync(&mut self, index: usize) -> bool {
-        if index < self.tokens.len() {
-            return true;
+    /// Iterates borrowing views of the original buffered token sequence.
+    pub const fn tokens(&self) -> TokenIter<'_> {
+        TokenIter {
+            store: &self.store,
+            next: 0,
+            stop: self.source_token_count,
         }
-        let needed = index + 1 - self.tokens.len();
-        self.fetch(needed) >= needed
     }
 
-    /// Fetches up to `count` more tokens, stopping early at EOF.
-    fn fetch(&mut self, count: usize) -> usize {
-        let mut fetched = 0;
-        while fetched < count && !self.fetched_eof {
-            self.fetch_one();
-            fetched += 1;
-        }
-        fetched
+    pub const fn token_count(&self) -> usize {
+        self.source_token_count
     }
 
-    fn fetch_one(&mut self) {
-        let mut token = self.source.next_token();
-        self.source_errors.extend(self.source.drain_errors());
-        let token_index = isize::try_from(self.tokens.len()).unwrap_or(isize::MAX);
-        token.set_token_index(token_index);
-        self.fetched_eof = token.token_type() == TOKEN_EOF;
-        self.tokens.push(Rc::new(token.clone()));
-        self.public_tokens.push(token);
-        self.next_visible_after.push(UNKNOWN_NEXT_VISIBLE);
+    pub(crate) fn token_view(&self, id: TokenId) -> Option<TokenView<'_>> {
+        self.store.view(id)
+    }
+
+    pub(crate) fn token_store_handle(&self) -> TokenStoreHandle {
+        self.store.clone()
+    }
+
+    pub(crate) fn insert(&self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
+        self.store.push(spec)
     }
 
     /// Moves a raw token index to the next token visible on this stream's
     /// channel.
-    fn adjust_seek_index(&mut self, index: usize) -> usize {
+    fn adjust_seek_index(&self, index: usize) -> usize {
         self.next_token_on_channel(index, self.channel)
     }
 
-    /// Finds the next buffered token on `channel`, fetching as needed.
-    fn next_token_on_channel(&mut self, mut index: usize, channel: i32) -> usize {
-        self.sync(index);
-        while let Some(token) = self.tokens.get(index) {
+    /// Finds the next buffered token on `channel`.
+    fn next_token_on_channel(&self, mut index: usize, channel: i32) -> usize {
+        while let Some(token) = self.get(index) {
             if token.token_type() == TOKEN_EOF || token.channel() == channel {
                 return index;
             }
             index += 1;
-            self.sync(index);
         }
         index
     }
@@ -196,7 +187,7 @@ where
     fn previous_token_on_channel(&self, mut index: usize, channel: i32) -> Option<usize> {
         while index > 0 {
             index -= 1;
-            let token = self.tokens.get(index)?;
+            let token = self.get(index)?;
             if token.token_type() == TOKEN_EOF || token.channel() == channel {
                 return Some(index);
             }
@@ -206,16 +197,7 @@ where
 
     /// Finds the previous buffered token visible to this stream before
     /// `index`.
-    ///
-    /// Parser rule intervals and `$text` actions are defined in terms of
-    /// visible tokens, but their rendered source text still includes hidden
-    /// tokens between the visible start and stop. Returning the previous token
-    /// on the stream channel avoids accidentally using trailing hidden
-    /// whitespace as the stop token.
-    pub fn previous_visible_token_index(&mut self, index: usize) -> Option<usize> {
-        if index > 0 {
-            self.sync(index - 1);
-        }
+    pub fn previous_visible_token_index(&self, index: usize) -> Option<usize> {
         self.previous_token_on_channel(index, self.channel)
     }
 }
@@ -245,7 +227,7 @@ where
     }
 
     fn size(&self) -> usize {
-        self.tokens.len()
+        self.source_token_count
     }
 
     fn source_name(&self) -> &str {
@@ -262,19 +244,15 @@ impl<S> CommonTokenStream<S>
 where
     S: TokenSource,
 {
-    pub fn la_token(&mut self, offset: isize) -> i32 {
-        self.lt(offset).map_or(TOKEN_EOF, Token::token_type)
+    pub fn la_token(&self, offset: isize) -> i32 {
+        self.lt(offset)
+            .map_or(TOKEN_EOF, |token| token.token_type())
     }
 
-    /// Returns the token type at a buffered absolute index, fetching from the
-    /// source on demand. Past-EOF reads are reported as `TOKEN_EOF` so the
-    /// caller does not need to special-case the buffer's stop. The cursor is
-    /// not modified, which lets hot speculative loops avoid the seek
-    /// round-trip when they only need lookahead types.
-    pub fn token_type_at_index(&mut self, index: usize) -> i32 {
-        self.sync(index);
-        self.tokens
-            .get(index)
+    /// Returns the token type at a buffered absolute index. Past-EOF reads are
+    /// reported as `TOKEN_EOF`.
+    pub fn token_type_at_index(&self, index: usize) -> i32 {
+        self.get(index)
             .map_or(TOKEN_EOF, |token| token.token_type())
     }
 
@@ -284,11 +262,8 @@ where
     }
 
     /// Returns the next parser-visible token index after consuming the token
-    /// at `index`, skipping hidden-channel tokens. The parser's stream cursor
-    /// is not modified. Used by speculative recognition that simulates token
-    /// consumption thousands of times without committing it.
+    /// at `index`, skipping hidden-channel tokens.
     pub fn next_visible_after(&mut self, index: usize) -> usize {
-        self.sync(index);
         if let Some(cached) = self
             .next_visible_after
             .get(index)
@@ -300,8 +275,7 @@ where
 
         let mut next = index + 1;
         let found = loop {
-            self.sync(next);
-            match self.tokens.get(next) {
+            match self.get(next) {
                 Some(token)
                     if token.token_type() != TOKEN_EOF && token.channel() != self.channel =>
                 {
@@ -317,65 +291,93 @@ where
         found
     }
 
-    pub fn text(&mut self, start: usize, stop: usize) -> String {
-        self.sync(stop);
-        if start > stop || start >= self.tokens.len() {
+    pub fn text(&self, start: usize, stop: usize) -> String {
+        if start > stop || start >= self.source_token_count {
             return String::new();
         }
-        // Java's `BufferedTokenStream.getText(Interval)` stops at the first
-        // EOF token, so an interval whose stop index lands on EOF renders
-        // without a trailing `<EOF>` (diagnostics rely on this).
-        self.tokens[start..=stop.min(self.tokens.len().saturating_sub(1))]
-            .iter()
+        (start..=stop.min(self.source_token_count.saturating_sub(1)))
+            .filter_map(|index| self.get(index))
             .take_while(|token| token.token_type() != TOKEN_EOF)
-            .map(|token| token.text())
-            .collect::<Vec<_>>()
-            .join("")
-    }
-
-    /// Concatenated text of every buffered token except EOF — ANTLR's
-    /// `TokenStream.getText()`, the shape generated test actions read through
-    /// `self.input().text()`.
-    pub fn text_all(&mut self) -> String {
-        self.fill();
-        self.tokens
-            .iter()
-            .filter(|token| token.token_type() != TOKEN_EOF)
-            .map(|token| token.text())
+            .map(|token| token.text().to_owned())
             .collect()
     }
 
-    /// Returns and clears diagnostics emitted by the underlying token source
-    /// while this stream was fetching tokens.
+    /// Concatenated text of every buffered token except EOF.
+    pub fn text_all(&self) -> String {
+        self.tokens()
+            .filter(|token| token.token_type() != TOKEN_EOF)
+            .map(|token| token.text().to_owned())
+            .collect()
+    }
+
+    /// Returns and clears diagnostics emitted by the underlying token source.
     pub fn drain_source_errors(&mut self) -> Vec<TokenSourceError> {
         std::mem::take(&mut self.source_errors)
     }
 
     pub const fn is_filled(&self) -> bool {
-        self.fetched_eof
+        true
     }
 }
+
+#[derive(Debug)]
+pub struct TokenIter<'a> {
+    store: &'a TokenStoreHandle,
+    next: usize,
+    stop: usize,
+}
+
+impl<'a> Iterator for TokenIter<'a> {
+    type Item = TokenView<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next >= self.stop {
+            return None;
+        }
+        let id = TokenId::try_from(self.next).ok()?;
+        self.next += 1;
+        self.store.view(id)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.stop - self.next;
+        (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for TokenIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.next >= self.stop {
+            return None;
+        }
+        self.stop -= 1;
+        let id = TokenId::try_from(self.stop).ok()?;
+        self.store.view(id)
+    }
+}
+
+impl ExactSizeIterator for TokenIter<'_> {}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::token::{CommonToken, HIDDEN_CHANNEL};
+    use crate::token::HIDDEN_CHANNEL;
+    use std::collections::VecDeque;
 
     #[derive(Debug)]
     struct VecTokenSource {
-        tokens: Vec<CommonToken>,
+        tokens: VecDeque<TokenSpec>,
         index: usize,
     }
 
     impl TokenSource for VecTokenSource {
-        fn next_token(&mut self) -> CommonToken {
-            let token = self
+        fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {
+            let spec = self
                 .tokens
-                .get(self.index)
-                .cloned()
-                .unwrap_or_else(|| CommonToken::eof("vec", self.index, 1, self.index));
+                .pop_front()
+                .unwrap_or_else(|| TokenSpec::eof(self.index, self.index, 1, self.index));
             self.index += 1;
-            token
+            sink.push(spec)
         }
 
         fn line(&self) -> usize {
@@ -391,20 +393,21 @@ mod tests {
         }
     }
 
+    fn source(tokens: Vec<TokenSpec>) -> VecTokenSource {
+        VecTokenSource {
+            tokens: tokens.into(),
+            index: 0,
+        }
+    }
+
     #[test]
     fn stream_skips_hidden_channel_for_lookahead() {
-        let source = VecTokenSource {
-            tokens: vec![
-                CommonToken::new(1).with_text("a"),
-                CommonToken::new(2)
-                    .with_text(" ")
-                    .with_channel(HIDDEN_CHANNEL),
-                CommonToken::new(3).with_text("b"),
-                CommonToken::eof("vec", 3, 1, 3),
-            ],
-            index: 0,
-        };
-        let mut stream = CommonTokenStream::new(source);
+        let mut stream = CommonTokenStream::new(source(vec![
+            TokenSpec::explicit(1, "a"),
+            TokenSpec::explicit(2, " ").with_channel(HIDDEN_CHANNEL),
+            TokenSpec::explicit(3, "b"),
+            TokenSpec::eof(3, 3, 1, 3),
+        ]));
         assert_eq!(stream.la_token(1), 1);
         stream.consume();
         assert_eq!(stream.la_token(1), 3);
@@ -418,62 +421,28 @@ mod tests {
     }
 
     #[test]
-    fn lookahead_skips_hidden_token_at_initial_cursor() {
-        let source = VecTokenSource {
-            tokens: vec![
-                CommonToken::new(2)
-                    .with_text(" ")
-                    .with_channel(HIDDEN_CHANNEL),
-                CommonToken::new(1).with_text("a"),
-                CommonToken::eof("vec", 2, 1, 2),
-            ],
-            index: 0,
-        };
-        let mut stream = CommonTokenStream::new(source);
-
-        assert_eq!(stream.la_token(1), 1);
-        assert_eq!(stream.lt(1).and_then(Token::text), Some("a"));
-        stream.consume();
-        assert_eq!(stream.la_token(1), TOKEN_EOF);
-    }
-
-    #[test]
     fn text_returns_empty_when_start_is_past_buffer() {
-        let source = VecTokenSource {
-            tokens: vec![
-                CommonToken::new(1).with_text("a"),
-                CommonToken::eof("vec", 1, 1, 1),
-            ],
-            index: 0,
-        };
-        let mut stream = CommonTokenStream::new(source);
-
+        let stream = CommonTokenStream::new(source(vec![
+            TokenSpec::explicit(1, "a"),
+            TokenSpec::eof(1, 1, 1, 1),
+        ]));
         assert_eq!(stream.text(10, 12), "");
     }
 
     #[test]
-    fn tokens_returns_public_slice() {
-        let source = VecTokenSource {
-            tokens: vec![
-                CommonToken::new(1).with_text("a"),
-                CommonToken::new(2).with_text("b"),
-                CommonToken::eof("vec", 2, 1, 2),
-            ],
-            index: 0,
-        };
-        let mut stream = CommonTokenStream::new(source);
-        stream.fill();
-
-        fn token_count(tokens: &[CommonToken]) -> usize {
-            tokens.len()
-        }
-
-        let tokens = stream.tokens();
-        assert_eq!(token_count(tokens), 3);
-        assert_eq!(tokens[0].token_type(), 1);
-        assert_eq!(tokens.first().map(Token::token_type), Some(1));
+    fn tokens_returns_borrowing_views() {
+        let stream = CommonTokenStream::new(source(vec![
+            TokenSpec::explicit(1, "a"),
+            TokenSpec::explicit(2, "b"),
+            TokenSpec::eof(2, 2, 1, 2),
+        ]));
+        assert_eq!(stream.tokens().len(), 3);
         assert_eq!(
-            tokens.iter().next_back().map(Token::token_type),
+            stream.tokens().next().map(|token| token.token_type()),
+            Some(1)
+        );
+        assert_eq!(
+            stream.tokens().next_back().map(|token| token.token_type()),
             Some(TOKEN_EOF)
         );
     }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -55,8 +55,17 @@ where
         let mut store = TokenStore::new(source.source_text(), source_name);
         let mut source_errors = Vec::new();
         loop {
+            let expected_id = store.len();
             let mut sink = TokenSink::new(&mut store);
             let id = source.next_token(&mut sink)?;
+            let appended = sink.token_count().saturating_sub(expected_id);
+            if appended != 1 || id.index() != expected_id {
+                return Err(TokenStoreError::invalid_source_output(
+                    expected_id,
+                    id.index(),
+                    appended,
+                ));
+            }
             source_errors.extend(source.drain_errors().into_iter().map(|error| {
                 BufferedSourceError {
                     token_index: id.index(),
@@ -474,6 +483,30 @@ mod tests {
         }
     }
 
+    #[derive(Debug, Default)]
+    struct StaleIdTokenSource {
+        previous: Option<TokenId>,
+    }
+
+    impl TokenSource for StaleIdTokenSource {
+        fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {
+            let emitted = sink.push(TokenSpec::explicit(1, "x"))?;
+            Ok(self.previous.replace(emitted).unwrap_or(emitted))
+        }
+
+        fn line(&self) -> usize {
+            1
+        }
+
+        fn column(&self) -> usize {
+            0
+        }
+
+        fn source_name(&self) -> &'static str {
+            "stale-id"
+        }
+    }
+
     fn source(tokens: Vec<TokenSpec>) -> VecTokenSource {
         VecTokenSource {
             tokens: tokens.into(),
@@ -519,6 +552,15 @@ mod tests {
         ]));
         assert_eq!(stream.text(0, 1), "ab");
         assert_eq!(stream.text_all(), "ab");
+    }
+
+    #[test]
+    fn construction_rejects_stale_non_eof_token_id() {
+        let error = CommonTokenStream::try_new(StaleIdTokenSource::default())
+            .expect_err("a stale token ID must terminate buffering with an error");
+
+        assert!(error.to_string().contains("return ID 1"));
+        assert!(error.to_string().contains("returned ID 0"));
     }
 
     #[test]

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -2,13 +2,13 @@ use crate::int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
 
 use crate::token::{
     DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenId, TokenSink, TokenSource, TokenSourceError,
-    TokenSpec, TokenStore, TokenStoreError, TokenStoreHandle, TokenView,
+    TokenSpec, TokenStore, TokenStoreError, TokenView,
 };
 
 #[derive(Debug)]
 pub struct CommonTokenStream<S> {
     source: S,
-    store: TokenStoreHandle,
+    store: TokenStore,
     source_token_count: usize,
     next_visible_after: Vec<usize>,
     cursor: usize,
@@ -58,7 +58,6 @@ where
             }
         }
         let source_token_count = store.len();
-        let store = TokenStoreHandle::new(store);
         let mut stream = Self {
             source,
             store,
@@ -154,15 +153,23 @@ where
         self.source_token_count
     }
 
+    /// Returns the canonical token store owned by this stream.
+    #[must_use]
+    pub const fn token_store(&self) -> &TokenStore {
+        &self.store
+    }
+
+    /// Consumes the stream and returns its canonical token store.
+    #[must_use]
+    pub fn into_token_store(self) -> TokenStore {
+        self.store
+    }
+
     pub(crate) fn token_view(&self, id: TokenId) -> Option<TokenView<'_>> {
         self.store.view(id)
     }
 
-    pub(crate) fn token_store_handle(&self) -> TokenStoreHandle {
-        self.store.clone()
-    }
-
-    pub(crate) fn insert(&self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
+    pub(crate) fn insert(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
         self.store.push(spec)
     }
 
@@ -174,8 +181,10 @@ where
 
     /// Finds the next buffered token on `channel`.
     fn next_token_on_channel(&self, mut index: usize, channel: i32) -> usize {
-        while let Some(token) = self.get(index) {
-            if token.token_type() == TOKEN_EOF || token.channel() == channel {
+        while let Some(id) = self.get_id(index) {
+            if self.store.token_type(id) == Some(TOKEN_EOF)
+                || self.store.channel(id) == Some(channel)
+            {
                 return index;
             }
             index += 1;
@@ -187,8 +196,10 @@ where
     fn previous_token_on_channel(&self, mut index: usize, channel: i32) -> Option<usize> {
         while index > 0 {
             index -= 1;
-            let token = self.get(index)?;
-            if token.token_type() == TOKEN_EOF || token.channel() == channel {
+            let id = self.get_id(index)?;
+            if self.store.token_type(id) == Some(TOKEN_EOF)
+                || self.store.channel(id) == Some(channel)
+            {
                 return Some(index);
             }
         }
@@ -245,15 +256,17 @@ where
     S: TokenSource,
 {
     pub fn la_token(&self, offset: isize) -> i32 {
-        self.lt(offset)
-            .map_or(TOKEN_EOF, |token| token.token_type())
+        self.lt_id(offset)
+            .and_then(|id| self.store.token_type(id))
+            .unwrap_or(TOKEN_EOF)
     }
 
     /// Returns the token type at a buffered absolute index. Past-EOF reads are
     /// reported as `TOKEN_EOF`.
     pub fn token_type_at_index(&self, index: usize) -> i32 {
-        self.get(index)
-            .map_or(TOKEN_EOF, |token| token.token_type())
+        self.get_id(index)
+            .and_then(|id| self.store.token_type(id))
+            .unwrap_or(TOKEN_EOF)
     }
 
     /// Returns the token channel visible to `LT/LA` operations.
@@ -275,9 +288,10 @@ where
 
         let mut next = index + 1;
         let found = loop {
-            match self.get(next) {
-                Some(token)
-                    if token.token_type() != TOKEN_EOF && token.channel() != self.channel =>
+            match self.get_id(next) {
+                Some(id)
+                    if self.store.token_type(id) != Some(TOKEN_EOF)
+                        && self.store.channel(id) != Some(self.channel) =>
                 {
                     next += 1;
                     continue;
@@ -322,7 +336,7 @@ where
 
 #[derive(Debug)]
 pub struct TokenIter<'a> {
-    store: &'a TokenStoreHandle,
+    store: &'a TokenStore,
     next: usize,
     stop: usize,
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::fmt;
 use std::rc::Rc;
 
-use crate::token::{CommonToken, Token, TokenRef};
+use crate::token::{Token, TokenId, TokenStoreHandle, TokenView};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -83,7 +83,7 @@ impl ParseTree {
     }
 
     /// Finds the stop token for the first rule node with `rule_index`.
-    pub fn first_rule_stop(&self, rule_index: usize) -> Option<&CommonToken> {
+    pub fn first_rule_stop(&self, rule_index: usize) -> Option<TokenView<'_>> {
         let Self::Rule(rule) = self else {
             return None;
         };
@@ -124,7 +124,7 @@ impl ParseTree {
     }
 
     /// Finds the first recovery error token in a depth-first walk.
-    pub fn first_error_token(&self) -> Option<&CommonToken> {
+    pub fn first_error_token(&self) -> Option<TokenView<'_>> {
         match self {
             Self::Rule(rule) => rule
                 .context()
@@ -241,8 +241,9 @@ pub struct ParserRuleContext {
     rule_index: usize,
     invoking_state: isize,
     alt_number: usize,
-    start: Option<TokenRef>,
-    stop: Option<TokenRef>,
+    token_store: Option<TokenStoreHandle>,
+    start: Option<TokenId>,
+    stop: Option<TokenId>,
     int_returns: Option<Box<IntReturns>>,
     children: Vec<ParseTree>,
     /// Whether any child has been offered to this context, independent of whether
@@ -304,6 +305,7 @@ impl ParserRuleContext {
             rule_index,
             invoking_state,
             alt_number: 0,
+            token_store: None,
             start: None,
             stop: None,
             int_returns: None,
@@ -323,6 +325,7 @@ impl ParserRuleContext {
             rule_index,
             invoking_state,
             alt_number: 0,
+            token_store: None,
             start: None,
             stop: None,
             int_returns: None,
@@ -349,32 +352,35 @@ impl ParserRuleContext {
         self.alt_number = alt_number;
     }
 
-    pub fn start(&self) -> Option<&CommonToken> {
-        self.start.as_deref()
+    pub fn start(&self) -> Option<TokenView<'_>> {
+        self.start
+            .and_then(|id| self.token_store.as_ref()?.view(id))
     }
 
-    pub(crate) fn start_ref(&self) -> Option<TokenRef> {
-        self.start.as_ref().map(Rc::clone)
+    pub(crate) const fn start_id(&self) -> Option<TokenId> {
+        self.start
     }
 
-    pub fn stop(&self) -> Option<&CommonToken> {
-        self.stop.as_deref()
+    pub fn stop(&self) -> Option<TokenView<'_>> {
+        self.stop.and_then(|id| self.token_store.as_ref()?.view(id))
     }
 
-    pub fn set_start(&mut self, token: CommonToken) {
-        self.start = Some(Rc::new(token));
-    }
-
-    pub(crate) fn set_start_ref(&mut self, token: TokenRef) {
+    pub(crate) fn set_start_id(&mut self, token: TokenId, store: TokenStoreHandle) {
+        self.token_store = Some(store);
         self.start = Some(token);
     }
 
-    pub fn set_stop(&mut self, token: CommonToken) {
-        self.stop = Some(Rc::new(token));
+    pub(crate) fn set_stop_id(&mut self, token: TokenId, store: TokenStoreHandle) {
+        self.token_store = Some(store);
+        self.stop = Some(token);
     }
 
-    pub(crate) fn set_stop_ref(&mut self, token: TokenRef) {
-        self.stop = Some(token);
+    pub(crate) const fn set_start_from_context(&mut self, other: &Self) {
+        self.start = other.start;
+    }
+
+    pub(crate) fn set_store_from_context(&mut self, other: &Self) {
+        self.token_store.clone_from(&other.token_store);
     }
 
     /// Stores a generated integer return value on this rule context.
@@ -545,26 +551,23 @@ impl ParserRuleContext {
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TerminalNode {
-    token: TokenRef,
+    token: TokenId,
+    store: TokenStoreHandle,
 }
 
 impl TerminalNode {
-    pub fn new(token: CommonToken) -> Self {
-        Self {
-            token: Rc::new(token),
-        }
+    pub(crate) const fn from_id(token: TokenId, store: TokenStoreHandle) -> Self {
+        Self { token, store }
     }
 
-    pub(crate) const fn from_ref(token: TokenRef) -> Self {
-        Self { token }
-    }
-
-    pub fn symbol(&self) -> &CommonToken {
-        self.token.as_ref()
+    pub fn symbol(&self) -> TokenView<'_> {
+        self.store
+            .view(self.token)
+            .expect("terminal node token ID should remain valid")
     }
 
     pub fn text(&self) -> String {
-        self.token.text().to_owned()
+        self.symbol().text().to_owned()
     }
 }
 
@@ -572,7 +575,7 @@ impl TerminalNode {
 /// test listeners print terminal nodes directly (`java_style_list(&ctx.INT_all())`).
 impl fmt::Display for TerminalNode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.token.text())
+        f.write_str(&self.text())
     }
 }
 
@@ -582,15 +585,9 @@ pub struct ErrorNode {
 }
 
 impl ErrorNode {
-    pub fn new(token: CommonToken) -> Self {
+    pub(crate) const fn from_id(token: TokenId, store: TokenStoreHandle) -> Self {
         Self {
-            terminal: TerminalNode::new(token),
-        }
-    }
-
-    pub(crate) const fn from_ref(token: TokenRef) -> Self {
-        Self {
-            terminal: TerminalNode::from_ref(token),
+            terminal: TerminalNode::from_id(token, store),
         }
     }
 
@@ -598,7 +595,7 @@ impl ErrorNode {
         &self.terminal
     }
 
-    pub fn symbol(&self) -> &CommonToken {
+    pub fn symbol(&self) -> TokenView<'_> {
         self.terminal.symbol()
     }
 
@@ -662,13 +659,38 @@ impl ParseTreeWalker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::token::CommonToken;
+    use crate::token::{TokenSpec, TokenStore};
+
+    struct TreeToken(TokenSpec);
+
+    impl TreeToken {
+        fn new(token_type: i32) -> Self {
+            Self(TokenSpec::explicit(token_type, ""))
+        }
+
+        fn with_text(mut self, text: impl Into<String>) -> Self {
+            self.0.text = Some(text.into());
+            self
+        }
+    }
+
+    fn terminal(token: TreeToken) -> TerminalNode {
+        let store = TokenStoreHandle::new(TokenStore::new(None, ""));
+        let id = store.push(token.0).expect("test token should fit");
+        TerminalNode::from_id(id, store)
+    }
+
+    fn error(token: TreeToken) -> ErrorNode {
+        let store = TokenStoreHandle::new(TokenStore::new(None, ""));
+        let id = store.push(token.0).expect("test token should fit");
+        ErrorNode::from_id(id, store)
+    }
 
     #[test]
     fn renders_rule_tree() {
         let mut ctx = ParserRuleContext::new(0, -1);
-        ctx.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(1).with_text("x"),
+        ctx.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(1).with_text("x"),
         )));
         let tree = ParseTree::Rule(RuleNode::new(ctx));
         assert_eq!(tree.to_string_tree_with_names(&["expr"]), "(expr x)");
@@ -677,8 +699,8 @@ mod tests {
     #[test]
     fn finds_first_rule_depth_first() {
         let mut nested = ParserRuleContext::new(1, -1);
-        nested.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(1).with_text("x"),
+        nested.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(1).with_text("x"),
         )));
 
         let mut root = ParserRuleContext::new(0, -1);
@@ -696,8 +718,8 @@ mod tests {
     #[test]
     fn reports_rule_invocation_stack_from_leaf_to_root() {
         let mut nested = ParserRuleContext::new(1, -1);
-        nested.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(1).with_text("x"),
+        nested.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(1).with_text("x"),
         )));
 
         let mut root = ParserRuleContext::new(0, -1);
@@ -712,9 +734,8 @@ mod tests {
 
     #[test]
     fn parse_tree_children_returns_rule_children_and_empty_leaf_slices() {
-        let terminal =
-            ParseTree::Terminal(TerminalNode::new(CommonToken::new(1).with_text("terminal")));
-        let error = ParseTree::Error(ErrorNode::new(CommonToken::new(2).with_text("error")));
+        let terminal = ParseTree::Terminal(terminal(TreeToken::new(1).with_text("terminal")));
+        let error = ParseTree::Error(error(TreeToken::new(2).with_text("error")));
 
         let mut root = ParserRuleContext::new(0, -1);
         root.add_child(terminal);
@@ -734,17 +755,17 @@ mod tests {
     #[test]
     fn iterates_descendants_in_pre_order() {
         let mut nested = ParserRuleContext::new(1, -1);
-        nested.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(10).with_text("child"),
+        nested.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(10).with_text("child"),
         )));
 
         let mut root = ParserRuleContext::new(0, -1);
-        root.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(11).with_text("prefix"),
+        root.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(11).with_text("prefix"),
         )));
         root.add_child(ParseTree::Rule(RuleNode::new(nested)));
-        root.add_child(ParseTree::Error(ErrorNode::new(
-            CommonToken::new(12).with_text("error"),
+        root.add_child(ParseTree::Error(error(
+            TreeToken::new(12).with_text("error"),
         )));
         let tree = ParseTree::Rule(RuleNode::new(root));
 
@@ -778,20 +799,20 @@ mod tests {
     #[test]
     fn finds_direct_child_rules_by_index() {
         let mut direct = ParserRuleContext::new(1, -1);
-        direct.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(10).with_text("direct"),
+        direct.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(10).with_text("direct"),
         )));
 
         let mut nested_match = ParserRuleContext::new(1, -1);
-        nested_match.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(11).with_text("nested"),
+        nested_match.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(11).with_text("nested"),
         )));
         let mut wrapper = ParserRuleContext::new(2, -1);
         wrapper.add_child(ParseTree::Rule(RuleNode::new(nested_match)));
 
         let mut root = ParserRuleContext::new(0, -1);
-        root.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(12).with_text("prefix"),
+        root.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(12).with_text("prefix"),
         )));
         root.add_child(ParseTree::Rule(RuleNode::new(direct)));
         root.add_child(ParseTree::Rule(RuleNode::new(wrapper)));
@@ -812,19 +833,19 @@ mod tests {
     #[test]
     fn finds_direct_terminal_children_by_token_type() {
         let mut nested = ParserRuleContext::new(1, -1);
-        nested.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(13).with_text("nested"),
+        nested.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(13).with_text("nested"),
         )));
 
         let mut root = ParserRuleContext::new(0, -1);
-        root.add_child(ParseTree::Error(ErrorNode::new(
-            CommonToken::new(12).with_text("error"),
+        root.add_child(ParseTree::Error(error(
+            TreeToken::new(12).with_text("error"),
         )));
-        root.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(10).with_text("direct"),
+        root.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(10).with_text("direct"),
         )));
-        root.add_child(ParseTree::Terminal(TerminalNode::new(
-            CommonToken::new(11).with_text("other"),
+        root.add_child(ParseTree::Terminal(terminal(
+            TreeToken::new(11).with_text("other"),
         )));
         root.add_child(ParseTree::Rule(RuleNode::new(nested)));
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -4,7 +4,7 @@ use std::any::Any;
 use std::fmt;
 use std::rc::Rc;
 
-use crate::token::{Token, TokenId, TokenStoreHandle, TokenView};
+use crate::token::{TokenId, TokenStore, TokenView};
 use std::collections::BTreeMap;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -40,29 +40,37 @@ impl ParseTree {
         self.descendants()
     }
 
-    pub fn text(&self) -> String {
+    pub fn text(&self, tokens: &TokenStore) -> String {
         match self {
-            Self::Rule(rule) => rule.text(),
-            Self::Terminal(node) => node.text(),
-            Self::Error(node) => node.text(),
+            Self::Rule(rule) => rule.text(tokens),
+            Self::Terminal(node) => node.text(tokens).to_owned(),
+            Self::Error(node) => node.text(tokens).to_owned(),
         }
     }
 
-    pub fn to_string_tree_with_names<S: AsRef<str>>(&self, rule_names: &[S]) -> String {
+    pub fn to_string_tree_with_names<S: AsRef<str>>(
+        &self,
+        rule_names: &[S],
+        tokens: &TokenStore,
+    ) -> String {
         match self {
-            Self::Rule(rule) => rule.to_string_tree_with_names(rule_names),
-            Self::Terminal(node) => escape_tree_text(&node.text()),
-            Self::Error(node) => escape_tree_text(&node.text()),
+            Self::Rule(rule) => rule.to_string_tree_with_names(rule_names, tokens),
+            Self::Terminal(node) => escape_tree_text(node.text(tokens)),
+            Self::Error(node) => escape_tree_text(node.text(tokens)),
         }
     }
 
     /// Renders the LISP-style tree using rule names resolved through a
     /// recognizer, matching ANTLR's `toStringTree(parser)` shape used by
-    /// generated test actions (`<tree>.to_string_tree(Some(self))`).
-    pub fn to_string_tree<R: Recognizer>(&self, recognizer: Option<&R>) -> String {
+    /// generated test actions (`<tree>.to_string_tree(Some(self), tokens)`).
+    pub fn to_string_tree<R: Recognizer>(
+        &self,
+        recognizer: Option<&R>,
+        tokens: &TokenStore,
+    ) -> String {
         recognizer.map_or_else(
-            || self.to_string_tree_with_names::<&str>(&[]),
-            |recognizer| self.to_string_tree_with_names(recognizer.data().rule_names()),
+            || self.to_string_tree_with_names::<&str>(&[], tokens),
+            |recognizer| self.to_string_tree_with_names(recognizer.data().rule_names(), tokens),
         )
     }
 
@@ -83,17 +91,21 @@ impl ParseTree {
     }
 
     /// Finds the stop token for the first rule node with `rule_index`.
-    pub fn first_rule_stop(&self, rule_index: usize) -> Option<TokenView<'_>> {
+    pub fn first_rule_stop<'a>(
+        &self,
+        rule_index: usize,
+        tokens: &'a TokenStore,
+    ) -> Option<TokenView<'a>> {
         let Self::Rule(rule) = self else {
             return None;
         };
         if rule.context().rule_index() == rule_index {
-            return rule.context().stop();
+            return rule.context().stop(tokens);
         }
         rule.context()
             .children()
             .iter()
-            .find_map(|child| child.first_rule_stop(rule_index))
+            .find_map(|child| child.first_rule_stop(rule_index, tokens))
     }
 
     /// Reads an integer return value from the first rule node with
@@ -124,15 +136,15 @@ impl ParseTree {
     }
 
     /// Finds the first recovery error token in a depth-first walk.
-    pub fn first_error_token(&self) -> Option<TokenView<'_>> {
+    pub fn first_error_token<'a>(&self, tokens: &'a TokenStore) -> Option<TokenView<'a>> {
         match self {
             Self::Rule(rule) => rule
                 .context()
                 .children()
                 .iter()
-                .find_map(Self::first_error_token),
+                .find_map(|child| child.first_error_token(tokens)),
             Self::Terminal(_) => None,
-            Self::Error(node) => Some(node.symbol()),
+            Self::Error(node) => Some(node.symbol(tokens)),
         }
     }
 
@@ -227,12 +239,16 @@ impl RuleNode {
         &mut self.context
     }
 
-    pub fn text(&self) -> String {
-        self.context.text()
+    pub fn text(&self, tokens: &TokenStore) -> String {
+        self.context.text(tokens)
     }
 
-    pub fn to_string_tree_with_names<S: AsRef<str>>(&self, rule_names: &[S]) -> String {
-        self.context.to_string_tree_with_names(rule_names)
+    pub fn to_string_tree_with_names<S: AsRef<str>>(
+        &self,
+        rule_names: &[S],
+        tokens: &TokenStore,
+    ) -> String {
+        self.context.to_string_tree_with_names(rule_names, tokens)
     }
 }
 
@@ -241,7 +257,6 @@ pub struct ParserRuleContext {
     rule_index: usize,
     invoking_state: isize,
     alt_number: usize,
-    token_store: Option<TokenStoreHandle>,
     start: Option<TokenId>,
     stop: Option<TokenId>,
     int_returns: Option<Box<IntReturns>>,
@@ -305,7 +320,6 @@ impl ParserRuleContext {
             rule_index,
             invoking_state,
             alt_number: 0,
-            token_store: None,
             start: None,
             stop: None,
             int_returns: None,
@@ -325,7 +339,6 @@ impl ParserRuleContext {
             rule_index,
             invoking_state,
             alt_number: 0,
-            token_store: None,
             start: None,
             stop: None,
             int_returns: None,
@@ -352,35 +365,32 @@ impl ParserRuleContext {
         self.alt_number = alt_number;
     }
 
-    pub fn start(&self) -> Option<TokenView<'_>> {
-        self.start
-            .and_then(|id| self.token_store.as_ref()?.view(id))
+    pub fn start<'a>(&self, tokens: &'a TokenStore) -> Option<TokenView<'a>> {
+        self.start.and_then(|id| tokens.view(id))
     }
 
     pub(crate) const fn start_id(&self) -> Option<TokenId> {
         self.start
     }
 
-    pub fn stop(&self) -> Option<TokenView<'_>> {
-        self.stop.and_then(|id| self.token_store.as_ref()?.view(id))
+    pub fn stop<'a>(&self, tokens: &'a TokenStore) -> Option<TokenView<'a>> {
+        self.stop.and_then(|id| tokens.view(id))
     }
 
-    pub(crate) fn set_start_id(&mut self, token: TokenId, store: TokenStoreHandle) {
-        self.token_store = Some(store);
+    pub(crate) const fn stop_id(&self) -> Option<TokenId> {
+        self.stop
+    }
+
+    pub(crate) const fn set_start_id(&mut self, token: TokenId) {
         self.start = Some(token);
     }
 
-    pub(crate) fn set_stop_id(&mut self, token: TokenId, store: TokenStoreHandle) {
-        self.token_store = Some(store);
+    pub(crate) const fn set_stop_id(&mut self, token: TokenId) {
         self.stop = Some(token);
     }
 
     pub(crate) const fn set_start_from_context(&mut self, other: &Self) {
         self.start = other.start;
-    }
-
-    pub(crate) fn set_store_from_context(&mut self, other: &Self) {
-        self.token_store.clone_from(&other.token_store);
     }
 
     /// Stores a generated integer return value on this rule context.
@@ -444,8 +454,12 @@ impl ParserRuleContext {
     ///
     /// Includes recovery error nodes, which ANTLR treats as terminal nodes for
     /// token-getter helpers.
-    pub fn child_token(&self, token_type: i32) -> Option<&TerminalNode> {
-        self.child_tokens(token_type).next()
+    pub fn child_token<'a>(
+        &'a self,
+        token_type: i32,
+        tokens: &'a TokenStore,
+    ) -> Option<&'a TerminalNode> {
+        self.child_tokens(token_type, tokens).next()
     }
 
     /// Iterates over direct child subtrees whose root rule has `rule_index`.
@@ -462,10 +476,16 @@ impl ParserRuleContext {
 
     /// Iterates over direct token children with `token_type`, including
     /// recovery error nodes (ANTLR treats those as terminals for getters).
-    pub fn child_tokens(&self, token_type: i32) -> impl Iterator<Item = &TerminalNode> + '_ {
+    pub fn child_tokens<'a>(
+        &'a self,
+        token_type: i32,
+        tokens: &'a TokenStore,
+    ) -> impl Iterator<Item = &'a TerminalNode> + 'a {
         self.children.iter().filter_map(move |child| match child {
-            ParseTree::Terminal(node) if node.symbol().token_type() == token_type => Some(node),
-            ParseTree::Error(node) if node.symbol().token_type() == token_type => {
+            ParseTree::Terminal(node) if tokens.token_type(node.token_id()) == Some(token_type) => {
+                Some(node)
+            }
+            ParseTree::Error(node) if tokens.token_type(node.token_id()) == Some(token_type) => {
                 Some(node.terminal())
             }
             _ => None,
@@ -485,14 +505,14 @@ impl ParserRuleContext {
     ///
     /// Generated parsers implement [`FromRuleContext`] for each context type;
     /// this mirrors ANTLR's `((BinaryContext) $ctx)` cast in test actions
-    /// (`$ctx.downcast_ref::<BinaryContext>()`).
-    pub fn downcast_ref<T: FromRuleContext>(&self) -> Option<T> {
-        T::from_rule_context(self)
+    /// (`$ctx.downcast_ref::<BinaryContext>(tokens)`).
+    pub fn downcast_ref<'a, T: FromRuleContext<'a>>(&self, tokens: &'a TokenStore) -> Option<T> {
+        T::from_rule_context(self, tokens)
     }
 
     /// Returns whether this context has a direct token child with `token_type`.
-    pub fn has_token(&self, token_type: i32) -> bool {
-        self.child_token(token_type).is_some()
+    pub fn has_token(&self, token_type: i32, tokens: &TokenStore) -> bool {
+        self.child_token(token_type, tokens).is_some()
     }
 
     pub fn add_child(&mut self, child: ParseTree) {
@@ -513,11 +533,18 @@ impl ParserRuleContext {
         self.matched_child
     }
 
-    pub fn text(&self) -> String {
-        self.children.iter().map(ParseTree::text).collect()
+    pub fn text(&self, tokens: &TokenStore) -> String {
+        self.children
+            .iter()
+            .map(|child| child.text(tokens))
+            .collect()
     }
 
-    pub fn to_string_tree_with_names<S: AsRef<str>>(&self, rule_names: &[S]) -> String {
+    pub fn to_string_tree_with_names<S: AsRef<str>>(
+        &self,
+        rule_names: &[S],
+        tokens: &TokenStore,
+    ) -> String {
         let name = rule_names
             .get(self.rule_index)
             .map_or("<unknown>", |name| name.as_ref());
@@ -532,7 +559,7 @@ impl ParserRuleContext {
         let children = self
             .children
             .iter()
-            .map(|child| child.to_string_tree_with_names(rule_names))
+            .map(|child| child.to_string_tree_with_names(rule_names, tokens))
             .collect::<Vec<_>>()
             .join(" ");
         format!("({display_name} {children})")
@@ -541,10 +568,14 @@ impl ParserRuleContext {
     /// Renders the LISP-style tree using rule names resolved through a
     /// recognizer, matching ANTLR's `toStringTree(parser)` shape used by
     /// generated test actions on a mid-rule `$ctx`.
-    pub fn to_string_tree<R: Recognizer>(&self, recognizer: Option<&R>) -> String {
+    pub fn to_string_tree<R: Recognizer>(
+        &self,
+        recognizer: Option<&R>,
+        tokens: &TokenStore,
+    ) -> String {
         recognizer.map_or_else(
-            || self.to_string_tree_with_names::<&str>(&[]),
-            |recognizer| self.to_string_tree_with_names(recognizer.data().rule_names()),
+            || self.to_string_tree_with_names::<&str>(&[], tokens),
+            |recognizer| self.to_string_tree_with_names(recognizer.data().rule_names(), tokens),
         )
     }
 }
@@ -552,30 +583,26 @@ impl ParserRuleContext {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TerminalNode {
     token: TokenId,
-    store: TokenStoreHandle,
 }
 
 impl TerminalNode {
-    pub(crate) const fn from_id(token: TokenId, store: TokenStoreHandle) -> Self {
-        Self { token, store }
+    pub(crate) const fn from_id(token: TokenId) -> Self {
+        Self { token }
     }
 
-    pub fn symbol(&self) -> TokenView<'_> {
-        self.store
+    #[must_use]
+    pub const fn token_id(&self) -> TokenId {
+        self.token
+    }
+
+    pub fn symbol<'a>(&self, tokens: &'a TokenStore) -> TokenView<'a> {
+        tokens
             .view(self.token)
             .expect("terminal node token ID should remain valid")
     }
 
-    pub fn text(&self) -> String {
-        self.symbol().text().to_owned()
-    }
-}
-
-/// Java's `TerminalNodeImpl.toString()` returns the token text; generated
-/// test listeners print terminal nodes directly (`java_style_list(&ctx.INT_all())`).
-impl fmt::Display for TerminalNode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.text())
+    pub fn text<'a>(&self, tokens: &'a TokenStore) -> &'a str {
+        tokens.text(self.token).unwrap_or("")
     }
 }
 
@@ -585,9 +612,9 @@ pub struct ErrorNode {
 }
 
 impl ErrorNode {
-    pub(crate) const fn from_id(token: TokenId, store: TokenStoreHandle) -> Self {
+    pub(crate) const fn from_id(token: TokenId) -> Self {
         Self {
-            terminal: TerminalNode::from_id(token, store),
+            terminal: TerminalNode::from_id(token),
         }
     }
 
@@ -595,12 +622,17 @@ impl ErrorNode {
         &self.terminal
     }
 
-    pub fn symbol(&self) -> TokenView<'_> {
-        self.terminal.symbol()
+    #[must_use]
+    pub const fn token_id(&self) -> TokenId {
+        self.terminal.token_id()
     }
 
-    pub fn text(&self) -> String {
-        self.terminal.text()
+    pub fn symbol<'a>(&self, tokens: &'a TokenStore) -> TokenView<'a> {
+        self.terminal.symbol(tokens)
+    }
+
+    pub fn text<'a>(&self, tokens: &'a TokenStore) -> &'a str {
+        tokens.text(self.token_id()).unwrap_or("")
     }
 }
 
@@ -608,26 +640,43 @@ impl ErrorNode {
 /// context view.
 ///
 /// Implemented by generated per-rule / per-labeled-alternative context types
-/// so `ctx.downcast_ref::<XContext>()` can check the rule shape and
-/// materialize the typed view, mirroring ANTLR's context-class casts.
-pub trait FromRuleContext: Sized {
-    fn from_rule_context(context: &ParserRuleContext) -> Option<Self>;
+/// so `ctx.downcast_ref::<XContext>(tokens)` can check the rule shape and
+/// materialize the typed view with a token resolver, mirroring ANTLR's
+/// context-class casts.
+pub trait FromRuleContext<'a>: Sized {
+    fn from_rule_context(context: &ParserRuleContext, tokens: &'a TokenStore) -> Option<Self>;
 }
 
 pub trait ParseTreeListener {
-    fn enter_every_rule(&mut self, _ctx: &ParserRuleContext) -> Result<(), AntlrError> {
+    fn enter_every_rule(
+        &mut self,
+        _ctx: &ParserRuleContext,
+        _tokens: &TokenStore,
+    ) -> Result<(), AntlrError> {
         Ok(())
     }
 
-    fn exit_every_rule(&mut self, _ctx: &ParserRuleContext) -> Result<(), AntlrError> {
+    fn exit_every_rule(
+        &mut self,
+        _ctx: &ParserRuleContext,
+        _tokens: &TokenStore,
+    ) -> Result<(), AntlrError> {
         Ok(())
     }
 
-    fn visit_terminal(&mut self, _node: &TerminalNode) -> Result<(), AntlrError> {
+    fn visit_terminal(
+        &mut self,
+        _node: &TerminalNode,
+        _tokens: &TokenStore,
+    ) -> Result<(), AntlrError> {
         Ok(())
     }
 
-    fn visit_error_node(&mut self, _node: &ErrorNode) -> Result<(), AntlrError> {
+    fn visit_error_node(
+        &mut self,
+        _node: &ErrorNode,
+        _tokens: &TokenStore,
+    ) -> Result<(), AntlrError> {
         Ok(())
     }
 }
@@ -641,18 +690,48 @@ impl ParseTreeWalker {
     pub fn walk<L: ParseTreeListener>(
         listener: &mut L,
         tree: &ParseTree,
+        tokens: &TokenStore,
     ) -> Result<(), AntlrError> {
         match tree {
             ParseTree::Rule(rule) => {
-                listener.enter_every_rule(rule.context())?;
+                listener.enter_every_rule(rule.context(), tokens)?;
                 for child in rule.context().children() {
-                    Self::walk(listener, child)?;
+                    Self::walk(listener, child, tokens)?;
                 }
-                listener.exit_every_rule(rule.context())
+                listener.exit_every_rule(rule.context(), tokens)
             }
-            ParseTree::Terminal(node) => listener.visit_terminal(node),
-            ParseTree::Error(node) => listener.visit_error_node(node),
+            ParseTree::Terminal(node) => listener.visit_terminal(node, tokens),
+            ParseTree::Error(node) => listener.visit_error_node(node, tokens),
         }
+    }
+}
+
+/// A completed parse result paired with the canonical tokens referenced by it.
+#[derive(Debug)]
+pub struct ParsedFile<R> {
+    pub tokens: TokenStore,
+    pub tree: R,
+}
+
+impl<R> ParsedFile<R> {
+    #[must_use]
+    pub const fn new(tokens: TokenStore, tree: R) -> Self {
+        Self { tokens, tree }
+    }
+
+    #[must_use]
+    pub const fn tokens(&self) -> &TokenStore {
+        &self.tokens
+    }
+
+    #[must_use]
+    pub const fn tree(&self) -> &R {
+        &self.tree
+    }
+
+    #[must_use]
+    pub fn into_parts(self) -> (TokenStore, R) {
+        (self.tokens, self.tree)
     }
 }
 
@@ -674,32 +753,37 @@ mod tests {
         }
     }
 
-    fn terminal(token: TreeToken) -> TerminalNode {
-        let store = TokenStoreHandle::new(TokenStore::new(None, ""));
+    fn terminal(store: &mut TokenStore, token: TreeToken) -> TerminalNode {
         let id = store.push(token.0).expect("test token should fit");
-        TerminalNode::from_id(id, store)
+        TerminalNode::from_id(id)
     }
 
-    fn error(token: TreeToken) -> ErrorNode {
-        let store = TokenStoreHandle::new(TokenStore::new(None, ""));
+    fn error(store: &mut TokenStore, token: TreeToken) -> ErrorNode {
         let id = store.push(token.0).expect("test token should fit");
-        ErrorNode::from_id(id, store)
+        ErrorNode::from_id(id)
     }
 
     #[test]
     fn renders_rule_tree() {
+        let mut tokens = TokenStore::new(None, "");
         let mut ctx = ParserRuleContext::new(0, -1);
         ctx.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(1).with_text("x"),
         )));
         let tree = ParseTree::Rule(RuleNode::new(ctx));
-        assert_eq!(tree.to_string_tree_with_names(&["expr"]), "(expr x)");
+        assert_eq!(
+            tree.to_string_tree_with_names(&["expr"], &tokens),
+            "(expr x)"
+        );
     }
 
     #[test]
     fn finds_first_rule_depth_first() {
+        let mut tokens = TokenStore::new(None, "");
         let mut nested = ParserRuleContext::new(1, -1);
         nested.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(1).with_text("x"),
         )));
 
@@ -709,7 +793,7 @@ mod tests {
 
         let rule = tree.first_rule(1).expect("nested rule should be found");
         assert_eq!(
-            rule.to_string_tree_with_names(&["root".to_owned(), "child".to_owned()]),
+            rule.to_string_tree_with_names(&["root".to_owned(), "child".to_owned()], &tokens),
             "(child x)"
         );
         assert!(tree.first_rule(2).is_none());
@@ -717,8 +801,10 @@ mod tests {
 
     #[test]
     fn reports_rule_invocation_stack_from_leaf_to_root() {
+        let mut tokens = TokenStore::new(None, "");
         let mut nested = ParserRuleContext::new(1, -1);
         nested.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(1).with_text("x"),
         )));
 
@@ -734,8 +820,12 @@ mod tests {
 
     #[test]
     fn parse_tree_children_returns_rule_children_and_empty_leaf_slices() {
-        let terminal = ParseTree::Terminal(terminal(TreeToken::new(1).with_text("terminal")));
-        let error = ParseTree::Error(error(TreeToken::new(2).with_text("error")));
+        let mut tokens = TokenStore::new(None, "");
+        let terminal = ParseTree::Terminal(terminal(
+            &mut tokens,
+            TreeToken::new(1).with_text("terminal"),
+        ));
+        let error = ParseTree::Error(error(&mut tokens, TreeToken::new(2).with_text("error")));
 
         let mut root = ParserRuleContext::new(0, -1);
         root.add_child(terminal);
@@ -746,25 +836,29 @@ mod tests {
         let [first, second] = children else {
             panic!("expected exactly 2 children");
         };
-        assert_eq!(first.text(), "terminal");
-        assert_eq!(second.text(), "error");
+        assert_eq!(first.text(&tokens), "terminal");
+        assert_eq!(second.text(&tokens), "error");
         assert!(first.children().is_empty());
         assert!(second.children().is_empty());
     }
 
     #[test]
     fn iterates_descendants_in_pre_order() {
+        let mut tokens = TokenStore::new(None, "");
         let mut nested = ParserRuleContext::new(1, -1);
         nested.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(10).with_text("child"),
         )));
 
         let mut root = ParserRuleContext::new(0, -1);
         root.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(11).with_text("prefix"),
         )));
         root.add_child(ParseTree::Rule(RuleNode::new(nested)));
         root.add_child(ParseTree::Error(error(
+            &mut tokens,
             TreeToken::new(12).with_text("error"),
         )));
         let tree = ParseTree::Rule(RuleNode::new(root));
@@ -773,8 +867,10 @@ mod tests {
             .descendants()
             .map(|node| match node {
                 ParseTree::Rule(rule) => format!("rule:{}", rule.context().rule_index()),
-                ParseTree::Terminal(terminal) => format!("terminal:{}", terminal.text()),
-                ParseTree::Error(error) => format!("error:{}", error.text()),
+                ParseTree::Terminal(terminal) => {
+                    format!("terminal:{}", terminal.text(&tokens))
+                }
+                ParseTree::Error(error) => format!("error:{}", error.text(&tokens)),
             })
             .collect::<Vec<_>>();
 
@@ -789,7 +885,10 @@ mod tests {
             ]
         );
 
-        let preorder = tree.pre_order().map(ParseTree::text).collect::<Vec<_>>();
+        let preorder = tree
+            .pre_order()
+            .map(|node| node.text(&tokens))
+            .collect::<Vec<_>>();
         assert_eq!(
             preorder,
             vec!["prefixchilderror", "prefix", "child", "child", "error"]
@@ -797,14 +896,40 @@ mod tests {
     }
 
     #[test]
+    fn parsed_file_resolves_tokens_while_traversing() {
+        let mut tokens = TokenStore::new(None, "");
+        let mut root = ParserRuleContext::new(0, -1);
+        root.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
+            TreeToken::new(10).with_text("first"),
+        )));
+        root.add_child(ParseTree::Error(error(
+            &mut tokens,
+            TreeToken::new(11).with_text("second"),
+        )));
+        let parsed = ParsedFile::new(tokens, ParseTree::Rule(RuleNode::new(root)));
+
+        let visited = parsed
+            .tree()
+            .descendants()
+            .map(|node| node.text(parsed.tokens()))
+            .collect::<Vec<_>>();
+
+        assert_eq!(visited, vec!["firstsecond", "first", "second"]);
+    }
+
+    #[test]
     fn finds_direct_child_rules_by_index() {
+        let mut tokens = TokenStore::new(None, "");
         let mut direct = ParserRuleContext::new(1, -1);
         direct.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(10).with_text("direct"),
         )));
 
         let mut nested_match = ParserRuleContext::new(1, -1);
         nested_match.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(11).with_text("nested"),
         )));
         let mut wrapper = ParserRuleContext::new(2, -1);
@@ -812,6 +937,7 @@ mod tests {
 
         let mut root = ParserRuleContext::new(0, -1);
         root.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(12).with_text("prefix"),
         )));
         root.add_child(ParseTree::Rule(RuleNode::new(direct)));
@@ -820,7 +946,7 @@ mod tests {
         assert_eq!(root.child_count(), 3);
         assert_eq!(root.child_rules(1).count(), 1);
         assert_eq!(
-            root.child_rule(1).map(ParserRuleContext::text),
+            root.child_rule(1).map(|context| context.text(&tokens)),
             Some("direct".to_owned())
         );
         assert_eq!(
@@ -832,38 +958,43 @@ mod tests {
 
     #[test]
     fn finds_direct_terminal_children_by_token_type() {
+        let mut tokens = TokenStore::new(None, "");
         let mut nested = ParserRuleContext::new(1, -1);
         nested.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(13).with_text("nested"),
         )));
 
         let mut root = ParserRuleContext::new(0, -1);
         root.add_child(ParseTree::Error(error(
+            &mut tokens,
             TreeToken::new(12).with_text("error"),
         )));
         root.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(10).with_text("direct"),
         )));
         root.add_child(ParseTree::Terminal(terminal(
+            &mut tokens,
             TreeToken::new(11).with_text("other"),
         )));
         root.add_child(ParseTree::Rule(RuleNode::new(nested)));
 
         assert_eq!(root.child_count(), 4);
-        assert!(root.has_token(10));
-        assert!(root.has_token(12));
+        assert!(root.has_token(10, &tokens));
+        assert!(root.has_token(12, &tokens));
         assert_eq!(
-            root.child_token(10).map(TerminalNode::text),
-            Some("direct".to_owned())
+            root.child_token(10, &tokens).map(|node| node.text(&tokens)),
+            Some("direct")
         );
         assert_eq!(
-            root.child_token(11).map(TerminalNode::text),
-            Some("other".to_owned())
+            root.child_token(11, &tokens).map(|node| node.text(&tokens)),
+            Some("other")
         );
         assert_eq!(
-            root.child_token(12).map(TerminalNode::text),
-            Some("error".to_owned())
+            root.child_token(12, &tokens).map(|node| node.text(&tokens)),
+            Some("error")
         );
-        assert!(root.child_token(13).is_none());
+        assert!(root.child_token(13, &tokens).is_none());
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -709,8 +709,8 @@ impl ParseTreeWalker {
 /// A completed parse result paired with the canonical tokens referenced by it.
 #[derive(Debug)]
 pub struct ParsedFile<R> {
-    pub tokens: TokenStore,
-    pub tree: R,
+    tokens: TokenStore,
+    tree: R,
 }
 
 impl<R> ParsedFile<R> {

--- a/tests/javascript-parity/dumper/src/javascript_lexer_base.rs
+++ b/tests/javascript-parity/dumper/src/javascript_lexer_base.rs
@@ -1,11 +1,9 @@
-use antlr4_runtime::{
-    CharStream, CommonToken, DEFAULT_CHANNEL, LexerSemCtx, Token, TokenFactory,
-};
+use antlr4_runtime::{CharStream, DEFAULT_CHANNEL, LexerSemCtx, Token, TokenView};
 
 use crate::generated::java_script_lexer::{
-    BOOLEAN_LITERAL, CLOSE_BRACKET, CLOSE_PAREN, DECIMAL_LITERAL, HEX_INTEGER_LITERAL,
-    IDENTIFIER, JavaScriptLexerHooks, MINUS_MINUS, NULL_LITERAL, OCTAL_INTEGER_LITERAL,
-    OPEN_BRACE, PLUS_PLUS, STRING_LITERAL, THIS,
+    BOOLEAN_LITERAL, CLOSE_BRACKET, CLOSE_PAREN, DECIMAL_LITERAL, HEX_INTEGER_LITERAL, IDENTIFIER,
+    JavaScriptLexerHooks, MINUS_MINUS, NULL_LITERAL, OCTAL_INTEGER_LITERAL, OPEN_BRACE, PLUS_PLUS,
+    STRING_LITERAL, THIS,
 };
 
 #[derive(Clone, Debug, Default)]
@@ -38,26 +36,23 @@ impl JavaScriptLexerBase {
 }
 
 impl JavaScriptLexerHooks for JavaScriptLexerBase {
-    fn is_start_of_file<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_start_of_file<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.last_token_type.is_none()
     }
 
-    fn is_strict_mode<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_strict_mode<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.use_strict_current
     }
 
-    fn is_regex_possible<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_regex_possible<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         !matches!(
             self.last_token_type,
@@ -78,18 +73,16 @@ impl JavaScriptLexerHooks for JavaScriptLexerBase {
         )
     }
 
-    fn is_in_template_string<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_in_template_string<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.template_depth_stack.last().copied() == Some(self.current_depth)
     }
 
-    fn process_open_brace<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_open_brace<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.current_depth += 1;
         self.use_strict_current = self.use_strict_default;
@@ -99,10 +92,9 @@ impl JavaScriptLexerHooks for JavaScriptLexerBase {
         self.push_strict_mode_scope(self.use_strict_current);
     }
 
-    fn process_close_brace<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_close_brace<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.use_strict_current = self
             .pop_strict_mode_scope()
@@ -110,10 +102,9 @@ impl JavaScriptLexerHooks for JavaScriptLexerBase {
         self.current_depth -= 1;
     }
 
-    fn process_string_literal<I, F>(&mut self, ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_string_literal<I>(&mut self, ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         if self.last_token_type.is_none() || self.last_token_type == Some(OPEN_BRACE) {
             let text = ctx.text_so_far();
@@ -125,25 +116,23 @@ impl JavaScriptLexerHooks for JavaScriptLexerBase {
         }
     }
 
-    fn process_template_open_brace<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_template_open_brace<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.current_depth += 1;
         self.template_depth_stack.push(self.current_depth);
     }
 
-    fn process_template_close_brace<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_template_close_brace<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         let _ = self.template_depth_stack.pop();
         self.current_depth -= 1;
     }
 
-    fn token_emitted(&mut self, token: &CommonToken) {
+    fn token_emitted(&mut self, token: TokenView<'_>) {
         if token.channel() == DEFAULT_CHANNEL {
             self.last_token_type = Some(token.token_type());
         }

--- a/tests/javascript-parity/dumper/src/javascript_parser_base.rs
+++ b/tests/javascript-parity/dumper/src/javascript_parser_base.rs
@@ -1,8 +1,8 @@
 use antlr4_runtime::{HIDDEN_CHANNEL, ParserSemCtx, Token, TokenSource};
 
 use crate::generated::java_script_parser::{
-    CLOSE_BRACE, FUNCTION, JavaScriptParserHooks, LINE_TERMINATOR, MULTI_LINE_COMMENT,
-    OPEN_BRACE, WHITE_SPACES,
+    CLOSE_BRACE, FUNCTION, JavaScriptParserHooks, LINE_TERMINATOR, MULTI_LINE_COMMENT, OPEN_BRACE,
+    WHITE_SPACES,
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -54,7 +54,8 @@ impl JavaScriptParserHooks for JavaScriptParserBase {
     where
         S: TokenSource,
     {
-        ctx.token_text(1) == Some(expected)
+        ctx.token_text(1)
+            .is_some_and(|token| token.text() == expected)
     }
 
     fn not_line_terminator<S>(&mut self, ctx: &mut ParserSemCtx<'_, S>) -> bool

--- a/tests/javascript-parity/dumper/src/main.rs
+++ b/tests/javascript-parity/dumper/src/main.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 
 use antlr4_runtime::{
-    CommonTokenStream, InputStream, ParseTree, Parser, Token, TOKEN_EOF,
+    CommonTokenStream, InputStream, ParseTree, Parser, TOKEN_EOF, Token, TokenStore,
 };
 
 #[allow(dead_code, unused_imports, unreachable_pub, unused_qualifications)]
@@ -26,6 +26,7 @@ use javascript_parser_base::JavaScriptParserBase;
 fn dump_tree<S: AsRef<str>>(
     out: &mut dyn Write,
     tree: &ParseTree,
+    tokens: &TokenStore,
     rule_names: &[S],
     depth: usize,
 ) -> io::Result<()> {
@@ -41,11 +42,11 @@ fn dump_tree<S: AsRef<str>>(
                 rule.context().children().len()
             )?;
             for child in rule.context().children() {
-                dump_tree(out, child, rule_names, depth + 1)?;
+                dump_tree(out, child, tokens, rule_names, depth + 1)?;
             }
         }
-        ParseTree::Terminal(token) => writeln!(out, "{pad}Term({:?})", token.text())?,
-        ParseTree::Error(token) => writeln!(out, "{pad}Err({:?})", token.text())?,
+        ParseTree::Terminal(token) => writeln!(out, "{pad}Term({:?})", token.text(tokens))?,
+        ParseTree::Error(token) => writeln!(out, "{pad}Err({:?})", token.text(tokens))?,
     }
     Ok(())
 }
@@ -92,7 +93,12 @@ fn main() -> ExitCode {
         }
         for token in stream.tokens() {
             if token.token_type() != TOKEN_EOF {
-                println!("{}\t{}\t{:?}", token.token_type(), token.channel(), token.text());
+                println!(
+                    "{}\t{}\t{:?}",
+                    token.token_type(),
+                    token.channel(),
+                    token.text()
+                );
             }
         }
         return ExitCode::SUCCESS;
@@ -112,12 +118,16 @@ fn main() -> ExitCode {
         }
     };
     if parser.number_of_syntax_errors() != 0 {
-        eprintln!("parse produced {} syntax error(s)", parser.number_of_syntax_errors());
+        eprintln!(
+            "parse produced {} syntax error(s)",
+            parser.number_of_syntax_errors()
+        );
         return ExitCode::FAILURE;
     }
     if let Err(error) = dump_tree(
         &mut io::stdout().lock(),
         &tree,
+        parser.token_store(),
         java_script_parser::rule_names(),
         0,
     ) {

--- a/tests/kotlin-parity/dumper/src/main.rs
+++ b/tests/kotlin-parity/dumper/src/main.rs
@@ -175,7 +175,13 @@ fn main() -> ExitCode {
         },
         None => Box::new(io::stdout().lock()),
     };
-    if let Err(err) = dump(sink.as_mut(), &parsed.tree, &parsed.tokens, &rule_names, 0) {
+    if let Err(err) = dump(
+        sink.as_mut(),
+        parsed.tree(),
+        parsed.tokens(),
+        &rule_names,
+        0,
+    ) {
         eprintln!("write failed: {err}");
         return ExitCode::from(1);
     }

--- a/tests/kotlin-parity/dumper/src/main.rs
+++ b/tests/kotlin-parity/dumper/src/main.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::process::ExitCode;
 use std::time::Instant;
 
-use antlr4_runtime::ParseTree;
+use antlr4_runtime::{ParseTree, TokenStore};
 
 mod generated {
     #![allow(dead_code, unused_imports, unreachable_pub, unused_qualifications)]
@@ -45,6 +45,7 @@ impl EntryRule {
 fn dump<S: AsRef<str>>(
     out: &mut dyn Write,
     tree: &ParseTree,
+    tokens: &TokenStore,
     rule_names: &[S],
     depth: usize,
 ) -> io::Result<()> {
@@ -60,11 +61,11 @@ fn dump<S: AsRef<str>>(
                 rl.context().children().len()
             )?;
             for c in rl.context().children() {
-                dump(out, c, rule_names, depth + 1)?;
+                dump(out, c, tokens, rule_names, depth + 1)?;
             }
         }
-        ParseTree::Terminal(t) => writeln!(out, "{pad}Term({:?})", t.text())?,
-        ParseTree::Error(e) => writeln!(out, "{pad}Err({:?})", e.text())?,
+        ParseTree::Terminal(t) => writeln!(out, "{pad}Term({:?})", t.text(tokens))?,
+        ParseTree::Error(e) => writeln!(out, "{pad}Err({:?})", e.text(tokens))?,
     }
     Ok(())
 }
@@ -157,7 +158,7 @@ fn main() -> ExitCode {
             avg_us as f64 / 1000.0,
         );
     }
-    let Some(tree) = last_tree else {
+    let Some(parsed) = last_tree else {
         eprintln!("no parse iterations produced a tree");
         return ExitCode::from(1);
     };
@@ -174,7 +175,7 @@ fn main() -> ExitCode {
         },
         None => Box::new(io::stdout().lock()),
     };
-    if let Err(err) = dump(sink.as_mut(), &tree, &rule_names, 0) {
+    if let Err(err) = dump(sink.as_mut(), &parsed.tree, &parsed.tokens, &rule_names, 0) {
         eprintln!("write failed: {err}");
         return ExitCode::from(1);
     }

--- a/tests/typescript-parity/dumper/src/main.rs
+++ b/tests/typescript-parity/dumper/src/main.rs
@@ -6,7 +6,9 @@ use std::io::{self, Write};
 use std::path::PathBuf;
 use std::process::ExitCode;
 
-use antlr4_runtime::{CommonTokenStream, InputStream, ParseTree, Parser, TOKEN_EOF, Token};
+use antlr4_runtime::{
+    CommonTokenStream, InputStream, ParseTree, Parser, TOKEN_EOF, Token, TokenStore,
+};
 
 #[allow(dead_code, unused_imports, unreachable_pub, unused_qualifications)]
 mod generated {
@@ -24,6 +26,7 @@ use typescript_parser_base::TypeScriptParserBase;
 fn dump_tree<S: AsRef<str>>(
     out: &mut dyn Write,
     tree: &ParseTree,
+    tokens: &TokenStore,
     rule_names: &[S],
     depth: usize,
 ) -> io::Result<()> {
@@ -39,11 +42,11 @@ fn dump_tree<S: AsRef<str>>(
                 rule.context().children().len()
             )?;
             for child in rule.context().children() {
-                dump_tree(out, child, rule_names, depth + 1)?;
+                dump_tree(out, child, tokens, rule_names, depth + 1)?;
             }
         }
-        ParseTree::Terminal(token) => writeln!(out, "{pad}Term({:?})", token.text())?,
-        ParseTree::Error(token) => writeln!(out, "{pad}Err({:?})", token.text())?,
+        ParseTree::Terminal(token) => writeln!(out, "{pad}Term({:?})", token.text(tokens))?,
+        ParseTree::Error(token) => writeln!(out, "{pad}Err({:?})", token.text(tokens))?,
     }
     Ok(())
 }
@@ -124,6 +127,7 @@ fn main() -> ExitCode {
     if let Err(error) = dump_tree(
         &mut io::stdout().lock(),
         &tree,
+        parser.token_store(),
         type_script_parser::rule_names(),
         0,
     ) {

--- a/tests/typescript-parity/dumper/src/typescript_lexer_base.rs
+++ b/tests/typescript-parity/dumper/src/typescript_lexer_base.rs
@@ -1,4 +1,4 @@
-use antlr4_runtime::{CharStream, CommonToken, DEFAULT_CHANNEL, LexerSemCtx, Token, TokenFactory};
+use antlr4_runtime::{CharStream, DEFAULT_CHANNEL, LexerSemCtx, Token, TokenView};
 
 use crate::generated::type_script_lexer::{
     BOOLEAN_LITERAL, CLOSE_BRACKET, CLOSE_PAREN, DECIMAL_LITERAL, HEX_INTEGER_LITERAL, IDENTIFIER,
@@ -36,18 +36,16 @@ impl TypeScriptLexerBase {
 }
 
 impl TypeScriptLexerHooks for TypeScriptLexerBase {
-    fn is_strict_mode<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_strict_mode<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.use_strict_current
     }
 
-    fn is_regex_possible<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_regex_possible<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         !matches!(
             self.last_token_type,
@@ -68,18 +66,16 @@ impl TypeScriptLexerHooks for TypeScriptLexerBase {
         )
     }
 
-    fn is_in_template_string<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>) -> bool
+    fn is_in_template_string<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>) -> bool
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.template_depth > 0 && self.braces_depth == 0
     }
 
-    fn process_open_brace<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_open_brace<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.braces_depth += 1;
         self.use_strict_current =
@@ -87,10 +83,9 @@ impl TypeScriptLexerHooks for TypeScriptLexerBase {
         self.push_strict_mode_scope(self.use_strict_current);
     }
 
-    fn process_close_brace<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_close_brace<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.braces_depth -= 1;
         self.use_strict_current = self
@@ -98,10 +93,9 @@ impl TypeScriptLexerHooks for TypeScriptLexerBase {
             .unwrap_or(self.use_strict_default);
     }
 
-    fn process_string_literal<I, F>(&mut self, ctx: &mut LexerSemCtx<'_, I, F>)
+    fn process_string_literal<I>(&mut self, ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         if self.last_token_type.is_none() || self.last_token_type == Some(OPEN_BRACE) {
             let text = ctx.text_so_far();
@@ -113,31 +107,28 @@ impl TypeScriptLexerHooks for TypeScriptLexerBase {
         }
     }
 
-    fn start_template_string<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn start_template_string<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.braces_depth = 0;
     }
 
-    fn increase_template_depth<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn increase_template_depth<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.template_depth += 1;
     }
 
-    fn decrease_template_depth<I, F>(&mut self, _ctx: &mut LexerSemCtx<'_, I, F>)
+    fn decrease_template_depth<I>(&mut self, _ctx: &mut LexerSemCtx<'_, I>)
     where
         I: CharStream,
-        F: TokenFactory,
     {
         self.template_depth -= 1;
     }
 
-    fn token_emitted(&mut self, token: &CommonToken) {
+    fn token_emitted(&mut self, token: TokenView<'_>) {
         if token.channel() == DEFAULT_CHANNEL {
             self.last_token_type = Some(token.token_type());
         }

--- a/tests/typescript-parity/dumper/src/typescript_parser_base.rs
+++ b/tests/typescript-parity/dumper/src/typescript_parser_base.rs
@@ -65,14 +65,16 @@ impl TypeScriptParserHooks for TypeScriptParserBase {
     where
         S: TokenSource,
     {
-        ctx.token_text(-1) == Some(expected)
+        ctx.token_text(-1)
+            .is_some_and(|token| token.text() == expected)
     }
 
     fn n<S>(&mut self, ctx: &mut ParserSemCtx<'_, S>, expected: &str) -> bool
     where
         S: TokenSource,
     {
-        ctx.token_text(1) == Some(expected)
+        ctx.token_text(1)
+            .is_some_and(|token| token.text() == expected)
     }
 
     fn not_line_terminator<S>(&mut self, ctx: &mut ParserSemCtx<'_, S>) -> bool


### PR DESCRIPTION
## Summary

- replace pointer-owned `CommonToken` / `TokenRef` buffering with one compact, index-addressed `TokenStore`
- write lexer output directly into the store through `TokenSink`, while parser, prediction, and CST paths carry `TokenId`
- remove `Rc<RefCell<TokenStore>>` handles; parse-tree nodes now store IDs and token-dependent APIs accept an explicit `&TokenStore`
- return generated convenience parses as `ParsedFile<R>` so completed trees retain their canonical token store
- update generated actions/listeners, parity harnesses, migration documentation, changelog, and Rust-versus-Go benchmark data

## Why

The previous stream representation stored each logical token more than once and paid per-token allocation, reference-counting, and cache-footprint costs before parsing began. This change makes the stream-owned store the only canonical representation and keeps text/source payloads sparse or stream-wide.

## Breaking changes

Generated lexers and parsers must be regenerated with the matching runtime/generator release. Custom token sources now append `TokenSpec` values through `TokenSink`. Tree token/text APIs require the owning store, and generated `parse()` helpers return `ParsedFile<R>`.

## Measurements

The 10x Solidity `governor.sol` allocation corpus improved as follows:

| Mode | Allocation count | Allocated bytes | Peak live bytes |
|---|---:|---:|---:|
| Full tree | -22.0% | -9.6% | -27.3% |
| No tree | -24.2% | -11.4% | -62.7% |
| Lex only | -51.2% | -64.6% | -74.0% |

A same-machine generated-parser comparison covered 12 Kotlin, C#, and Java fixtures. Eleven were faster and the remaining Kotlin fixture was +1.0%; the regression gate passed for all results.

## Validation

- `cargo fmt --check`
- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- JavaScript, TypeScript, and Kotlin parser parity suites
- ANTLR runtime testsuite: `356 passed, 0 failed, 1 skipped`
- generated-parser benchmark comparison: 12/12 passed
- focused `ParsedFile` traversal/token-resolution regression preserving the PR #69 traversal helpers

Fixes #82