### PR TITLE
Split parser DFA hot and cold storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,13 @@
   `PredictionContext`/`AtnConfig` compatibility API are removed. Prediction
   contexts are canonical `ContextId` values in pooled storage owned together
   with learned parser DFAs; overlapping stores remap IDs before DFA union.
+- Learned parser DFAs now use compact `DfaStateId` values, pooled dense/sparse
+  edge rows, aligned hot accept tables, and a separate cold config store.
+  Public `Dfa`/`DfaState` fields are removed in favor of opaque `ParserDfa`
+  diagnostics and borrowing state views.
 - `ParserAtnSimulator::prediction_context_stats()` reports context creation,
   singleton/array distribution, pooled entries and bytes, and interner hits.
+- `ParserAtnSimulator::parser_dfa_stats()` reports edge density, hot/cold
+  retained bytes, and fingerprint-interner activity.
 - Generated lexers and parsers must be regenerated with the matching
   `antlr4-rust-gen` release.

--- a/README.md
+++ b/README.md
@@ -431,10 +431,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | 24.968x                 |
-| Java     | 4        | 3.055x                  |
-| C#       | 4        | 2.206x                  |
-| Trino SQL | 5       | 3.412x                  |
+| Kotlin   | 4        | 25.536x                 |
+| Java     | 4        | 3.116x                  |
+| C#       | 4        | 1.884x                  |
+| Trino SQL | 5       | 3.531x                  |
 
 ## Useful Information
 

--- a/README.md
+++ b/README.md
@@ -431,10 +431,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | 25.536x                 |
-| Java     | 4        | 3.116x                  |
-| C#       | 4        | 1.884x                  |
-| Trino SQL | 5       | 3.531x                  |
+| Kotlin   | 4        | 25.705x                 |
+| Java     | 4        | 3.115x                  |
+| C#       | 4        | 2.238x                  |
+| Trino SQL | 5       | 3.522x                  |
 
 ## Useful Information
 

--- a/docs/issue-86-dfa-benchmark.md
+++ b/docs/issue-86-dfa-benchmark.md
@@ -1,0 +1,82 @@
+# Issue 86 parser-DFA benchmark record
+
+Measurements were taken on 2026-07-16 on an Apple M3 Pro. The baseline was
+`origin/main` at `16e904796`; generated parsers were rebuilt with the matching
+generator/runtime for each revision.
+
+## Protected parser suites
+
+The Kotlin, C#, Java, and Trino suite used 5 warmups and 20 measured parses for
+each of 17 fixtures. Compared with the baseline, the compact DFA was 2.39%
+faster by geometric mean and 2.51% faster by aggregate time. It improved 16 of
+17 fixtures; the remaining Java fixture was 0.17% slower. The repository's 2%
+regression check passed for every fixture.
+
+An untimed instrumentation parse of each fixture produced these aggregate
+store measurements:
+
+| Measurement | Value |
+|---|---:|
+| states | 20,396 |
+| transitions | 24,355 |
+| empty rows | 2,766 |
+| one-edge inline rows | 13,862 |
+| rows with 2-3 edges | 3,201 |
+| rows with 4-7 edges | 461 |
+| rows with 8-15 edges | 85 |
+| rows with at least 16 edges | 21 |
+| dense rows | 4 |
+| fingerprint candidates checked | 4,725 |
+| structural fingerprint collisions | 0 |
+| retained hot bytes | 1,253,968 (61.5/state) |
+| retained cold bytes | 157,249,424 (7,709.8/state) |
+
+All fixture vocabulary rows were 131-342 slots wide. Of the states, 18,150
+had width at most 256 and 2,246 had width at most 512. Cache import took 0.280
+ms total across 17 processes; publication took 0.029 ms for 20,396 states.
+
+## Dense threshold selection
+
+Three policies were measured over the same fixtures with 10 iterations:
+
+| Policy versus selected hybrid | Geometric time | Aggregate time | Wins |
+|---|---:|---:|---:|
+| sparse only | 1.0055x | 1.0073x | 5/17 |
+| aggressive dense promotion | 1.0402x | 1.0306x | 0/17 |
+| selected hybrid | 1.0000x | 1.0000x | 17/17 |
+
+The selected policy keeps empty and one-edge rows allocation-free, and promotes
+a sparse row only when its vocabulary width is at most 512, it contains at
+least 8 edges, and its density is at least 12.5%.
+
+## Solidity and Go
+
+The issue #76 Solidity fixtures used five independently warmed processes with
+80 measured parses per process. The table reports the median of those process
+medians. Go used `antlr4-go/antlr` v4.13.1 and the same ANTLR 4.13.2 grammar.
+
+| Fixture | Bytes | Current Rust | Main Rust | Go | Rust over Go |
+|---|---:|---:|---:|---:|---:|
+| Ownable | 3,102 | 241 us | 241 us | 718 us | 2.98x |
+| ERC20 | 10,800 | 699 us | 695 us | 2,096 us | 3.00x |
+| ERC721 | 16,201 | 1,075 us | 1,065 us | 4,034 us | 3.75x |
+| Governor | 32,182 | 1,837 us | 1,827 us | 6,826 us | 3.72x |
+
+The largest current-versus-main difference was 0.94%. Repeating Governor to
+64, 129, and 257 KB produced Rust median ranges of 3.62-3.68 ms, 7.24-7.68 ms,
+and 14.55-14.61 ms respectively. Go took 13.66-14.32 ms, 27.27-27.61 ms, and
+55.11-55.56 ms. Current and main produced identical parse-tree hashes for all
+four source fixtures.
+
+The counting allocator measured one cold full-tree parse:
+
+| Fixture | Current allocated | Main allocated | Change | Current peak | Main peak | Change |
+|---|---:|---:|---:|---:|---:|---:|
+| Ownable | 4,876,494 | 5,294,082 | -7.9% | 1,795,172 | 2,178,804 | -17.6% |
+| ERC20 | 8,066,082 | 8,596,250 | -6.2% | 1,954,632 | 2,436,324 | -19.8% |
+| ERC721 | 10,474,874 | 11,077,706 | -5.4% | 2,128,788 | 2,665,308 | -20.1% |
+| Governor | 15,388,610 | 16,462,362 | -6.5% | 2,574,336 | 3,541,292 | -27.3% |
+
+These are whole-parse allocation totals, measured with otherwise identical
+generated parsers and harnesses; the branch difference is the parser-DFA
+storage change.

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -39,6 +39,18 @@ stores. `prediction_context_stats()` exposes arena allocation and interner
 totals, retained capacities, workspace usage, and outer-context cache activity
 for measurement.
 
+Learned parser DFAs are also opaque, compact stores. `Dfa` and the mutable
+field-oriented `DfaState` API are removed. Use `ParserDfa::state_count`,
+`ParserDfa::states`, `ParserDfa::transitions`, and borrowing
+`ParserDfaStateView` values for diagnostics. State and transition targets are
+identified by `DfaStateId`; ATN configuration sets remain internal cold data.
+`ParserAtnSimulator::parser_dfa_stats()` reports dense/sparse row distribution,
+hot/cold retained bytes, and state-interner measurements.
+
+Regenerate parsers with the matching `antlr4-rust-gen` release. Parsers
+generated against the removed DFA and prediction-context APIs are not source
+compatible with this runtime.
+
 Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
 numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);
 `u32::MAX` is reserved for ANTLR's synthetic `-1` boundary. All conversions are

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -1,5 +1,7 @@
 use crate::atn::{Atn, AtnState, AtnStateKind, Transition};
-use crate::dfa::{Dfa, DfaState};
+use crate::dfa::{
+    DfaStateBuilder, DfaStateId, NO_DFA_STATE, ParserDfa, ParserDfaStateView, ParserDfaStats,
+};
 use crate::int_stream::IntStream;
 use crate::prediction::{
     AtnConfig, AtnConfigSet, ContextArena, ContextId, EMPTY_CONTEXT, EMPTY_RETURN_STATE,
@@ -38,7 +40,7 @@ struct CachedOuterContext {
 #[derive(Debug, Default)]
 struct PredictionStore {
     contexts: ContextArena,
-    decision_to_dfa: Vec<Dfa>,
+    decision_to_dfa: Vec<ParserDfa>,
 }
 
 impl PredictionStore {
@@ -86,7 +88,7 @@ pub enum ParserAtnPredictionDiagnosticKind {
 struct PredictionCheck {
     decision: usize,
     decision_state: usize,
-    state_number: usize,
+    state_number: DfaStateId,
     start_index: usize,
     precedence: i32,
     outer_context: ContextId,
@@ -113,7 +115,7 @@ struct AdaptivePredictRequest {
 #[derive(Clone, Copy)]
 struct DfaEdge {
     decision: usize,
-    source_state: usize,
+    source_state: DfaStateId,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -248,13 +250,13 @@ impl IntStream for LookaheadIntStream {
     }
 }
 
-fn initial_decision_dfas(atn: &Atn) -> Vec<Dfa> {
+fn initial_decision_dfas(atn: &Atn) -> Vec<ParserDfa> {
     atn.decision_to_state()
         .iter()
         .copied()
         .enumerate()
         .map(|(decision, state)| {
-            let mut dfa = Dfa::with_max_token_type(state, decision, atn.max_token_type());
+            let mut dfa = ParserDfa::with_max_token_type(state, decision, atn.max_token_type());
             if atn
                 .state(state)
                 .is_some_and(|state| state.precedence_rule_decision)
@@ -270,12 +272,12 @@ fn initial_decision_dfas(atn: &Atn) -> Vec<Dfa> {
 /// checked in first, losslessly. The two evolved independently (the
 /// later-constructed one started cold), so numeric state ids are not
 /// comparable — but DFA states ARE comparable by their ATN config set, the
-/// same identity `Dfa::add_state` dedups on. Re-keying `local`'s states into
+/// same identity `ParserDfa::add_state` dedups on. Re-keying `local`'s states into
 /// `shared`'s numbering and unioning edges/starts means overlapping
 /// simulators never lose learned coverage, however it is distributed.
 /// Walking every state is fine here: this only runs on the rare
 /// overlapping-simulators drop path.
-fn union_decision_dfas(shared: &mut Vec<Dfa>, local: Vec<Dfa>) {
+fn union_decision_dfas(shared: &mut Vec<ParserDfa>, local: Vec<ParserDfa>) {
     if shared.len() != local.len() {
         *shared = local;
         return;
@@ -297,11 +299,11 @@ fn union_prediction_stores(
     union_decision_dfas(&mut shared.decision_to_dfa, local.decision_to_dfa);
 }
 
-fn union_decision_dfa(shared: &mut Dfa, local: Dfa) {
+fn union_decision_dfa(shared: &mut ParserDfa, local: ParserDfa) {
     if shared.is_precedence_dfa() != local.is_precedence_dfa() {
         // A mode flip resets the tables (`set_precedence_dfa`), so the two are
         // not unionable; keep whichever learned more states.
-        if local.states().len() > shared.states().len() {
+        if local.state_count() > shared.state_count() {
             *shared = local;
         }
         return;
@@ -310,50 +312,42 @@ fn union_decision_dfa(shared: &mut Dfa, local: Dfa) {
     // config-set identity, inserting the states shared has not learned.
     // Their edges reference local numbering, so they are cleared here and
     // re-added in pass 2 under the shared numbering.
-    let mut renumber = Vec::with_capacity(local.states().len());
+    let mut renumber = Vec::with_capacity(local.state_count());
     for state in local.states() {
-        let number = shared
-            .state_number_for_configs(&state.configs)
-            .unwrap_or_else(|| {
-                let missing = state.clone_without_edges();
-                shared.insert_state(missing)
-            });
+        let configs = local.configs(state.id());
+        let number = shared.state_id_for_configs(configs).unwrap_or_else(|| {
+            let missing = local.clone_state_without_edges(state.id());
+            shared.insert_state(missing)
+        });
         renumber.push(number);
     }
     // Pass 2: union edges, translating targets into shared numbering. The
     // incumbent's entries win; only gaps are filled. Accept metadata needs no
     // reconciliation: it is a pure function of the config set, and equal
     // config sets produced it through the same accept-time computation.
-    for (state, &mapped) in local.states().iter().zip(&renumber) {
-        for (index, target) in state.edges.iter().enumerate() {
-            let (Some(target), Ok(index)) = (*target, i32::try_from(index)) else {
+    for state in local.states() {
+        let mapped = renumber[state.id().index()];
+        for transition in state.transitions() {
+            let Some(&mapped_target) = renumber.get(transition.target.index()) else {
                 continue;
             };
-            // Inverse of `edge_index`: slot 0 holds EOF (symbol -1).
-            let symbol = index - 1;
-            let Some(&mapped_target) = renumber.get(target) else {
-                continue;
-            };
-            let Some(shared_state) = shared.state_mut(mapped) else {
-                continue;
-            };
-            if shared_state.edge(symbol).is_none() {
-                shared_state.add_edge(symbol, mapped_target);
+            if shared.edge(mapped, transition.symbol).is_none() {
+                shared.add_edge(mapped, transition.symbol, mapped_target);
             }
         }
     }
     if shared.start_state().is_none()
         && let Some(start) = local.start_state()
-        && let Some(&mapped) = renumber.get(start)
+        && let Some(&mapped) = renumber.get(start.index())
     {
         shared.set_start_state(mapped);
     }
-    for (precedence, start) in local.precedence_start_states().iter().enumerate() {
-        let Some(start) = *start else {
+    for (precedence, start) in local.precedence_start_states().iter().copied().enumerate() {
+        if start == NO_DFA_STATE {
             continue;
-        };
+        }
         if shared.precedence_start_state(precedence).is_none()
-            && let Some(&mapped) = renumber.get(start)
+            && let Some(&mapped) = renumber.get(start.index())
         {
             shared.set_precedence_start_state(precedence, mapped);
         }
@@ -365,6 +359,15 @@ impl Drop for ParserAtnSimulator<'_> {
         let Some(key) = self.shared_cache_key else {
             return;
         };
+        #[cfg(feature = "perf-counters")]
+        let publication_started = std::time::Instant::now();
+        #[cfg(feature = "perf-counters")]
+        let published_states = self
+            .store
+            .decision_to_dfa
+            .iter()
+            .map(ParserDfa::state_count)
+            .sum();
         // Check the DFAs back IN by move. The slot is normally vacant because
         // `new_shared` checked them out; it is occupied only when another
         // simulator for the same ATN was created while this one was alive
@@ -379,6 +382,11 @@ impl Drop for ParserAtnSimulator<'_> {
                 cache.insert(key, store);
             }
         });
+        #[cfg(feature = "perf-counters")]
+        crate::perf::record_dfa_cache_publication(
+            publication_started.elapsed().as_nanos(),
+            published_states,
+        );
     }
 }
 
@@ -424,7 +432,7 @@ impl<'a> ParserAtnSimulator<'a> {
         let mut out = String::new();
         let mut seen_one = false;
         for dfa in &self.store.decision_to_dfa {
-            if dfa.states().is_empty() {
+            if dfa.is_empty() {
                 continue;
             }
             if seen_one {
@@ -434,15 +442,11 @@ impl<'a> ParserAtnSimulator<'a> {
             let _ = writeln!(out, "Decision {}:", dfa.decision());
             for state in dfa.states() {
                 let source = dfa_state_display(state);
-                for (index, target) in state.edges.iter().enumerate() {
-                    let Some(target) = target else {
+                for transition in state.transitions() {
+                    let Some(target_state) = dfa.state(transition.target) else {
                         continue;
                     };
-                    let Some(target_state) = dfa.state(*target) else {
-                        continue;
-                    };
-                    let symbol = i32::try_from(index).unwrap_or_default() - 1;
-                    let label = vocabulary.display_name(symbol);
+                    let label = vocabulary.display_name(transition.symbol);
                     let _ = writeln!(out, "{source}-{label}->{}", dfa_state_display(target_state));
                 }
             }
@@ -453,9 +457,20 @@ impl<'a> ParserAtnSimulator<'a> {
     pub fn new_shared(atn: &'static Atn) -> Self {
         let ptr: *const Atn = atn;
         let key = ptr as usize;
+        #[cfg(feature = "perf-counters")]
+        let import_started = std::time::Instant::now();
         let store = SHARED_PREDICTION_STORES
             .with(|cache| cache.borrow_mut().remove(&key))
             .unwrap_or_else(|| PredictionStore::new(atn));
+        #[cfg(feature = "perf-counters")]
+        crate::perf::record_dfa_cache_import(
+            import_started.elapsed().as_nanos(),
+            store
+                .decision_to_dfa
+                .iter()
+                .map(ParserDfa::state_count)
+                .sum(),
+        );
         Self {
             atn,
             store,
@@ -468,8 +483,17 @@ impl<'a> ParserAtnSimulator<'a> {
         }
     }
 
-    pub fn decision_dfas(&self) -> &[Dfa] {
+    pub fn decision_dfas(&self) -> &[ParserDfa] {
         &self.store.decision_to_dfa
+    }
+
+    /// Returns aggregate learned parser-DFA storage and interning measurements.
+    pub fn parser_dfa_stats(&self) -> ParserDfaStats {
+        let mut stats = ParserDfaStats::default();
+        for dfa in &self.store.decision_to_dfa {
+            stats.add_assign(dfa.stats());
+        }
+        stats
     }
 
     /// Returns compact prediction-context allocation and interning totals for
@@ -694,21 +718,21 @@ impl<'a> ParserAtnSimulator<'a> {
         }
         loop {
             let symbol = input.la(1);
-            if let Some(target) = self
+            let target = self
                 .store
                 .decision_to_dfa
                 .get(decision)
-                .and_then(|dfa| dfa.state(state_number))
-                .and_then(|state| state.edge(symbol))
-            {
+                .and_then(|dfa| dfa.edge(state_number, symbol));
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_dfa_edge_lookup(target.is_some());
+            if let Some(target) = target {
                 state_number = target;
             } else {
                 let configs = self
                     .store
                     .decision_to_dfa
                     .get(decision)
-                    .and_then(|dfa| dfa.state(state_number))
-                    .map(|state| state.configs.clone())
+                    .map(|dfa| dfa.configs(state_number).clone())
                     .ok_or(ParserAtnSimulatorError::MissingDfaState(state_number))?;
                 let target = match self.compute_target_state(
                     DfaEdge {
@@ -761,8 +785,7 @@ impl<'a> ParserAtnSimulator<'a> {
                     .store
                     .decision_to_dfa
                     .get(decision)
-                    .and_then(|dfa| dfa.state(state_number))
-                    .map(|state| state.configs.clone())
+                    .map(|dfa| dfa.configs(state_number).clone())
                     && let Some(alt) = self.alt_that_finished_decision_entry_rule(&configs)
                 {
                     return Ok(ParserAtnPrediction {
@@ -862,7 +885,7 @@ impl<'a> ParserAtnSimulator<'a> {
         &self,
         decision: usize,
         decision_state: usize,
-        state_number: usize,
+        state_number: DfaStateId,
     ) -> Option<ParserAtnPrediction> {
         if !self
             .atn
@@ -875,8 +898,7 @@ impl<'a> ParserAtnSimulator<'a> {
             .store
             .decision_to_dfa
             .get(decision)?
-            .state(state_number)?
-            .configs;
+            .configs(state_number);
         let alt = configs
             .configs()
             .iter()
@@ -902,7 +924,7 @@ impl<'a> ParserAtnSimulator<'a> {
         decision_state: usize,
         precedence: i32,
         merge_cache: &mut PredictionWorkspace,
-    ) -> Result<usize, ParserAtnSimulatorError> {
+    ) -> Result<DfaStateId, ParserAtnSimulatorError> {
         if self.store.decision_to_dfa[decision].is_precedence_dfa() {
             let precedence_key = usize::try_from(precedence.max(0)).unwrap_or_default();
             if let Some(start) =
@@ -918,7 +940,7 @@ impl<'a> ParserAtnSimulator<'a> {
             .state(decision_state)
             .ok_or(ParserAtnSimulatorError::MissingAtnState(decision_state))?;
         let configs = self.compute_start_state(decision_state, precedence, merge_cache);
-        let state_number = self.add_dfa_state(decision, DfaState::new(configs));
+        let state_number = self.add_dfa_state(decision, DfaStateBuilder::new(configs));
         if self.store.decision_to_dfa[decision].is_precedence_dfa() {
             let precedence_key = usize::try_from(precedence.max(0)).unwrap_or_default();
             self.store.decision_to_dfa[decision]
@@ -929,16 +951,8 @@ impl<'a> ParserAtnSimulator<'a> {
         Ok(state_number)
     }
 
-    fn add_dfa_state(&mut self, decision: usize, state: DfaState) -> usize {
-        if state.configs.is_readonly() {
-            return self.store.decision_to_dfa[decision].add_state(state);
-        }
-        if let Some(existing) =
-            self.store.decision_to_dfa[decision].state_number_for_configs(&state.configs)
-        {
-            return existing;
-        }
-        self.store.decision_to_dfa[decision].insert_state(state)
+    fn add_dfa_state(&mut self, decision: usize, state: DfaStateBuilder) -> DfaStateId {
+        self.store.decision_to_dfa[decision].add_state(state)
     }
 
     fn compute_start_state(
@@ -1099,22 +1113,24 @@ impl<'a> ParserAtnSimulator<'a> {
         symbol: i32,
         precedence: i32,
         merge_cache: &mut PredictionWorkspace,
-    ) -> Result<usize, ParserAtnSimulatorError> {
+    ) -> Result<DfaStateId, ParserAtnSimulatorError> {
         let mut reach = self.compute_reach_set(configs, symbol, false, precedence, merge_cache);
         if reach.is_empty() {
             if let Some(prediction) = self.alt_that_finished_decision_entry_rule(configs) {
-                let mut dfa_state = DfaState::new(configs.clone());
+                let mut dfa_state = DfaStateBuilder::new(configs.clone());
                 dfa_state.mark_accept(prediction);
                 // The set-wide flag gates the per-alt scan: if no config in the
                 // set carries a semantic context, no alt can either.
-                dfa_state.has_semantic_context_for_alt = dfa_state.configs.has_semantic_context()
-                    && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
+                dfa_state.set_has_semantic_context_for_alt(
+                    configs.has_semantic_context()
+                        && configs_have_semantic_context_for_alt(configs, prediction),
+                );
                 let target_state = self.add_dfa_state(edge.decision, dfa_state);
-                if let Some(source) =
-                    self.store.decision_to_dfa[edge.decision].state_mut(edge.source_state)
-                {
-                    source.add_edge(symbol, target_state);
-                }
+                self.store.decision_to_dfa[edge.decision].add_edge(
+                    edge.source_state,
+                    symbol,
+                    target_state,
+                );
                 return Ok(target_state);
             }
             return Err(ParserAtnSimulatorError::NoViableAlt { symbol, index: 0 });
@@ -1145,21 +1161,20 @@ impl<'a> ParserAtnSimulator<'a> {
         } else {
             Vec::new()
         };
-        let mut dfa_state = DfaState::new(reach);
+        let mut dfa_state = DfaStateBuilder::new(reach);
         if let Some(prediction) = conflict_prediction {
             dfa_state.mark_accept(prediction);
-            dfa_state.requires_full_context = requires_full_context;
-            dfa_state.conflicting_alts = conflicting_alts;
+            dfa_state.set_requires_full_context(requires_full_context);
+            dfa_state.set_conflicting_alts(conflicting_alts);
             // The set-wide flag gates the per-alt scan: if no config in the set
             // carries a semantic context, no alt can either.
-            dfa_state.has_semantic_context_for_alt = dfa_state.configs.has_semantic_context()
-                && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction);
+            dfa_state.set_has_semantic_context_for_alt(
+                dfa_state.configs.has_semantic_context()
+                    && configs_have_semantic_context_for_alt(&dfa_state.configs, prediction),
+            );
         }
         let target_state = self.add_dfa_state(edge.decision, dfa_state);
-        if let Some(source) = self.store.decision_to_dfa[edge.decision].state_mut(edge.source_state)
-        {
-            source.add_edge(symbol, target_state);
-        }
+        self.store.decision_to_dfa[edge.decision].add_edge(edge.source_state, symbol, target_state);
         Ok(target_state)
     }
 
@@ -1478,36 +1493,33 @@ impl<'a> ParserAtnSimulator<'a> {
     fn dfa_prediction_info(
         &self,
         decision: usize,
-        state_number: usize,
+        state_number: DfaStateId,
     ) -> Option<DfaPredictionInfo> {
-        self.store
-            .decision_to_dfa
-            .get(decision)
-            .and_then(|dfa| dfa.state(state_number))
-            .and_then(|state| {
-                state.prediction.map(|alt| {
-                    let conflicting_alts = if state.requires_full_context {
-                        if state.conflicting_alts.is_empty() {
-                            state.configs.alts().into_iter().collect()
-                        } else {
-                            state.conflicting_alts.clone()
-                        }
-                    } else {
-                        Vec::new()
-                    };
-                    DfaPredictionInfo {
-                        prediction: ParserAtnPrediction {
-                            alt,
-                            requires_full_context: state.requires_full_context,
-                            // Precomputed at accept time (see compute_target_state)
-                            // so this warm-hit path avoids an O(configs) rescan.
-                            has_semantic_context: state.has_semantic_context_for_alt,
-                            diagnostic: None,
-                        },
-                        conflicting_alts,
-                    }
-                })
-            })
+        let dfa = self.store.decision_to_dfa.get(decision)?;
+        let state = dfa.state(state_number)?;
+        let alt = state.prediction()?;
+        let requires_full_context = state.requires_full_context();
+        let conflicting_alts = if requires_full_context {
+            let stored = dfa.conflicting_alts(state_number);
+            if stored.is_empty() {
+                dfa.configs(state_number).alts().into_iter().collect()
+            } else {
+                stored.to_vec()
+            }
+        } else {
+            Vec::new()
+        };
+        Some(DfaPredictionInfo {
+            prediction: ParserAtnPrediction {
+                alt,
+                requires_full_context,
+                // Precomputed at accept time (see compute_target_state) so
+                // warm accept lookup does not rescan the cold config set.
+                has_semantic_context: state.has_semantic_context(),
+                diagnostic: None,
+            },
+            conflicting_alts,
+        })
     }
 }
 
@@ -1593,28 +1605,28 @@ fn configs_have_semantic_context_for_alt(configs: &AtnConfigSet, alt: usize) -> 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ParserAtnSimulatorError {
     MissingAtnState(usize),
-    MissingDfaState(usize),
+    MissingDfaState(DfaStateId),
     NoViableAlt { symbol: i32, index: usize },
     PredictionRequiresMoreLookahead,
     UnknownDecision(usize),
 }
 
 /// Java `DFASerializer.getStateString`: `:sN^=>alt` for accept states.
-fn dfa_state_display(state: &DfaState) -> String {
+fn dfa_state_display(state: ParserDfaStateView<'_>) -> String {
     let mut out = String::new();
-    if state.is_accept_state {
+    if state.is_accept_state() {
         out.push(':');
     }
     out.push('s');
-    out.push_str(&state.state_number.to_string());
-    if state.requires_full_context {
+    out.push_str(&state.id().index().to_string());
+    if state.requires_full_context() {
         out.push('^');
     }
-    if state.is_accept_state {
+    if state.is_accept_state() {
         out.push_str("=>");
         out.push_str(
             &state
-                .prediction
+                .prediction()
                 .map(|prediction| prediction.to_string())
                 .unwrap_or_default(),
         );
@@ -1646,8 +1658,8 @@ mod tests {
             atn_state: usize,
             arena: &mut ContextArena,
             workspace: &mut PredictionWorkspace,
-        ) -> DfaState {
-            DfaState::new(configs(atn_state, arena, workspace))
+        ) -> DfaStateBuilder {
+            DfaStateBuilder::new(configs(atn_state, arena, workspace))
         }
         let mut arena = ContextArena::new();
         let mut workspace = PredictionWorkspace::default();
@@ -1655,34 +1667,27 @@ mod tests {
         // Two DFAs that evolved independently from the same grammar: equal
         // state/edge counts, but disjoint transitions and different state
         // numbering for the shared successor.
-        let mut shared = Dfa::with_max_token_type(0, 0, 8);
+        let mut shared = ParserDfa::with_max_token_type(0, 0, 8);
         let shared_root = shared.add_state(state(10, &mut arena, &mut workspace));
         let shared_a = shared.add_state(state(11, &mut arena, &mut workspace));
-        shared
-            .state_mut(shared_root)
-            .expect("shared root")
-            .add_edge(1, shared_a);
+        shared.add_edge(shared_root, 1, shared_a);
         shared.set_start_state(shared_root);
 
-        let mut local = Dfa::with_max_token_type(0, 0, 8);
+        let mut local = ParserDfa::with_max_token_type(0, 0, 8);
         let local_b = local.add_state(state(12, &mut arena, &mut workspace));
         let local_root = local.add_state(state(10, &mut arena, &mut workspace));
-        local
-            .state_mut(local_root)
-            .expect("local root")
-            .add_edge(2, local_b);
+        local.add_edge(local_root, 2, local_b);
         local.set_precedence_start_state(3, local_root);
 
         union_decision_dfa(&mut shared, local);
 
         // The root (same config set) gained local's edge without losing its
         // own, with the target re-keyed into shared numbering.
-        let root = shared.state(shared_root).expect("root");
-        assert_eq!(root.edge(1), Some(shared_a));
+        assert_eq!(shared.edge(shared_root, 1), Some(shared_a));
         let merged_b = shared
-            .state_number_for_configs(&configs(12, &mut arena, &mut workspace))
+            .state_id_for_configs(&configs(12, &mut arena, &mut workspace))
             .expect("local-only state adopted");
-        assert_eq!(root.edge(2), Some(merged_b));
+        assert_eq!(shared.edge(shared_root, 2), Some(merged_b));
         assert_eq!(shared.states().len(), 3);
         // Start-state gaps fill from local; incumbents are kept.
         assert_eq!(shared.start_state(), Some(shared_root));
@@ -1706,14 +1711,13 @@ mod tests {
             &mut local.contexts,
             &mut workspace,
         );
-        local.decision_to_dfa[0].add_state(DfaState::new(configs));
+        local.decision_to_dfa[0].add_state(DfaStateBuilder::new(configs));
 
         union_prediction_stores(&mut shared, local, &mut workspace);
 
         let imported = shared.decision_to_dfa[0]
             .states()
-            .iter()
-            .flat_map(|state| state.configs.configs())
+            .flat_map(|state| shared.decision_to_dfa[0].configs(state.id()).configs())
             .find(|config| config.state == 42)
             .expect("local DFA config imported");
         assert_ne!(imported.context, local_context);
@@ -1831,9 +1835,9 @@ mod tests {
             .and_then(|state| state.edge(1))
             .expect("edge for token 1");
         let state = dfa.state(target).expect("target state");
-        assert!(state.is_accept_state);
-        assert!(state.requires_full_context);
-        assert_eq!(state.prediction, Some(1));
+        assert!(state.is_accept_state());
+        assert!(state.requires_full_context());
+        assert_eq!(state.prediction(), Some(1));
     }
 
     #[test]
@@ -1934,7 +1938,8 @@ mod tests {
             &mut simulator.store.contexts,
             &mut workspace,
         );
-        let start = simulator.store.decision_to_dfa[0].add_state(DfaState::new(start_configs));
+        let start =
+            simulator.store.decision_to_dfa[0].add_state(DfaStateBuilder::new(start_configs));
         simulator.store.decision_to_dfa[0].set_start_state(start);
 
         let mut accept_configs = AtnConfigSet::new();
@@ -1949,15 +1954,12 @@ mod tests {
             &mut simulator.store.contexts,
             &mut workspace,
         );
-        let mut accept_state = DfaState::new(accept_configs);
+        let mut accept_state = DfaStateBuilder::new(accept_configs);
         accept_state.mark_accept(1);
-        accept_state.requires_full_context = true;
-        accept_state.conflicting_alts = vec![1, 2];
+        accept_state.set_requires_full_context(true);
+        accept_state.set_conflicting_alts(vec![1, 2]);
         let accept = simulator.store.decision_to_dfa[0].add_state(accept_state);
-        simulator.store.decision_to_dfa[0]
-            .state_mut(start)
-            .expect("start state")
-            .add_edge(1, accept);
+        simulator.store.decision_to_dfa[0].add_edge(start, 1, accept);
 
         let mut input = VecIntStream::new(vec![1, 3, TOKEN_EOF]);
         let prediction = simulator

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -7441,6 +7441,14 @@ where
     }}
 
     #[must_use]
+    pub fn parser_dfa_stats(&self) -> antlr4_runtime::ParserDfaStats {{
+        self.simulator.as_ref().map_or_else(
+            antlr4_runtime::ParserDfaStats::default,
+            antlr4_runtime::ParserAtnSimulator::parser_dfa_stats,
+        )
+    }}
+
+    #[must_use]
     pub fn node(&self, id: antlr4_runtime::NodeId) -> antlr4_runtime::Node<'_> {{
         self.base.node(id)
     }}

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -1,28 +1,151 @@
-use crate::prediction::{AtnConfigSet, ContextArena, ContextId};
-use std::collections::BTreeMap;
+use crate::prediction::{AtnConfigSet, ContextArena, ContextId, PredictionFxHasher};
+use std::collections::HashMap;
+use std::hash::BuildHasherDefault;
+use std::mem::size_of;
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct Dfa {
+type FxHashMap<K, V> = HashMap<K, V, BuildHasherDefault<PredictionFxHasher>>;
+
+const NO_EDGE_INDEX: u32 = u32::MAX;
+const NO_PREDICTION: u32 = u32::MAX;
+const ACCEPT_STATE: u8 = 1 << 0;
+const REQUIRES_FULL_CONTEXT: u8 = 1 << 1;
+const HAS_SEMANTIC_CONTEXT: u8 = 1 << 2;
+
+// Across the protected Kotlin, C#, Java, and Trino fixtures, rows with fewer
+// than eight edges were overwhelmingly sparse. Above that point, dense rows
+// won once at least one eighth of a bounded vocabulary was populated.
+const DENSE_MAX_ROW_WIDTH: u32 = 512;
+const DENSE_MIN_EDGES: u32 = 8;
+const DENSE_DENSITY_DENOMINATOR: u32 = 8;
+
+fn compact_index(index: usize, message: &'static str) -> u32 {
+    u32::try_from(index)
+        .ok()
+        .filter(|value| *value != u32::MAX)
+        .expect(message)
+}
+
+/// Compact identity for one learned parser-DFA state.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct DfaStateId(u32);
+
+pub(crate) const NO_DFA_STATE: DfaStateId = DfaStateId(u32::MAX);
+
+impl DfaStateId {
+    fn from_index(index: usize) -> Self {
+        Self(compact_index(
+            index,
+            "parser DFA state count must fit below the u32 sentinel",
+        ))
+    }
+
+    /// Returns this state's zero-based diagnostic index.
+    pub fn index(self) -> usize {
+        usize::try_from(self.0).expect("u32 DFA state ID fits in usize")
+    }
+}
+
+/// Read-only transition exposed by parser-DFA diagnostics.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DfaTransition {
+    pub source: DfaStateId,
+    pub symbol: i32,
+    pub target: DfaStateId,
+}
+
+/// Storage and learning measurements for one parser DFA.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ParserDfaStats {
+    pub states: usize,
+    pub transitions: usize,
+    pub max_row_width: usize,
+    pub dense_rows: usize,
+    pub sparse_rows: usize,
+    pub empty_rows: usize,
+    pub dense_slots: usize,
+    pub sparse_entries: usize,
+    /// Widths <=64, <=128, <=256, <=512, and >512.
+    pub row_width_histogram: [usize; 5],
+    /// Populated-edge counts 0, 1, 2-3, 4-7, 8-15, and >=16.
+    pub populated_edge_histogram: [usize; 6],
+    /// Empty, <=1%, <=5%, <=12.5%, <=25%, and >25% populated rows.
+    pub edge_density_histogram: [usize; 6],
+    pub hot_bytes: usize,
+    pub cold_bytes: usize,
+    pub states_created: usize,
+    pub states_deduplicated: usize,
+    pub fingerprint_candidates: usize,
+    pub fingerprint_collisions: usize,
+}
+
+impl ParserDfaStats {
+    pub(crate) fn add_assign(&mut self, other: Self) {
+        self.states = self.states.saturating_add(other.states);
+        self.transitions = self.transitions.saturating_add(other.transitions);
+        self.max_row_width = self.max_row_width.max(other.max_row_width);
+        self.dense_rows = self.dense_rows.saturating_add(other.dense_rows);
+        self.sparse_rows = self.sparse_rows.saturating_add(other.sparse_rows);
+        self.empty_rows = self.empty_rows.saturating_add(other.empty_rows);
+        self.dense_slots = self.dense_slots.saturating_add(other.dense_slots);
+        self.sparse_entries = self.sparse_entries.saturating_add(other.sparse_entries);
+        for (total, value) in self
+            .row_width_histogram
+            .iter_mut()
+            .zip(other.row_width_histogram)
+        {
+            *total = total.saturating_add(value);
+        }
+        for (total, value) in self
+            .populated_edge_histogram
+            .iter_mut()
+            .zip(other.populated_edge_histogram)
+        {
+            *total = total.saturating_add(value);
+        }
+        for (total, value) in self
+            .edge_density_histogram
+            .iter_mut()
+            .zip(other.edge_density_histogram)
+        {
+            *total = total.saturating_add(value);
+        }
+        self.hot_bytes = self.hot_bytes.saturating_add(other.hot_bytes);
+        self.cold_bytes = self.cold_bytes.saturating_add(other.cold_bytes);
+        self.states_created = self.states_created.saturating_add(other.states_created);
+        self.states_deduplicated = self
+            .states_deduplicated
+            .saturating_add(other.states_deduplicated);
+        self.fingerprint_candidates = self
+            .fingerprint_candidates
+            .saturating_add(other.fingerprint_candidates);
+        self.fingerprint_collisions = self
+            .fingerprint_collisions
+            .saturating_add(other.fingerprint_collisions);
+    }
+}
+
+/// Opaque learned parser DFA with split hot transition and cold ATN-config data.
+#[derive(Debug)]
+pub struct ParserDfa {
     decision: usize,
     atn_start_state: usize,
     max_token_type: i32,
-    states: Vec<DfaState>,
-    state_index: BTreeMap<AtnConfigSet, usize>,
-    start_state: Option<usize>,
-    precedence_start_states: Vec<Option<usize>>,
+    hot: DfaHotTables,
+    cold: DfaColdStore,
+    interner: DfaStateInterner,
+    start_state: DfaStateId,
+    precedence_start_states: Vec<DfaStateId>,
     precedence_mode: bool,
-    /// Set whenever a state, edge, or start state is learned. Lets the shared
-    /// decision-DFA cache skip cloning DFAs that a parse never extended, avoiding
-    /// per-parse churn when the cache is already warm. Not part of DFA identity.
-    dirty: bool,
+    learning: DfaLearningCounters,
 }
 
-impl Dfa {
-    pub const fn new(atn_start_state: usize, decision: usize) -> Self {
+impl ParserDfa {
+    pub fn new(atn_start_state: usize, decision: usize) -> Self {
         Self::with_max_token_type(atn_start_state, decision, 0)
     }
 
-    pub const fn with_max_token_type(
+    pub fn with_max_token_type(
         atn_start_state: usize,
         decision: usize,
         max_token_type: i32,
@@ -31,12 +154,13 @@ impl Dfa {
             decision,
             atn_start_state,
             max_token_type,
-            states: Vec::new(),
-            state_index: BTreeMap::new(),
-            start_state: None,
+            hot: DfaHotTables::new(max_token_type),
+            cold: DfaColdStore::default(),
+            interner: DfaStateInterner::default(),
+            start_state: NO_DFA_STATE,
             precedence_start_states: Vec::new(),
             precedence_mode: false,
-            dirty: false,
+            learning: DfaLearningCounters::default(),
         }
     }
 
@@ -52,142 +176,290 @@ impl Dfa {
         self.max_token_type
     }
 
-    pub fn states(&self) -> &[DfaState] {
-        &self.states
+    pub const fn state_count(&self) -> usize {
+        self.hot.len()
     }
 
-    pub const fn start_state(&self) -> Option<usize> {
-        self.start_state
+    pub const fn is_empty(&self) -> bool {
+        self.hot.is_empty()
     }
 
-    pub const fn set_start_state(&mut self, state_number: usize) {
-        self.start_state = Some(state_number);
-        self.dirty = true;
+    pub fn states(&self) -> impl ExactSizeIterator<Item = ParserDfaStateView<'_>> {
+        (0..self.state_count()).map(|index| ParserDfaStateView {
+            dfa: self,
+            id: DfaStateId::from_index(index),
+        })
     }
 
-    /// Whether this DFA learned any new state/edge/start since it was created or
-    /// last cleared. The shared-cache merge uses this to skip untouched DFAs.
-    pub const fn is_dirty(&self) -> bool {
-        self.dirty
+    pub fn state(&self, id: DfaStateId) -> Option<ParserDfaStateView<'_>> {
+        (id.index() < self.state_count()).then_some(ParserDfaStateView { dfa: self, id })
     }
 
-    /// Clears the dirty flag, marking the current contents as the clean baseline
-    /// (called after publishing to / cloning from the shared cache).
-    pub const fn clear_dirty(&mut self) {
-        self.dirty = false;
+    pub fn transitions(&self) -> impl Iterator<Item = DfaTransition> + '_ {
+        self.states().flat_map(ParserDfaStateView::transitions)
+    }
+
+    pub fn start_state(&self) -> Option<DfaStateId> {
+        (self.start_state != NO_DFA_STATE).then_some(self.start_state)
+    }
+
+    pub(crate) fn set_start_state(&mut self, state: DfaStateId) {
+        self.assert_valid_state(state);
+        self.start_state = state;
     }
 
     pub const fn is_precedence_dfa(&self) -> bool {
         self.precedence_mode
     }
 
-    pub fn set_precedence_dfa(&mut self, precedence_dfa: bool) {
+    pub(crate) fn set_precedence_dfa(&mut self, precedence_dfa: bool) {
         if self.precedence_mode == precedence_dfa {
             return;
         }
-        self.states.clear();
-        self.state_index.clear();
-        self.start_state = None;
+        self.hot.clear();
+        self.cold.clear();
+        self.interner.clear();
+        self.start_state = NO_DFA_STATE;
         self.precedence_start_states.clear();
         self.precedence_mode = precedence_dfa;
-        self.dirty = true;
         if precedence_dfa {
-            self.start_state = Some(self.add_state(DfaState::new(AtnConfigSet::new())));
+            let state = self.add_state(DfaStateBuilder::new(AtnConfigSet::new()));
+            self.start_state = state;
         }
     }
 
-    pub fn precedence_start_state(&self, precedence: usize) -> Option<usize> {
+    pub fn precedence_start_state(&self, precedence: usize) -> Option<DfaStateId> {
         self.precedence_start_states
             .get(precedence)
-            .and_then(|state| *state)
+            .copied()
+            .filter(|state| *state != NO_DFA_STATE)
     }
 
-    pub(crate) fn precedence_start_states(&self) -> &[Option<usize>] {
+    pub(crate) fn precedence_start_states(&self) -> &[DfaStateId] {
         &self.precedence_start_states
     }
 
-    pub fn set_precedence_start_state(&mut self, precedence: usize, state_number: usize) {
+    pub(crate) fn set_precedence_start_state(&mut self, precedence: usize, state: DfaStateId) {
+        self.assert_valid_state(state);
         if precedence >= self.precedence_start_states.len() {
-            self.precedence_start_states.resize(precedence + 1, None);
+            self.precedence_start_states
+                .resize(precedence + 1, NO_DFA_STATE);
         }
-        self.precedence_start_states[precedence] = Some(state_number);
-        self.dirty = true;
+        self.precedence_start_states[precedence] = state;
     }
 
-    /// Inserts a DFA state or returns the existing state number for an
-    /// equivalent ATN configuration set.
-    pub fn add_state(&mut self, state: DfaState) -> usize {
-        if let Some(existing) = self.state_number_for_configs(&state.configs) {
+    pub fn stats(&self) -> ParserDfaStats {
+        let edge_stats = self.hot.edges.stats();
+        ParserDfaStats {
+            states: self.state_count(),
+            transitions: edge_stats.transitions,
+            max_row_width: edge_stats.max_row_width,
+            dense_rows: edge_stats.dense_rows,
+            sparse_rows: edge_stats.sparse_rows,
+            empty_rows: edge_stats.empty_rows,
+            dense_slots: edge_stats.dense_slots,
+            sparse_entries: edge_stats.sparse_entries,
+            row_width_histogram: edge_stats.row_width_histogram,
+            populated_edge_histogram: edge_stats.populated_edge_histogram,
+            edge_density_histogram: edge_stats.edge_density_histogram,
+            hot_bytes: self.hot.retained_bytes()
+                + self.interner.retained_bytes()
+                + self.precedence_start_states.capacity() * size_of::<DfaStateId>(),
+            cold_bytes: self.cold.retained_bytes(),
+            states_created: self.learning.states_created,
+            states_deduplicated: self.learning.states_deduplicated,
+            fingerprint_candidates: self.learning.fingerprint_candidates,
+            fingerprint_collisions: self.learning.fingerprint_collisions,
+        }
+    }
+
+    pub(crate) fn add_state(&mut self, state: DfaStateBuilder) -> DfaStateId {
+        let fingerprint = state.configs.fingerprint();
+        if let Some(existing) = self.find_state(fingerprint, &state.configs) {
+            self.learning.states_deduplicated = self.learning.states_deduplicated.saturating_add(1);
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_dfa_state_deduplicated();
             return existing;
         }
-        self.insert_state(state)
+        self.insert_state_with_fingerprint(state, fingerprint)
     }
 
-    pub(crate) fn insert_state(&mut self, mut state: DfaState) -> usize {
-        let state_number = self.states.len();
-        state.state_number = state_number;
-        state.ensure_edge_capacity(self.max_token_type);
-        let state_key = state.configs.clone();
-        state.configs.set_readonly(true);
-        self.state_index.insert(state_key, state_number);
-        self.states.push(state);
-        self.dirty = true;
-        state_number
+    pub(crate) fn insert_state(&mut self, state: DfaStateBuilder) -> DfaStateId {
+        let fingerprint = state.configs.fingerprint();
+        self.insert_state_with_fingerprint(state, fingerprint)
     }
 
-    pub(crate) fn state_number_for_configs(&self, configs: &AtnConfigSet) -> Option<usize> {
-        self.state_index.get(configs).copied()
+    fn insert_state_with_fingerprint(
+        &mut self,
+        state: DfaStateBuilder,
+        fingerprint: u64,
+    ) -> DfaStateId {
+        let id = DfaStateId::from_index(self.state_count());
+        let DfaStateBuilder {
+            mut configs,
+            prediction,
+            requires_full_context,
+            conflicting_alts,
+            has_semantic_context_for_alt,
+        } = state;
+        configs.set_readonly(true);
+        self.hot.push_state(
+            prediction,
+            requires_full_context,
+            has_semantic_context_for_alt,
+        );
+        self.cold.push(configs, conflicting_alts);
+        self.interner.insert(fingerprint, id);
+        self.learning.states_created = self.learning.states_created.saturating_add(1);
+        #[cfg(feature = "perf-counters")]
+        crate::perf::record_dfa_state_created();
+        id
     }
 
-    pub fn state(&self, state_number: usize) -> Option<&DfaState> {
-        self.states.get(state_number)
+    pub(crate) fn state_id_for_configs(&mut self, configs: &AtnConfigSet) -> Option<DfaStateId> {
+        let state = self.find_state(configs.fingerprint(), configs);
+        if state.is_some() {
+            self.learning.states_deduplicated = self.learning.states_deduplicated.saturating_add(1);
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_dfa_state_deduplicated();
+        }
+        state
     }
 
-    pub fn state_mut(&mut self, state_number: usize) -> Option<&mut DfaState> {
-        // Handing out a mutable state (used to add learned edges) conservatively
-        // marks the DFA dirty so the shared-cache merge re-publishes it.
-        self.dirty = true;
-        self.states.get_mut(state_number)
+    fn find_state(&mut self, fingerprint: u64, configs: &AtnConfigSet) -> Option<DfaStateId> {
+        let mut candidate = self.interner.head(fingerprint);
+        while candidate != NO_DFA_STATE {
+            self.learning.fingerprint_candidates =
+                self.learning.fingerprint_candidates.saturating_add(1);
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_dfa_fingerprint_candidate();
+            if self.configs(candidate) == configs {
+                return Some(candidate);
+            }
+            self.learning.fingerprint_collisions =
+                self.learning.fingerprint_collisions.saturating_add(1);
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_dfa_fingerprint_collision();
+            candidate = self.interner.next(candidate);
+        }
+        None
+    }
+
+    pub(crate) fn edge(&self, source: DfaStateId, symbol: i32) -> Option<DfaStateId> {
+        self.hot.edges.target(source, symbol)
+    }
+
+    pub(crate) fn add_edge(&mut self, source: DfaStateId, symbol: i32, target: DfaStateId) {
+        self.assert_valid_state(source);
+        self.assert_valid_state(target);
+        self.hot.edges.add(source, symbol, target);
+    }
+
+    pub(crate) fn configs(&self, state: DfaStateId) -> &AtnConfigSet {
+        &self.cold.configs[state.index()]
+    }
+
+    pub(crate) fn conflicting_alts(&self, state: DfaStateId) -> &[usize] {
+        &self.cold.extras[state.index()].conflicting_alts
+    }
+
+    pub(crate) fn clone_state_without_edges(&self, state: DfaStateId) -> DfaStateBuilder {
+        let index = state.index();
+        DfaStateBuilder {
+            configs: self.cold.configs[index].clone(),
+            prediction: self.hot.prediction(state),
+            requires_full_context: self.hot.has_flag(state, REQUIRES_FULL_CONTEXT),
+            conflicting_alts: self.cold.extras[index].conflicting_alts.clone(),
+            has_semantic_context_for_alt: self.hot.has_flag(state, HAS_SEMANTIC_CONTEXT),
+        }
     }
 
     pub(crate) fn remap_contexts(&mut self, remap: &[ContextId], arena: &ContextArena) {
-        self.state_index.clear();
-        for (state_number, state) in self.states.iter_mut().enumerate() {
-            state.configs.remap_contexts(remap, arena);
-            self.state_index
-                .insert(state.configs.clone(), state_number);
+        for configs in &mut self.cold.configs {
+            configs.remap_contexts(remap, arena);
         }
+        self.interner.rebuild(&self.cold.configs);
+    }
+
+    fn assert_valid_state(&self, state: DfaStateId) {
+        assert_ne!(state, NO_DFA_STATE, "DFA state ID cannot be the sentinel");
+        assert!(
+            state.index() < self.state_count(),
+            "DFA state ID must index aligned hot/cold storage"
+        );
     }
 }
 
-#[derive(Debug, Eq, PartialEq)]
-pub struct DfaState {
-    pub state_number: usize,
-    pub(crate) configs: AtnConfigSet,
-    pub edges: Vec<Option<usize>>,
-    pub is_accept_state: bool,
-    pub prediction: Option<usize>,
-    pub requires_full_context: bool,
-    pub conflicting_alts: Vec<usize>,
-    /// Whether any config for the predicted alt carries a semantic context.
-    /// Precomputed once at accept time (mirrors Go's `DFAState.predicates`) so
-    /// warm DFA hits don't rescan `configs` on every prediction lookup. Only
-    /// meaningful when `prediction` is `Some`; `false` for non-accept states.
-    ///
-    /// Crate-private: this is an internal derived cache (a pure function of
-    /// `configs` + `prediction`), kept off the public `DfaState` contract so it
-    /// is neither a struct-literal source break nor a surprising participant in
-    /// the public type's identity.
-    pub(crate) has_semantic_context_for_alt: bool,
+/// Borrowing diagnostic view over one parser-DFA state.
+#[derive(Clone, Copy)]
+pub struct ParserDfaStateView<'a> {
+    dfa: &'a ParserDfa,
+    id: DfaStateId,
 }
 
-impl DfaState {
+impl std::fmt::Debug for ParserDfaStateView<'_> {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("ParserDfaStateView")
+            .field("id", &self.id)
+            .field("is_accept_state", &self.is_accept_state())
+            .field("prediction", &self.prediction())
+            .field("requires_full_context", &self.requires_full_context())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> ParserDfaStateView<'a> {
+    pub const fn id(self) -> DfaStateId {
+        self.id
+    }
+
+    pub fn is_accept_state(self) -> bool {
+        self.dfa.hot.has_flag(self.id, ACCEPT_STATE)
+    }
+
+    pub fn prediction(self) -> Option<usize> {
+        self.dfa.hot.prediction(self.id)
+    }
+
+    pub fn requires_full_context(self) -> bool {
+        self.dfa.hot.has_flag(self.id, REQUIRES_FULL_CONTEXT)
+    }
+
+    pub fn has_semantic_context(self) -> bool {
+        self.dfa.hot.has_flag(self.id, HAS_SEMANTIC_CONTEXT)
+    }
+
+    pub fn edge(self, symbol: i32) -> Option<DfaStateId> {
+        self.dfa.edge(self.id, symbol)
+    }
+
+    pub fn transitions(self) -> impl Iterator<Item = DfaTransition> + 'a {
+        self.dfa
+            .hot
+            .edges
+            .transitions(self.id)
+            .map(move |(symbol, target)| DfaTransition {
+                source: self.id,
+                symbol,
+                target,
+            })
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct DfaStateBuilder {
+    pub(crate) configs: AtnConfigSet,
+    prediction: Option<usize>,
+    requires_full_context: bool,
+    conflicting_alts: Vec<usize>,
+    has_semantic_context_for_alt: bool,
+}
+
+impl DfaStateBuilder {
     pub(crate) const fn new(configs: AtnConfigSet) -> Self {
         Self {
-            state_number: usize::MAX,
             configs,
-            edges: Vec::new(),
-            is_accept_state: false,
             prediction: None,
             requires_full_context: false,
             conflicting_alts: Vec::new(),
@@ -195,100 +467,787 @@ impl DfaState {
         }
     }
 
-    pub fn add_edge(&mut self, symbol: i32, target_state: usize) {
-        let Some(index) = edge_index(symbol) else {
-            return;
-        };
-        if index >= self.edges.len() {
-            self.edges.resize(index + 1, None);
-        }
-        self.edges[index] = Some(target_state);
-    }
-
-    pub fn edge(&self, symbol: i32) -> Option<usize> {
-        edge_index(symbol)
-            .and_then(|index| self.edges.get(index))
-            .and_then(|state| *state)
-    }
-
-    pub const fn mark_accept(&mut self, prediction: usize) {
-        self.is_accept_state = true;
+    pub(crate) const fn mark_accept(&mut self, prediction: usize) {
         self.prediction = Some(prediction);
     }
 
-    fn ensure_edge_capacity(&mut self, max_token_type: i32) {
-        let Ok(max) = usize::try_from(max_token_type) else {
-            return;
-        };
-        if self.edges.len() < max + 2 {
-            self.edges.resize(max + 2, None);
+    pub(crate) const fn set_requires_full_context(&mut self, required: bool) {
+        self.requires_full_context = required;
+    }
+
+    pub(crate) fn set_conflicting_alts(&mut self, conflicting_alts: Vec<usize>) {
+        self.conflicting_alts = conflicting_alts;
+    }
+
+    pub(crate) const fn set_has_semantic_context_for_alt(&mut self, has_semantic: bool) {
+        self.has_semantic_context_for_alt = has_semantic;
+    }
+}
+
+#[derive(Debug)]
+struct DfaHotTables {
+    edges: EdgeTable,
+    accept_predictions: Vec<u32>,
+    flags: Vec<u8>,
+}
+
+impl DfaHotTables {
+    fn new(max_token_type: i32) -> Self {
+        Self {
+            edges: EdgeTable::new(max_token_type),
+            accept_predictions: Vec::new(),
+            flags: Vec::new(),
         }
     }
 
-    pub(crate) fn clone_without_edges(&self) -> Self {
+    fn push_state(
+        &mut self,
+        prediction: Option<usize>,
+        requires_full_context: bool,
+        has_semantic_context: bool,
+    ) {
+        self.edges.push_row();
+        let prediction = prediction.map_or(NO_PREDICTION, |prediction| {
+            compact_index(prediction, "DFA prediction must fit below the u32 sentinel")
+        });
+        self.accept_predictions.push(prediction);
+        let mut flags = 0;
+        if prediction != NO_PREDICTION {
+            flags |= ACCEPT_STATE;
+        }
+        if requires_full_context {
+            flags |= REQUIRES_FULL_CONTEXT;
+        }
+        if has_semantic_context {
+            flags |= HAS_SEMANTIC_CONTEXT;
+        }
+        self.flags.push(flags);
+        debug_assert_eq!(self.edges.len(), self.accept_predictions.len());
+        debug_assert_eq!(self.edges.len(), self.flags.len());
+    }
+
+    fn prediction(&self, state: DfaStateId) -> Option<usize> {
+        let prediction = self.accept_predictions[state.index()];
+        (prediction != NO_PREDICTION)
+            .then(|| usize::try_from(prediction).expect("u32 DFA prediction fits in usize"))
+    }
+
+    fn has_flag(&self, state: DfaStateId, flag: u8) -> bool {
+        self.flags[state.index()] & flag != 0
+    }
+
+    const fn len(&self) -> usize {
+        self.flags.len()
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.flags.is_empty()
+    }
+
+    fn clear(&mut self) {
+        self.edges.clear();
+        self.accept_predictions.clear();
+        self.flags.clear();
+    }
+
+    const fn retained_bytes(&self) -> usize {
+        self.edges.retained_bytes()
+            + self.accept_predictions.capacity() * size_of::<u32>()
+            + self.flags.capacity() * size_of::<u8>()
+    }
+}
+
+#[derive(Debug, Default)]
+struct DfaColdStore {
+    configs: Vec<AtnConfigSet>,
+    extras: Vec<DfaColdExtras>,
+}
+
+impl DfaColdStore {
+    fn push(&mut self, configs: AtnConfigSet, conflicting_alts: Vec<usize>) {
+        self.configs.push(configs);
+        self.extras.push(DfaColdExtras { conflicting_alts });
+        debug_assert_eq!(self.configs.len(), self.extras.len());
+    }
+
+    fn clear(&mut self) {
+        self.configs.clear();
+        self.extras.clear();
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.configs.capacity() * size_of::<AtnConfigSet>()
+            + self.extras.capacity() * size_of::<DfaColdExtras>()
+            + self
+                .configs
+                .iter()
+                .map(AtnConfigSet::retained_bytes)
+                .sum::<usize>()
+            + self
+                .extras
+                .iter()
+                .map(|extra| extra.conflicting_alts.capacity() * size_of::<usize>())
+                .sum::<usize>()
+    }
+}
+
+#[derive(Debug, Default)]
+struct DfaColdExtras {
+    conflicting_alts: Vec<usize>,
+}
+
+#[derive(Debug, Default)]
+struct DfaStateInterner {
+    heads: FxHashMap<u64, DfaStateId>,
+    next: Vec<DfaStateId>,
+}
+
+impl DfaStateInterner {
+    fn head(&self, fingerprint: u64) -> DfaStateId {
+        self.heads
+            .get(&fingerprint)
+            .copied()
+            .unwrap_or(NO_DFA_STATE)
+    }
+
+    fn next(&self, state: DfaStateId) -> DfaStateId {
+        self.next[state.index()]
+    }
+
+    fn insert(&mut self, fingerprint: u64, state: DfaStateId) {
+        debug_assert_eq!(state.index(), self.next.len());
+        let previous = self
+            .heads
+            .insert(fingerprint, state)
+            .unwrap_or(NO_DFA_STATE);
+        self.next.push(previous);
+    }
+
+    fn rebuild(&mut self, configs: &[AtnConfigSet]) {
+        self.clear();
+        self.next.reserve(configs.len());
+        for (index, configs) in configs.iter().enumerate() {
+            self.insert(configs.fingerprint(), DfaStateId::from_index(index));
+        }
+    }
+
+    fn clear(&mut self) {
+        self.heads.clear();
+        self.next.clear();
+    }
+
+    fn retained_bytes(&self) -> usize {
+        self.heads.capacity() * size_of::<(u64, DfaStateId)>()
+            + self.next.capacity() * size_of::<DfaStateId>()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct DfaLearningCounters {
+    states_created: usize,
+    states_deduplicated: usize,
+    fingerprint_candidates: usize,
+    fingerprint_collisions: usize,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+enum EdgeRow {
+    #[default]
+    Empty,
+    Inline {
+        symbol: i32,
+        target: DfaStateId,
+    },
+    Sparse {
+        head: u32,
+        len: u32,
+    },
+    Dense {
+        start: u32,
+        populated: u32,
+    },
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SparseEdge {
+    symbol: i32,
+    target: DfaStateId,
+    next: u32,
+}
+
+#[derive(Debug)]
+struct EdgeTable {
+    width: u32,
+    rows: Vec<EdgeRow>,
+    dense_targets: Vec<DfaStateId>,
+    sparse_edges: Vec<SparseEdge>,
+}
+
+impl EdgeTable {
+    fn new(max_token_type: i32) -> Self {
+        let width = i64::from(max_token_type)
+            .checked_add(2)
+            .and_then(|value| u32::try_from(value).ok())
+            .unwrap_or(0);
         Self {
-            state_number: self.state_number,
-            configs: self.configs.clone(),
-            edges: Vec::new(),
-            is_accept_state: self.is_accept_state,
-            prediction: self.prediction,
-            requires_full_context: self.requires_full_context,
-            conflicting_alts: self.conflicting_alts.clone(),
-            has_semantic_context_for_alt: self.has_semantic_context_for_alt,
+            width,
+            rows: Vec::new(),
+            dense_targets: Vec::new(),
+            sparse_edges: Vec::new(),
+        }
+    }
+
+    fn push_row(&mut self) {
+        self.rows.push(EdgeRow::default());
+    }
+
+    const fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    fn target(&self, state: DfaStateId, symbol: i32) -> Option<DfaStateId> {
+        let slot = self.slot(symbol)?;
+        match *self.rows.get(state.index())? {
+            EdgeRow::Empty => None,
+            EdgeRow::Inline {
+                symbol: stored,
+                target,
+            } => (stored == symbol).then_some(target),
+            EdgeRow::Dense { start, .. } => {
+                let index = usize::try_from(start.checked_add(slot)?).ok()?;
+                self.dense_targets
+                    .get(index)
+                    .copied()
+                    .filter(|target| *target != NO_DFA_STATE)
+            }
+            EdgeRow::Sparse { mut head, .. } => {
+                while head != NO_EDGE_INDEX {
+                    let edge = self.sparse_edges[usize::try_from(head).ok()?];
+                    match edge.symbol.cmp(&symbol) {
+                        std::cmp::Ordering::Less => head = edge.next,
+                        std::cmp::Ordering::Equal => return Some(edge.target),
+                        std::cmp::Ordering::Greater => return None,
+                    }
+                }
+                None
+            }
+        }
+    }
+
+    fn add(&mut self, state: DfaStateId, symbol: i32, target: DfaStateId) -> bool {
+        let Some(slot) = self.slot(symbol) else {
+            return false;
+        };
+        match self.rows[state.index()] {
+            EdgeRow::Empty => {
+                self.rows[state.index()] = EdgeRow::Inline { symbol, target };
+                true
+            }
+            EdgeRow::Inline {
+                symbol: stored_symbol,
+                target: stored_target,
+            } => {
+                if stored_symbol == symbol {
+                    let changed = stored_target != target;
+                    self.rows[state.index()] = EdgeRow::Inline { symbol, target };
+                    return changed;
+                }
+                self.promote_inline_to_sparse(state, stored_symbol, stored_target, symbol, target);
+                true
+            }
+            EdgeRow::Dense { start, populated } => {
+                let index = usize::try_from(start.checked_add(slot).expect("dense slot overflow"))
+                    .expect("u32 dense slot fits in usize");
+                let changed = self.dense_targets[index] != target;
+                if self.dense_targets[index] == NO_DFA_STATE {
+                    self.rows[state.index()] = EdgeRow::Dense {
+                        start,
+                        populated: populated
+                            .checked_add(1)
+                            .expect("dense edge count must fit in u32"),
+                    };
+                }
+                self.dense_targets[index] = target;
+                changed
+            }
+            EdgeRow::Sparse { head, len } => {
+                if let Some(changed) = self.update_sparse(head, symbol, target) {
+                    return changed;
+                }
+                self.insert_sparse(state, head, len, symbol, target);
+                true
+            }
+        }
+    }
+
+    fn promote_inline_to_sparse(
+        &mut self,
+        state: DfaStateId,
+        first_symbol: i32,
+        first_target: DfaStateId,
+        second_symbol: i32,
+        second_target: DfaStateId,
+    ) {
+        let (lower_symbol, lower_target, upper_symbol, upper_target) =
+            if first_symbol < second_symbol {
+                (first_symbol, first_target, second_symbol, second_target)
+            } else {
+                (second_symbol, second_target, first_symbol, first_target)
+            };
+        let upper_index = compact_index(
+            self.sparse_edges.len(),
+            "sparse edge pool must fit below the u32 sentinel",
+        );
+        self.sparse_edges.push(SparseEdge {
+            symbol: upper_symbol,
+            target: upper_target,
+            next: NO_EDGE_INDEX,
+        });
+        let lower_index = compact_index(
+            self.sparse_edges.len(),
+            "sparse edge pool must fit below the u32 sentinel",
+        );
+        self.sparse_edges.push(SparseEdge {
+            symbol: lower_symbol,
+            target: lower_target,
+            next: upper_index,
+        });
+        self.rows[state.index()] = EdgeRow::Sparse {
+            head: lower_index,
+            len: 2,
+        };
+    }
+
+    fn update_sparse(
+        &mut self,
+        mut edge_index: u32,
+        symbol: i32,
+        target: DfaStateId,
+    ) -> Option<bool> {
+        while edge_index != NO_EDGE_INDEX {
+            let edge = &mut self.sparse_edges
+                [usize::try_from(edge_index).expect("u32 sparse edge index fits in usize")];
+            match edge.symbol.cmp(&symbol) {
+                std::cmp::Ordering::Less => edge_index = edge.next,
+                std::cmp::Ordering::Equal => {
+                    let changed = edge.target != target;
+                    edge.target = target;
+                    return Some(changed);
+                }
+                std::cmp::Ordering::Greater => return None,
+            }
+        }
+        None
+    }
+
+    fn insert_sparse(
+        &mut self,
+        state: DfaStateId,
+        head: u32,
+        len: u32,
+        symbol: i32,
+        target: DfaStateId,
+    ) {
+        let new_index = compact_index(
+            self.sparse_edges.len(),
+            "sparse edge pool must fit below the u32 sentinel",
+        );
+        let mut previous = NO_EDGE_INDEX;
+        let mut current = head;
+        while current != NO_EDGE_INDEX {
+            let edge = self.sparse_edges
+                [usize::try_from(current).expect("u32 sparse edge index fits in usize")];
+            if edge.symbol > symbol {
+                break;
+            }
+            previous = current;
+            current = edge.next;
+        }
+        self.sparse_edges.push(SparseEdge {
+            symbol,
+            target,
+            next: current,
+        });
+        let new_len = len
+            .checked_add(1)
+            .expect("sparse edge count must fit in u32");
+        if previous == NO_EDGE_INDEX {
+            self.rows[state.index()] = EdgeRow::Sparse {
+                head: new_index,
+                len: new_len,
+            };
+        } else {
+            self.sparse_edges
+                [usize::try_from(previous).expect("u32 sparse edge index fits in usize")]
+            .next = new_index;
+            self.rows[state.index()] = EdgeRow::Sparse { head, len: new_len };
+        }
+        if self.should_promote(new_len) {
+            self.promote(state);
+        }
+    }
+
+    const fn should_promote(&self, populated: u32) -> bool {
+        self.width <= DENSE_MAX_ROW_WIDTH
+            && populated >= DENSE_MIN_EDGES
+            && populated.saturating_mul(DENSE_DENSITY_DENOMINATOR) >= self.width
+    }
+
+    fn promote(&mut self, state: DfaStateId) {
+        let EdgeRow::Sparse {
+            mut head,
+            len: populated,
+        } = self.rows[state.index()]
+        else {
+            return;
+        };
+        let start = compact_index(
+            self.dense_targets.len(),
+            "dense edge pool must fit below the u32 sentinel",
+        );
+        let new_len = self
+            .dense_targets
+            .len()
+            .checked_add(usize::try_from(self.width).expect("u32 row width fits in usize"))
+            .expect("dense edge pool length overflow");
+        self.dense_targets.resize(new_len, NO_DFA_STATE);
+        while head != NO_EDGE_INDEX {
+            let edge = self.sparse_edges
+                [usize::try_from(head).expect("u32 sparse edge index fits in usize")];
+            let slot = self.slot(edge.symbol).expect("stored symbol fits row");
+            let index = usize::try_from(start.checked_add(slot).expect("dense slot overflow"))
+                .expect("u32 dense slot fits in usize");
+            self.dense_targets[index] = edge.target;
+            head = edge.next;
+        }
+        self.rows[state.index()] = EdgeRow::Dense { start, populated };
+    }
+
+    fn transitions(&self, state: DfaStateId) -> EdgeTransitions<'_> {
+        match self.rows[state.index()] {
+            EdgeRow::Empty => EdgeTransitions::Empty,
+            EdgeRow::Inline { symbol, target } => EdgeTransitions::Inline {
+                edge: Some((symbol, target)),
+            },
+            EdgeRow::Sparse { head, .. } => EdgeTransitions::Sparse {
+                table: self,
+                next: head,
+            },
+            EdgeRow::Dense { start, .. } => EdgeTransitions::Dense {
+                table: self,
+                start,
+                slot: 0,
+            },
+        }
+    }
+
+    fn slot(&self, symbol: i32) -> Option<u32> {
+        let slot = symbol
+            .checked_add(1)
+            .and_then(|value| u32::try_from(value).ok())?;
+        (slot < self.width).then_some(slot)
+    }
+
+    fn stats(&self) -> EdgeTableStats {
+        let mut stats = EdgeTableStats {
+            max_row_width: usize::try_from(self.width).expect("u32 row width fits in usize"),
+            dense_slots: self.dense_targets.len(),
+            sparse_entries: self.sparse_edges.len(),
+            ..EdgeTableStats::default()
+        };
+        for row in &self.rows {
+            let populated = match *row {
+                EdgeRow::Empty => {
+                    stats.empty_rows += 1;
+                    0
+                }
+                EdgeRow::Inline { .. } => {
+                    stats.sparse_rows += 1;
+                    1
+                }
+                EdgeRow::Dense { populated, .. } => {
+                    stats.dense_rows += 1;
+                    populated
+                }
+                EdgeRow::Sparse { len, .. } => {
+                    stats.sparse_rows += 1;
+                    len
+                }
+            };
+            stats.transitions = stats
+                .transitions
+                .saturating_add(usize::try_from(populated).expect("u32 edge count fits in usize"));
+            stats.row_width_histogram[row_width_bucket(self.width)] += 1;
+            stats.populated_edge_histogram[populated_edge_bucket(populated)] += 1;
+            let bucket = density_bucket(populated, self.width);
+            stats.edge_density_histogram[bucket] += 1;
+        }
+        stats
+    }
+
+    const fn retained_bytes(&self) -> usize {
+        self.rows.capacity() * size_of::<EdgeRow>()
+            + self.dense_targets.capacity() * size_of::<DfaStateId>()
+            + self.sparse_edges.capacity() * size_of::<SparseEdge>()
+    }
+
+    fn clear(&mut self) {
+        self.rows.clear();
+        self.dense_targets.clear();
+        self.sparse_edges.clear();
+    }
+}
+
+enum EdgeTransitions<'a> {
+    Empty,
+    Inline {
+        edge: Option<(i32, DfaStateId)>,
+    },
+    Sparse {
+        table: &'a EdgeTable,
+        next: u32,
+    },
+    Dense {
+        table: &'a EdgeTable,
+        start: u32,
+        slot: u32,
+    },
+}
+
+impl Iterator for EdgeTransitions<'_> {
+    type Item = (i32, DfaStateId);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Empty => None,
+            Self::Inline { edge } => edge.take(),
+            Self::Sparse { table, next } => {
+                if *next == NO_EDGE_INDEX {
+                    return None;
+                }
+                let edge = table.sparse_edges
+                    [usize::try_from(*next).expect("u32 sparse edge index fits in usize")];
+                *next = edge.next;
+                Some((edge.symbol, edge.target))
+            }
+            Self::Dense { table, start, slot } => {
+                while *slot < table.width {
+                    let current = *slot;
+                    *slot += 1;
+                    let index =
+                        usize::try_from(start.checked_add(current).expect("dense slot overflow"))
+                            .expect("u32 dense slot fits in usize");
+                    let target = table.dense_targets[index];
+                    if target != NO_DFA_STATE {
+                        let symbol =
+                            i32::try_from(current).expect("bounded dense row slot fits in i32") - 1;
+                        return Some((symbol, target));
+                    }
+                }
+                None
+            }
         }
     }
 }
 
-fn edge_index(symbol: i32) -> Option<usize> {
-    if symbol < -1 {
-        None
+#[derive(Debug, Default)]
+struct EdgeTableStats {
+    transitions: usize,
+    max_row_width: usize,
+    dense_rows: usize,
+    sparse_rows: usize,
+    empty_rows: usize,
+    dense_slots: usize,
+    sparse_entries: usize,
+    row_width_histogram: [usize; 5],
+    populated_edge_histogram: [usize; 6],
+    edge_density_histogram: [usize; 6],
+}
+
+const fn row_width_bucket(width: u32) -> usize {
+    if width <= 64 {
+        0
+    } else if width <= 128 {
+        1
+    } else if width <= 256 {
+        2
+    } else if width <= 512 {
+        3
     } else {
-        usize::try_from(symbol + 1).ok()
+        4
+    }
+}
+
+const fn populated_edge_bucket(populated: u32) -> usize {
+    match populated {
+        0 => 0,
+        1 => 1,
+        2..=3 => 2,
+        4..=7 => 3,
+        8..=15 => 4,
+        _ => 5,
+    }
+}
+
+const fn density_bucket(populated: u32, width: u32) -> usize {
+    if populated == 0 || width == 0 {
+        0
+    } else if populated.saturating_mul(100) <= width {
+        1
+    } else if populated.saturating_mul(20) <= width {
+        2
+    } else if populated.saturating_mul(8) <= width {
+        3
+    } else if populated.saturating_mul(4) <= width {
+        4
+    } else {
+        5
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::prediction::{
-        AtnConfig, AtnConfigSet, ContextArena, EMPTY_CONTEXT, PredictionWorkspace,
-    };
+    use crate::prediction::{AtnConfig, ContextArena, EMPTY_CONTEXT, PredictionWorkspace};
+    use crate::token::TOKEN_EOF;
 
-    #[test]
-    fn dfa_reuses_equal_config_sets() {
-        let mut arena = ContextArena::new();
+    fn configs(state: usize, arena: &mut ContextArena) -> AtnConfigSet {
         let mut workspace = PredictionWorkspace::default();
         let mut configs = AtnConfigSet::new();
         configs.add(
-            AtnConfig::new(1, 1, EMPTY_CONTEXT, &arena),
-            &mut arena,
+            AtnConfig::new(state, 1, EMPTY_CONTEXT, arena),
+            arena,
             &mut workspace,
         );
-        let state = DfaState::new(configs.clone());
-        let mut dfa = Dfa::with_max_token_type(0, 0, 16);
-        assert_eq!(dfa.add_state(state), 0);
-        assert_eq!(dfa.add_state(DfaState::new(configs)), 0);
+        configs
     }
 
     #[test]
-    fn dfa_edges_are_dense_by_token_type() {
-        let mut state = DfaState::new(AtnConfigSet::new());
-        state.add_edge(-1, 3);
-        state.add_edge(5, 7);
+    fn dfa_reuses_equal_config_sets_without_key_clone() {
+        let mut arena = ContextArena::new();
+        let configs = configs(1, &mut arena);
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 16);
 
-        assert_eq!(state.edge(-1), Some(3));
-        assert_eq!(state.edge(5), Some(7));
-        assert_eq!(state.edge(4), None);
+        assert_eq!(
+            dfa.add_state(DfaStateBuilder::new(configs.clone())).index(),
+            0
+        );
+        assert_eq!(dfa.add_state(DfaStateBuilder::new(configs)).index(), 0);
+        assert_eq!(dfa.state_count(), 1);
+        assert_eq!(dfa.stats().states_deduplicated, 1);
     }
 
     #[test]
-    fn precedence_dfa_tracks_start_states_by_precedence() {
-        let mut dfa = Dfa::new(10, 2);
+    fn fingerprint_collisions_are_verified_structurally() {
+        let mut arena = ContextArena::new();
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 16);
+        let first = DfaStateBuilder::new(configs(1, &mut arena));
+        let second = DfaStateBuilder::new(configs(2, &mut arena));
+        let fingerprint = 7;
+
+        let first_id = dfa.insert_state_with_fingerprint(first, fingerprint);
+        let second_id = dfa.insert_state_with_fingerprint(second, fingerprint);
+        let first_configs = configs(1, &mut arena);
+
+        assert_eq!(dfa.find_state(fingerprint, &first_configs), Some(first_id));
+        assert_ne!(first_id, second_id);
+        assert_eq!(dfa.stats().fingerprint_collisions, 1);
+    }
+
+    #[test]
+    fn sparse_edges_are_sorted_and_use_scalar_targets() {
+        let mut arena = ContextArena::new();
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 32);
+        let source = dfa.add_state(DfaStateBuilder::new(configs(1, &mut arena)));
+        let target = dfa.add_state(DfaStateBuilder::new(configs(2, &mut arena)));
+
+        dfa.add_edge(source, 5, target);
+        dfa.add_edge(source, -1, target);
+        dfa.add_edge(source, 2, target);
+
+        assert_eq!(dfa.edge(source, -1), Some(target));
+        assert_eq!(dfa.edge(source, 4), None);
+        assert_eq!(
+            dfa.state(source)
+                .expect("source")
+                .transitions()
+                .map(|edge| edge.symbol)
+                .collect::<Vec<_>>(),
+            [-1, 2, 5]
+        );
+    }
+
+    #[test]
+    fn populated_rows_promote_into_shared_dense_slab() {
+        let mut arena = ContextArena::new();
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 62);
+        let source = dfa.add_state(DfaStateBuilder::new(configs(1, &mut arena)));
+        let target = dfa.add_state(DfaStateBuilder::new(configs(2, &mut arena)));
+
+        for symbol in 0..8 {
+            dfa.add_edge(source, symbol, target);
+        }
+
+        assert_eq!(dfa.stats().dense_rows, 1);
+        assert_eq!(dfa.edge(source, 7), Some(target));
+        assert_eq!(dfa.edge(source, 8), None);
+    }
+
+    #[test]
+    fn creating_states_does_not_allocate_edge_rows() {
+        let mut arena = ContextArena::new();
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 255);
+
+        for state in 0..32 {
+            dfa.add_state(DfaStateBuilder::new(configs(state, &mut arena)));
+        }
+
+        let stats = dfa.stats();
+        assert_eq!(stats.dense_slots, 0);
+        assert_eq!(stats.sparse_entries, 0);
+        assert_eq!(stats.empty_rows, 32);
+    }
+
+    #[test]
+    fn edge_updates_do_not_duplicate_sparse_entries() {
+        let mut arena = ContextArena::new();
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 32);
+        let source = dfa.add_state(DfaStateBuilder::new(configs(1, &mut arena)));
+        let first = dfa.add_state(DfaStateBuilder::new(configs(2, &mut arena)));
+        let second = dfa.add_state(DfaStateBuilder::new(configs(3, &mut arena)));
+
+        dfa.add_edge(source, TOKEN_EOF, first);
+        dfa.add_edge(source, TOKEN_EOF, first);
+        dfa.add_edge(source, TOKEN_EOF, second);
+
+        assert_eq!(dfa.edge(source, TOKEN_EOF), Some(second));
+        assert_eq!(dfa.state(source).expect("source").transitions().count(), 1);
+    }
+
+    #[test]
+    fn out_of_vocabulary_edges_are_not_stored() {
+        let mut arena = ContextArena::new();
+        let mut dfa = ParserDfa::with_max_token_type(0, 0, 4);
+        let source = dfa.add_state(DfaStateBuilder::new(configs(1, &mut arena)));
+        let target = dfa.add_state(DfaStateBuilder::new(configs(2, &mut arena)));
+
+        dfa.add_edge(source, -2, target);
+        dfa.add_edge(source, 5, target);
+
+        assert_eq!(dfa.edge(source, -2), None);
+        assert_eq!(dfa.edge(source, 5), None);
+        assert_eq!(dfa.stats().transitions, 0);
+    }
+
+    #[test]
+    fn precedence_dfa_tracks_start_states_by_compact_id() {
+        let mut dfa = ParserDfa::new(10, 2);
         dfa.set_precedence_dfa(true);
-        dfa.set_precedence_start_state(4, 9);
+        let start = dfa.start_state().expect("precedence root");
+        dfa.set_precedence_start_state(4, start);
 
         assert!(dfa.is_precedence_dfa());
-        assert_eq!(dfa.precedence_start_state(4), Some(9));
+        assert_eq!(dfa.precedence_start_state(4), Some(start));
         assert_eq!(dfa.precedence_start_state(3), None);
     }
 }

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -734,31 +734,27 @@ impl EdgeTable {
         }
     }
 
-    fn add(&mut self, state: DfaStateId, symbol: i32, target: DfaStateId) -> bool {
+    fn add(&mut self, state: DfaStateId, symbol: i32, target: DfaStateId) {
         let Some(slot) = self.slot(symbol) else {
-            return false;
+            return;
         };
         match self.rows[state.index()] {
             EdgeRow::Empty => {
                 self.rows[state.index()] = EdgeRow::Inline { symbol, target };
-                true
             }
             EdgeRow::Inline {
                 symbol: stored_symbol,
                 target: stored_target,
             } => {
                 if stored_symbol == symbol {
-                    let changed = stored_target != target;
                     self.rows[state.index()] = EdgeRow::Inline { symbol, target };
-                    return changed;
+                    return;
                 }
                 self.promote_inline_to_sparse(state, stored_symbol, stored_target, symbol, target);
-                true
             }
             EdgeRow::Dense { start, populated } => {
                 let index = usize::try_from(start.checked_add(slot).expect("dense slot overflow"))
                     .expect("u32 dense slot fits in usize");
-                let changed = self.dense_targets[index] != target;
                 if self.dense_targets[index] == NO_DFA_STATE {
                     self.rows[state.index()] = EdgeRow::Dense {
                         start,
@@ -768,14 +764,12 @@ impl EdgeTable {
                     };
                 }
                 self.dense_targets[index] = target;
-                changed
             }
             EdgeRow::Sparse { head, len } => {
-                if let Some(changed) = self.update_sparse(head, symbol, target) {
-                    return changed;
+                if self.update_sparse(head, symbol, target).is_some() {
+                    return;
                 }
                 self.insert_sparse(state, head, len, symbol, target);
-                true
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub mod vocabulary;
 
 pub use atn::parser::{ParserAtnPrediction, ParserAtnSimulator, ParserAtnSimulatorError};
 pub use char_stream::{CharStream, InputStream, TextInterval};
-pub use dfa::{Dfa, DfaState};
+pub use dfa::{DfaStateId, DfaTransition, ParserDfa, ParserDfaStateView, ParserDfaStats};
 pub use errors::{AntlrError, ConsoleErrorListener, ErrorListener};
 pub use generated::{GeneratedLexer, GeneratedParser, GrammarMetadata};
 pub use int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -33,6 +33,20 @@ struct Counters {
     context_cache_hits: u64,
     context_cache_misses: u64,
     context_cache_inserts: u64,
+    dfa_edge_lookups: u64,
+    dfa_edge_hits: u64,
+    dfa_edge_misses: u64,
+    dfa_atn_fallbacks: u64,
+    dfa_states_created: u64,
+    dfa_states_deduplicated: u64,
+    dfa_fingerprint_candidates: u64,
+    dfa_fingerprint_collisions: u64,
+    dfa_cache_imports: u64,
+    dfa_cache_import_nanos: u64,
+    dfa_cache_import_states: u64,
+    dfa_cache_publications: u64,
+    dfa_cache_publication_nanos: u64,
+    dfa_cache_publication_states: u64,
     decisions: BTreeMap<usize, DecisionCounters>,
 }
 
@@ -196,6 +210,66 @@ pub(crate) fn record_context_cache_insert() {
     });
 }
 
+pub(crate) fn record_dfa_edge_lookup(hit: bool) {
+    with_counters(|counters| {
+        counters.dfa_edge_lookups = counters.dfa_edge_lookups.saturating_add(1);
+        if hit {
+            counters.dfa_edge_hits = counters.dfa_edge_hits.saturating_add(1);
+        } else {
+            counters.dfa_edge_misses = counters.dfa_edge_misses.saturating_add(1);
+            counters.dfa_atn_fallbacks = counters.dfa_atn_fallbacks.saturating_add(1);
+        }
+    });
+}
+
+pub(crate) fn record_dfa_state_created() {
+    with_counters(|counters| {
+        counters.dfa_states_created = counters.dfa_states_created.saturating_add(1);
+    });
+}
+
+pub(crate) fn record_dfa_state_deduplicated() {
+    with_counters(|counters| {
+        counters.dfa_states_deduplicated = counters.dfa_states_deduplicated.saturating_add(1);
+    });
+}
+
+pub(crate) fn record_dfa_fingerprint_candidate() {
+    with_counters(|counters| {
+        counters.dfa_fingerprint_candidates = counters.dfa_fingerprint_candidates.saturating_add(1);
+    });
+}
+
+pub(crate) fn record_dfa_fingerprint_collision() {
+    with_counters(|counters| {
+        counters.dfa_fingerprint_collisions = counters.dfa_fingerprint_collisions.saturating_add(1);
+    });
+}
+
+pub(crate) fn record_dfa_cache_import(nanos: u128, states: usize) {
+    with_counters(|counters| {
+        counters.dfa_cache_imports = counters.dfa_cache_imports.saturating_add(1);
+        counters.dfa_cache_import_nanos = counters
+            .dfa_cache_import_nanos
+            .saturating_add(u64::try_from(nanos).unwrap_or(u64::MAX));
+        counters.dfa_cache_import_states = counters
+            .dfa_cache_import_states
+            .saturating_add(u64::try_from(states).unwrap_or(u64::MAX));
+    });
+}
+
+pub(crate) fn record_dfa_cache_publication(nanos: u128, states: usize) {
+    with_counters(|counters| {
+        counters.dfa_cache_publications = counters.dfa_cache_publications.saturating_add(1);
+        counters.dfa_cache_publication_nanos = counters
+            .dfa_cache_publication_nanos
+            .saturating_add(u64::try_from(nanos).unwrap_or(u64::MAX));
+        counters.dfa_cache_publication_states = counters
+            .dfa_cache_publication_states
+            .saturating_add(u64::try_from(states).unwrap_or(u64::MAX));
+    });
+}
+
 pub fn reset() {
     COUNTERS.with(|counters| *counters.borrow_mut() = Counters::default());
 }
@@ -231,7 +305,7 @@ fn dump_decisions(counters: &Counters) {
     }
 }
 
-const fn totals(counters: &Counters) -> [(&'static str, u64); 26] {
+const fn totals(counters: &Counters) -> [(&'static str, u64); 40] {
     [
         ("prediction.adaptive_calls", counters.adaptive_calls),
         (
@@ -277,6 +351,32 @@ const fn totals(counters: &Counters) -> [(&'static str, u64); 26] {
         ("context_cache.hits", counters.context_cache_hits),
         ("context_cache.misses", counters.context_cache_misses),
         ("context_cache.inserts", counters.context_cache_inserts),
+        ("dfa.edge_lookups", counters.dfa_edge_lookups),
+        ("dfa.warm_hits", counters.dfa_edge_hits),
+        ("dfa.warm_misses", counters.dfa_edge_misses),
+        ("dfa.atn_fallbacks", counters.dfa_atn_fallbacks),
+        ("dfa.states_created", counters.dfa_states_created),
+        ("dfa.states_deduplicated", counters.dfa_states_deduplicated),
+        (
+            "dfa.fingerprint_candidates",
+            counters.dfa_fingerprint_candidates,
+        ),
+        (
+            "dfa.fingerprint_collisions",
+            counters.dfa_fingerprint_collisions,
+        ),
+        ("dfa_cache.imports", counters.dfa_cache_imports),
+        ("dfa_cache.import_nanos", counters.dfa_cache_import_nanos),
+        ("dfa_cache.import_states", counters.dfa_cache_import_states),
+        ("dfa_cache.publications", counters.dfa_cache_publications),
+        (
+            "dfa_cache.publication_nanos",
+            counters.dfa_cache_publication_nanos,
+        ),
+        (
+            "dfa_cache.publication_states",
+            counters.dfa_cache_publication_states,
+        ),
     ]
 }
 

--- a/src/prediction.rs
+++ b/src/prediction.rs
@@ -955,12 +955,9 @@ impl AtnConfigSet {
     pub(crate) fn set_readonly(&mut self, readonly: bool) {
         self.readonly = readonly;
         if readonly {
-            self.config_index.clear();
+            self.config_index = FxHashMap::default();
+            self.conflicting_alts.clear();
         }
-    }
-
-    pub(crate) const fn is_readonly(&self) -> bool {
-        self.readonly
     }
 
     pub(crate) const fn full_context(&self) -> bool {
@@ -1014,6 +1011,20 @@ impl AtnConfigSet {
                 self.config_index.insert(AtnConfigKey::from(config), index);
             }
         }
+    }
+
+    pub(crate) fn fingerprint(&self) -> u64 {
+        let mut hasher = PredictionFxHasher::default();
+        self.configs.hash(&mut hasher);
+        self.full_context.hash(&mut hasher);
+        self.has_semantic_context.hash(&mut hasher);
+        self.dips_into_outer_context.hash(&mut hasher);
+        hasher.finish()
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.configs.capacity() * size_of::<AtnConfig>()
+            + self.config_index.capacity() * size_of::<(AtnConfigKey, usize)>()
     }
 }
 

--- a/tools/parse-bench/README.md
+++ b/tools/parse-bench/README.md
@@ -89,8 +89,11 @@ ANTLR_PERF_DUMP=1 python3 tools/parse-bench/run.py \
 
 The dump includes canonical context counts, pooled and retained bytes, arena
 and workspace capacities, merge-cache activity, and outer-context cache
-hits/misses. Store statistics are collected in a separate untimed parse after
-the benchmark loop, so walking the arena does not affect reported timings.
+hits/misses. It also reports learned parser-DFA warm hits/misses, ATN
+fallbacks, state interning activity, dense/sparse row counts, edge-density
+histograms, and hot/cold retained bytes. Store statistics are collected in a
+separate untimed parse after the benchmark loop, so walking the stores does not
+affect reported timings.
 
 ## PR Watchdog
 

--- a/tools/parse-bench/run.py
+++ b/tools/parse-bench/run.py
@@ -391,7 +391,7 @@ def write_rust_runner(work_dir: Path, specs: list[LanguageSpec]) -> Path:
         for spec in specs
     )
     stats_arms = "\n".join(
-        f'        "{spec.name}" => prediction_context_stats_{spec.name}(&src).map_err(|err| err.to_string())?,'
+        f'        "{spec.name}" => prediction_stats_{spec.name}(&src).map_err(|err| err.to_string())?,'
         for spec in specs
     )
     functions = "\n\n".join(rust_parse_function(spec) for spec in specs)
@@ -470,8 +470,9 @@ fn run_main() -> Result<(), String> {{
         antlr4_runtime::dump_prediction_perf_counters();
     }}
     if collect_stats {{
-        let stats = prediction_context_stats_once(&language, &src)?;
-        dump_prediction_context_stats(stats);
+        let (context_stats, dfa_stats) = prediction_stats_once(&language, &src)?;
+        dump_prediction_context_stats(context_stats);
+        dump_parser_dfa_stats(dfa_stats);
     }}
     Ok(())
 }}
@@ -487,10 +488,10 @@ fn parse_once(
     Ok(())
 }}
 
-fn prediction_context_stats_once(
+fn prediction_stats_once(
     language: &str,
     src: &str,
-) -> Result<antlr4_runtime::PredictionContextStats, String> {{
+) -> Result<(antlr4_runtime::PredictionContextStats, antlr4_runtime::ParserDfaStats), String> {{
     let stats = match language {{
 {stats_arms}
         other => return Err(format!("unsupported language: {{other}}")),
@@ -523,6 +524,44 @@ fn dump_prediction_context_stats(stats: antlr4_runtime::PredictionContextStats) 
     eprintln!("perf context_store.outer_context_cache_hits={{}}", stats.outer_context_cache_hits);
     eprintln!("perf context_store.outer_context_cache_misses={{}}", stats.outer_context_cache_misses);
 }}
+
+fn dump_parser_dfa_stats(stats: antlr4_runtime::ParserDfaStats) {{
+    eprintln!("perf dfa_store.states={{}}", stats.states);
+    eprintln!("perf dfa_store.transitions={{}}", stats.transitions);
+    eprintln!("perf dfa_store.max_row_width={{}}", stats.max_row_width);
+    eprintln!("perf dfa_store.dense_rows={{}}", stats.dense_rows);
+    eprintln!("perf dfa_store.sparse_rows={{}}", stats.sparse_rows);
+    eprintln!("perf dfa_store.empty_rows={{}}", stats.empty_rows);
+    eprintln!("perf dfa_store.dense_slots={{}}", stats.dense_slots);
+    eprintln!("perf dfa_store.sparse_entries={{}}", stats.sparse_entries);
+    eprintln!("perf dfa_store.row_width.le_64={{}}", stats.row_width_histogram[0]);
+    eprintln!("perf dfa_store.row_width.le_128={{}}", stats.row_width_histogram[1]);
+    eprintln!("perf dfa_store.row_width.le_256={{}}", stats.row_width_histogram[2]);
+    eprintln!("perf dfa_store.row_width.le_512={{}}", stats.row_width_histogram[3]);
+    eprintln!("perf dfa_store.row_width.gt_512={{}}", stats.row_width_histogram[4]);
+    eprintln!("perf dfa_store.populated_edges.0={{}}", stats.populated_edge_histogram[0]);
+    eprintln!("perf dfa_store.populated_edges.1={{}}", stats.populated_edge_histogram[1]);
+    eprintln!("perf dfa_store.populated_edges.2_3={{}}", stats.populated_edge_histogram[2]);
+    eprintln!("perf dfa_store.populated_edges.4_7={{}}", stats.populated_edge_histogram[3]);
+    eprintln!("perf dfa_store.populated_edges.8_15={{}}", stats.populated_edge_histogram[4]);
+    eprintln!("perf dfa_store.populated_edges.ge_16={{}}", stats.populated_edge_histogram[5]);
+    eprintln!("perf dfa_store.edge_density.empty={{}}", stats.edge_density_histogram[0]);
+    eprintln!("perf dfa_store.edge_density.le_1_pct={{}}", stats.edge_density_histogram[1]);
+    eprintln!("perf dfa_store.edge_density.le_5_pct={{}}", stats.edge_density_histogram[2]);
+    eprintln!("perf dfa_store.edge_density.le_12_5_pct={{}}", stats.edge_density_histogram[3]);
+    eprintln!("perf dfa_store.edge_density.le_25_pct={{}}", stats.edge_density_histogram[4]);
+    eprintln!("perf dfa_store.edge_density.gt_25_pct={{}}", stats.edge_density_histogram[5]);
+    eprintln!("perf dfa_store.hot_bytes={{}}", stats.hot_bytes);
+    eprintln!("perf dfa_store.cold_bytes={{}}", stats.cold_bytes);
+    if stats.states > 0 {{
+        eprintln!("perf dfa_store.hot_bytes_per_state={{}}", stats.hot_bytes / stats.states);
+        eprintln!("perf dfa_store.cold_bytes_per_state={{}}", stats.cold_bytes / stats.states);
+    }}
+    eprintln!("perf dfa_store.states_created={{}}", stats.states_created);
+    eprintln!("perf dfa_store.states_deduplicated={{}}", stats.states_deduplicated);
+    eprintln!("perf dfa_store.fingerprint_candidates={{}}", stats.fingerprint_candidates);
+    eprintln!("perf dfa_store.fingerprint_collisions={{}}", stats.fingerprint_collisions);
+}}
 """
     )
     return runner
@@ -538,14 +577,14 @@ def rust_parse_function(spec: LanguageSpec) -> str:
     Ok(())
 }}
 
-fn prediction_context_stats_{spec.name}(
+fn prediction_stats_{spec.name}(
     src: &str,
-) -> Result<antlr4_runtime::PredictionContextStats, antlr4_runtime::AntlrError> {{
+) -> Result<(antlr4_runtime::PredictionContextStats, antlr4_runtime::ParserDfaStats), antlr4_runtime::AntlrError> {{
     let lexer = generated::{spec.rust_lexer_module}::{spec.rust_lexer_type}::new(InputStream::new(src));
     let tokens = CommonTokenStream::new(lexer);
     let mut parser = generated::{spec.rust_parser_module}::{spec.rust_parser_type}::new(tokens);
     let tree = parser.{spec.rust_entry}()?;
-    let stats = parser.prediction_context_stats();
+    let stats = (parser.prediction_context_stats(), parser.parser_dfa_stats());
     black_box(&tree);
     Ok(stats)
 }}"""


### PR DESCRIPTION
Closes #86.

## What changed

- Replace the public field-oriented `Dfa`/`DfaState` object graph with opaque `ParserDfa` storage indexed by compact `DfaStateId` values.
- Split aligned hot edge/accept/flag tables from the cold `AtnConfigSet` store so warm transition lookup touches only scalar hot data.
- Intern states through fingerprint-to-candidate chains with structural collision verification instead of cloned `BTreeMap<AtnConfigSet, _>` keys.
- Store edges as empty or inline rows, sorted pooled sparse entries, and shared dense slabs using a benchmark-derived promotion threshold.
- Expose borrowing diagnostics, deterministic transition iteration, generated `parser_dfa_stats()`, and perf counters for learning and shared-cache costs.
- Document the breaking API migration, regeneration requirement, and benchmark evidence.

## Why

The old representation mixed cold ATN configurations into every hot DFA state, allocated a growable edge vector per state, and cloned configuration sets into ordered-map keys. This increased warm-path indirection, allocation volume, and structural comparison work.

Generated parsers must be regenerated with the matching generator/runtime release.

## Validation

- `cargo fmt -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features` (331 tests passed)
- `cargo test --locked --doc --all-features`
- Full ANTLR runtime testsuite: 356 passed, 0 failed, 1 expected skip
- Kotlin parity: all 9 file/script fixtures matched Python byte-for-byte
- Protected 17-fixture benchmark: 16 improved, geometric mean improved 2.39%, worst fixture +0.17%, all within the 2% guardrail
- Solidity #76: median parse time stayed within 0.94% of main, Rust remained 2.98x-3.75x faster than Go, allocated bytes fell 5.4%-7.9%, and peak live bytes fell 17.6%-27.3%

Detailed measurements are in `docs/issue-86-dfa-benchmark.md`.