### PR TITLE
Intern prediction contexts behind compact IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,5 +22,11 @@
   payloads now live in one parser-owned, index-addressed recognition arena.
   `RecognitionArenaStats` reports total/live/dead records and retained
   capacities for the latest interpreted rule parse.
+- Recursive `Rc<PredictionContext>` graphs and the exported
+  `PredictionContext`/`AtnConfig` compatibility API are removed. Prediction
+  contexts are canonical `ContextId` values in pooled storage owned together
+  with learned parser DFAs; overlapping stores remap IDs before DFA union.
+- `ParserAtnSimulator::prediction_context_stats()` reports context creation,
+  singleton/array distribution, pooled entries and bytes, and interner hits.
 - Generated lexers and parsers must be regenerated with the matching
   `antlr4-rust-gen` release.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ than letting fmt explode the block to one element per line.
 - `src/lexer.rs`, `src/atn/lexer.rs` — `BaseLexer` + lexer ATN simulator
 - `src/parser.rs` — `BaseParser` and the recursive `recognize_state_fast` walker
 - `src/atn/`, `src/atn/serialized.rs` — ATN graph + ANTLR `.interp` deserializer
-- `src/prediction.rs` — `PredictionContext`, `AtnConfig`, `PredictionFxHasher`
+- `src/prediction.rs` — compact `ContextId` storage, `AtnConfig`, `PredictionFxHasher`
 - `src/token.rs`, `src/token_stream.rs`, `src/char_stream.rs` — input + token plumbing
 - `src/tree.rs` — public `ParseTree` / `ParserRuleContext`
 - `src/bin/antlr4-rust-gen.rs` — `.interp` → Rust parser code generator

--- a/README.md
+++ b/README.md
@@ -197,38 +197,6 @@ grammar's documentation. Calling the wrong rule can still recover and return a
 parse tree with error nodes, so check parser diagnostics when adding a new input
 form.
 
-## Token and Tree API Migration
-
-The compact token and flat CST stores are breaking runtime/generator changes.
-Regenerate all generated lexers and parsers with the matching
-`antlr4-rust-gen`; code generated against the pointer-owned token or recursive
-tree APIs does not compile against this runtime.
-
-`CommonToken`, `TokenRef`, and token factories are removed. Custom token sources
-now append a `TokenSpec` directly to the supplied `TokenSink` and return its
-`TokenId`. Buffered-token consumers use borrowing `TokenView` values from
-`get`, `lt`, or the `tokens()` iterator. Custom `CharStream` implementations
-should provide `source_text()` when the complete UTF-8 input can be shared;
-otherwise token text is stored explicitly in the sparse side pool.
-
-`CommonTokenStream` owns its `TokenStore` directly. `BaseParser` owns one
-`ParseTreeStorage`: nodes are addressed by `NodeId`, every rule child list is a
-range in one shared edge pool, and terminal/error records contain only
-`TokenId`. `Node`, `RuleNodeView`, and terminal/error views borrow the stores;
-there is no recursive `ParserRuleContext` ownership graph or legacy materializer.
-
-Generated `parse()` returns `ParsedFile`, which owns the token store, flat CST,
-and root ID. Access the root through `tree()`, inspect storage metrics through
-`storage().stats()`, or resolve another ID through `node()`. Direct rule calls
-return `NodeId`; use `parser.node(id)` while the parser is alive, or consume the
-parser with `into_parsed_file(id)`.
-
-Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
-numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);
-`u32::MAX` is reserved for ANTLR's synthetic `-1` boundary. All conversions are
-checked. Use `CommonTokenStream::try_new` or `try_with_channel` to handle limit
-errors; `new` and `with_channel` panic with the same error.
-
 ## Technical Notes
 
 - Pure Rust runtime implementation.
@@ -259,6 +227,7 @@ The runtime contains:
   for constructs a finite DFA cannot represent (semantic predicates,
   recursive lexer rules)
 - parser ATN rule recognition with backtracking over token stream indices
+- canonical `ContextId` prediction graphs pooled with learned parser DFA state
 - `antlr4-rust-gen`, a Rust generator that consumes ANTLR `.interp` metadata and
   emits Rust modules
 - `antlr4-runtime-testsuite`, a harness for running upstream ANTLR
@@ -462,10 +431,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | 24.541x                 |
-| Java     | 4        | 2.877x                  |
-| C#       | 4        | 2.092x                  |
-| Trino SQL| 5        | 3.495x                  |
+| Kotlin   | 4        | 24.959x                 |
+| Java     | 4        | 3.024x                  |
+| C#       | 4        | 2.205x                  |
+| Trino SQL | 5       | 3.413x                  |
 
 ## Useful Information
 

--- a/README.md
+++ b/README.md
@@ -431,10 +431,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | 24.959x                 |
-| Java     | 4        | 3.024x                  |
-| C#       | 4        | 2.205x                  |
-| Trino SQL | 5       | 3.413x                  |
+| Kotlin   | 4        | 24.968x                 |
+| Java     | 4        | 3.055x                  |
+| C#       | 4        | 2.206x                  |
+| Trino SQL | 5       | 3.412x                  |
 
 ## Useful Information
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -36,7 +36,8 @@ directly in a shared arena and array payloads use shared parent and return-state
 pools. Each `ParserAtnSimulator` owns that arena together with its learned
 parser DFAs, and remaps context IDs before combining independently learned
 stores. `prediction_context_stats()` exposes arena allocation and interner
-totals for measurement.
+totals, retained capacities, workspace usage, and outer-context cache activity
+for measurement.
 
 Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
 numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,0 +1,45 @@
+# Migration Notes
+
+`antlr-rust-runtime` is pre-1.0. Minor releases may include breaking runtime and
+generator changes. Generated lexers and parsers must use the same release of
+`antlr4-rust-gen` as the runtime.
+
+## Compact Token, Tree, and Prediction Stores
+
+The compact token, flat CST, and prediction-context stores replace the previous
+pointer-owned APIs. Code generated against the older token or recursive tree
+APIs does not compile against this runtime and must be regenerated.
+
+`CommonToken`, `TokenRef`, and token factories are removed. Custom token sources
+now append a `TokenSpec` directly to the supplied `TokenSink` and return its
+`TokenId`. Buffered-token consumers use borrowing `TokenView` values from
+`get`, `lt`, or the `tokens()` iterator. Custom `CharStream` implementations
+should provide `source_text()` when the complete UTF-8 input can be shared;
+otherwise token text is stored explicitly in the sparse side pool.
+
+`CommonTokenStream` owns its `TokenStore` directly. `BaseParser` owns one
+`ParseTreeStorage`: nodes are addressed by `NodeId`, every rule child list is a
+range in one shared edge pool, and terminal/error records contain only
+`TokenId`. `Node`, `RuleNodeView`, and terminal/error views borrow the stores;
+there is no recursive `ParserRuleContext` ownership graph or legacy
+materializer.
+
+Generated `parse()` returns `ParsedFile`, which owns the token store, flat CST,
+and root ID. Access the root through `tree()`, inspect storage metrics through
+`storage().stats()`, or resolve another ID through `node()`. Direct rule calls
+return `NodeId`; use `parser.node(id)` while the parser is alive, or consume the
+parser with `into_parsed_file(id)`.
+
+Parser prediction contexts are compact and store-local. `ContextId` replaces
+the exported recursive `PredictionContext` graph; singleton records live
+directly in a shared arena and array payloads use shared parent and return-state
+pools. Each `ParserAtnSimulator` owns that arena together with its learned
+parser DFAs, and remaps context IDs before combining independently learned
+stores. `prediction_context_stats()` exposes arena allocation and interner
+totals for measurement.
+
+Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
+numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);
+`u32::MAX` is reserved for ANTLR's synthetic `-1` boundary. All conversions are
+checked. Use `CommonTokenStream::try_new` or `try_with_channel` to handle limit
+errors; `new` and `with_channel` panic with the same error.

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -2,34 +2,47 @@ use crate::atn::{Atn, AtnState, AtnStateKind, Transition};
 use crate::dfa::{Dfa, DfaState};
 use crate::int_stream::IntStream;
 use crate::prediction::{
-    AtnConfig, AtnConfigSet, EMPTY_RETURN_STATE, PredictionContext, PredictionContextCache,
-    PredictionContextMergeCache, PredictionFxHasher, SemanticContext, all_subsets_conflict,
-    all_subsets_equal, conflicting_alt_subsets, has_sll_conflict_terminating_prediction,
-    single_viable_alt,
+    AtnConfig, AtnConfigSet, ContextArena, ContextId, EMPTY_CONTEXT, EMPTY_RETURN_STATE,
+    PredictionContextStats, PredictionFxHasher, PredictionWorkspace, SemanticContext,
+    all_subsets_conflict, all_subsets_equal, conflicting_alt_subsets,
+    has_sll_conflict_terminating_prediction, single_viable_alt,
 };
 use crate::token::TOKEN_EOF;
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
-use std::rc::Rc;
 
 type FxHashSet<T> = HashSet<T, BuildHasherDefault<PredictionFxHasher>>;
 
 #[derive(Debug)]
 pub struct ParserAtnSimulator<'a> {
     atn: &'a Atn,
-    decision_to_dfa: Vec<Dfa>,
+    store: PredictionStore,
+    workspace: PredictionWorkspace,
     shared_cache_key: Option<usize>,
-    context_cache: Rc<RefCell<PredictionContextCache>>,
     /// Java's `LL_EXACT_AMBIG_DETECTION`: the full-context loop keeps
     /// consuming past "resolves to one viable alt" conflicts until every
     /// `(state, context)` subset conflicts over the same alt set.
     exact_ambig_detection: bool,
 }
 
+#[derive(Debug, Default)]
+struct PredictionStore {
+    contexts: ContextArena,
+    decision_to_dfa: Vec<Dfa>,
+}
+
+impl PredictionStore {
+    fn new(atn: &Atn) -> Self {
+        Self {
+            contexts: ContextArena::new(),
+            decision_to_dfa: initial_decision_dfas(atn),
+        }
+    }
+}
+
 thread_local! {
-    static SHARED_DECISION_DFAS: RefCell<HashMap<usize, Vec<Dfa>>> = RefCell::new(HashMap::new());
-    static SHARED_CONTEXT_CACHES: RefCell<HashMap<usize, Rc<RefCell<PredictionContextCache>>>> =
+    static SHARED_PREDICTION_STORES: RefCell<HashMap<usize, PredictionStore>> =
         RefCell::new(HashMap::new());
 }
 
@@ -61,22 +74,22 @@ pub enum ParserAtnPredictionDiagnosticKind {
 }
 
 #[derive(Clone, Copy)]
-struct PredictionCheck<'a> {
+struct PredictionCheck {
     decision: usize,
     decision_state: usize,
     state_number: usize,
     start_index: usize,
     precedence: i32,
-    outer_context: &'a Rc<PredictionContext>,
+    outer_context: ContextId,
     force_full_context_retry: bool,
     sll_probe_only: bool,
 }
 
 #[derive(Clone, Copy)]
-struct AdaptivePredictRequest<'a> {
+struct AdaptivePredictRequest {
     decision: usize,
     precedence: usize,
-    outer_context: &'a Rc<PredictionContext>,
+    outer_context: ContextId,
     force_full_context_retry: bool,
     /// When set, the SLL walk stops at the first full-context-requiring conflict
     /// and returns the SLL prediction (carrying `requires_full_context = true`)
@@ -139,7 +152,7 @@ fn full_context_prediction(
 struct ClosureConfigKey {
     state: usize,
     alt: usize,
-    context: Rc<PredictionContext>,
+    context: ContextId,
     semantic_context: SemanticContext,
     precedence_filter_suppressed: bool,
 }
@@ -149,7 +162,7 @@ impl From<&AtnConfig> for ClosureConfigKey {
         Self {
             state: config.state,
             alt: config.alt,
-            context: Rc::clone(&config.context),
+            context: config.context,
             semantic_context: config.semantic_context.clone(),
             precedence_filter_suppressed: config.precedence_filter_suppressed,
         }
@@ -263,6 +276,18 @@ fn union_decision_dfas(shared: &mut Vec<Dfa>, local: Vec<Dfa>) {
     }
 }
 
+fn union_prediction_stores(
+    shared: &mut PredictionStore,
+    mut local: PredictionStore,
+    workspace: &mut PredictionWorkspace,
+) {
+    let remap = shared.contexts.import_all(&local.contexts, workspace);
+    for dfa in &mut local.decision_to_dfa {
+        dfa.remap_contexts(&remap, &shared.contexts);
+    }
+    union_decision_dfas(&mut shared.decision_to_dfa, local.decision_to_dfa);
+}
+
 fn union_decision_dfa(shared: &mut Dfa, local: Dfa) {
     if shared.is_precedence_dfa() != local.is_precedence_dfa() {
         // A mode flip resets the tables (`set_precedence_dfa`), so the two are
@@ -281,8 +306,7 @@ fn union_decision_dfa(shared: &mut Dfa, local: Dfa) {
         let number = shared
             .state_number_for_configs(&state.configs)
             .unwrap_or_else(|| {
-                let mut missing = state.clone();
-                missing.edges = Vec::new();
+                let missing = state.clone_without_edges();
                 shared.insert_state(missing)
             });
         renumber.push(number);
@@ -337,13 +361,13 @@ impl Drop for ParserAtnSimulator<'_> {
         // simulator for the same ATN was created while this one was alive
         // (that one started cold and checked its copy in first) — then union
         // the two by config-set identity so neither side's learning is lost.
-        let dfas = std::mem::take(&mut self.decision_to_dfa);
-        SHARED_DECISION_DFAS.with(|cache| {
+        let store = std::mem::take(&mut self.store);
+        SHARED_PREDICTION_STORES.with(|cache| {
             let mut cache = cache.borrow_mut();
             if let Some(shared) = cache.get_mut(&key) {
-                union_decision_dfas(shared, dfas);
+                union_prediction_stores(shared, store, &mut self.workspace);
             } else {
-                cache.insert(key, dfas);
+                cache.insert(key, store);
             }
         });
     }
@@ -353,9 +377,9 @@ impl<'a> ParserAtnSimulator<'a> {
     pub fn new(atn: &'a Atn) -> Self {
         Self {
             atn,
-            decision_to_dfa: initial_decision_dfas(atn),
+            store: PredictionStore::new(atn),
+            workspace: PredictionWorkspace::default(),
             shared_cache_key: None,
-            context_cache: Rc::new(RefCell::new(PredictionContextCache::new())),
             exact_ambig_detection: false,
         }
     }
@@ -378,7 +402,7 @@ impl<'a> ParserAtnSimulator<'a> {
     /// cloning a warm DFA per parser instance costs O(learned states) — ~10%
     /// of a small parse. A second simulator created for the same ATN while one
     /// is alive finds the slot empty and starts cold; the drop-time check-in
-    /// then keeps whichever tables learned more.
+    /// then remaps its context IDs and unions both independently learned stores.
     /// Renders every non-empty learned decision DFA in the format of Java's
     /// `Parser.dumpDFA()` / `DFASerializer` — `Decision N:` headers followed
     /// by `s0-'else'->:s1^=>1` edge lines — which the runtime testsuite's
@@ -387,7 +411,7 @@ impl<'a> ParserAtnSimulator<'a> {
         use std::fmt::Write as _;
         let mut out = String::new();
         let mut seen_one = false;
-        for dfa in &self.decision_to_dfa {
+        for dfa in &self.store.decision_to_dfa {
             if dfa.states().is_empty() {
                 continue;
             }
@@ -417,28 +441,39 @@ impl<'a> ParserAtnSimulator<'a> {
     pub fn new_shared(atn: &'static Atn) -> Self {
         let ptr: *const Atn = atn;
         let key = ptr as usize;
-        let decision_to_dfa = SHARED_DECISION_DFAS
+        let store = SHARED_PREDICTION_STORES
             .with(|cache| cache.borrow_mut().remove(&key))
-            .unwrap_or_else(|| initial_decision_dfas(atn));
-        let context_cache = SHARED_CONTEXT_CACHES.with(|cache| {
-            Rc::clone(
-                cache
-                    .borrow_mut()
-                    .entry(key)
-                    .or_insert_with(|| Rc::new(RefCell::new(PredictionContextCache::new()))),
-            )
-        });
+            .unwrap_or_else(|| PredictionStore::new(atn));
         Self {
             atn,
-            decision_to_dfa,
+            store,
+            workspace: PredictionWorkspace::default(),
             shared_cache_key: Some(key),
-            context_cache,
             exact_ambig_detection: false,
         }
     }
 
     pub fn decision_dfas(&self) -> &[Dfa] {
-        &self.decision_to_dfa
+        &self.store.decision_to_dfa
+    }
+
+    /// Returns compact prediction-context allocation and interning totals for
+    /// this simulator's learned store.
+    pub fn prediction_context_stats(&self) -> PredictionContextStats {
+        self.store.contexts.stats()
+    }
+
+    /// Interns a generated parser's outer call stack in this simulator's
+    /// context arena. Return states must be supplied outermost to innermost.
+    pub fn intern_prediction_context(
+        &mut self,
+        return_states: impl IntoIterator<Item = usize>,
+    ) -> ContextId {
+        let mut context = EMPTY_CONTEXT;
+        for return_state in return_states {
+            context = self.store.contexts.singleton(context, return_state);
+        }
+        context
     }
 
     pub fn adaptive_predict(
@@ -473,21 +508,22 @@ impl<'a> ParserAtnSimulator<'a> {
         precedence: usize,
         input: &mut T,
     ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
-        let empty = PredictionContext::empty();
         let marker = input.mark();
         let index = input.index();
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut workspace = std::mem::take(&mut self.workspace);
+        workspace.reset();
         let result = self.adaptive_predict_stream_inner(
             AdaptivePredictRequest {
                 decision,
                 precedence,
-                outer_context: &empty,
+                outer_context: EMPTY_CONTEXT,
                 force_full_context_retry: false,
                 sll_probe_only: false,
             },
             input,
-            &mut merge_cache,
+            &mut workspace,
         );
+        self.workspace = workspace;
         input.seek(index);
         input.release(marker);
         result
@@ -508,21 +544,22 @@ impl<'a> ParserAtnSimulator<'a> {
         precedence: usize,
         input: &mut T,
     ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
-        let empty = PredictionContext::empty();
         let marker = input.mark();
         let index = input.index();
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut workspace = std::mem::take(&mut self.workspace);
+        workspace.reset();
         let result = self.adaptive_predict_stream_inner(
             AdaptivePredictRequest {
                 decision,
                 precedence,
-                outer_context: &empty,
+                outer_context: EMPTY_CONTEXT,
                 force_full_context_retry: false,
                 sll_probe_only: true,
             },
             input,
-            &mut merge_cache,
+            &mut workspace,
         );
+        self.workspace = workspace;
         input.seek(index);
         input.release(marker);
         result
@@ -533,11 +570,13 @@ impl<'a> ParserAtnSimulator<'a> {
         decision: usize,
         precedence: usize,
         input: &mut T,
-        outer_context: &Rc<PredictionContext>,
+        outer_context: ContextId,
     ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
+        self.store.contexts.assert_valid(outer_context);
         let marker = input.mark();
         let index = input.index();
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut workspace = std::mem::take(&mut self.workspace);
+        workspace.reset();
         let result = self.adaptive_predict_stream_inner(
             AdaptivePredictRequest {
                 decision,
@@ -547,8 +586,9 @@ impl<'a> ParserAtnSimulator<'a> {
                 sll_probe_only: false,
             },
             input,
-            &mut merge_cache,
+            &mut workspace,
         );
+        self.workspace = workspace;
         input.seek(index);
         input.release(marker);
         result
@@ -576,9 +616,9 @@ impl<'a> ParserAtnSimulator<'a> {
 
     fn adaptive_predict_stream_inner<T: IntStream>(
         &mut self,
-        request: AdaptivePredictRequest<'_>,
+        request: AdaptivePredictRequest,
         input: &mut T,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
         let AdaptivePredictRequest {
             decision,
@@ -620,6 +660,7 @@ impl<'a> ParserAtnSimulator<'a> {
         loop {
             let symbol = input.la(1);
             if let Some(target) = self
+                .store
                 .decision_to_dfa
                 .get(decision)
                 .and_then(|dfa| dfa.state(state_number))
@@ -628,6 +669,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 state_number = target;
             } else {
                 let configs = self
+                    .store
                     .decision_to_dfa
                     .get(decision)
                     .and_then(|dfa| dfa.state(state_number))
@@ -681,6 +723,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 // exit the loop cleanly instead of reporting a spurious
                 // "no viable alternative at input '<EOF>'".
                 if let Some(configs) = self
+                    .store
                     .decision_to_dfa
                     .get(decision)
                     .and_then(|dfa| dfa.state(state_number))
@@ -701,10 +744,10 @@ impl<'a> ParserAtnSimulator<'a> {
     }
 
     fn prediction_or_full_context<T: IntStream>(
-        &self,
+        &mut self,
         input: &mut T,
-        check: PredictionCheck<'_>,
-        merge_cache: &mut PredictionContextMergeCache,
+        check: PredictionCheck,
+        merge_cache: &mut PredictionWorkspace,
     ) -> Result<Option<ParserAtnPrediction>, ParserAtnSimulatorError> {
         let PredictionCheck {
             decision,
@@ -716,7 +759,7 @@ impl<'a> ParserAtnSimulator<'a> {
             force_full_context_retry,
             sll_probe_only,
         } = check;
-        if outer_context.is_empty()
+        if self.store.contexts.is_empty(outer_context)
             && let Some(prediction) =
                 self.non_greedy_exit_prediction(decision, decision_state, state_number)
         {
@@ -794,6 +837,7 @@ impl<'a> ParserAtnSimulator<'a> {
             return None;
         }
         let configs = &self
+            .store
             .decision_to_dfa
             .get(decision)?
             .state(state_number)?
@@ -805,7 +849,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 self.atn
                     .state(config.state)
                     .is_some_and(AtnState::is_rule_stop)
-                    && config.context.has_empty_path()
+                    && self.store.contexts.has_empty_path(config.context)
             })
             .map(|config| config.alt)
             .min()?;
@@ -822,16 +866,16 @@ impl<'a> ParserAtnSimulator<'a> {
         decision: usize,
         decision_state: usize,
         precedence: i32,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> Result<usize, ParserAtnSimulatorError> {
-        if self.decision_to_dfa[decision].is_precedence_dfa() {
+        if self.store.decision_to_dfa[decision].is_precedence_dfa() {
             let precedence_key = usize::try_from(precedence.max(0)).unwrap_or_default();
             if let Some(start) =
-                self.decision_to_dfa[decision].precedence_start_state(precedence_key)
+                self.store.decision_to_dfa[decision].precedence_start_state(precedence_key)
             {
                 return Ok(start);
             }
-        } else if let Some(start) = self.decision_to_dfa[decision].start_state() {
+        } else if let Some(start) = self.store.decision_to_dfa[decision].start_state() {
             return Ok(start);
         }
         let decision_state = self
@@ -840,53 +884,50 @@ impl<'a> ParserAtnSimulator<'a> {
             .ok_or(ParserAtnSimulatorError::MissingAtnState(decision_state))?;
         let configs = self.compute_start_state(decision_state, precedence, merge_cache);
         let state_number = self.add_dfa_state(decision, DfaState::new(configs));
-        if self.decision_to_dfa[decision].is_precedence_dfa() {
+        if self.store.decision_to_dfa[decision].is_precedence_dfa() {
             let precedence_key = usize::try_from(precedence.max(0)).unwrap_or_default();
-            self.decision_to_dfa[decision].set_precedence_start_state(precedence_key, state_number);
+            self.store.decision_to_dfa[decision]
+                .set_precedence_start_state(precedence_key, state_number);
         } else {
-            self.decision_to_dfa[decision].set_start_state(state_number);
+            self.store.decision_to_dfa[decision].set_start_state(state_number);
         }
         Ok(state_number)
     }
 
-    fn add_dfa_state(&mut self, decision: usize, mut state: DfaState) -> usize {
+    fn add_dfa_state(&mut self, decision: usize, state: DfaState) -> usize {
         if state.configs.is_readonly() {
-            return self.decision_to_dfa[decision].add_state(state);
+            return self.store.decision_to_dfa[decision].add_state(state);
         }
         if let Some(existing) =
-            self.decision_to_dfa[decision].state_number_for_configs(&state.configs)
+            self.store.decision_to_dfa[decision].state_number_for_configs(&state.configs)
         {
             return existing;
         }
-        state
-            .configs
-            .optimize_contexts(&mut self.context_cache.borrow_mut());
-        self.decision_to_dfa[decision].insert_state(state)
+        self.store.decision_to_dfa[decision].insert_state(state)
     }
 
     fn compute_start_state(
-        &self,
+        &mut self,
         decision_state: &AtnState,
         precedence: i32,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> AtnConfigSet {
-        let empty = PredictionContext::empty();
         self.compute_start_state_with_context(
             decision_state,
             false,
-            &empty,
+            EMPTY_CONTEXT,
             precedence,
             merge_cache,
         )
     }
 
     fn compute_start_state_with_context(
-        &self,
+        &mut self,
         decision_state: &AtnState,
         full_context: bool,
-        initial_context: &Rc<PredictionContext>,
+        initial_context: ContextId,
         precedence: i32,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> AtnConfigSet {
         let mut configs = AtnConfigSet::new_full_context(full_context);
         let mut scratch = ClosureScratch::default();
@@ -897,19 +938,24 @@ impl<'a> ParserAtnSimulator<'a> {
         };
         for (index, transition) in decision_state.transitions.iter().enumerate() {
             let alt = index + 1;
-            let config = AtnConfig::new(transition.target(), alt, Rc::clone(initial_context));
+            let config = AtnConfig::new(
+                transition.target(),
+                alt,
+                initial_context,
+                &self.store.contexts,
+            );
             self.closure(config, &mut configs, merge_cache, &mut scratch, params);
         }
         configs
     }
 
     fn adaptive_predict_full_context<T: IntStream>(
-        &self,
+        &mut self,
         decision_state: usize,
         input: &mut T,
         precedence: i32,
-        outer_context: &Rc<PredictionContext>,
-        merge_cache: &mut PredictionContextMergeCache,
+        outer_context: ContextId,
+        merge_cache: &mut PredictionWorkspace,
     ) -> Result<FullContextPrediction, ParserAtnSimulatorError> {
         let decision_state = self
             .atn
@@ -1017,7 +1063,7 @@ impl<'a> ParserAtnSimulator<'a> {
         configs: &AtnConfigSet,
         symbol: i32,
         precedence: i32,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> Result<usize, ParserAtnSimulatorError> {
         let mut reach = self.compute_reach_set(configs, symbol, false, precedence, merge_cache);
         if reach.is_empty() {
@@ -1030,7 +1076,7 @@ impl<'a> ParserAtnSimulator<'a> {
                     && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
                 let target_state = self.add_dfa_state(edge.decision, dfa_state);
                 if let Some(source) =
-                    self.decision_to_dfa[edge.decision].state_mut(edge.source_state)
+                    self.store.decision_to_dfa[edge.decision].state_mut(edge.source_state)
                 {
                     source.add_edge(symbol, target_state);
                 }
@@ -1075,19 +1121,20 @@ impl<'a> ParserAtnSimulator<'a> {
                 && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
         }
         let target_state = self.add_dfa_state(edge.decision, dfa_state);
-        if let Some(source) = self.decision_to_dfa[edge.decision].state_mut(edge.source_state) {
+        if let Some(source) = self.store.decision_to_dfa[edge.decision].state_mut(edge.source_state)
+        {
             source.add_edge(symbol, target_state);
         }
         Ok(target_state)
     }
 
     fn compute_reach_set(
-        &self,
+        &mut self,
         configs: &AtnConfigSet,
         symbol: i32,
         full_context: bool,
         precedence: i32,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> AtnConfigSet {
         let mut intermediate = AtnConfigSet::new_full_context(full_context);
         let mut skipped_stop_states = Vec::new();
@@ -1103,15 +1150,9 @@ impl<'a> ParserAtnSimulator<'a> {
             }
             for transition in &state.transitions {
                 if transition.matches(symbol, 1, self.atn.max_token_type()) {
-                    let target = AtnConfig {
-                        state: transition.target(),
-                        alt: config.alt,
-                        context: Rc::clone(&config.context),
-                        semantic_context: config.semantic_context.clone(),
-                        reaches_into_outer_context: config.reaches_into_outer_context,
-                        precedence_filter_suppressed: config.precedence_filter_suppressed,
-                    };
-                    intermediate.add_with_merge_cache(target, Some(merge_cache));
+                    let target =
+                        config.moved_to(transition.target(), config.context, &self.store.contexts);
+                    intermediate.add(target, &mut self.store.contexts, merge_cache);
                 }
             }
         }
@@ -1141,7 +1182,7 @@ impl<'a> ParserAtnSimulator<'a> {
         }
         if !full_context || !self.configs_contain_rule_stop(&reach) {
             for config in skipped_stop_states {
-                reach.add_with_merge_cache(config, Some(merge_cache));
+                reach.add(config, &mut self.store.contexts, merge_cache);
             }
         }
         #[cfg(feature = "perf-counters")]
@@ -1150,12 +1191,12 @@ impl<'a> ParserAtnSimulator<'a> {
     }
 
     fn close_intermediate_reach_set(
-        &self,
+        &mut self,
         intermediate: AtnConfigSet,
         full_context: bool,
         precedence: i32,
         symbol: i32,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> AtnConfigSet {
         let mut reach = AtnConfigSet::new_full_context(full_context);
         let mut scratch = ClosureScratch::default();
@@ -1182,16 +1223,16 @@ impl<'a> ParserAtnSimulator<'a> {
                         .atn
                         .state(config.state)
                         .is_some_and(AtnState::is_rule_stop)
-                        && config.context.has_empty_path()
+                        && self.store.contexts.has_empty_path(config.context)
             })
             .map(|config| config.alt)
             .min()
     }
 
     fn rule_stop_configs(
-        &self,
+        &mut self,
         configs: AtnConfigSet,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
     ) -> AtnConfigSet {
         if configs.configs().iter().all(|config| {
             self.atn
@@ -1206,7 +1247,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 .state(config.state)
                 .is_some_and(AtnState::is_rule_stop)
         }) {
-            result.add_with_merge_cache(config.clone(), Some(merge_cache));
+            result.add(config.clone(), &mut self.store.contexts, merge_cache);
         }
         result
     }
@@ -1228,10 +1269,10 @@ impl<'a> ParserAtnSimulator<'a> {
     }
 
     fn closure(
-        &self,
+        &mut self,
         config: AtnConfig,
         configs: &mut AtnConfigSet,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
         scratch: &mut ClosureScratch,
         params: ClosureParams,
     ) {
@@ -1265,11 +1306,16 @@ impl<'a> ParserAtnSimulator<'a> {
             let epsilon_only = !state.transitions.is_empty()
                 && state.transitions.iter().all(Transition::is_epsilon);
             if !epsilon_only {
-                configs.add_with_merge_cache(config.clone(), Some(merge_cache));
+                configs.add(config.clone(), &mut self.store.contexts, merge_cache);
             }
             for (index, transition) in state.transitions.iter().enumerate() {
                 if index == 0
-                    && can_drop_left_recursive_loop_entry_edge(self.atn, state, &config.context)
+                    && can_drop_left_recursive_loop_entry_edge(
+                        self.atn,
+                        state,
+                        &self.store.contexts,
+                        config.context,
+                    )
                 {
                     continue;
                 }
@@ -1296,14 +1342,7 @@ impl<'a> ParserAtnSimulator<'a> {
                     && transition.matches(TOKEN_EOF, 1, self.atn.max_token_type())
                 {
                     scratch.stack.push((
-                        AtnConfig {
-                            state: transition.target(),
-                            alt: config.alt,
-                            context: Rc::clone(&config.context),
-                            semantic_context: config.semantic_context.clone(),
-                            reaches_into_outer_context: config.reaches_into_outer_context,
-                            precedence_filter_suppressed: config.precedence_filter_suppressed,
-                        },
+                        config.moved_to(transition.target(), config.context, &self.store.contexts),
                         collect_predicates,
                     ));
                 }
@@ -1314,54 +1353,48 @@ impl<'a> ParserAtnSimulator<'a> {
     }
 
     fn closure_at_rule_stop(
-        &self,
+        &mut self,
         config: AtnConfig,
         collect_predicates: bool,
         configs: &mut AtnConfigSet,
-        merge_cache: &mut PredictionContextMergeCache,
+        merge_cache: &mut PredictionWorkspace,
         stack: &mut Vec<(AtnConfig, bool)>,
     ) -> bool {
-        if config.context.is_empty() {
+        if self.store.contexts.is_empty(config.context) {
             if configs.full_context() {
-                configs.add_with_merge_cache(config, Some(merge_cache));
+                configs.add(config, &mut self.store.contexts, merge_cache);
                 return true;
             }
             return false;
         }
         let mut handled_all_paths = true;
-        for index in 0..config.context.len() {
-            let Some(return_state) = config.context.return_state(index) else {
+        for index in 0..self.store.contexts.len(config.context) {
+            let Some(return_state) = self.store.contexts.return_state(config.context, index) else {
                 continue;
             };
             if return_state == EMPTY_RETURN_STATE {
                 if configs.full_context() {
                     let mut empty_context_config = config.clone();
-                    empty_context_config.context = PredictionContext::empty();
-                    configs.add_with_merge_cache(empty_context_config, Some(merge_cache));
+                    empty_context_config.set_context(EMPTY_CONTEXT, &self.store.contexts);
+                    configs.add(empty_context_config, &mut self.store.contexts, merge_cache);
                 } else {
                     handled_all_paths = false;
                 }
                 continue;
             }
-            let parent = config
-                .context
-                .parent(index)
-                .unwrap_or_else(PredictionContext::empty);
-            let next = AtnConfig {
-                state: return_state,
-                alt: config.alt,
-                context: parent,
-                semantic_context: config.semantic_context.clone(),
-                reaches_into_outer_context: config.reaches_into_outer_context,
-                precedence_filter_suppressed: config.precedence_filter_suppressed,
-            };
+            let parent = self
+                .store
+                .contexts
+                .parent(config.context, index)
+                .unwrap_or(EMPTY_CONTEXT);
+            let next = config.moved_to(return_state, parent, &self.store.contexts);
             stack.push((next, collect_predicates));
         }
         handled_all_paths
     }
 
     fn epsilon_target_config(
-        &self,
+        &mut self,
         config: &AtnConfig,
         transition: &Transition,
         precedence: i32,
@@ -1398,18 +1431,13 @@ impl<'a> ParserAtnSimulator<'a> {
         };
         let context = match transition {
             Transition::Rule { follow_state, .. } => {
-                PredictionContext::singleton(Rc::clone(&config.context), *follow_state)
+                self.store.contexts.singleton(config.context, *follow_state)
             }
-            _ => Rc::clone(&config.context),
+            _ => config.context,
         };
-        Some(AtnConfig {
-            state: transition.target(),
-            alt: config.alt,
-            context,
-            semantic_context,
-            reaches_into_outer_context: config.reaches_into_outer_context,
-            precedence_filter_suppressed: config.precedence_filter_suppressed,
-        })
+        let mut target = config.moved_to(transition.target(), context, &self.store.contexts);
+        target.semantic_context = semantic_context;
+        Some(target)
     }
 
     fn dfa_prediction_info(
@@ -1417,7 +1445,8 @@ impl<'a> ParserAtnSimulator<'a> {
         decision: usize,
         state_number: usize,
     ) -> Option<DfaPredictionInfo> {
-        self.decision_to_dfa
+        self.store
+            .decision_to_dfa
             .get(decision)
             .and_then(|dfa| dfa.state(state_number))
             .and_then(|state| {
@@ -1452,20 +1481,21 @@ impl<'a> ParserAtnSimulator<'a> {
 pub(crate) fn can_drop_left_recursive_loop_entry_edge(
     atn: &Atn,
     state: &AtnState,
-    context: &PredictionContext,
+    contexts: &ContextArena,
+    context: ContextId,
 ) -> bool {
     if state.kind != AtnStateKind::StarLoopEntry
         || !state.precedence_rule_decision
-        || context.is_empty()
-        || context.has_empty_path()
+        || contexts.is_empty(context)
+        || contexts.has_empty_path(context)
     {
         return false;
     }
     let Some(rule_index) = state.rule_index else {
         return false;
     };
-    for index in 0..context.len() {
-        let Some(return_state_number) = context.return_state(index) else {
+    for index in 0..contexts.len(context) {
+        let Some(return_state_number) = contexts.return_state(context, index) else {
             return false;
         };
         let Some(return_state) = atn.state(return_state_number) else {
@@ -1483,9 +1513,9 @@ pub(crate) fn can_drop_left_recursive_loop_entry_edge(
     else {
         return false;
     };
-    for index in 0..context.len() {
-        let return_state_number = context
-            .return_state(index)
+    for index in 0..contexts.len(context) {
+        let return_state_number = contexts
+            .return_state(context, index)
             .expect("return state checked above");
         let return_state = atn
             .state(return_state_number)
@@ -1564,21 +1594,35 @@ mod tests {
 
     #[test]
     fn union_decision_dfa_preserves_disjoint_coverage() {
-        fn configs(atn_state: usize) -> AtnConfigSet {
+        fn configs(
+            atn_state: usize,
+            arena: &mut ContextArena,
+            workspace: &mut PredictionWorkspace,
+        ) -> AtnConfigSet {
             let mut set = AtnConfigSet::new();
-            set.add(AtnConfig::new(atn_state, 1, PredictionContext::empty()));
+            set.add(
+                AtnConfig::new(atn_state, 1, EMPTY_CONTEXT, arena),
+                arena,
+                workspace,
+            );
             set
         }
-        fn state(atn_state: usize) -> DfaState {
-            DfaState::new(configs(atn_state))
+        fn state(
+            atn_state: usize,
+            arena: &mut ContextArena,
+            workspace: &mut PredictionWorkspace,
+        ) -> DfaState {
+            DfaState::new(configs(atn_state, arena, workspace))
         }
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
 
         // Two DFAs that evolved independently from the same grammar: equal
         // state/edge counts, but disjoint transitions and different state
         // numbering for the shared successor.
         let mut shared = Dfa::with_max_token_type(0, 0, 8);
-        let shared_root = shared.add_state(state(10));
-        let shared_a = shared.add_state(state(11));
+        let shared_root = shared.add_state(state(10, &mut arena, &mut workspace));
+        let shared_a = shared.add_state(state(11, &mut arena, &mut workspace));
         shared
             .state_mut(shared_root)
             .expect("shared root")
@@ -1586,8 +1630,8 @@ mod tests {
         shared.set_start_state(shared_root);
 
         let mut local = Dfa::with_max_token_type(0, 0, 8);
-        let local_b = local.add_state(state(12));
-        let local_root = local.add_state(state(10));
+        let local_b = local.add_state(state(12, &mut arena, &mut workspace));
+        let local_root = local.add_state(state(10, &mut arena, &mut workspace));
         local
             .state_mut(local_root)
             .expect("local root")
@@ -1601,13 +1645,45 @@ mod tests {
         let root = shared.state(shared_root).expect("root");
         assert_eq!(root.edge(1), Some(shared_a));
         let merged_b = shared
-            .state_number_for_configs(&configs(12))
+            .state_number_for_configs(&configs(12, &mut arena, &mut workspace))
             .expect("local-only state adopted");
         assert_eq!(root.edge(2), Some(merged_b));
         assert_eq!(shared.states().len(), 3);
         // Start-state gaps fill from local; incumbents are kept.
         assert_eq!(shared.start_state(), Some(shared_root));
         assert_eq!(shared.precedence_start_state(3), Some(shared_root));
+    }
+
+    #[test]
+    fn union_prediction_stores_remaps_context_ids_before_dfa_union() {
+        let atn = two_token_decision_atn();
+        let mut shared = PredictionStore::new(&atn);
+        let mut local = PredictionStore::new(&atn);
+        let mut workspace = PredictionWorkspace::default();
+
+        let distracting = shared.contexts.singleton(EMPTY_CONTEXT, 99);
+        let local_context = local.contexts.singleton(EMPTY_CONTEXT, 7);
+        assert_eq!(distracting, local_context, "both stores allocate ID 1");
+
+        let mut configs = AtnConfigSet::new();
+        configs.add(
+            AtnConfig::new(42, 1, local_context, &local.contexts),
+            &mut local.contexts,
+            &mut workspace,
+        );
+        local.decision_to_dfa[0].add_state(DfaState::new(configs));
+
+        union_prediction_stores(&mut shared, local, &mut workspace);
+
+        let imported = shared.decision_to_dfa[0]
+            .states()
+            .iter()
+            .flat_map(|state| state.configs.configs())
+            .find(|config| config.state == 42)
+            .expect("local DFA config imported");
+        assert_ne!(imported.context, local_context);
+        assert_eq!(shared.contexts.return_state(imported.context, 0), Some(7));
+        imported.assert_store(&shared.contexts);
     }
 
     #[test]
@@ -1780,35 +1856,41 @@ mod tests {
     fn context_prediction_reports_context_sensitivity_for_dfa_conflict() {
         let atn = two_token_decision_atn();
         let mut simulator = ParserAtnSimulator::new(&atn);
-        let empty = PredictionContext::empty();
+        let mut workspace = PredictionWorkspace::default();
         let mut start_configs = AtnConfigSet::new();
-        start_configs.add(AtnConfig::new(2, 1, Rc::clone(&empty)));
-        let start = simulator.decision_to_dfa[0].add_state(DfaState::new(start_configs));
-        simulator.decision_to_dfa[0].set_start_state(start);
+        start_configs.add(
+            AtnConfig::new(2, 1, EMPTY_CONTEXT, &simulator.store.contexts),
+            &mut simulator.store.contexts,
+            &mut workspace,
+        );
+        let start = simulator.store.decision_to_dfa[0].add_state(DfaState::new(start_configs));
+        simulator.store.decision_to_dfa[0].set_start_state(start);
 
         let mut accept_configs = AtnConfigSet::new();
         accept_configs.add(
-            AtnConfig::new(3, 1, Rc::clone(&empty)).with_semantic_context(
+            AtnConfig::new(3, 1, EMPTY_CONTEXT, &simulator.store.contexts).with_semantic_context(
                 SemanticContext::Predicate {
                     rule_index: 0,
                     pred_index: 0,
                     context_dependent: false,
                 },
             ),
+            &mut simulator.store.contexts,
+            &mut workspace,
         );
         let mut accept_state = DfaState::new(accept_configs);
         accept_state.mark_accept(1);
         accept_state.requires_full_context = true;
         accept_state.conflicting_alts = vec![1, 2];
-        let accept = simulator.decision_to_dfa[0].add_state(accept_state);
-        simulator.decision_to_dfa[0]
+        let accept = simulator.store.decision_to_dfa[0].add_state(accept_state);
+        simulator.store.decision_to_dfa[0]
             .state_mut(start)
             .expect("start state")
             .add_edge(1, accept);
 
         let mut input = VecIntStream::new(vec![1, 3, TOKEN_EOF]);
         let prediction = simulator
-            .adaptive_predict_stream_info_with_context(0, 0, &mut input, &empty)
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, EMPTY_CONTEXT)
             .expect("prediction");
 
         assert_eq!(
@@ -1833,12 +1915,19 @@ mod tests {
     #[test]
     fn full_context_reach_prefers_longer_match_over_skipped_stop_state() {
         let atn = prefix_alt_decision_atn();
-        let simulator = ParserAtnSimulator::new(&atn);
-        let empty = PredictionContext::empty();
+        let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new_full_context(true);
-        configs.add(AtnConfig::new(2, 1, Rc::clone(&empty)));
-        configs.add(AtnConfig::new(1, 2, empty));
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut merge_cache = PredictionWorkspace::default();
+        configs.add(
+            AtnConfig::new(2, 1, EMPTY_CONTEXT, &simulator.store.contexts),
+            &mut simulator.store.contexts,
+            &mut merge_cache,
+        );
+        configs.add(
+            AtnConfig::new(1, 2, EMPTY_CONTEXT, &simulator.store.contexts),
+            &mut simulator.store.contexts,
+            &mut merge_cache,
+        );
 
         let reach = simulator.compute_reach_set(&configs, 2, true, 0, &mut merge_cache);
 
@@ -1862,12 +1951,13 @@ mod tests {
                 label: 1,
             });
 
-        let simulator = ParserAtnSimulator::new(&atn);
+        let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new_full_context(false);
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut merge_cache = PredictionWorkspace::default();
         let mut scratch = ClosureScratch::default();
+        let config = AtnConfig::new(0, 2, EMPTY_CONTEXT, &simulator.store.contexts);
         simulator.closure(
-            AtnConfig::new(0, 2, PredictionContext::empty()),
+            config,
             &mut configs,
             &mut merge_cache,
             &mut scratch,
@@ -1890,12 +1980,12 @@ mod tests {
         let mut atn = Atn::new(AtnType::Parser, 1);
         add_state(&mut atn, 0, AtnStateKind::Basic);
         add_state(&mut atn, 1, AtnStateKind::Basic);
-        let simulator = ParserAtnSimulator::new(&atn);
+        let mut simulator = ParserAtnSimulator::new(&atn);
         let transition = Transition::Precedence {
             target: 1,
             precedence: 2,
         };
-        let config = AtnConfig::new(0, 1, PredictionContext::empty());
+        let config = AtnConfig::new(0, 1, EMPTY_CONTEXT, &simulator.store.contexts);
 
         let sll_start = simulator
             .epsilon_target_config(&config, &transition, 1, true, false)
@@ -1958,12 +2048,13 @@ mod tests {
                 label: 1,
             });
 
-        let simulator = ParserAtnSimulator::new(&atn);
+        let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new();
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut merge_cache = PredictionWorkspace::default();
         let mut scratch = ClosureScratch::default();
+        let config = AtnConfig::new(0, 1, EMPTY_CONTEXT, &simulator.store.contexts);
         simulator.closure(
-            AtnConfig::new(0, 1, PredictionContext::empty()),
+            config,
             &mut configs,
             &mut merge_cache,
             &mut scratch,
@@ -1989,9 +2080,10 @@ mod tests {
         // Control: the SAME predicate reached WITHOUT an intervening action edge
         // IS collected (so the assertion above is about the action edge, not a
         // blanket failure to collect predicates).
+        let direct_config = AtnConfig::new(1, 1, EMPTY_CONTEXT, &simulator.store.contexts);
         let direct = simulator
             .epsilon_target_config(
-                &AtnConfig::new(1, 1, PredictionContext::empty()),
+                &direct_config,
                 &Transition::Predicate {
                     target: 2,
                     rule_index: 0,
@@ -2025,11 +2117,14 @@ mod tests {
             .expect("state 1")
             .add_transition(Transition::Epsilon { target: 2 });
 
-        let simulator = ParserAtnSimulator::new(&atn);
-        let empty = PredictionContext::empty();
+        let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new_full_context(false);
-        configs.add(AtnConfig::new(0, 1, empty));
-        let mut merge_cache = PredictionContextMergeCache::new();
+        let mut merge_cache = PredictionWorkspace::default();
+        configs.add(
+            AtnConfig::new(0, 1, EMPTY_CONTEXT, &simulator.store.contexts),
+            &mut simulator.store.contexts,
+            &mut merge_cache,
+        );
 
         let reach = simulator.compute_reach_set(&configs, 7, false, 0, &mut merge_cache);
 
@@ -2039,16 +2134,25 @@ mod tests {
 
     #[test]
     fn semantic_context_flag_is_scoped_to_predicted_alt() {
-        let empty = PredictionContext::empty();
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
         let mut configs = AtnConfigSet::new();
-        configs.add(AtnConfig::new(1, 1, Rc::clone(&empty)));
-        configs.add(AtnConfig::new(2, 2, empty).with_semantic_context(
-            SemanticContext::Predicate {
-                rule_index: 0,
-                pred_index: 0,
-                context_dependent: false,
-            },
-        ));
+        configs.add(
+            AtnConfig::new(1, 1, EMPTY_CONTEXT, &arena),
+            &mut arena,
+            &mut workspace,
+        );
+        configs.add(
+            AtnConfig::new(2, 2, EMPTY_CONTEXT, &arena).with_semantic_context(
+                SemanticContext::Predicate {
+                    rule_index: 0,
+                    pred_index: 0,
+                    context_dependent: false,
+                },
+            ),
+            &mut arena,
+            &mut workspace,
+        );
 
         assert!(!configs_have_semantic_context_for_alt(&configs, 1));
         assert!(configs_have_semantic_context_for_alt(&configs, 2));
@@ -2066,23 +2170,27 @@ mod tests {
     fn left_recursive_loop_entry_drop_requires_same_rule_return() {
         let atn = left_recursive_loop_entry_atn();
         let loop_entry = atn.state(1).expect("loop entry");
-        let same_rule_context = PredictionContext::singleton(PredictionContext::empty(), 4);
-        let other_rule_context = PredictionContext::singleton(PredictionContext::empty(), 5);
+        let mut contexts = ContextArena::new();
+        let same_rule_context = contexts.singleton(EMPTY_CONTEXT, 4);
+        let other_rule_context = contexts.singleton(EMPTY_CONTEXT, 5);
 
         assert!(can_drop_left_recursive_loop_entry_edge(
             &atn,
             loop_entry,
-            &same_rule_context
+            &contexts,
+            same_rule_context
         ));
         assert!(!can_drop_left_recursive_loop_entry_edge(
             &atn,
             loop_entry,
-            &other_rule_context
+            &contexts,
+            other_rule_context
         ));
         assert!(!can_drop_left_recursive_loop_entry_edge(
             &atn,
             loop_entry,
-            &PredictionContext::empty()
+            &contexts,
+            EMPTY_CONTEXT
         ));
     }
 

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -19,11 +19,20 @@ pub struct ParserAtnSimulator<'a> {
     atn: &'a Atn,
     store: PredictionStore,
     workspace: PredictionWorkspace,
+    outer_context_cache: Option<CachedOuterContext>,
+    outer_context_cache_hits: usize,
+    outer_context_cache_misses: usize,
     shared_cache_key: Option<usize>,
     /// Java's `LL_EXACT_AMBIG_DETECTION`: the full-context loop keeps
     /// consuming past "resolves to one viable alt" conflicts until every
     /// `(state, context)` subset conflicts over the same alt set.
     exact_ambig_detection: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CachedOuterContext {
+    rule_context_version: usize,
+    context: ContextId,
 }
 
 #[derive(Debug, Default)]
@@ -379,6 +388,9 @@ impl<'a> ParserAtnSimulator<'a> {
             atn,
             store: PredictionStore::new(atn),
             workspace: PredictionWorkspace::default(),
+            outer_context_cache: None,
+            outer_context_cache_hits: 0,
+            outer_context_cache_misses: 0,
             shared_cache_key: None,
             exact_ambig_detection: false,
         }
@@ -448,6 +460,9 @@ impl<'a> ParserAtnSimulator<'a> {
             atn,
             store,
             workspace: PredictionWorkspace::default(),
+            outer_context_cache: None,
+            outer_context_cache_hits: 0,
+            outer_context_cache_misses: 0,
             shared_cache_key: Some(key),
             exact_ambig_detection: false,
         }
@@ -460,19 +475,39 @@ impl<'a> ParserAtnSimulator<'a> {
     /// Returns compact prediction-context allocation and interning totals for
     /// this simulator's learned store.
     pub fn prediction_context_stats(&self) -> PredictionContextStats {
-        self.store.contexts.stats()
+        let mut stats = self.store.contexts.stats();
+        stats.retained_bytes += self.workspace.retained_bytes();
+        stats.workspace_merge_cache_entries = self.workspace.merge_cache_len();
+        stats.workspace_merge_cache_capacity = self.workspace.merge_cache_capacity();
+        stats.workspace_entry_capacity = self.workspace.entry_capacity();
+        stats.outer_context_cache_hits = self.outer_context_cache_hits;
+        stats.outer_context_cache_misses = self.outer_context_cache_misses;
+        stats
     }
 
     /// Interns a generated parser's outer call stack in this simulator's
-    /// context arena. Return states must be supplied outermost to innermost.
+    /// context arena. Return states must be supplied outermost to innermost,
+    /// and `rule_context_version` must change whenever that stack changes.
     pub fn intern_prediction_context(
         &mut self,
+        rule_context_version: usize,
         return_states: impl IntoIterator<Item = usize>,
     ) -> ContextId {
+        if let Some(cached) = self.outer_context_cache
+            && cached.rule_context_version == rule_context_version
+        {
+            self.outer_context_cache_hits = self.outer_context_cache_hits.saturating_add(1);
+            return cached.context;
+        }
+        self.outer_context_cache_misses = self.outer_context_cache_misses.saturating_add(1);
         let mut context = EMPTY_CONTEXT;
         for return_state in return_states {
             context = self.store.contexts.singleton(context, return_state);
         }
+        self.outer_context_cache = Some(CachedOuterContext {
+            rule_context_version,
+            context,
+        });
         context
     }
 
@@ -1684,6 +1719,42 @@ mod tests {
         assert_ne!(imported.context, local_context);
         assert_eq!(shared.contexts.return_state(imported.context, 0), Some(7));
         imported.assert_store(&shared.contexts);
+    }
+
+    #[test]
+    fn outer_context_cache_invalidates_with_rule_context_version() {
+        let atn = two_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+
+        let first = simulator.intern_prediction_context(1, [7]);
+        let cached = simulator.intern_prediction_context(1, [99]);
+        let refreshed = simulator.intern_prediction_context(2, [99]);
+
+        assert_eq!(cached, first);
+        assert_ne!(refreshed, first);
+        assert_eq!(
+            simulator.store.contexts.return_state(refreshed, 0),
+            Some(99)
+        );
+        let stats = simulator.prediction_context_stats();
+        assert_eq!(stats.outer_context_cache_hits, 1);
+        assert_eq!(stats.outer_context_cache_misses, 2);
+    }
+
+    #[test]
+    fn outer_context_cache_is_simulator_local() {
+        let atn = two_token_decision_atn();
+        let mut first = ParserAtnSimulator::new(&atn);
+        let mut second = ParserAtnSimulator::new(&atn);
+
+        let first_context = first.intern_prediction_context(1, [7]);
+        let second_context = second.intern_prediction_context(1, [99]);
+
+        assert_eq!(first.store.contexts.return_state(first_context, 0), Some(7));
+        assert_eq!(
+            second.store.contexts.return_state(second_context, 0),
+            Some(99)
+        );
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5282,12 +5282,12 @@ fn render_generated_adaptive_prediction_with_indent(
     let nested = format!("{pad}{}", "    ".repeat(extra_indent));
     writeln!(
         out,
-        "{nested}let __prediction_context = self.base.prediction_context(atn());"
+        "{nested}let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
     )
     .expect("writing to a string cannot fail");
     writeln!(
         out,
-        "{nested}let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
+        "{nested}let __prediction_context = __simulator.intern_prediction_context(self.base.prediction_context_return_states(atn()));"
     )
     .expect("writing to a string cannot fail");
     writeln!(
@@ -5297,7 +5297,7 @@ fn render_generated_adaptive_prediction_with_indent(
     .expect("writing to a string cannot fail");
     writeln!(
         out,
-        "{nested}__simulator.adaptive_predict_stream_info_with_context({decision}, 0, self.base.input(), &__prediction_context)"
+        "{nested}__simulator.adaptive_predict_stream_info_with_context({decision}, 0, self.base.input(), __prediction_context)"
     )
     .expect("writing to a string cannot fail");
     writeln!(out, "{nested}    .map_err(|__error| match __error {{")
@@ -5521,12 +5521,12 @@ fn render_generated_left_recursive_loop(
             .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}        let __prediction_context = self.base.prediction_context(atn());"
+            "{pad}        let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
         )
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}        let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
+            "{pad}        let __prediction_context = __simulator.intern_prediction_context(self.base.prediction_context_return_states(atn()));"
         )
         .expect("writing to a string cannot fail");
         writeln!(
@@ -5536,7 +5536,7 @@ fn render_generated_left_recursive_loop(
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}        __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context)"
+            "{pad}        __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), __prediction_context)"
         )
         .expect("writing to a string cannot fail");
         writeln!(out, "{pad}    }} {{").expect("writing to a string cannot fail");
@@ -5593,12 +5593,12 @@ fn render_generated_left_recursive_loop(
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}            let __prediction_context = self.base.prediction_context(atn());"
+            "{pad}            let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
         )
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}            let __simulator = self.simulator.get_or_insert_with(|| antlr4_runtime::ParserAtnSimulator::new_shared(atn()));"
+            "{pad}            let __prediction_context = __simulator.intern_prediction_context(self.base.prediction_context_return_states(atn()));"
         )
         .expect("writing to a string cannot fail");
         writeln!(
@@ -5608,7 +5608,7 @@ fn render_generated_left_recursive_loop(
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}            match __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), &__prediction_context) {{"
+            "{pad}            match __simulator.adaptive_predict_stream_info_with_context({decision}, __prediction_precedence, self.base.input(), __prediction_context) {{"
         )
         .expect("writing to a string cannot fail");
         writeln!(
@@ -10787,6 +10787,10 @@ atn:
         // stage 2 re-runs with the real context only when full context is needed.
         assert!(rendered.contains("adaptive_predict_stream_info_sll_probe(0, 0"));
         assert!(rendered.contains("adaptive_predict_stream_info_with_context(0, 0"));
+        assert!(rendered.contains(
+            "intern_prediction_context(self.base.prediction_context_return_states(atn()))"
+        ));
+        assert!(!rendered.contains("self.base.prediction_context(atn())"));
 
         let rendered_with_alt_numbers =
             render_generated_rule_dispatch(&[Some(body)], &[], &BTreeMap::new(), true);

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5287,7 +5287,7 @@ fn render_generated_adaptive_prediction_with_indent(
     .expect("writing to a string cannot fail");
     writeln!(
         out,
-        "{nested}let __prediction_context = __simulator.intern_prediction_context(self.base.prediction_context_return_states(atn()));"
+        "{nested}let __prediction_context = __simulator.intern_prediction_context(self.base.rule_context_version(), self.base.prediction_context_return_states(atn()));"
     )
     .expect("writing to a string cannot fail");
     writeln!(
@@ -5526,7 +5526,7 @@ fn render_generated_left_recursive_loop(
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}        let __prediction_context = __simulator.intern_prediction_context(self.base.prediction_context_return_states(atn()));"
+            "{pad}        let __prediction_context = __simulator.intern_prediction_context(self.base.rule_context_version(), self.base.prediction_context_return_states(atn()));"
         )
         .expect("writing to a string cannot fail");
         writeln!(
@@ -5598,7 +5598,7 @@ fn render_generated_left_recursive_loop(
         .expect("writing to a string cannot fail");
         writeln!(
             out,
-            "{pad}            let __prediction_context = __simulator.intern_prediction_context(self.base.prediction_context_return_states(atn()));"
+            "{pad}            let __prediction_context = __simulator.intern_prediction_context(self.base.rule_context_version(), self.base.prediction_context_return_states(atn()));"
         )
         .expect("writing to a string cannot fail");
         writeln!(
@@ -7430,6 +7430,14 @@ where
     #[must_use]
     pub const fn parse_tree_storage(&self) -> &antlr4_runtime::ParseTreeStorage {{
         self.base.parse_tree_storage()
+    }}
+
+    #[must_use]
+    pub fn prediction_context_stats(&self) -> antlr4_runtime::PredictionContextStats {{
+        self.simulator.as_ref().map_or_else(
+            antlr4_runtime::PredictionContextStats::default,
+            antlr4_runtime::ParserAtnSimulator::prediction_context_stats,
+        )
     }}
 
     #[must_use]
@@ -10788,7 +10796,7 @@ atn:
         assert!(rendered.contains("adaptive_predict_stream_info_sll_probe(0, 0"));
         assert!(rendered.contains("adaptive_predict_stream_info_with_context(0, 0"));
         assert!(rendered.contains(
-            "intern_prediction_context(self.base.prediction_context_return_states(atn()))"
+            "intern_prediction_context(self.base.rule_context_version(), self.base.prediction_context_return_states(atn()))"
         ));
         assert!(!rendered.contains("self.base.prediction_context(atn())"));
 

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -1,7 +1,7 @@
-use crate::prediction::AtnConfigSet;
+use crate::prediction::{AtnConfigSet, ContextArena, ContextId};
 use std::collections::BTreeMap;
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct Dfa {
     decision: usize,
     atn_start_state: usize,
@@ -149,12 +149,21 @@ impl Dfa {
         self.dirty = true;
         self.states.get_mut(state_number)
     }
+
+    pub(crate) fn remap_contexts(&mut self, remap: &[ContextId], arena: &ContextArena) {
+        self.state_index.clear();
+        for (state_number, state) in self.states.iter_mut().enumerate() {
+            state.configs.remap_contexts(remap, arena);
+            self.state_index
+                .insert(state.configs.clone(), state_number);
+        }
+    }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub struct DfaState {
     pub state_number: usize,
-    pub configs: AtnConfigSet,
+    pub(crate) configs: AtnConfigSet,
     pub edges: Vec<Option<usize>>,
     pub is_accept_state: bool,
     pub prediction: Option<usize>,
@@ -173,7 +182,7 @@ pub struct DfaState {
 }
 
 impl DfaState {
-    pub const fn new(configs: AtnConfigSet) -> Self {
+    pub(crate) const fn new(configs: AtnConfigSet) -> Self {
         Self {
             state_number: usize::MAX,
             configs,
@@ -215,6 +224,19 @@ impl DfaState {
             self.edges.resize(max + 2, None);
         }
     }
+
+    pub(crate) fn clone_without_edges(&self) -> Self {
+        Self {
+            state_number: self.state_number,
+            configs: self.configs.clone(),
+            edges: Vec::new(),
+            is_accept_state: self.is_accept_state,
+            prediction: self.prediction,
+            requires_full_context: self.requires_full_context,
+            conflicting_alts: self.conflicting_alts.clone(),
+            has_semantic_context_for_alt: self.has_semantic_context_for_alt,
+        }
+    }
 }
 
 fn edge_index(symbol: i32) -> Option<usize> {
@@ -228,12 +250,20 @@ fn edge_index(symbol: i32) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prediction::{AtnConfig, AtnConfigSet, PredictionContext};
+    use crate::prediction::{
+        AtnConfig, AtnConfigSet, ContextArena, EMPTY_CONTEXT, PredictionWorkspace,
+    };
 
     #[test]
     fn dfa_reuses_equal_config_sets() {
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
         let mut configs = AtnConfigSet::new();
-        configs.add(AtnConfig::new(1, 1, PredictionContext::empty()));
+        configs.add(
+            AtnConfig::new(1, 1, EMPTY_CONTEXT, &arena),
+            &mut arena,
+            &mut workspace,
+        );
         let state = DfaState::new(configs.clone());
         let mut dfa = Dfa::with_max_token_type(0, 0, 16);
         assert_eq!(dfa.add_state(state), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,9 +33,7 @@ pub use parser::{
 };
 #[cfg(feature = "perf-counters")]
 pub use perf::{dump as dump_prediction_perf_counters, reset as reset_prediction_perf_counters};
-pub use prediction::{
-    AtnConfig, AtnConfigSet, PredictionContext, PredictionContextMergeCache, SemanticContext,
-};
+pub use prediction::{ContextId, PredictionContextStats, SemanticContext};
 pub use recognizer::{Recognizer, RecognizerData};
 pub use token::{
     DEFAULT_CHANNEL, HIDDEN_CHANNEL, INVALID_TOKEN_TYPE, MAX_TOKEN_OFFSET, TOKEN_EOF, Token,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -80,7 +80,6 @@ use crate::char_stream::CharStream;
 use crate::errors::AntlrError;
 use crate::int_stream::IntStream;
 use crate::lexer::{LexerCustomAction, LexerSemCtx};
-use crate::prediction::{EMPTY_RETURN_STATE, PredictionContext};
 use crate::recognizer::{Recognizer, RecognizerData};
 use crate::semir::{self, AStmt, ArithOp, CmpOp, ExprId, HookId, PExpr, SemIr, StmtId};
 use crate::token::{
@@ -996,18 +995,11 @@ pub trait Parser: Recognizer {
 }
 
 #[derive(Debug)]
-struct CachedPredictionContext {
-    version: usize,
-    atn_key: usize,
-    context: Rc<PredictionContext>,
-}
-
-#[derive(Debug)]
 struct LeftRecursiveCallerOverlap {
     atn_key: SharedAtnCacheKey,
     state_number: usize,
     symbol: i32,
-    context: Rc<PredictionContext>,
+    context_version: usize,
     overlaps: bool,
 }
 
@@ -1030,7 +1022,6 @@ pub struct BaseParser<S, H = NoSemanticHooks> {
     int_members: BTreeMap<usize, i64>,
     rule_context_stack: Vec<RuleContextFrame>,
     rule_context_version: usize,
-    prediction_context_cache: Option<CachedPredictionContext>,
     left_recursive_caller_overlap_cache:
         [Option<LeftRecursiveCallerOverlap>; LEFT_RECURSIVE_CALLER_OVERLAP_CACHE_SIZE],
     pending_invoking_states: Vec<isize>,
@@ -3101,31 +3092,22 @@ fn state_before_stop_lookahead_inner(
     }
 }
 
-fn context_can_match_symbol_before_state(
+fn caller_context_can_match_symbol_before_state(
     atn: &Atn,
-    context: &PredictionContext,
+    return_states: impl DoubleEndedIterator<Item = usize>,
     stop_state_number: usize,
     symbol: i32,
 ) -> bool {
-    (0..context.len()).any(|index| {
-        context.return_state(index).is_some_and(|return_state| {
-            if return_state == EMPTY_RETURN_STATE {
-                return false;
-            }
-            let parent = context
-                .parent(index)
-                .unwrap_or_else(PredictionContext::empty);
-            let lookahead = state_before_stop_lookahead(atn, return_state, stop_state_number);
-            lookahead.symbols.contains(symbol)
-                || (lookahead.reaches_context_boundary
-                    && context_can_match_symbol_before_state(
-                        atn,
-                        &parent,
-                        stop_state_number,
-                        symbol,
-                    ))
-        })
-    })
+    for return_state in return_states.rev() {
+        let lookahead = state_before_stop_lookahead(atn, return_state, stop_state_number);
+        if lookahead.symbols.contains(symbol) {
+            return true;
+        }
+        if !lookahead.reaches_context_boundary {
+            return false;
+        }
+    }
+    false
 }
 
 /// Carries recovery expectations and their restart state through epsilon-only
@@ -3955,7 +3937,6 @@ where
             int_members: BTreeMap::new(),
             rule_context_stack: Vec::new(),
             rule_context_version: 0,
-            prediction_context_cache: None,
             left_recursive_caller_overlap_cache: std::array::from_fn(|_| None),
             pending_invoking_states: Vec::new(),
             precedence_stack: vec![0],
@@ -4673,7 +4654,7 @@ where
             rule_index,
             invoking_state,
         });
-        self.invalidate_prediction_context_cache();
+        self.advance_rule_context_version();
         let start_index = self.current_visible_index();
         let mut context = ParserRuleContext::new(rule_index, invoking_state);
         if let Some(token) = self.token_id_at(start_index) {
@@ -4702,44 +4683,31 @@ where
     /// Exits the current generated parser rule.
     pub fn exit_rule(&mut self) {
         self.rule_context_stack.pop();
-        self.invalidate_prediction_context_cache();
+        self.advance_rule_context_version();
     }
 
-    /// Converts the active generated-parser rule stack into an ANTLR prediction
-    /// context for full-context adaptive prediction.
-    pub fn prediction_context(&mut self, atn: &Atn) -> Rc<PredictionContext> {
-        let atn_ptr: *const Atn = atn;
-        let atn_key = atn_ptr as usize;
-        if let Some(cached) = &self.prediction_context_cache
-            && cached.version == self.rule_context_version
-            && cached.atn_key == atn_key
-        {
-            return Rc::clone(&cached.context);
-        }
-        let mut context = PredictionContext::empty();
-        for frame in self.rule_context_stack.iter().skip(1) {
+    /// Returns caller follow states for interning in a parser ATN simulator's
+    /// prediction store. States are yielded outermost to innermost.
+    pub fn prediction_context_return_states<'a>(
+        &'a self,
+        atn: &'a Atn,
+    ) -> impl DoubleEndedIterator<Item = usize> + 'a {
+        self.rule_context_stack.iter().skip(1).filter_map(|frame| {
             let Ok(state_number) = usize::try_from(frame.invoking_state) else {
-                continue;
+                return None;
             };
             let Some(Transition::Rule { follow_state, .. }) = atn
                 .state(state_number)
                 .and_then(|state| state.transitions.first())
             else {
-                continue;
+                return None;
             };
-            context = PredictionContext::singleton(context, *follow_state);
-        }
-        self.prediction_context_cache = Some(CachedPredictionContext {
-            version: self.rule_context_version,
-            atn_key,
-            context: Rc::clone(&context),
-        });
-        context
+            Some(*follow_state)
+        })
     }
 
-    fn invalidate_prediction_context_cache(&mut self) {
+    const fn advance_rule_context_version(&mut self) {
         self.rule_context_version = self.rule_context_version.wrapping_add(1);
-        self.prediction_context_cache = None;
     }
 
     /// Adds a generated parser child only when parse-tree construction is
@@ -4958,7 +4926,6 @@ where
             }
             return Some(false);
         }
-        let context = self.prediction_context(atn);
         let atn_key = SharedAtnCacheKey::for_atn(atn);
         let cached_overlap = self
             .left_recursive_caller_overlap_cache
@@ -4968,12 +4935,16 @@ where
                 entry.atn_key == atn_key
                     && entry.state_number == state_number
                     && entry.symbol == symbol
-                    && entry.context == context
+                    && entry.context_version == self.rule_context_version
             })
             .map(|entry| entry.overlaps);
         let caller_overlaps = cached_overlap.unwrap_or_else(|| {
-            let overlaps =
-                context_can_match_symbol_before_state(atn, &context, state_number, symbol);
+            let overlaps = caller_context_can_match_symbol_before_state(
+                atn,
+                self.prediction_context_return_states(atn),
+                state_number,
+                symbol,
+            );
             if let Some(slot) = self
                 .left_recursive_caller_overlap_cache
                 .iter_mut()
@@ -4983,7 +4954,7 @@ where
                     atn_key,
                     state_number,
                     symbol,
-                    context: Rc::clone(&context),
+                    context_version: self.rule_context_version,
                     overlaps,
                 });
             }
@@ -5334,16 +5305,48 @@ where
     }
 
     fn context_expected_symbols(&mut self, atn: &Atn) -> BTreeSet<i32> {
-        let context = self.prediction_context(atn);
         let mut expected = BTreeSet::new();
-        self.collect_context_expected_symbols(atn, &context, &mut expected);
+        for index in (1..self.rule_context_stack.len()).rev() {
+            let invoking_state = self.rule_context_stack[index].invoking_state;
+            let Ok(state_number) = usize::try_from(invoking_state) else {
+                continue;
+            };
+            let Some(Transition::Rule { follow_state, .. }) = atn
+                .state(state_number)
+                .and_then(|state| state.transitions.first())
+            else {
+                continue;
+            };
+            let return_state = *follow_state;
+            expected.extend(self.cached_state_expected_symbols(atn, return_state).iter());
+            if !self.cached_state_can_reach_rule_stop(atn, return_state) {
+                return expected;
+            }
+        }
+        expected.insert(TOKEN_EOF);
         expected
     }
 
     fn context_expected_token_set(&mut self, atn: &Atn) -> TokenBitSet {
-        let context = self.prediction_context(atn);
         let mut expected = TokenBitSet::default();
-        self.collect_context_expected_token_set(atn, &context, &mut expected);
+        for index in (1..self.rule_context_stack.len()).rev() {
+            let invoking_state = self.rule_context_stack[index].invoking_state;
+            let Ok(state_number) = usize::try_from(invoking_state) else {
+                continue;
+            };
+            let Some(Transition::Rule { follow_state, .. }) = atn
+                .state(state_number)
+                .and_then(|state| state.transitions.first())
+            else {
+                continue;
+            };
+            let follow_state = *follow_state;
+            expected.extend_from(&self.cached_state_expected_token_set(atn, follow_state));
+            if !self.cached_state_can_reach_rule_stop(atn, follow_state) {
+                return expected;
+            }
+        }
+        expected.insert(TOKEN_EOF);
         expected
     }
 
@@ -5352,8 +5355,8 @@ where
     ///
     /// This walks the rule-invocation stack directly, innermost frame first —
     /// the same frames, in the same order, with the same rule-stop gating as
-    /// `collect_context_expected_token_set` over `prediction_context(atn)`
-    /// (whose chain head is the innermost frame's follow state). The nullable
+    /// the same outer-context return-state chain used by adaptive prediction.
+    /// The nullable
     /// exit in `sync_decision` asks only this membership question, and on
     /// valid input the innermost frame answers it, so the early exit replaces
     /// an O(stack-depth) set union per loop/optional exit with one probe.
@@ -5381,61 +5384,6 @@ where
             }
         }
         symbol == TOKEN_EOF
-    }
-
-    fn collect_context_expected_symbols(
-        &mut self,
-        atn: &Atn,
-        context: &Rc<PredictionContext>,
-        expected: &mut BTreeSet<i32>,
-    ) {
-        if context.is_empty() {
-            expected.insert(TOKEN_EOF);
-            return;
-        }
-        for index in 0..context.len() {
-            let Some(return_state) = context.return_state(index) else {
-                continue;
-            };
-            if return_state == EMPTY_RETURN_STATE {
-                expected.insert(TOKEN_EOF);
-                continue;
-            }
-            expected.extend(self.cached_state_expected_symbols(atn, return_state).iter());
-            if self.cached_state_can_reach_rule_stop(atn, return_state)
-                && let Some(parent) = context.parent(index)
-            {
-                self.collect_context_expected_symbols(atn, &parent, expected);
-            }
-        }
-    }
-
-    fn collect_context_expected_token_set(
-        &mut self,
-        atn: &Atn,
-        context: &Rc<PredictionContext>,
-        expected: &mut TokenBitSet,
-    ) {
-        if context.is_empty() {
-            expected.insert(TOKEN_EOF);
-            return;
-        }
-        for index in 0..context.len() {
-            let Some(return_state) = context.return_state(index) else {
-                continue;
-            };
-            if return_state == EMPTY_RETURN_STATE {
-                expected.insert(TOKEN_EOF);
-                continue;
-            }
-            let state_expected = self.cached_state_expected_token_set(atn, return_state);
-            expected.extend_from(&state_expected);
-            if self.cached_state_can_reach_rule_stop(atn, return_state)
-                && let Some(parent) = context.parent(index)
-            {
-                self.collect_context_expected_token_set(atn, &parent, expected);
-            }
-        }
     }
 
     /// Builds a generated no-viable-alternative parser error.
@@ -12104,7 +12052,7 @@ mod tests {
     }
 
     #[test]
-    fn prediction_context_reuses_cached_stack_until_rule_stack_changes() {
+    fn prediction_context_return_states_track_rule_stack_changes() {
         let atn = nested_nullable_context_atn();
         let mut parser = mini_parser(vec![TestToken::eof("parser-test", 1, 1, 1)]);
         parser.rule_context_stack = vec![
@@ -12122,13 +12070,13 @@ mod tests {
             },
         ];
 
-        let first = parser.prediction_context(&atn);
-        let second = parser.prediction_context(&atn);
-        assert!(Rc::ptr_eq(&first, &second));
+        let first: Vec<_> = parser.prediction_context_return_states(&atn).collect();
+        let second: Vec<_> = parser.prediction_context_return_states(&atn).collect();
+        assert_eq!(first, second);
 
         parser.exit_rule();
-        let after_pop = parser.prediction_context(&atn);
-        assert!(!Rc::ptr_eq(&first, &after_pop));
+        let after_pop: Vec<_> = parser.prediction_context_return_states(&atn).collect();
+        assert_ne!(first, after_pop);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4706,6 +4706,14 @@ where
         })
     }
 
+    /// Returns a generation that changes whenever the active rule stack changes.
+    ///
+    /// A parser ATN simulator uses this to reuse an interned outer prediction
+    /// context while generated predictions remain in the same rule context.
+    pub const fn rule_context_version(&self) -> usize {
+        self.rule_context_version
+    }
+
     const fn advance_rule_context_version(&mut self) {
         self.rule_context_version = self.rule_context_version.wrapping_add(1);
     }
@@ -12070,13 +12078,16 @@ mod tests {
             },
         ];
 
+        let initial_version = parser.rule_context_version();
         let first: Vec<_> = parser.prediction_context_return_states(&atn).collect();
         let second: Vec<_> = parser.prediction_context_return_states(&atn).collect();
         assert_eq!(first, second);
+        assert_eq!(parser.rule_context_version(), initial_version);
 
         parser.exit_rule();
         let after_pop: Vec<_> = parser.prediction_context_return_states(&atn).collect();
         assert_ne!(first, after_pop);
+        assert_ne!(parser.rule_context_version(), initial_version);
     }
 
     #[test]

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -30,12 +30,9 @@ struct Counters {
     context_merge_cache_misses: u64,
     context_merge_uncached: u64,
     context_cache_calls: u64,
-    context_cache_empty: u64,
     context_cache_hits: u64,
     context_cache_misses: u64,
     context_cache_inserts: u64,
-    context_cache_visited_total: u64,
-    context_cache_visited_max: u64,
     decisions: BTreeMap<usize, DecisionCounters>,
 }
 
@@ -181,12 +178,6 @@ pub(crate) fn record_context_cache_call() {
     });
 }
 
-pub(crate) fn record_context_cache_empty() {
-    with_counters(|counters| {
-        counters.context_cache_empty = counters.context_cache_empty.saturating_add(1);
-    });
-}
-
 pub(crate) fn record_context_cache_hit() {
     with_counters(|counters| {
         counters.context_cache_hits = counters.context_cache_hits.saturating_add(1);
@@ -202,16 +193,6 @@ pub(crate) fn record_context_cache_miss() {
 pub(crate) fn record_context_cache_insert() {
     with_counters(|counters| {
         counters.context_cache_inserts = counters.context_cache_inserts.saturating_add(1);
-    });
-}
-
-pub(crate) fn record_context_cache_visited(visited_contexts: usize) {
-    with_counters(|counters| {
-        add_len(
-            &mut counters.context_cache_visited_total,
-            &mut counters.context_cache_visited_max,
-            visited_contexts,
-        );
     });
 }
 
@@ -250,7 +231,7 @@ fn dump_decisions(counters: &Counters) {
     }
 }
 
-const fn totals(counters: &Counters) -> [(&'static str, u64); 29] {
+const fn totals(counters: &Counters) -> [(&'static str, u64); 26] {
     [
         ("prediction.adaptive_calls", counters.adaptive_calls),
         (
@@ -293,18 +274,9 @@ const fn totals(counters: &Counters) -> [(&'static str, u64); 29] {
         ),
         ("context_merge.uncached", counters.context_merge_uncached),
         ("context_cache.calls", counters.context_cache_calls),
-        ("context_cache.empty", counters.context_cache_empty),
         ("context_cache.hits", counters.context_cache_hits),
         ("context_cache.misses", counters.context_cache_misses),
         ("context_cache.inserts", counters.context_cache_inserts),
-        (
-            "context_cache.visited_total",
-            counters.context_cache_visited_total,
-        ),
-        (
-            "context_cache.visited_max",
-            counters.context_cache_visited_max,
-        ),
     ]
 }
 

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -1,15 +1,12 @@
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::hash::{BuildHasherDefault, Hash, Hasher};
-use std::rc::Rc;
+use std::mem::size_of;
 
 pub const EMPTY_RETURN_STATE: usize = usize::MAX;
+const COMPACT_EMPTY_RETURN_STATE: u32 = u32::MAX;
 
-/// Lightweight `FxHash`-style hasher.
-///
-/// Used by `BaseLexer`'s DFA-trace map and the `epsilon_closure` `seen`
-/// set to avoid the `SipHash` overhead of `std::collections::HashMap`'s
-/// default hasher on the hot lexer path.
+/// Lightweight `FxHash`-style hasher used on prediction hot paths.
 #[derive(Debug, Default)]
 pub struct PredictionFxHasher {
     hash: u64,
@@ -28,8 +25,8 @@ impl Hasher for PredictionFxHasher {
             self.hash = (self.hash.rotate_left(FX_ROT) ^ word).wrapping_mul(FX_SEED);
             bytes = rest;
         }
-        for &b in bytes {
-            self.hash = (self.hash.rotate_left(FX_ROT) ^ u64::from(b)).wrapping_mul(FX_SEED);
+        for &byte in bytes {
+            self.hash = (self.hash.rotate_left(FX_ROT) ^ u64::from(byte)).wrapping_mul(FX_SEED);
         }
     }
 
@@ -66,115 +63,244 @@ impl Hasher for PredictionFxHasher {
 
 type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<PredictionFxHasher>>;
 
-#[derive(Clone, Debug)]
-pub enum PredictionContext {
-    Empty {
-        cached_hash: u64,
-    },
-    Singleton {
-        parent: Rc<Self>,
-        return_state: usize,
-        cached_hash: u64,
-    },
-    Array {
-        parents: Vec<Rc<Self>>,
-        return_states: Vec<usize>,
-        cached_hash: u64,
-    },
+/// Store-local identity for one canonical prediction-context graph node.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ContextId(u32);
+
+pub const EMPTY_CONTEXT: ContextId = ContextId(0);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ContextTag {
+    Empty,
+    Singleton,
+    Array,
 }
 
-impl PredictionContext {
-    pub fn empty() -> Rc<Self> {
-        EMPTY_PREDICTION_CONTEXT.with(Rc::clone)
-    }
+#[derive(Clone, Copy, Debug)]
+struct ContextRecord {
+    tag: ContextTag,
+    cached_hash: u64,
+    parent_or_start: u32,
+    return_state_or_len: u32,
+}
 
-    pub fn singleton(parent: Rc<Self>, return_state: usize) -> Rc<Self> {
-        if return_state == EMPTY_RETURN_STATE {
-            Self::empty()
-        } else {
-            Rc::new(Self::Singleton {
-                cached_hash: prediction_context_singleton_hash(&parent, return_state),
-                parent,
-                return_state,
-            })
+/// Allocation and interning totals for one prediction-context arena.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct PredictionContextStats {
+    pub contexts_created: usize,
+    pub singleton_contexts: usize,
+    pub array_contexts: usize,
+    pub array_entries: usize,
+    pub interner_hits: usize,
+    pub pooled_bytes: usize,
+}
+
+/// Canonical compact storage paired with one learned parser DFA store.
+#[derive(Debug)]
+pub(crate) struct ContextArena {
+    records: Vec<ContextRecord>,
+    array_parents: Vec<ContextId>,
+    array_return_states: Vec<u32>,
+    interner_heads: FxHashMap<u64, ContextId>,
+    interner_next: Vec<Option<ContextId>>,
+    interner_hits: usize,
+    #[cfg(debug_assertions)]
+    generation: u64,
+}
+
+#[cfg(debug_assertions)]
+fn next_context_arena_generation() -> u64 {
+    use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
+
+    static NEXT_GENERATION: AtomicU64 = AtomicU64::new(1);
+    NEXT_GENERATION.fetch_add(1, AtomicOrdering::Relaxed)
+}
+
+impl ContextArena {
+    pub(crate) fn new() -> Self {
+        let empty = ContextRecord {
+            tag: ContextTag::Empty,
+            cached_hash: prediction_context_empty_hash(),
+            parent_or_start: 0,
+            return_state_or_len: 0,
+        };
+        let mut interner_heads = FxHashMap::default();
+        interner_heads.insert(empty.cached_hash, EMPTY_CONTEXT);
+        Self {
+            records: vec![empty],
+            array_parents: Vec::new(),
+            array_return_states: Vec::new(),
+            interner_heads,
+            interner_next: vec![None],
+            interner_hits: 0,
+            #[cfg(debug_assertions)]
+            generation: next_context_arena_generation(),
         }
     }
 
-    fn array(parents: Vec<Rc<Self>>, return_states: Vec<usize>) -> Rc<Self> {
-        Rc::new(Self::Array {
-            cached_hash: prediction_context_array_hash(&parents, &return_states),
-            parents,
-            return_states,
+    #[cfg(debug_assertions)]
+    pub(crate) const fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub(crate) fn stats(&self) -> PredictionContextStats {
+        let mut singleton_contexts = 0;
+        let mut array_contexts = 0;
+        for record in &self.records {
+            match record.tag {
+                ContextTag::Empty => {}
+                ContextTag::Singleton => singleton_contexts += 1,
+                ContextTag::Array => array_contexts += 1,
+            }
+        }
+        PredictionContextStats {
+            contexts_created: self.records.len(),
+            singleton_contexts,
+            array_contexts,
+            array_entries: self.array_parents.len(),
+            interner_hits: self.interner_hits,
+            pooled_bytes: self.records.len() * size_of::<ContextRecord>()
+                + self.array_parents.len() * size_of::<ContextId>()
+                + self.array_return_states.len() * size_of::<u32>()
+                + self.interner_next.len() * size_of::<Option<ContextId>>(),
+        }
+    }
+
+    pub(crate) fn singleton(&mut self, parent: ContextId, return_state: usize) -> ContextId {
+        self.assert_valid(parent);
+        if return_state == EMPTY_RETURN_STATE {
+            return EMPTY_CONTEXT;
+        }
+        #[cfg(feature = "perf-counters")]
+        crate::perf::record_context_cache_call();
+        let return_state =
+            u32::try_from(return_state).expect("prediction return state must fit in u32");
+        let cached_hash = prediction_context_singleton_hash(self.cached_hash(parent), return_state);
+        if let Some(existing) = self.find_interned(cached_hash, |record| {
+            record.tag == ContextTag::Singleton
+                && record.parent_or_start == parent.0
+                && record.return_state_or_len == return_state
+        }) {
+            self.interner_hits = self.interner_hits.saturating_add(1);
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_context_cache_hit();
+            return existing;
+        }
+        #[cfg(feature = "perf-counters")]
+        {
+            crate::perf::record_context_cache_miss();
+            crate::perf::record_context_cache_insert();
+        }
+        self.push_record(ContextRecord {
+            tag: ContextTag::Singleton,
+            cached_hash,
+            parent_or_start: parent.0,
+            return_state_or_len: return_state,
         })
     }
 
-    pub const fn cached_hash(&self) -> u64 {
-        match self {
-            Self::Empty { cached_hash }
-            | Self::Singleton { cached_hash, .. }
-            | Self::Array { cached_hash, .. } => *cached_hash,
+    fn intern_entries(&mut self, entries: &[(ContextId, u32)]) -> ContextId {
+        match entries {
+            [] => EMPTY_CONTEXT,
+            [(parent, return_state)] => {
+                if *return_state == COMPACT_EMPTY_RETURN_STATE {
+                    EMPTY_CONTEXT
+                } else {
+                    self.singleton(
+                        *parent,
+                        usize::try_from(*return_state).expect("u32 return state fits in usize"),
+                    )
+                }
+            }
+            _ => {
+                debug_assert!(
+                    entries
+                        .windows(2)
+                        .all(|pair| { compare_entries(pair[0], pair[1]) == Ordering::Less })
+                );
+                #[cfg(feature = "perf-counters")]
+                crate::perf::record_context_cache_call();
+                let cached_hash = prediction_context_array_hash(self, entries);
+                if let Some(existing) = self.find_interned(cached_hash, |record| {
+                    if record.tag != ContextTag::Array
+                        || usize::try_from(record.return_state_or_len).ok() != Some(entries.len())
+                    {
+                        return false;
+                    }
+                    let start =
+                        usize::try_from(record.parent_or_start).expect("u32 pool index fits usize");
+                    let end = start + entries.len();
+                    self.array_parents[start..end]
+                        .iter()
+                        .copied()
+                        .zip(self.array_return_states[start..end].iter().copied())
+                        .eq(entries.iter().copied())
+                }) {
+                    self.interner_hits = self.interner_hits.saturating_add(1);
+                    #[cfg(feature = "perf-counters")]
+                    crate::perf::record_context_cache_hit();
+                    return existing;
+                }
+                #[cfg(feature = "perf-counters")]
+                {
+                    crate::perf::record_context_cache_miss();
+                    crate::perf::record_context_cache_insert();
+                }
+                let start = u32::try_from(self.array_parents.len())
+                    .expect("prediction-context parent pool must fit in u32");
+                let len = u32::try_from(entries.len())
+                    .expect("prediction-context array length must fit in u32");
+                self.array_parents
+                    .extend(entries.iter().map(|(parent, _)| *parent));
+                self.array_return_states
+                    .extend(entries.iter().map(|(_, return_state)| *return_state));
+                self.push_record(ContextRecord {
+                    tag: ContextTag::Array,
+                    cached_hash,
+                    parent_or_start: start,
+                    return_state_or_len: len,
+                })
+            }
         }
     }
 
-    pub const fn len(&self) -> usize {
-        match self {
-            Self::Empty { .. } => 1,
-            Self::Singleton { .. } => 1,
-            Self::Array { return_states, .. } => return_states.len(),
+    fn find_interned(
+        &self,
+        cached_hash: u64,
+        matches: impl Fn(&ContextRecord) -> bool,
+    ) -> Option<ContextId> {
+        let mut candidate = self.interner_heads.get(&cached_hash).copied();
+        while let Some(id) = candidate {
+            let index = usize::try_from(id.0).expect("u32 context ID fits in usize");
+            let record = &self.records[index];
+            if matches(record) {
+                return Some(id);
+            }
+            candidate = self.interner_next[index];
         }
+        None
     }
 
-    pub const fn is_empty(&self) -> bool {
-        matches!(self, Self::Empty { .. })
+    fn push_record(&mut self, record: ContextRecord) -> ContextId {
+        let id = ContextId(
+            u32::try_from(self.records.len()).expect("prediction-context arena must fit in u32"),
+        );
+        let previous = self.interner_heads.insert(record.cached_hash, id);
+        self.records.push(record);
+        self.interner_next.push(previous);
+        id
     }
 
-    pub fn return_state(&self, index: usize) -> Option<usize> {
-        match self {
-            Self::Empty { .. } if index == 0 => Some(EMPTY_RETURN_STATE),
-            Self::Singleton { return_state, .. } if index == 0 => Some(*return_state),
-            Self::Array { return_states, .. } => return_states.get(index).copied(),
-            Self::Empty { .. } => None,
-            Self::Singleton { .. } => None,
-        }
-    }
-
-    pub fn parent(&self, index: usize) -> Option<Rc<Self>> {
-        match self {
-            Self::Empty { .. } => None,
-            Self::Singleton { parent, .. } if index == 0 => Some(Rc::clone(parent)),
-            Self::Array { parents, .. } => parents.get(index).cloned(),
-            Self::Singleton { .. } => None,
-        }
-    }
-
-    pub fn has_empty_path(&self) -> bool {
-        match self {
-            Self::Empty { .. } => true,
-            Self::Singleton { return_state, .. } => *return_state == EMPTY_RETURN_STATE,
-            // Array return states are kept sorted ascending and
-            // `EMPTY_RETURN_STATE` is `usize::MAX`, so the empty path can only be
-            // the final entry — an O(1) check instead of a linear scan.
-            Self::Array { return_states, .. } => return_states.last() == Some(&EMPTY_RETURN_STATE),
-        }
-    }
-
-    pub fn merge(left: Rc<Self>, right: Rc<Self>) -> Rc<Self> {
-        Self::merge_with_options(left, right, false, None)
-    }
-
-    /// Merges two prediction contexts using ANTLR's SLL/LL root semantics.
-    ///
-    /// In SLL mode the empty root is a wildcard: `$ + x = $`. In full LL mode
-    /// it is an ordinary array entry: `$ + x = [$, x]`. The optional merge
-    /// cache is intentionally per prediction operation so large conflict-heavy
-    /// parses can drop the cache immediately after `adaptive_predict`.
-    #[allow(clippy::needless_pass_by_value)]
-    pub fn merge_with_options(
-        left: Rc<Self>,
-        right: Rc<Self>,
+    pub(crate) fn merge(
+        &mut self,
+        left: ContextId,
+        right: ContextId,
         root_is_wildcard: bool,
-        mut cache: Option<&mut PredictionContextMergeCache>,
-    ) -> Rc<Self> {
+        workspace: &mut PredictionWorkspace,
+    ) -> ContextId {
+        self.assert_valid(left);
+        self.assert_valid(right);
         #[cfg(feature = "perf-counters")]
         crate::perf::record_context_merge_call();
         if left == right {
@@ -182,407 +308,309 @@ impl PredictionContext {
             crate::perf::record_context_merge_identical();
             return left;
         }
-        if let Some(cache) = cache.as_deref_mut() {
-            if let Some(merged) = cache.get(&left, &right) {
-                #[cfg(feature = "perf-counters")]
-                crate::perf::record_context_merge_cache_hit();
-                return merged;
-            }
+        let key = MergeKey::new(left, right, root_is_wildcard);
+        if let Some(merged) = workspace.merge_cache.get(&key).copied() {
             #[cfg(feature = "perf-counters")]
+            crate::perf::record_context_merge_cache_hit();
+            return merged;
+        }
+        #[cfg(feature = "perf-counters")]
+        {
             crate::perf::record_context_merge_cache_miss();
-        }
-        let merged = if root_is_wildcard && (left.is_empty() || right.is_empty()) {
-            Self::empty()
-        } else {
-            #[cfg(feature = "perf-counters")]
             crate::perf::record_context_merge_uncached();
-            merge_contexts_uncached(&left, &right)
-        };
-        if let Some(cache) = cache {
-            cache.insert(&left, &right, &merged);
         }
+        let merged = if root_is_wildcard && (left == EMPTY_CONTEXT || right == EMPTY_CONTEXT) {
+            EMPTY_CONTEXT
+        } else {
+            self.merge_uncached(left, right, workspace)
+        };
+        workspace.merge_cache.insert(key, merged);
         merged
     }
-}
 
-fn merge_contexts_uncached(
-    left: &Rc<PredictionContext>,
-    right: &Rc<PredictionContext>,
-) -> Rc<PredictionContext> {
-    if left == right {
-        return Rc::clone(left);
+    fn merge_uncached(
+        &mut self,
+        left: ContextId,
+        right: ContextId,
+        workspace: &mut PredictionWorkspace,
+    ) -> ContextId {
+        match (self.tag(left), self.tag(right)) {
+            (ContextTag::Array, ContextTag::Array) => self.merge_arrays(left, right, workspace),
+            (ContextTag::Array, _) => {
+                let entry = self.first_entry(right);
+                self.merge_array_with_entry(left, entry, false, workspace)
+            }
+            (_, ContextTag::Array) => {
+                let entry = self.first_entry(left);
+                self.merge_array_with_entry(right, entry, true, workspace)
+            }
+            _ => self.merge_two_entries(self.first_entry(left), self.first_entry(right), workspace),
+        }
     }
-    match (left.as_ref(), right.as_ref()) {
-        (PredictionContext::Empty { .. }, PredictionContext::Empty { .. }) => {
-            PredictionContext::empty()
-        }
-        (
-            PredictionContext::Singleton {
-                parent: left_parent,
-                return_state: left_return_state,
-                ..
-            },
-            PredictionContext::Singleton {
-                parent: right_parent,
-                return_state: right_return_state,
-                ..
-            },
-        ) => merge_two_context_entries(
-            Rc::clone(left_parent),
-            *left_return_state,
-            Rc::clone(right_parent),
-            *right_return_state,
-        ),
-        (PredictionContext::Empty { .. }, PredictionContext::Singleton { .. })
-        | (PredictionContext::Singleton { .. }, PredictionContext::Empty { .. }) => {
-            let (left_parent, left_return_state) = first_context_entry(left);
-            let (right_parent, right_return_state) = first_context_entry(right);
-            merge_two_context_entries(
-                left_parent,
-                left_return_state,
-                right_parent,
-                right_return_state,
-            )
-        }
-        (
-            PredictionContext::Array {
-                parents,
-                return_states,
-                ..
-            },
-            PredictionContext::Singleton { .. } | PredictionContext::Empty { .. },
-        ) => {
-            let (parent, return_state) = first_context_entry(right);
-            merge_array_with_entry(
-                Rc::clone(left),
-                parents,
-                return_states,
-                parent,
-                return_state,
-                false,
-            )
-        }
-        (
-            PredictionContext::Singleton { .. } | PredictionContext::Empty { .. },
-            PredictionContext::Array {
-                parents,
-                return_states,
-                ..
-            },
-        ) => {
-            let (parent, return_state) = first_context_entry(left);
-            merge_array_with_entry(
-                Rc::clone(right),
-                parents,
-                return_states,
-                parent,
-                return_state,
-                true,
-            )
-        }
-        (
-            PredictionContext::Array {
-                parents: left_parents,
-                return_states: left_return_states,
-                ..
-            },
-            PredictionContext::Array {
-                parents: right_parents,
-                return_states: right_return_states,
-                ..
-            },
-        ) => merge_arrays(
-            left_parents,
-            left_return_states,
-            right_parents,
-            right_return_states,
-        ),
-    }
-}
 
-fn first_context_entry(context: &Rc<PredictionContext>) -> (Rc<PredictionContext>, usize) {
-    match context.as_ref() {
-        PredictionContext::Empty { .. } => (Rc::clone(context), EMPTY_RETURN_STATE),
-        PredictionContext::Singleton {
-            parent,
-            return_state,
-            ..
-        } => (Rc::clone(parent), *return_state),
-        PredictionContext::Array { .. } => unreachable!("array contexts have multiple entries"),
-    }
-}
-
-fn merge_two_context_entries(
-    left_parent: Rc<PredictionContext>,
-    left_return_state: usize,
-    right_parent: Rc<PredictionContext>,
-    right_return_state: usize,
-) -> Rc<PredictionContext> {
-    if left_return_state == right_return_state && left_parent == right_parent {
-        return PredictionContext::singleton(left_parent, left_return_state);
-    }
-    let (first_parent, first_return_state, second_parent, second_return_state) = if compare_entries(
-        &right_parent,
-        right_return_state,
-        &left_parent,
-        left_return_state,
-    )
-        == Ordering::Less
-    {
-        (
-            right_parent,
-            right_return_state,
-            left_parent,
-            left_return_state,
-        )
-    } else {
-        (
-            left_parent,
-            left_return_state,
-            right_parent,
-            right_return_state,
-        )
-    };
-    PredictionContext::array(
-        vec![first_parent, second_parent],
-        vec![first_return_state, second_return_state],
-    )
-}
-
-fn merge_array_with_entry(
-    array_context: Rc<PredictionContext>,
-    array_parents: &[Rc<PredictionContext>],
-    array_return_states: &[usize],
-    entry_parent: Rc<PredictionContext>,
-    entry_return_state: usize,
-    entry_on_left: bool,
-) -> Rc<PredictionContext> {
-    let mut insert_index = array_parents.len();
-    for (index, (parent, return_state)) in array_parents.iter().zip(array_return_states).enumerate()
-    {
-        let ordering = compare_entries(&entry_parent, entry_return_state, parent, *return_state);
-        if ordering == Ordering::Equal && parent == &entry_parent {
-            return array_context;
+    fn merge_two_entries(
+        &mut self,
+        left: (ContextId, u32),
+        right: (ContextId, u32),
+        workspace: &mut PredictionWorkspace,
+    ) -> ContextId {
+        if left == right {
+            return self.intern_entries(std::slice::from_ref(&left));
         }
-        let should_insert = if entry_on_left {
-            ordering != Ordering::Greater
+        workspace.entries.clear();
+        if compare_entries(right, left) == Ordering::Less {
+            workspace.entries.extend([right, left]);
         } else {
-            ordering == Ordering::Less
-        };
-        if should_insert {
-            insert_index = index;
-            break;
+            workspace.entries.extend([left, right]);
+        }
+        self.intern_entries(&workspace.entries)
+    }
+
+    fn merge_array_with_entry(
+        &mut self,
+        array: ContextId,
+        entry: (ContextId, u32),
+        entry_on_left: bool,
+        workspace: &mut PredictionWorkspace,
+    ) -> ContextId {
+        let array_len = self.len(array);
+        let mut insert_index = array_len;
+        for index in 0..array_len {
+            let current = self.entry(array, index).expect("array entry in range");
+            let ordering = compare_entries(entry, current);
+            if ordering == Ordering::Equal {
+                return array;
+            }
+            let should_insert = if entry_on_left {
+                ordering != Ordering::Greater
+            } else {
+                ordering == Ordering::Less
+            };
+            if should_insert {
+                insert_index = index;
+                break;
+            }
+        }
+
+        workspace.entries.clear();
+        for index in 0..insert_index {
+            workspace
+                .entries
+                .push(self.entry(array, index).expect("array entry in range"));
+        }
+        workspace.entries.push(entry);
+        for index in insert_index..array_len {
+            workspace
+                .entries
+                .push(self.entry(array, index).expect("array entry in range"));
+        }
+        self.intern_entries(&workspace.entries)
+    }
+
+    fn merge_arrays(
+        &mut self,
+        left: ContextId,
+        right: ContextId,
+        workspace: &mut PredictionWorkspace,
+    ) -> ContextId {
+        workspace.entries.clear();
+        let mut left_index = 0;
+        let mut right_index = 0;
+        while left_index < self.len(left) && right_index < self.len(right) {
+            let left_entry = self.entry(left, left_index).expect("array entry in range");
+            let right_entry = self
+                .entry(right, right_index)
+                .expect("array entry in range");
+            match compare_entries(left_entry, right_entry) {
+                Ordering::Less => {
+                    workspace.entries.push(left_entry);
+                    left_index += 1;
+                }
+                Ordering::Greater => {
+                    workspace.entries.push(right_entry);
+                    right_index += 1;
+                }
+                Ordering::Equal => {
+                    workspace.entries.push(left_entry);
+                    left_index += 1;
+                    right_index += 1;
+                }
+            }
+        }
+        while left_index < self.len(left) {
+            workspace
+                .entries
+                .push(self.entry(left, left_index).expect("array entry in range"));
+            left_index += 1;
+        }
+        while right_index < self.len(right) {
+            workspace.entries.push(
+                self.entry(right, right_index)
+                    .expect("array entry in range"),
+            );
+            right_index += 1;
+        }
+        self.intern_entries(&workspace.entries)
+    }
+
+    pub(crate) fn len(&self, context: ContextId) -> usize {
+        let record = self.record(context);
+        match record.tag {
+            ContextTag::Empty | ContextTag::Singleton => 1,
+            ContextTag::Array => usize::try_from(record.return_state_or_len)
+                .expect("u32 context length fits in usize"),
         }
     }
 
-    let mut parents = Vec::with_capacity(array_parents.len() + 1);
-    let mut return_states = Vec::with_capacity(array_return_states.len() + 1);
-    parents.extend(array_parents[..insert_index].iter().cloned());
-    return_states.extend_from_slice(&array_return_states[..insert_index]);
-    parents.push(entry_parent);
-    return_states.push(entry_return_state);
-    parents.extend(array_parents[insert_index..].iter().cloned());
-    return_states.extend_from_slice(&array_return_states[insert_index..]);
-    PredictionContext::array(parents, return_states)
-}
-
-fn merge_arrays(
-    left_parents: &[Rc<PredictionContext>],
-    left_return_states: &[usize],
-    right_parents: &[Rc<PredictionContext>],
-    right_return_states: &[usize],
-) -> Rc<PredictionContext> {
-    let mut parents = Vec::with_capacity(left_parents.len() + right_parents.len());
-    let mut return_states =
-        Vec::with_capacity(left_return_states.len() + right_return_states.len());
-    let mut left_index = 0;
-    let mut right_index = 0;
-
-    while left_index < left_parents.len() && right_index < right_parents.len() {
-        match compare_entries(
-            &left_parents[left_index],
-            left_return_states[left_index],
-            &right_parents[right_index],
-            right_return_states[right_index],
-        ) {
-            Ordering::Less => {
-                parents.push(Rc::clone(&left_parents[left_index]));
-                return_states.push(left_return_states[left_index]);
-                left_index += 1;
-            }
-            Ordering::Greater => {
-                parents.push(Rc::clone(&right_parents[right_index]));
-                return_states.push(right_return_states[right_index]);
-                right_index += 1;
-            }
-            // `compare_entries` is a strict total order whose final tie-break is a
-            // structural `parent.cmp`, so `Equal` means the two entries are
-            // structurally identical — keep one and drop the duplicate.
-            Ordering::Equal => {
-                parents.push(Rc::clone(&left_parents[left_index]));
-                return_states.push(left_return_states[left_index]);
-                left_index += 1;
-                right_index += 1;
-            }
-        }
+    pub(crate) fn is_empty(&self, context: ContextId) -> bool {
+        self.assert_valid(context);
+        context == EMPTY_CONTEXT
     }
 
-    for index in left_index..left_parents.len() {
-        parents.push(Rc::clone(&left_parents[index]));
-        return_states.push(left_return_states[index]);
-    }
-    for index in right_index..right_parents.len() {
-        parents.push(Rc::clone(&right_parents[index]));
-        return_states.push(right_return_states[index]);
-    }
-
-    if parents.len() == 1 {
-        return PredictionContext::singleton(
-            parents.pop().expect("single merged parent"),
-            return_states.pop().expect("single merged return state"),
-        );
-    }
-    PredictionContext::array(parents, return_states)
-}
-
-/// Strict total order over array context entries, used as the merge-sort key by
-/// all three merge helpers (`merge_two_context_entries`, `merge_array_with_entry`,
-/// `merge_arrays`). Orders by `return_state`, then `cached_hash`, then a
-/// structural `parent.cmp(parent)` tie-break.
-///
-/// The structural tie-break is what makes Array canonicalization collision-proof:
-/// two structurally-distinct parents that share a `return_state` *and* a colliding
-/// `cached_hash` (astronomically rare, but possible with a 64-bit hash) would
-/// otherwise compare equal and be appended in operand order, so `merge(a, b)` and
-/// `merge(b, a)` could produce arrays that are structurally unequal (Array `eq` is
-/// element-by-element) — breaking the "equal logical context ⇒ equal
-/// representation" invariant the merge/context caches rely on. Falling through to
-/// `parent.cmp` gives such entries a deterministic, order-independent position.
-/// On the common path (no hash collision) this is identical to comparing the old
-/// `(return_state, cached_hash)` key, so it is perf-neutral.
-///
-/// All three helpers must use this so every Array is built in this order; the
-/// 2-pointer sorted-merge in `merge_arrays` is only correct on inputs sorted by
-/// the same total order.
-fn compare_entries(
-    left_parent: &Rc<PredictionContext>,
-    left_return_state: usize,
-    right_parent: &Rc<PredictionContext>,
-    right_return_state: usize,
-) -> Ordering {
-    left_return_state
-        .cmp(&right_return_state)
-        .then_with(|| left_parent.cached_hash().cmp(&right_parent.cached_hash()))
-        .then_with(|| left_parent.cmp(right_parent))
-}
-
-impl PartialEq for PredictionContext {
-    fn eq(&self, other: &Self) -> bool {
-        if std::ptr::eq(self, other) {
+    pub(crate) fn has_empty_path(&self, context: ContextId) -> bool {
+        if context == EMPTY_CONTEXT {
             return true;
         }
-        if self.cached_hash() != other.cached_hash() {
-            return false;
-        }
-        match (self, other) {
-            (Self::Empty { .. }, Self::Empty { .. }) => true,
-            (
-                Self::Singleton {
-                    parent,
-                    return_state,
-                    ..
-                },
-                Self::Singleton {
-                    parent: other_parent,
-                    return_state: other_return_state,
-                    ..
-                },
-            ) => return_state == other_return_state && parent == other_parent,
-            (
-                Self::Array {
-                    parents,
-                    return_states,
-                    ..
-                },
-                Self::Array {
-                    parents: other_parents,
-                    return_states: other_return_states,
-                    ..
-                },
-            ) => return_states == other_return_states && parents == other_parents,
-            _ => false,
+        let record = self.record(context);
+        match record.tag {
+            ContextTag::Empty => true,
+            ContextTag::Singleton => false,
+            ContextTag::Array => {
+                let len = usize::try_from(record.return_state_or_len)
+                    .expect("u32 context length fits in usize");
+                let start = usize::try_from(record.parent_or_start)
+                    .expect("u32 context pool index fits in usize");
+                self.array_return_states[start + len - 1] == COMPACT_EMPTY_RETURN_STATE
+            }
         }
     }
-}
 
-impl Eq for PredictionContext {}
-
-thread_local! {
-    static EMPTY_PREDICTION_CONTEXT: Rc<PredictionContext> = Rc::new(PredictionContext::Empty {
-        cached_hash: prediction_context_empty_hash(),
-    });
-}
-
-impl Hash for PredictionContext {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.cached_hash());
+    pub(crate) fn return_state(&self, context: ContextId, index: usize) -> Option<usize> {
+        let (_, return_state) = self.entry(context, index)?;
+        Some(expand_return_state(return_state))
     }
-}
 
-impl Ord for PredictionContext {
-    fn cmp(&self, other: &Self) -> Ordering {
-        if std::ptr::eq(self, other) {
-            return Ordering::Equal;
+    pub(crate) fn parent(&self, context: ContextId, index: usize) -> Option<ContextId> {
+        if context == EMPTY_CONTEXT {
+            self.assert_valid(context);
+            return None;
         }
-        self.cached_hash()
-            .cmp(&other.cached_hash())
-            .then_with(|| prediction_context_variant(self).cmp(&prediction_context_variant(other)))
-            .then_with(|| match (self, other) {
-                (Self::Empty { .. }, Self::Empty { .. }) => Ordering::Equal,
-                (
-                    Self::Singleton {
-                        parent,
-                        return_state,
-                        ..
-                    },
-                    Self::Singleton {
-                        parent: other_parent,
-                        return_state: other_return_state,
-                        ..
-                    },
-                ) => return_state
-                    .cmp(other_return_state)
-                    .then_with(|| parent.cmp(other_parent)),
-                (
-                    Self::Array {
-                        parents,
-                        return_states,
-                        ..
-                    },
-                    Self::Array {
-                        parents: other_parents,
-                        return_states: other_return_states,
-                        ..
-                    },
-                ) => return_states
-                    .cmp(other_return_states)
-                    .then_with(|| parents.cmp(other_parents)),
-                _ => Ordering::Equal,
-            })
+        self.entry(context, index).map(|(parent, _)| parent)
+    }
+
+    fn first_entry(&self, context: ContextId) -> (ContextId, u32) {
+        self.entry(context, 0)
+            .expect("empty and singleton contexts have one logical entry")
+    }
+
+    fn entry(&self, context: ContextId, index: usize) -> Option<(ContextId, u32)> {
+        let record = self.record(context);
+        match record.tag {
+            ContextTag::Empty if index == 0 => Some((EMPTY_CONTEXT, COMPACT_EMPTY_RETURN_STATE)),
+            ContextTag::Singleton if index == 0 => Some((
+                ContextId(record.parent_or_start),
+                record.return_state_or_len,
+            )),
+            ContextTag::Array => {
+                let len = usize::try_from(record.return_state_or_len).ok()?;
+                if index >= len {
+                    return None;
+                }
+                let start = usize::try_from(record.parent_or_start).ok()?;
+                Some((
+                    self.array_parents[start + index],
+                    self.array_return_states[start + index],
+                ))
+            }
+            ContextTag::Empty | ContextTag::Singleton => None,
+        }
+    }
+
+    fn tag(&self, context: ContextId) -> ContextTag {
+        self.record(context).tag
+    }
+
+    fn cached_hash(&self, context: ContextId) -> u64 {
+        self.record(context).cached_hash
+    }
+
+    fn record(&self, context: ContextId) -> &ContextRecord {
+        self.assert_valid(context);
+        &self.records[usize::try_from(context.0).expect("u32 context ID fits in usize")]
+    }
+
+    pub(crate) fn assert_valid(&self, context: ContextId) {
+        assert!(
+            usize::try_from(context.0).is_ok_and(|index| index < self.records.len()),
+            "prediction ContextId does not belong to this store"
+        );
+    }
+
+    pub(crate) fn import_all(
+        &mut self,
+        source: &Self,
+        workspace: &mut PredictionWorkspace,
+    ) -> Vec<ContextId> {
+        let mut remap = Vec::with_capacity(source.records.len());
+        remap.push(EMPTY_CONTEXT);
+        for source_index in 1..source.records.len() {
+            let source_id = ContextId(
+                u32::try_from(source_index).expect("source prediction-context ID fits in u32"),
+            );
+            let imported = match source.tag(source_id) {
+                ContextTag::Empty => EMPTY_CONTEXT,
+                ContextTag::Singleton => {
+                    let (parent, return_state) = source.first_entry(source_id);
+                    let parent_index =
+                        usize::try_from(parent.0).expect("u32 context ID fits usize");
+                    assert!(
+                        parent_index < remap.len(),
+                        "prediction contexts must reference earlier arena records"
+                    );
+                    self.singleton(remap[parent_index], expand_return_state(return_state))
+                }
+                ContextTag::Array => {
+                    workspace.entries.clear();
+                    for entry_index in 0..source.len(source_id) {
+                        let (parent, return_state) = source
+                            .entry(source_id, entry_index)
+                            .expect("source array entry in range");
+                        let parent_index =
+                            usize::try_from(parent.0).expect("u32 context ID fits usize");
+                        assert!(
+                            parent_index < remap.len(),
+                            "prediction contexts must reference earlier arena records"
+                        );
+                        workspace.entries.push((remap[parent_index], return_state));
+                    }
+                    workspace
+                        .entries
+                        .sort_unstable_by(|left, right| compare_entries(*left, *right));
+                    workspace.entries.dedup();
+                    self.intern_entries(&workspace.entries)
+                }
+            };
+            remap.push(imported);
+        }
+        remap
     }
 }
 
-impl PartialOrd for PredictionContext {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
+impl Default for ContextArena {
+    fn default() -> Self {
+        Self::new()
     }
 }
 
-const fn prediction_context_variant(context: &PredictionContext) -> u8 {
-    match context {
-        PredictionContext::Empty { .. } => 0,
-        PredictionContext::Singleton { .. } => 1,
-        PredictionContext::Array { .. } => 2,
+fn compare_entries(left: (ContextId, u32), right: (ContextId, u32)) -> Ordering {
+    left.1.cmp(&right.1).then_with(|| left.0.cmp(&right.0))
+}
+
+fn expand_return_state(return_state: u32) -> usize {
+    if return_state == COMPACT_EMPTY_RETURN_STATE {
+        EMPTY_RETURN_STATE
+    } else {
+        usize::try_from(return_state).expect("u32 return state fits in usize")
     }
 }
 
@@ -592,247 +620,73 @@ fn prediction_context_empty_hash() -> u64 {
     hasher.finish()
 }
 
-fn prediction_context_singleton_hash(parent: &Rc<PredictionContext>, return_state: usize) -> u64 {
+fn prediction_context_singleton_hash(parent_hash: u64, return_state: u32) -> u64 {
     let mut hasher = PredictionFxHasher::default();
     hasher.write_u8(1);
-    hasher.write_u64(parent.cached_hash());
-    hasher.write_usize(return_state);
+    hasher.write_u64(parent_hash);
+    hasher.write_u32(return_state);
     hasher.finish()
 }
 
-fn prediction_context_array_hash(
-    parents: &[Rc<PredictionContext>],
-    return_states: &[usize],
-) -> u64 {
+fn prediction_context_array_hash(arena: &ContextArena, entries: &[(ContextId, u32)]) -> u64 {
     let mut hasher = PredictionFxHasher::default();
     hasher.write_u8(2);
-    hasher.write_usize(parents.len());
-    for parent in parents {
-        hasher.write_u64(parent.cached_hash());
+    hasher.write_usize(entries.len());
+    for (parent, _) in entries {
+        hasher.write_u64(arena.cached_hash(*parent));
     }
-    hasher.write_usize(return_states.len());
-    for return_state in return_states {
-        hasher.write_usize(*return_state);
+    hasher.write_usize(entries.len());
+    for (_, return_state) in entries {
+        hasher.write_u32(*return_state);
     }
     hasher.finish()
 }
 
-/// Per-prediction memo for graph-structured stack merges.
-#[derive(Debug, Default)]
-pub struct PredictionContextMergeCache {
-    entries: FxHashMap<PredictionContextMergeKey, Rc<PredictionContext>>,
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct MergeKey {
+    left: ContextId,
+    right: ContextId,
+    root_is_wildcard: bool,
 }
 
-impl PredictionContextMergeCache {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn get(
-        &self,
-        left: &Rc<PredictionContext>,
-        right: &Rc<PredictionContext>,
-    ) -> Option<Rc<PredictionContext>> {
-        let key = PredictionContextMergeKey::new(left, right);
-        self.entries.get(&key).cloned()
-    }
-
-    fn insert(
-        &mut self,
-        left: &Rc<PredictionContext>,
-        right: &Rc<PredictionContext>,
-        merged: &Rc<PredictionContext>,
-    ) {
-        self.entries.insert(
-            PredictionContextMergeKey::new(left, right),
-            Rc::clone(merged),
-        );
-    }
-}
-
-/// Shared canonical store for prediction-context graphs retained in DFA states.
-#[derive(Debug)]
-pub(crate) struct PredictionContextCache {
-    empty: Rc<PredictionContext>,
-    entries: FxHashMap<Rc<PredictionContext>, Rc<PredictionContext>>,
-}
-
-impl PredictionContextCache {
-    pub(crate) fn new() -> Self {
-        Self {
-            empty: PredictionContext::empty(),
-            entries: FxHashMap::default(),
-        }
-    }
-
-    pub(crate) fn get_cached_context(
-        &mut self,
-        context: &Rc<PredictionContext>,
-    ) -> Rc<PredictionContext> {
-        #[cfg(feature = "perf-counters")]
-        crate::perf::record_context_cache_call();
-        if context.is_empty() {
-            #[cfg(feature = "perf-counters")]
-            crate::perf::record_context_cache_empty();
-            return Rc::clone(&self.empty);
-        }
-        if let Some(existing) = self.entries.get(context) {
-            #[cfg(feature = "perf-counters")]
-            crate::perf::record_context_cache_hit();
-            return Rc::clone(existing);
-        }
-        #[cfg(feature = "perf-counters")]
-        crate::perf::record_context_cache_miss();
-        let mut visited = FxHashMap::default();
-        let cached = self.get_cached_context_inner(context, &mut visited);
-        #[cfg(feature = "perf-counters")]
-        crate::perf::record_context_cache_visited(visited.len());
-        cached
-    }
-
-    fn get_cached_context_inner(
-        &mut self,
-        context: &Rc<PredictionContext>,
-        visited: &mut FxHashMap<usize, Rc<PredictionContext>>,
-    ) -> Rc<PredictionContext> {
-        if context.is_empty() {
-            return Rc::clone(&self.empty);
-        }
-        // Key the per-traversal memo by pointer identity. We only need to detect
-        // the exact same node revisited within this canonicalization pass, so a
-        // pointer compare avoids recursive structural `PredictionContext::eq`.
-        let context_ptr = Rc::as_ptr(context) as usize;
-        if let Some(existing) = visited.get(&context_ptr) {
-            return Rc::clone(existing);
-        }
-        if let Some(existing) = self.entries.get(context) {
-            #[cfg(feature = "perf-counters")]
-            crate::perf::record_context_cache_hit();
-            let existing = Rc::clone(existing);
-            visited.insert(context_ptr, Rc::clone(&existing));
-            return existing;
-        }
-        let cached = match context.as_ref() {
-            PredictionContext::Empty { .. } => Rc::clone(&self.empty),
-            PredictionContext::Singleton {
-                parent,
-                return_state,
-                ..
-            } => {
-                let cached_parent = self.get_cached_context_inner(parent, visited);
-                if Rc::ptr_eq(parent, &cached_parent) {
-                    self.add(Rc::clone(context))
-                } else {
-                    self.add(PredictionContext::singleton(cached_parent, *return_state))
-                }
-            }
-            PredictionContext::Array {
-                parents,
-                return_states,
-                ..
-            } => {
-                let mut changed = false;
-                let mut cached_parents = Vec::with_capacity(parents.len());
-                for parent in parents {
-                    let cached_parent = self.get_cached_context_inner(parent, visited);
-                    changed |= !Rc::ptr_eq(parent, &cached_parent);
-                    cached_parents.push(cached_parent);
-                }
-                if changed {
-                    self.add(PredictionContext::array(
-                        cached_parents,
-                        return_states.clone(),
-                    ))
-                } else {
-                    self.add(Rc::clone(context))
-                }
-            }
+impl MergeKey {
+    fn new(left: ContextId, right: ContextId, root_is_wildcard: bool) -> Self {
+        let (left, right) = if right < left {
+            (right, left)
+        } else {
+            (left, right)
         };
-        visited.insert(context_ptr, Rc::clone(&cached));
-        cached
-    }
-
-    fn add(&mut self, context: Rc<PredictionContext>) -> Rc<PredictionContext> {
-        if context.is_empty() {
-            return Rc::clone(&self.empty);
-        }
-        if let Some(existing) = self.entries.get(&context) {
-            #[cfg(feature = "perf-counters")]
-            crate::perf::record_context_cache_hit();
-            return Rc::clone(existing);
-        }
-        #[cfg(feature = "perf-counters")]
-        crate::perf::record_context_cache_insert();
-        self.entries
-            .insert(Rc::clone(&context), Rc::clone(&context));
-        context
-    }
-}
-
-impl Default for PredictionContextCache {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[derive(Clone, Debug)]
-struct PredictionContextMergeKey {
-    left: Rc<PredictionContext>,
-    right: Rc<PredictionContext>,
-    left_hash: u64,
-    right_hash: u64,
-}
-
-impl PredictionContextMergeKey {
-    fn new(left: &Rc<PredictionContext>, right: &Rc<PredictionContext>) -> Self {
-        let left_hash = prediction_context_hash(left);
-        let right_hash = prediction_context_hash(right);
-        if should_swap_merge_key(left, left_hash, right, right_hash) {
-            return Self {
-                left: Rc::clone(right),
-                right: Rc::clone(left),
-                left_hash: right_hash,
-                right_hash: left_hash,
-            };
-        }
         Self {
-            left: Rc::clone(left),
-            right: Rc::clone(right),
-            left_hash,
-            right_hash,
+            left,
+            right,
+            root_is_wildcard,
         }
     }
 }
 
-fn should_swap_merge_key(
-    left: &Rc<PredictionContext>,
-    left_hash: u64,
-    right: &Rc<PredictionContext>,
-    right_hash: u64,
-) -> bool {
-    (right_hash, Rc::as_ptr(right) as usize) < (left_hash, Rc::as_ptr(left) as usize)
+const MAX_RETAINED_MERGE_CACHE_ENTRIES: usize = 65_536;
+const MAX_RETAINED_CONTEXT_ENTRIES: usize = 16_384;
+
+/// Reusable per-prediction merge cache and temporary compact entry storage.
+#[derive(Debug, Default)]
+pub(crate) struct PredictionWorkspace {
+    merge_cache: FxHashMap<MergeKey, ContextId>,
+    entries: Vec<(ContextId, u32)>,
 }
 
-impl PartialEq for PredictionContextMergeKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.left_hash == other.left_hash
-            && self.right_hash == other.right_hash
-            && self.left == other.left
-            && self.right == other.right
+impl PredictionWorkspace {
+    pub(crate) fn reset(&mut self) {
+        if self.merge_cache.capacity() > MAX_RETAINED_MERGE_CACHE_ENTRIES {
+            self.merge_cache = FxHashMap::default();
+        } else {
+            self.merge_cache.clear();
+        }
+        if self.entries.capacity() > MAX_RETAINED_CONTEXT_ENTRIES {
+            self.entries = Vec::new();
+        } else {
+            self.entries.clear();
+        }
     }
-}
-
-impl Eq for PredictionContextMergeKey {}
-
-impl Hash for PredictionContextMergeKey {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_u64(self.left_hash);
-        state.write_u64(self.right_hash);
-    }
-}
-
-fn prediction_context_hash(context: &Rc<PredictionContext>) -> u64 {
-    context.cached_hash()
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
@@ -901,17 +755,20 @@ fn combine_semantic_context(
 }
 
 #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct AtnConfig {
-    pub state: usize,
-    pub alt: usize,
-    pub context: Rc<PredictionContext>,
-    pub semantic_context: SemanticContext,
-    pub reaches_into_outer_context: usize,
-    pub precedence_filter_suppressed: bool,
+pub(crate) struct AtnConfig {
+    pub(crate) state: usize,
+    pub(crate) alt: usize,
+    pub(crate) context: ContextId,
+    pub(crate) semantic_context: SemanticContext,
+    pub(crate) reaches_into_outer_context: usize,
+    pub(crate) precedence_filter_suppressed: bool,
+    #[cfg(debug_assertions)]
+    context_generation: u64,
 }
 
 impl AtnConfig {
-    pub const fn new(state: usize, alt: usize, context: Rc<PredictionContext>) -> Self {
+    pub(crate) fn new(state: usize, alt: usize, context: ContextId, arena: &ContextArena) -> Self {
+        arena.assert_valid(context);
         Self {
             state,
             alt,
@@ -919,24 +776,48 @@ impl AtnConfig {
             semantic_context: SemanticContext::None,
             reaches_into_outer_context: 0,
             precedence_filter_suppressed: false,
+            #[cfg(debug_assertions)]
+            context_generation: arena.generation(),
         }
     }
 
     #[must_use]
-    pub fn with_semantic_context(mut self, semantic_context: SemanticContext) -> Self {
+    #[cfg(test)]
+    pub(crate) fn with_semantic_context(mut self, semantic_context: SemanticContext) -> Self {
         self.semantic_context = semantic_context;
         self
     }
 
-    #[must_use]
-    pub const fn with_reaches_into_outer_context(mut self, reaches: usize) -> Self {
-        self.reaches_into_outer_context = reaches;
-        self
+    pub(crate) fn set_context(&mut self, context: ContextId, arena: &ContextArena) {
+        arena.assert_valid(context);
+        self.context = context;
+        #[cfg(debug_assertions)]
+        {
+            self.context_generation = arena.generation();
+        }
+    }
+
+    pub(crate) fn moved_to(&self, state: usize, context: ContextId, arena: &ContextArena) -> Self {
+        let mut moved = Self::new(state, self.alt, context, arena);
+        moved.semantic_context = self.semantic_context.clone();
+        moved.reaches_into_outer_context = self.reaches_into_outer_context;
+        moved.precedence_filter_suppressed = self.precedence_filter_suppressed;
+        moved
+    }
+
+    pub(crate) fn assert_store(&self, arena: &ContextArena) {
+        arena.assert_valid(self.context);
+        #[cfg(debug_assertions)]
+        assert_eq!(
+            self.context_generation,
+            arena.generation(),
+            "ATN config carries a ContextId from another prediction store"
+        );
     }
 }
 
 #[derive(Clone, Debug, Default)]
-pub struct AtnConfigSet {
+pub(crate) struct AtnConfigSet {
     configs: Vec<AtnConfig>,
     config_index: FxHashMap<AtnConfigKey, usize>,
     full_context: bool,
@@ -948,11 +829,11 @@ pub struct AtnConfigSet {
 }
 
 impl AtnConfigSet {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self::default()
     }
 
-    pub fn new_full_context(full_context: bool) -> Self {
+    pub(crate) fn new_full_context(full_context: bool) -> Self {
         Self {
             configs: Vec::new(),
             config_index: FxHashMap::default(),
@@ -965,18 +846,15 @@ impl AtnConfigSet {
         }
     }
 
-    pub fn add(&mut self, config: AtnConfig) -> bool {
-        self.add_with_merge_cache(config, None)
-    }
-
-    /// Adds a configuration, merging prediction contexts for equivalent
-    /// `(state, alt, semantic-context)` keys.
-    pub fn add_with_merge_cache(
+    /// Adds a configuration, merging contexts for equivalent config keys.
+    pub(crate) fn add(
         &mut self,
         config: AtnConfig,
-        cache: Option<&mut PredictionContextMergeCache>,
+        arena: &mut ContextArena,
+        workspace: &mut PredictionWorkspace,
     ) -> bool {
         assert!(!self.readonly, "cannot mutate readonly ATN config set");
+        config.assert_store(arena);
         #[cfg(feature = "perf-counters")]
         crate::perf::record_config_add_call();
         if !config.semantic_context.is_none() {
@@ -989,25 +867,18 @@ impl AtnConfigSet {
         if let Some(existing_index) = self.config_index.get(&key).copied() {
             #[cfg(feature = "perf-counters")]
             crate::perf::record_config_merge();
-            let root_is_wildcard = !self.full_context;
             let existing = &mut self.configs[existing_index];
-            existing.context = PredictionContext::merge_with_options(
-                Rc::clone(&existing.context),
+            existing.assert_store(arena);
+            existing.context = arena.merge(
+                existing.context,
                 config.context,
-                root_is_wildcard,
-                cache,
+                !self.full_context,
+                workspace,
             );
             existing.reaches_into_outer_context = existing
                 .reaches_into_outer_context
                 .max(config.reaches_into_outer_context);
             existing.precedence_filter_suppressed |= config.precedence_filter_suppressed;
-            // Merging rewrites `existing.context`, which can change the
-            // (state, context) groupings `conflicting_alts()` derives. Drop the
-            // lazily-populated cache so a later call recomputes — mirroring the
-            // insert branch's `self.conflicting_alts.clear()`. (All current callers
-            // read `conflicting_alts()` only after the set is fully built, so this
-            // is a no-op today; it keeps the two branches consistent and prevents a
-            // stale read if a future caller interleaves reads with merges.)
             self.conflicting_alts.clear();
             false
         } else {
@@ -1022,75 +893,57 @@ impl AtnConfigSet {
         }
     }
 
-    pub fn configs(&self) -> &[AtnConfig] {
+    pub(crate) fn configs(&self) -> &[AtnConfig] {
         &self.configs
     }
 
-    /// Consumes the set and returns its configs, letting callers drain configs
-    /// by value (e.g. feeding `closure`, which takes `AtnConfig` by value)
-    /// instead of cloning each one.
     pub(crate) fn into_configs(self) -> Vec<AtnConfig> {
         self.configs
     }
 
-    pub const fn is_empty(&self) -> bool {
+    pub(crate) const fn is_empty(&self) -> bool {
         self.configs.is_empty()
     }
 
-    pub const fn len(&self) -> usize {
+    pub(crate) const fn len(&self) -> usize {
         self.configs.len()
     }
 
-    pub fn set_readonly(&mut self, readonly: bool) {
+    pub(crate) fn set_readonly(&mut self, readonly: bool) {
         self.readonly = readonly;
         if readonly {
             self.config_index.clear();
         }
     }
 
-    pub(crate) fn optimize_contexts(&mut self, cache: &mut PredictionContextCache) {
-        assert!(!self.readonly, "cannot mutate readonly ATN config set");
-        for config in &mut self.configs {
-            config.context = cache.get_cached_context(&config.context);
-        }
-    }
-
-    pub const fn is_readonly(&self) -> bool {
+    pub(crate) const fn is_readonly(&self) -> bool {
         self.readonly
     }
 
-    pub const fn full_context(&self) -> bool {
+    pub(crate) const fn full_context(&self) -> bool {
         self.full_context
     }
 
-    pub const fn has_semantic_context(&self) -> bool {
+    pub(crate) const fn has_semantic_context(&self) -> bool {
         self.has_semantic_context
     }
 
-    pub const fn set_has_semantic_context(&mut self, value: bool) {
-        self.has_semantic_context = value;
-    }
-
-    pub const fn dips_into_outer_context(&self) -> bool {
-        self.dips_into_outer_context
-    }
-
-    pub fn unique_alt(&mut self) -> Option<usize> {
+    pub(crate) fn unique_alt(&mut self) -> Option<usize> {
         if self.unique_alt.is_none() {
             self.unique_alt = unique_alt(self.configs());
         }
         self.unique_alt
     }
 
-    pub fn alts(&self) -> BTreeSet<usize> {
+    pub(crate) fn alts(&self) -> BTreeSet<usize> {
         self.configs.iter().map(|config| config.alt).collect()
     }
 
-    pub fn conflicting_alt_subsets(&self) -> Vec<BTreeSet<usize>> {
+    pub(crate) fn conflicting_alt_subsets(&self) -> Vec<BTreeSet<usize>> {
         conflicting_alt_subsets(self.configs())
     }
 
-    pub fn conflicting_alts(&mut self) -> BTreeSet<usize> {
+    pub(crate) fn conflicting_alts(&mut self) -> BTreeSet<usize> {
         if self.conflicting_alts.is_empty() {
             self.conflicting_alts = self
                 .conflicting_alt_subsets()
@@ -1100,6 +953,24 @@ impl AtnConfigSet {
                 .collect();
         }
         self.conflicting_alts.clone()
+    }
+
+    pub(crate) fn remap_contexts(&mut self, remap: &[ContextId], arena: &ContextArena) {
+        for config in &mut self.configs {
+            let index = usize::try_from(config.context.0).expect("u32 context ID fits usize");
+            config.set_context(
+                *remap
+                    .get(index)
+                    .expect("every imported context ID has a remap"),
+                arena,
+            );
+        }
+        self.config_index.clear();
+        if !self.readonly {
+            for (index, config) in self.configs.iter().enumerate() {
+                self.config_index.insert(AtnConfigKey::from(config), index);
+            }
+        }
     }
 }
 
@@ -1150,7 +1021,7 @@ impl From<&AtnConfig> for AtnConfigKey {
     }
 }
 
-pub fn unique_alt(configs: &[AtnConfig]) -> Option<usize> {
+pub(crate) fn unique_alt(configs: &[AtnConfig]) -> Option<usize> {
     let mut alt = None;
     for config in configs {
         match alt {
@@ -1162,33 +1033,22 @@ pub fn unique_alt(configs: &[AtnConfig]) -> Option<usize> {
     alt
 }
 
-pub fn conflicting_alt_subsets(configs: &[AtnConfig]) -> Vec<BTreeSet<usize>> {
-    // The subset order is irrelevant to every caller, so hash by the cheap
-    // cached context hash instead of paying `BTreeMap`'s recursive
-    // `PredictionContext::cmp` on every key comparison.
-    let mut by_state_context =
-        FxHashMap::<(usize, Rc<PredictionContext>), BTreeSet<usize>>::default();
+pub(crate) fn conflicting_alt_subsets(configs: &[AtnConfig]) -> Vec<BTreeSet<usize>> {
+    let mut by_state_context = FxHashMap::<(usize, ContextId), BTreeSet<usize>>::default();
     for config in configs {
         by_state_context
-            .entry((config.state, Rc::clone(&config.context)))
+            .entry((config.state, config.context))
             .or_default()
             .insert(config.alt);
     }
     by_state_context.into_values().collect()
 }
 
-pub fn resolves_to_just_one_viable_alt(configs: &[AtnConfig]) -> Option<usize> {
-    single_viable_alt(&conflicting_alt_subsets(configs))
-}
-
-/// Java `PredictionMode.allSubsetsConflict`: every `(state, context)` subset
-/// holds more than one alternative.
-pub fn all_subsets_conflict(alt_subsets: &[BTreeSet<usize>]) -> bool {
+pub(crate) fn all_subsets_conflict(alt_subsets: &[BTreeSet<usize>]) -> bool {
     alt_subsets.iter().all(|alts| alts.len() > 1)
 }
 
-/// Java `PredictionMode.allSubsetsEqual`: every subset is the same alt set.
-pub fn all_subsets_equal(alt_subsets: &[BTreeSet<usize>]) -> bool {
+pub(crate) fn all_subsets_equal(alt_subsets: &[BTreeSet<usize>]) -> bool {
     let mut subsets = alt_subsets.iter();
     let Some(first) = subsets.next() else {
         return true;
@@ -1196,7 +1056,7 @@ pub fn all_subsets_equal(alt_subsets: &[BTreeSet<usize>]) -> bool {
     subsets.all(|alts| alts == first)
 }
 
-pub fn single_viable_alt(alt_subsets: &[BTreeSet<usize>]) -> Option<usize> {
+pub(crate) fn single_viable_alt(alt_subsets: &[BTreeSet<usize>]) -> Option<usize> {
     let mut result = None;
     for alts in alt_subsets {
         let min_alt = alts.iter().next().copied()?;
@@ -1209,7 +1069,7 @@ pub fn single_viable_alt(alt_subsets: &[BTreeSet<usize>]) -> Option<usize> {
     result
 }
 
-pub fn has_sll_conflict_terminating_prediction(
+pub(crate) fn has_sll_conflict_terminating_prediction(
     configs: &AtnConfigSet,
     is_rule_stop_state: impl Fn(usize) -> bool,
 ) -> bool {
@@ -1238,205 +1098,135 @@ mod tests {
     use super::*;
 
     #[test]
-    fn config_set_deduplicates_configs() {
-        let empty = PredictionContext::empty();
-        let mut set = AtnConfigSet::new();
-        assert!(set.add(AtnConfig::new(1, 1, Rc::clone(&empty))));
-        assert!(!set.add(AtnConfig::new(1, 1, Rc::clone(&empty))));
-        assert_eq!(set.len(), 1);
+    fn arena_interns_singletons_without_per_context_objects() {
+        let mut arena = ContextArena::new();
+        let first = arena.singleton(EMPTY_CONTEXT, 7);
+        let second = arena.singleton(EMPTY_CONTEXT, 7);
+
+        assert_eq!(first, second);
+        assert_eq!(arena.stats().singleton_contexts, 1);
+        assert_eq!(arena.stats().interner_hits, 1);
     }
 
     #[test]
-    fn sll_conflict_does_not_stop_for_empty_contexts_alone() {
-        let empty = PredictionContext::empty();
-        let mut set = AtnConfigSet::new();
-        set.add(AtnConfig::new(1, 1, Rc::clone(&empty)));
-        set.add(AtnConfig::new(2, 2, empty));
-
-        assert!(!has_sll_conflict_terminating_prediction(&set, |_| false));
-    }
-
-    #[test]
-    fn sll_conflict_stops_when_all_configs_reached_rule_stop() {
-        let empty = PredictionContext::empty();
-        let mut set = AtnConfigSet::new();
-        set.add(AtnConfig::new(10, 1, Rc::clone(&empty)));
-        set.add(AtnConfig::new(11, 2, empty));
-
-        assert!(has_sll_conflict_terminating_prediction(&set, |state| {
-            matches!(state, 10 | 11)
-        }));
-    }
-
-    #[test]
-    fn viable_alt_resolves_to_shared_conflict_minimum() {
-        let empty = PredictionContext::empty();
-        let mut set = AtnConfigSet::new_full_context(true);
-        set.add(AtnConfig::new(10, 1, Rc::clone(&empty)));
-        set.add(AtnConfig::new(10, 2, Rc::clone(&empty)));
-        set.add(AtnConfig::new(11, 1, empty));
-
-        assert_eq!(resolves_to_just_one_viable_alt(set.configs()), Some(1));
-    }
-
-    #[test]
-    fn viable_alt_keeps_looking_for_different_conflict_minimums() {
-        let empty = PredictionContext::empty();
-        let mut set = AtnConfigSet::new_full_context(true);
-        set.add(AtnConfig::new(10, 1, Rc::clone(&empty)));
-        set.add(AtnConfig::new(10, 2, Rc::clone(&empty)));
-        set.add(AtnConfig::new(11, 2, Rc::clone(&empty)));
-        set.add(AtnConfig::new(11, 3, empty));
-
-        assert_eq!(resolves_to_just_one_viable_alt(set.configs()), None);
-    }
-
-    #[test]
-    fn singleton_context_reports_parent_and_return_state() {
-        let empty = PredictionContext::empty();
-        let context = PredictionContext::singleton(Rc::clone(&empty), 42);
-        assert_eq!(context.return_state(0), Some(42));
-        assert_eq!(context.parent(0), Some(empty));
-    }
-
-    #[test]
-    fn merge_with_empty_preserves_non_empty_return_state() {
-        let empty = PredictionContext::empty();
-        let singleton = PredictionContext::singleton(Rc::clone(&empty), 42);
-
-        let merged = PredictionContext::merge(Rc::clone(&singleton), Rc::clone(&empty));
-
-        assert_eq!(merged.len(), 2);
-        assert_eq!(merged.return_state(0), Some(42));
-        assert_eq!(merged.parent(0), Some(empty.clone()));
-        assert_eq!(merged.return_state(1), Some(EMPTY_RETURN_STATE));
-        assert_eq!(merged.parent(1), Some(empty));
-    }
-
-    #[test]
-    fn merge_deduplicates_entries_with_same_parent_and_return_state() {
-        let empty = PredictionContext::empty();
-        let parent_one = PredictionContext::singleton(Rc::clone(&empty), 1);
-        let parent_two = PredictionContext::singleton(Rc::clone(&empty), 2);
-        let left = PredictionContext::array(vec![Rc::clone(&parent_one), parent_two], vec![42, 42]);
-        let right = PredictionContext::singleton(Rc::clone(&parent_one), 42);
-
-        let merged = PredictionContext::merge(left, right);
-
-        assert_eq!(merged.len(), 2);
-    }
-
-    #[test]
-    fn merge_arrays_linearly_preserves_order_and_deduplicates_entries() {
-        let empty = PredictionContext::empty();
-        let parent_one = PredictionContext::singleton(Rc::clone(&empty), 1);
-        let parent_two = PredictionContext::singleton(Rc::clone(&empty), 2);
-        let parent_three = PredictionContext::singleton(Rc::clone(&empty), 3);
-        let left = PredictionContext::array(
-            vec![Rc::clone(&parent_one), Rc::clone(&parent_three)],
-            vec![10, 30],
-        );
-        let right =
-            PredictionContext::array(vec![parent_two, Rc::clone(&parent_three)], vec![20, 30]);
-
-        let merged = PredictionContext::merge(left, right);
-
-        assert_eq!(merged.len(), 3);
-        assert_eq!(merged.return_state(0), Some(10));
-        assert_eq!(merged.parent(0), Some(parent_one));
-        assert_eq!(merged.return_state(1), Some(20));
-        assert_eq!(merged.return_state(2), Some(30));
-        assert_eq!(merged.parent(2), Some(parent_three));
-    }
-
-    /// Builds a `Singleton` with a caller-chosen `cached_hash` so a test can force
-    /// two structurally-distinct contexts to collide on their hash — the only way
-    /// to reach the canonicalization hazard `compare_entries` guards against (a real
-    /// 64-bit `cached_hash` collision is astronomically rare to produce organically).
-    fn singleton_with_forced_hash(
-        parent: Rc<PredictionContext>,
-        return_state: usize,
-        cached_hash: u64,
-    ) -> Rc<PredictionContext> {
-        Rc::new(PredictionContext::Singleton {
-            parent,
-            return_state,
+    fn array_interner_verifies_payload_after_hash_collision() {
+        let mut arena = ContextArena::new();
+        let first_parent = arena.singleton(EMPTY_CONTEXT, 1);
+        let second_parent = arena.singleton(EMPTY_CONTEXT, 2);
+        let expected = [(first_parent, 10), (second_parent, 20)];
+        let colliding = [(second_parent, 10), (first_parent, 20)];
+        let cached_hash = prediction_context_array_hash(&arena, &expected);
+        let start = u32::try_from(arena.array_parents.len()).expect("pool index fits u32");
+        arena
+            .array_parents
+            .extend(colliding.iter().map(|(parent, _)| *parent));
+        arena
+            .array_return_states
+            .extend(colliding.iter().map(|(_, return_state)| *return_state));
+        let collision = arena.push_record(ContextRecord {
+            tag: ContextTag::Array,
             cached_hash,
-        })
+            parent_or_start: start,
+            return_state_or_len: 2,
+        });
+
+        let interned = arena.intern_entries(&expected);
+
+        assert_ne!(interned, collision);
+        assert_eq!(arena.entry(interned, 0), Some(expected[0]));
+        assert_eq!(arena.entry(interned, 1), Some(expected[1]));
     }
 
     #[test]
-    fn merge_is_order_independent_under_hash_collision() {
-        // Two structurally-different parents (return states 100 vs 200) forced to
-        // share one `cached_hash`, both reached via the same outer return state 7.
-        let empty = PredictionContext::empty();
-        let parent_a = singleton_with_forced_hash(Rc::clone(&empty), 100, 0xDEAD_BEEF);
-        let parent_b = singleton_with_forced_hash(Rc::clone(&empty), 200, 0xDEAD_BEEF);
-        assert_ne!(parent_a, parent_b, "parents must be structurally distinct");
-        assert_eq!(
-            parent_a.cached_hash(),
-            parent_b.cached_hash(),
-            "test must force the hash collision"
-        );
+    fn merge_with_empty_preserves_full_context_empty_path() {
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
+        let singleton = arena.singleton(EMPTY_CONTEXT, 42);
 
-        // singleton+singleton path (merge_two_context_entries): same return_state,
-        // colliding-hash parents, merged in both orders.
-        let left = PredictionContext::singleton(Rc::clone(&parent_a), 7);
-        let right = PredictionContext::singleton(Rc::clone(&parent_b), 7);
-        let merged_lr = PredictionContext::merge(Rc::clone(&left), Rc::clone(&right));
-        let merged_rl = PredictionContext::merge(right, left);
-        assert_eq!(
-            merged_lr, merged_rl,
-            "merge_two_context_entries must canonicalize regardless of operand order"
-        );
+        let merged = arena.merge(singleton, EMPTY_CONTEXT, false, &mut workspace);
 
-        // array+array path (merge_arrays): each operand carries one colliding-hash
-        // entry at return_state 7 plus a shared non-colliding entry at 30, so the
-        // merge walks the rs=7 group from both sides. The result must not depend on
-        // operand order. (A shared trailing entry keeps both operands distinct so
-        // `merge` does not short-circuit on `left == right`.)
-        let shared = PredictionContext::singleton(Rc::clone(&empty), 30);
-        let left_array =
-            PredictionContext::array(vec![Rc::clone(&parent_a), Rc::clone(&shared)], vec![7, 30]);
-        let right_array = PredictionContext::array(vec![Rc::clone(&parent_b), shared], vec![7, 30]);
-        let merged_arrays_lr =
-            PredictionContext::merge(Rc::clone(&left_array), Rc::clone(&right_array));
-        let merged_arrays_rl = PredictionContext::merge(right_array, left_array);
-        assert_eq!(
-            merged_arrays_lr, merged_arrays_rl,
-            "merge_arrays must canonicalize colliding-hash entries to one order"
-        );
-        assert_eq!(merged_arrays_lr.len(), 3, "two rs=7 entries + one rs=30");
+        assert_eq!(arena.len(merged), 2);
+        assert_eq!(arena.return_state(merged, 0), Some(42));
+        assert_eq!(arena.parent(merged, 0), Some(EMPTY_CONTEXT));
+        assert_eq!(arena.return_state(merged, 1), Some(EMPTY_RETURN_STATE));
+        assert!(arena.has_empty_path(merged));
     }
 
     #[test]
-    fn prediction_context_cache_reuses_equal_context_graphs() {
-        let mut cache = PredictionContextCache::new();
-        let left_parent = PredictionContext::singleton(PredictionContext::empty(), 1);
-        let right_parent = PredictionContext::singleton(PredictionContext::empty(), 1);
-        let left = PredictionContext::singleton(left_parent, 42);
-        let right = PredictionContext::singleton(right_parent, 42);
+    fn wildcard_merge_collapses_to_empty() {
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
+        let singleton = arena.singleton(EMPTY_CONTEXT, 42);
 
-        let cached_left = cache.get_cached_context(&left);
-        let cached_right = cache.get_cached_context(&right);
-        let cached_left_parent = cached_left.parent(0).expect("singleton parent");
-        let cached_right_parent = cached_right.parent(0).expect("singleton parent");
-
-        assert!(Rc::ptr_eq(&cached_left, &cached_right));
-        assert!(Rc::ptr_eq(&cached_left_parent, &cached_right_parent));
+        assert_eq!(
+            arena.merge(singleton, EMPTY_CONTEXT, true, &mut workspace),
+            EMPTY_CONTEXT
+        );
     }
 
     #[test]
-    fn config_set_optimize_contexts_canonicalizes_contexts() {
-        let mut cache = PredictionContextCache::new();
-        let first = PredictionContext::singleton(PredictionContext::empty(), 7);
-        let second = PredictionContext::singleton(PredictionContext::empty(), 7);
-        let mut set = AtnConfigSet::new();
-        set.add(AtnConfig::new(1, 1, first));
-        set.add(AtnConfig::new(2, 2, second));
+    fn merge_is_order_independent() {
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
+        let left_parent = arena.singleton(EMPTY_CONTEXT, 100);
+        let right_parent = arena.singleton(EMPTY_CONTEXT, 200);
+        let left = arena.singleton(left_parent, 7);
+        let right = arena.singleton(right_parent, 7);
 
-        set.optimize_contexts(&mut cache);
+        let left_right = arena.merge(left, right, false, &mut workspace);
+        workspace.reset();
+        let right_left = arena.merge(right, left, false, &mut workspace);
 
-        assert!(Rc::ptr_eq(&set.configs[0].context, &set.configs[1].context));
+        assert_eq!(left_right, right_left);
+        assert_eq!(arena.len(left_right), 2);
+    }
+
+    #[test]
+    fn import_remaps_contexts_into_destination_arena() {
+        let mut source = ContextArena::new();
+        let parent = source.singleton(EMPTY_CONTEXT, 3);
+        let child = source.singleton(parent, 9);
+        let mut destination = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
+
+        let remap = destination.import_all(&source, &mut workspace);
+        let imported = remap[usize::try_from(child.0).expect("context ID fits usize")];
+
+        assert_eq!(destination.return_state(imported, 0), Some(9));
+        let imported_parent = destination.parent(imported, 0).expect("parent");
+        assert_eq!(destination.return_state(imported_parent, 0), Some(3));
+    }
+
+    #[test]
+    fn config_set_merges_context_ids() {
+        let mut arena = ContextArena::new();
+        let mut workspace = PredictionWorkspace::default();
+        let left = arena.singleton(EMPTY_CONTEXT, 1);
+        let right = arena.singleton(EMPTY_CONTEXT, 2);
+        let mut set = AtnConfigSet::new_full_context(true);
+
+        assert!(set.add(
+            AtnConfig::new(1, 1, left, &arena),
+            &mut arena,
+            &mut workspace
+        ));
+        assert!(!set.add(
+            AtnConfig::new(1, 1, right, &arena),
+            &mut arena,
+            &mut workspace
+        ));
+        assert_eq!(set.len(), 1);
+        assert_eq!(arena.len(set.configs()[0].context), 2);
+    }
+
+    #[test]
+    fn workspace_drops_pathological_capacity() {
+        let mut workspace = PredictionWorkspace::default();
+        workspace
+            .entries
+            .reserve(MAX_RETAINED_CONTEXT_ENTRIES.saturating_mul(2));
+        workspace.reset();
+
+        assert!(workspace.entries.capacity() <= MAX_RETAINED_CONTEXT_ENTRIES);
     }
 }

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -94,6 +94,18 @@ pub struct PredictionContextStats {
     pub array_entries: usize,
     pub interner_hits: usize,
     pub pooled_bytes: usize,
+    /// Element storage implied by retained capacities, excluding allocator and
+    /// hash-table control metadata.
+    pub retained_bytes: usize,
+    pub context_capacity: usize,
+    pub array_parent_capacity: usize,
+    pub array_return_state_capacity: usize,
+    pub interner_capacity: usize,
+    pub workspace_merge_cache_entries: usize,
+    pub workspace_merge_cache_capacity: usize,
+    pub workspace_entry_capacity: usize,
+    pub outer_context_cache_hits: usize,
+    pub outer_context_cache_misses: usize,
 }
 
 /// Canonical compact storage paired with one learned parser DFA store.
@@ -164,6 +176,20 @@ impl ContextArena {
                 + self.array_parents.len() * size_of::<ContextId>()
                 + self.array_return_states.len() * size_of::<u32>()
                 + self.interner_next.len() * size_of::<Option<ContextId>>(),
+            retained_bytes: self.records.capacity() * size_of::<ContextRecord>()
+                + self.array_parents.capacity() * size_of::<ContextId>()
+                + self.array_return_states.capacity() * size_of::<u32>()
+                + self.interner_heads.capacity() * size_of::<(u64, ContextId)>()
+                + self.interner_next.capacity() * size_of::<Option<ContextId>>(),
+            context_capacity: self.records.capacity(),
+            array_parent_capacity: self.array_parents.capacity(),
+            array_return_state_capacity: self.array_return_states.capacity(),
+            interner_capacity: self.interner_heads.capacity(),
+            workspace_merge_cache_entries: 0,
+            workspace_merge_cache_capacity: 0,
+            workspace_entry_capacity: 0,
+            outer_context_cache_hits: 0,
+            outer_context_cache_misses: 0,
         }
     }
 
@@ -686,6 +712,23 @@ impl PredictionWorkspace {
         } else {
             self.entries.clear();
         }
+    }
+
+    pub(crate) fn merge_cache_capacity(&self) -> usize {
+        self.merge_cache.capacity()
+    }
+
+    pub(crate) fn merge_cache_len(&self) -> usize {
+        self.merge_cache.len()
+    }
+
+    pub(crate) const fn entry_capacity(&self) -> usize {
+        self.entries.capacity()
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.merge_cache.capacity() * size_of::<(MergeKey, ContextId)>()
+            + self.entries.capacity() * size_of::<(ContextId, u32)>()
     }
 }
 
@@ -1223,10 +1266,14 @@ mod tests {
     fn workspace_drops_pathological_capacity() {
         let mut workspace = PredictionWorkspace::default();
         workspace
+            .merge_cache
+            .reserve(MAX_RETAINED_MERGE_CACHE_ENTRIES.saturating_mul(2));
+        workspace
             .entries
             .reserve(MAX_RETAINED_CONTEXT_ENTRIES.saturating_mul(2));
         workspace.reset();
 
+        assert!(workspace.merge_cache.capacity() <= MAX_RETAINED_MERGE_CACHE_ENTRIES);
         assert!(workspace.entries.capacity() <= MAX_RETAINED_CONTEXT_ENTRIES);
     }
 }

--- a/tools/parse-bench/README.md
+++ b/tools/parse-bench/README.md
@@ -73,6 +73,25 @@ Use `--rust-generated-only` for Adaptive LL delivery evidence so the Rust
 generator fails if any parser rule lacks a generated body and the Rust runner
 fails if a generated parser path falls back to the interpreter.
 
+## Prediction Memory Counters
+
+Set `ANTLR_PERF_DUMP=1` to build the Rust runner with prediction counters and
+print context-store measurements:
+
+```bash
+ANTLR_PERF_DUMP=1 python3 tools/parse-bench/run.py \
+  --languages csharp \
+  --runtimes rust-antlr \
+  --iters 10 \
+  --warmups 2 \
+  --rust-generated-only
+```
+
+The dump includes canonical context counts, pooled and retained bytes, arena
+and workspace capacities, merge-cache activity, and outer-context cache
+hits/misses. Store statistics are collected in a separate untimed parse after
+the benchmark loop, so walking the arena does not affect reported timings.
+
 ## PR Watchdog
 
 For CI, run the benchmark on the base checkout and the PR checkout on the same

--- a/tools/parse-bench/run.py
+++ b/tools/parse-bench/run.py
@@ -390,6 +390,10 @@ def write_rust_runner(work_dir: Path, specs: list[LanguageSpec]) -> Path:
         f'        "{spec.name}" => parse_{spec.name}(&src).map_err(|err| err.to_string())?,'
         for spec in specs
     )
+    stats_arms = "\n".join(
+        f'        "{spec.name}" => prediction_context_stats_{spec.name}(&src).map_err(|err| err.to_string())?,'
+        for spec in specs
+    )
     functions = "\n\n".join(rust_parse_function(spec) for spec in specs)
     (runner / "src" / "main.rs").write_text(
         f"""#![allow(clippy::print_stdout)]
@@ -442,6 +446,7 @@ fn run_main() -> Result<(), String> {{
     }}
     let src = fs::read_to_string(&input)
         .map_err(|err| format!("failed to read {{}}: {{err}}", input.display()))?;
+    let collect_stats = env::var_os("ANTLR_PERF_DUMP").is_some();
 
     for _ in 0..warmups {{
         parse_once(&language, &src)?;
@@ -461,13 +466,20 @@ fn run_main() -> Result<(), String> {{
     let avg_ns = total_ns / iters as u128;
     println!("min_ns={{min_ns}} avg_ns={{avg_ns}}");
     #[cfg(feature = "perf-counters")]
-    if env::var_os("ANTLR_PERF_DUMP").is_some() {{
+    if collect_stats {{
         antlr4_runtime::dump_prediction_perf_counters();
+    }}
+    if collect_stats {{
+        let stats = prediction_context_stats_once(&language, &src)?;
+        dump_prediction_context_stats(stats);
     }}
     Ok(())
 }}
 
-fn parse_once(language: &str, src: &str) -> Result<(), String> {{
+fn parse_once(
+    language: &str,
+    src: &str,
+) -> Result<(), String> {{
     match language {{
 {arms}
         other => return Err(format!("unsupported language: {{other}}")),
@@ -475,11 +487,41 @@ fn parse_once(language: &str, src: &str) -> Result<(), String> {{
     Ok(())
 }}
 
+fn prediction_context_stats_once(
+    language: &str,
+    src: &str,
+) -> Result<antlr4_runtime::PredictionContextStats, String> {{
+    let stats = match language {{
+{stats_arms}
+        other => return Err(format!("unsupported language: {{other}}")),
+    }};
+    Ok(stats)
+}}
+
 fn parse_usize(value: Option<String>, flag: &str) -> Result<usize, String> {{
     let value = value.ok_or_else(|| format!("missing value for {{flag}}"))?;
     value
         .parse::<usize>()
         .map_err(|err| format!("invalid {{flag}} value {{value}}: {{err}}"))
+}}
+
+fn dump_prediction_context_stats(stats: antlr4_runtime::PredictionContextStats) {{
+    eprintln!("perf context_store.contexts_created={{}}", stats.contexts_created);
+    eprintln!("perf context_store.singleton_contexts={{}}", stats.singleton_contexts);
+    eprintln!("perf context_store.array_contexts={{}}", stats.array_contexts);
+    eprintln!("perf context_store.array_entries={{}}", stats.array_entries);
+    eprintln!("perf context_store.interner_hits={{}}", stats.interner_hits);
+    eprintln!("perf context_store.pooled_bytes={{}}", stats.pooled_bytes);
+    eprintln!("perf context_store.retained_bytes={{}}", stats.retained_bytes);
+    eprintln!("perf context_store.context_capacity={{}}", stats.context_capacity);
+    eprintln!("perf context_store.array_parent_capacity={{}}", stats.array_parent_capacity);
+    eprintln!("perf context_store.array_return_state_capacity={{}}", stats.array_return_state_capacity);
+    eprintln!("perf context_store.interner_capacity={{}}", stats.interner_capacity);
+    eprintln!("perf context_store.workspace_merge_cache_entries={{}}", stats.workspace_merge_cache_entries);
+    eprintln!("perf context_store.workspace_merge_cache_capacity={{}}", stats.workspace_merge_cache_capacity);
+    eprintln!("perf context_store.workspace_entry_capacity={{}}", stats.workspace_entry_capacity);
+    eprintln!("perf context_store.outer_context_cache_hits={{}}", stats.outer_context_cache_hits);
+    eprintln!("perf context_store.outer_context_cache_misses={{}}", stats.outer_context_cache_misses);
 }}
 """
     )
@@ -494,6 +536,18 @@ def rust_parse_function(spec: LanguageSpec) -> str:
     let tree = parser.{spec.rust_entry}()?;
     black_box(&tree);
     Ok(())
+}}
+
+fn prediction_context_stats_{spec.name}(
+    src: &str,
+) -> Result<antlr4_runtime::PredictionContextStats, antlr4_runtime::AntlrError> {{
+    let lexer = generated::{spec.rust_lexer_module}::{spec.rust_lexer_type}::new(InputStream::new(src));
+    let tokens = CommonTokenStream::new(lexer);
+    let mut parser = generated::{spec.rust_parser_module}::{spec.rust_parser_type}::new(tokens);
+    let tree = parser.{spec.rust_entry}()?;
+    let stats = parser.prediction_context_stats();
+    black_box(&tree);
+    Ok(stats)
 }}"""
 
 
@@ -945,6 +999,8 @@ def measure_fixture(
         ]
     )
     completed = run(cmd, env=env, quiet=True)
+    if runtime == "rust-antlr" and os.environ.get("ANTLR_PERF_DUMP") and completed.stderr:
+        print(completed.stderr, file=sys.stderr, end="")
     match = RUNNER_OUTPUT.search(completed.stdout)
     if match is None:
         raise SystemExit(


### PR DESCRIPTION
## Summary

- replace recursive `Rc<PredictionContext>` graphs with canonical store-local `ContextId` handles
- pool singleton and array contexts, reuse bounded prediction scratch storage, and remap context IDs when independently learned DFA stores are combined
- cache generated outer prediction contexts by `BaseParser` rule-stack version inside the owning simulator
- expose prediction-context counts, retained capacities, workspace usage, and outer-cache activity through generated parsers and the benchmark harness
- remove the old exported recursive compatibility API
- move migration notes from the main README into `docs/migration.md`
- refresh the README Rust-vs-Go benchmark table

## Why

Recursive prediction contexts imposed object allocation, reference-counting, and structural equality/hash costs on parser prediction. Pairing compact context storage with learned DFA state makes canonical equality and copying integer operations while preserving ANTLR prediction semantics and explicit store ownership.

Closes #85.

## Impact

This is a breaking pre-1.0 runtime/generator change. Generated parsers must use the matching generator/runtime release. Detailed upgrade notes live outside the main README in `docs/migration.md`.

The final-head 10-iteration, 2-warmup Rust-vs-Go benchmark produced these geometric means across the existing fixture groups:

| Language | Fixtures | Rust vs Go |
| --- | ---: | ---: |
| Kotlin | 4 | 24.968x |
| Java | 4 | 3.055x |
| C# | 4 | 2.206x |
| Trino SQL | 5 | 3.412x |

Rust was faster on all 17 fixtures.

## Follow-up performance work

The simulator now caches an interned outer call stack only while the parser's rule-context version is unchanged. The cache remains simulator/store-local, and focused tests cover invalidation and store isolation. On a representative Java fixture this removed about 1.8% of context-interner calls (`121,425` to `119,196` over three measured parses); grammars with no repeated same-stack prediction, including the large C# fixture, correctly report zero cache hits.

A bounded cross-prediction merge memo was prototyped and benchmarked, then removed: versus the outer-cache-only control it measured just `1.003x` overall and `0.985x` on Kotlin, which did not justify a persistent hash table.

`ANTLR_PERF_DUMP=1` now reports store statistics in a separate untimed parse. On `mono-statement.cs` the compact store retained `134,541` canonical contexts, `6,830,288` pooled payload bytes, and `16,267,520` bytes implied by retained payload capacities. Peak RSS was neutral versus the previous PR head (`122,748,928` vs `122,847,232` bytes). Against `main`, the C#-only cold run improved from about `252 ms` to `210 ms` while peak RSS increased from `113,541,120` to `116,015,104` bytes (`+2.2%`); this tradeoff is now explicit rather than inferred from object counts.

## Validation

- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `tests/kotlin-parity/run.sh --antlr-jar /tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar --grammars-v4 /tmp/antlr-cleanroom/grammars-v4 --python /tmp/antlr-cleanroom/python-venv/bin/python`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` (`356 passed, 0 failed, 1 known skip`)
- final-head same-machine Rust-vs-Go timing across all 17 fixtures
- same-machine 17-fixture timing against `6f9b9be`, plus an outer-cache-only control for merge-memo gating
- C#-only cold/warm `/usr/bin/time -l` peak-RSS comparison against `main` and `6f9b9be`
- `ANTLR_PERF_DUMP=1` benchmark smoke verifying context counts and retained-capacity output