### PR TITLE
Compile parser ATN into packed tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,15 @@
   edge rows, aligned hot accept tables, and a separate cold config store.
   Public `Dfa`/`DfaState` fields are removed in favor of opaque `ParserDfa`
   diagnostics and borrowing state views.
+- Parser ATNs are versioned packed word streams with compact state/transition
+  IDs, contiguous transition ranges, and pooled interval data. The parser
+  object graph and its public `Atn`/`AtnState`/`Transition` types are removed;
+  the remaining lexer graph is explicitly named `LexerAtn`,
+  `LexerAtnState`, and `LexerTransition`.
 - `ParserAtnSimulator::prediction_context_stats()` reports context creation,
   singleton/array distribution, pooled entries and bytes, and interner hits.
 - `ParserAtnSimulator::parser_dfa_stats()` reports edge density, hot/cold
   retained bytes, and fingerprint-interner activity.
 - Generated lexers and parsers must be regenerated with the matching
-  `antlr4-rust-gen` release.
+  `antlr4-rust-gen` release. Older generated parsers do not contain the packed
+  parser format and are intentionally incompatible.

--- a/README.md
+++ b/README.md
@@ -201,7 +201,8 @@ form.
 
 - Pure Rust runtime implementation.
 - Written from scratch as a clean-room implementation.
-- Supports ANTLR serialized ATN deserialization.
+- Supports ANTLR serialized lexer ATN deserialization and generator-side
+  compilation of serialized parser ATNs into packed runtime tables.
 - Supports lexer and parser execution through generated Rust wrappers.
 - Supports real split lexer/parser grammars, including Kotlin smoke builds.
 - Passes every supported upstream ANTLR runtime-testsuite descriptor discovered
@@ -219,14 +220,15 @@ The runtime contains:
 - `Vocabulary`
 - recognizer metadata and error listener plumbing
 - parse tree node types, rule contexts, terminal nodes, error nodes, and walkers
-- ANTLR v4 serialized ATN deserialization
+- ANTLR v4 serialized lexer ATN deserialization
 - lexer ATN recognition with longest-match/rule-priority behavior and lexer
   actions
 - ahead-of-time compiled lexer DFA tables, built by `antlr4-rust-gen` and
   embedded in generated lexers, with per-token escape to ATN interpretation
   for constructs a finite DFA cannot represent (semantic predicates,
   recursive lexer rules)
-- parser ATN rule recognition with backtracking over token stream indices
+- versioned, packed parser ATN tables embedded directly in generated parsers,
+  with rule recognition over borrowing state/transition views
 - canonical `ContextId` prediction graphs pooled with learned parser DFA state
 - `antlr4-rust-gen`, a Rust generator that consumes ANTLR `.interp` metadata and
   emits Rust modules
@@ -431,10 +433,10 @@ group (**> 1.0** means Rust is faster than Go; **< 1.0** means slower):
 
 | Language | Fixtures | Rust vs Go (parse time) |
 |----------|---------:|-------------------------|
-| Kotlin   | 4        | 25.705x                 |
-| Java     | 4        | 3.115x                  |
-| C#       | 4        | 2.238x                  |
-| Trino SQL | 5       | 3.522x                  |
+| Kotlin   | 4        | 24.924x                 |
+| Java     | 4        | 3.088x                  |
+| C#       | 4        | 2.199x                  |
+| Trino SQL | 5       | 3.390x                  |
 
 ## Useful Information
 

--- a/docs/issue-87-parser-atn-benchmark.md
+++ b/docs/issue-87-parser-atn-benchmark.md
@@ -1,0 +1,64 @@
+# Issue 87 packed parser-ATN benchmark record
+
+Measurements were taken on 2026-07-17 on an Apple M3 Pro. The baseline was
+`origin/main` at `e01e5e8c5`; generated parsers were rebuilt with the matching
+generator/runtime for each revision. The grammars-v4 checkout was
+`284602b3f23ca54dc30778204ab7ae9e969145e9`.
+
+## Protected parser suites
+
+The Kotlin, C#, Java, and Trino suite used 10 warmups and 50 measured
+end-to-end parses for each of 17 fixtures. Compared with the object-graph
+baseline, the packed ATN was 0.86% faster by geometric mean and 3.65% faster by
+aggregate time.
+
+Short-fixture ratios near the 2% limit were checked with interleaved processes
+and higher iteration counts. Trino q47 measured `1.0120x`, the Java filter
+fixture `0.9969x`, and C# anonymous types `0.9905x`. No confirmed fixture
+regressed by more than 2%.
+
+DFA-cold performance used seven interleaved process pairs per fixture, with no
+warmups and one timed parse in each fresh process. The geometric ratio was
+`0.9919x` and the aggregate ratio was `0.9965x`. The initial seven-pair Java
+Mojang sample measured `1.0217x`; expanding it to 31 pairs stabilized at
+`1.0086x`.
+
+## Construction and resident storage
+
+A counting global allocator was reset immediately before the first parser-ATN
+initialization in a fresh process. Allocation bytes are cumulative requested
+bytes, including temporary construction storage. Baseline resident bytes are
+the serialized static stream plus retained object-graph heap; packed resident
+bytes are the validated static word stream, with no retained parser-ATN heap.
+
+| Grammar | States | Transitions | Baseline allocations | Baseline allocated | Baseline resident | Packed allocations | Packed resident | Resident change |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Kotlin | 2,854 | 3,582 | 3,037 | 1,224,384 | 937,496 | 0 | 155,188 | -83.4% |
+| C# | 2,629 | 3,504 | 2,931 | 1,241,648 | 904,648 | 0 | 147,804 | -83.7% |
+| Java | 1,841 | 2,461 | 2,038 | 713,616 | 561,500 | 0 | 103,364 | -81.6% |
+| Trino | 3,278 | 4,404 | 3,696 | 1,394,152 | 1,047,020 | 0 | 184,088 | -82.4% |
+| **Total** | **10,602** | **13,951** | **11,702** | **4,573,800** | **3,450,664** | **0** | **590,444** | **-82.9%** |
+
+Validation time was the median of 21 interleaved fresh-process pairs:
+
+| Grammar | Baseline construction | Packed validation | Ratio |
+|---|---:|---:|---:|
+| Kotlin | 159.2 us | 41.5 us | 0.261x |
+| C# | 171.5 us | 43.5 us | 0.254x |
+| Java | 121.8 us | 31.0 us | 0.255x |
+| Trino | 200.4 us | 57.6 us | 0.287x |
+
+## Artifact size
+
+Packing stores more precomputed information in the generated artifact so the
+runtime does not rebuild links, transition vectors, or interval sets:
+
+| Measurement | Baseline | Packed | Change |
+|---|---:|---:|---:|
+| Static parser-ATN data | 391,008 | 590,444 | +51.0% |
+| Generated parser source | 8,123,871 | 8,455,102 | +4.1% |
+| Four-grammar benchmark executable | 8,467,424 | 8,668,352 | +2.4% |
+
+The static-data increase is offset by removing 3,059,656 retained heap bytes
+and all 11,702 cold construction allocation operations across the four
+grammars.

--- a/docs/kotlin-build.md
+++ b/docs/kotlin-build.md
@@ -35,7 +35,9 @@ This emits:
 - `kotlin_lexer.rs`
 - `kotlin_parser.rs`
 
-The generated lexer and parser cache a deserialized ATN with `OnceLock` and delegate recognition to `antlr4_runtime`.
+The generated lexer caches its deserialized lexer ATN with `OnceLock`. The
+generated parser embeds a versioned packed parser ATN, validates it once without
+rebuilding an object graph, and delegates recognition to `antlr4_runtime`.
 
 ## Choose the Kotlin Entry Rule
 

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -47,9 +47,32 @@ identified by `DfaStateId`; ATN configuration sets remain internal cold data.
 `ParserAtnSimulator::parser_dfa_stats()` reports dense/sparse row distribution,
 hot/cold retained bytes, and state-interner measurements.
 
-Regenerate parsers with the matching `antlr4-rust-gen` release. Parsers
-generated against the removed DFA and prediction-context APIs are not source
-compatible with this runtime.
+## Packed Parser ATNs
+
+Parser ATNs now use `ParserAtn`, a validated packed word stream with checked
+compact IDs, contiguous transition ranges, and pooled interval data. Generated
+parsers embed this versioned stream directly and borrow it without rebuilding
+an object graph. `ParserAtn::from_static` rejects bad magic, byte order,
+versions, section lengths, offsets, and indices; it never falls back to the old
+representation.
+
+The old parser-facing `Atn`, `AtnState`, and `Transition` graph APIs are
+removed. The graph retained for lexer simulation is now explicitly named
+`LexerAtn`, `LexerAtnState`, and `LexerTransition`. Borrow parser diagnostics
+through `ParserAtnState`, `ParserTransition`, and their iterators instead of
+materializing owned records.
+
+Parser `GrammarMetadata::serialized_atn()` is empty because the generated
+module carries `PARSER_ATN_DATA` as its single parser-ATN artifact. Code that
+needs parser ATN diagnostics must use the module's `parser_atn()` function (or
+`GeneratedParser::parser_atn()`) and the runtime borrowing views rather than
+re-deserializing metadata.
+
+Regenerate lexers and parsers with the matching `antlr4-rust-gen` release.
+Older generated parsers do not contain the packed parser format and are
+intentionally source- and data-incompatible with this runtime. A format
+mismatch reports both the generated version and the runtime-supported range;
+there is no compatibility repacker.
 
 Token IDs cover indices through `u32::MAX`. Source scalar/byte offsets, line
 numbers, and columns are limited to `u32::MAX - 1` (4,294,967,294);

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::hash::BuildHasherDefault;
 
 use crate::atn::lexer_dfa::{CompiledLexerAccept, CompiledLexerDfa, DEAD_STATE, ESCAPE_STATE};
-use crate::atn::{Atn, AtnStateKind, LexerAction, Transition};
+use crate::atn::{AtnStateKind, LexerAction, LexerAtn, LexerTransition};
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
 use crate::lexer::{
@@ -125,7 +125,7 @@ struct ClosureState {
 pub fn next_token<I>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
 ) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
@@ -142,7 +142,7 @@ where
 pub fn next_token_with_actions<I, A>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     custom_action: A,
 ) -> Result<TokenId, TokenStoreError>
 where
@@ -161,7 +161,7 @@ where
 pub fn next_token_with_accept_adjuster<I, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     accept_adjuster: E,
 ) -> Result<TokenId, TokenStoreError>
 where
@@ -178,7 +178,7 @@ where
 pub fn next_token_with_actions_and_predicates<I, A, P>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mut custom_action: A,
     mut semantic_predicate: P,
 ) -> Result<TokenId, TokenStoreError>
@@ -205,7 +205,7 @@ where
 pub fn next_token_with_hooks<I, A, P, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mut custom_action: A,
     mut semantic_predicate: P,
     mut accept_adjuster: E,
@@ -290,7 +290,7 @@ where
 pub fn next_token_with_semantic_hooks<I, H>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     hooks: &mut H,
 ) -> Result<TokenId, TokenStoreError>
 where
@@ -324,7 +324,7 @@ where
 pub fn next_token_compiled<I>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     dfa: &CompiledLexerDfa,
 ) -> Result<TokenId, TokenStoreError>
 where
@@ -353,7 +353,7 @@ where
 pub fn next_token_compiled_with_hooks<I, A, P, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     dfa: &CompiledLexerDfa,
     mut custom_action: A,
     mut semantic_predicate: P,
@@ -384,7 +384,7 @@ where
 pub fn next_token_compiled_with_semantic_hooks<I, H>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     dfa: &CompiledLexerDfa,
     hooks: &mut H,
 ) -> Result<TokenId, TokenStoreError>
@@ -423,7 +423,7 @@ where
 pub fn next_token_with_semantic_dispatch<I, H, A, P, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     hooks: &mut H,
     mut generated_action: A,
     mut generated_predicate: P,
@@ -485,7 +485,7 @@ where
 pub fn next_token_compiled_with_semantic_dispatch<I, H, A, P, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     dfa: &CompiledLexerDfa,
     hooks: &mut H,
     mut generated_action: A,
@@ -547,7 +547,7 @@ where
 fn next_token_with_cache<I, A, P, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mut custom_action: A,
     mut semantic_predicate: P,
     mut accept_adjuster: E,
@@ -586,7 +586,7 @@ struct LexerMatchStrategy<'a> {
 /// Dispatches one token match to the strategy's backend.
 fn match_token_with_strategy<I, P>(
     lexer: &mut BaseLexer<I>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mode: i32,
     start: usize,
     semantic_predicate: &mut P,
@@ -614,7 +614,7 @@ where
 fn next_token_with_hooks_impl<I, A, P, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
-    atn: &Atn,
+    atn: &LexerAtn,
     custom_action: &mut A,
     semantic_predicate: &mut P,
     accept_adjuster: &mut E,
@@ -719,7 +719,7 @@ where
 /// the token. Fragment-rule actions remain eligible because fragments have no
 /// token type of their own.
 pub(super) fn lexer_action_belongs_to_accept(
-    atn: &Atn,
+    atn: &LexerAtn,
     accept_rule: usize,
     action_rule: usize,
 ) -> bool {
@@ -741,7 +741,7 @@ pub(super) fn lexer_action_belongs_to_accept(
 /// supplies matching semantics shared by all generated grammars.
 fn match_token<I, P>(
     lexer: &mut BaseLexer<I>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mode: i32,
     start: usize,
     semantic_predicate: &mut P,
@@ -844,7 +844,7 @@ where
 
 fn match_token_cached<I, P>(
     lexer: &mut BaseLexer<I>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mode: i32,
     start: usize,
     semantic_predicate: &mut P,
@@ -1060,7 +1060,7 @@ fn record_compiled_accept(
 
 fn cached_mode_start_state<I, P>(
     lexer: &BaseLexer<I>,
-    atn: &Atn,
+    atn: &LexerAtn,
     mode: i32,
     start: usize,
     semantic_predicate: &mut P,
@@ -1105,7 +1105,7 @@ where
 
 fn cache_dfa_state<I>(
     lexer: &BaseLexer<I>,
-    atn: &Atn,
+    atn: &LexerAtn,
     active: &[LexerConfig],
     has_semantic_context: bool,
     token_start: usize,
@@ -1176,7 +1176,7 @@ fn cached_accept_state(
 /// fragment rules and nested lexer constructs compile to rule transitions in the
 /// serialized ATN.
 pub(super) fn epsilon_closure<P>(
-    atn: &Atn,
+    atn: &LexerAtn,
     configs: impl IntoIterator<Item = LexerConfig>,
     semantic_predicate: &mut P,
 ) -> ClosureResult
@@ -1206,7 +1206,7 @@ where
 /// loop path before the exit path, while non-greedy entries serialize the exit
 /// path first. The later accept-pruning step relies on this order.
 fn close_config<P>(
-    atn: &Atn,
+    atn: &LexerAtn,
     config: LexerConfig,
     closure: &mut ClosureState,
     semantic_predicate: &mut P,
@@ -1234,13 +1234,13 @@ fn close_config<P>(
 
     for transition in &state.transitions {
         match transition {
-            Transition::Epsilon { target } => {
+            LexerTransition::Epsilon { target } => {
                 let mut next = config.clone();
                 set_config_state(atn, &mut next, *target);
                 next.passed_non_greedy |= state.non_greedy;
                 close_config(atn, next, closure, semantic_predicate);
             }
-            Transition::Rule {
+            LexerTransition::Rule {
                 target,
                 follow_state,
                 ..
@@ -1251,7 +1251,7 @@ fn close_config<P>(
                 next.stack.push(*follow_state);
                 close_config(atn, next, closure, semantic_predicate);
             }
-            Transition::Predicate {
+            LexerTransition::Predicate {
                 target,
                 rule_index,
                 pred_index,
@@ -1269,13 +1269,13 @@ fn close_config<P>(
                     close_config(atn, next, closure, semantic_predicate);
                 }
             }
-            Transition::Precedence { target, .. } => {
+            LexerTransition::Precedence { target, .. } => {
                 let mut next = config.clone();
                 set_config_state(atn, &mut next, *target);
                 next.passed_non_greedy |= state.non_greedy;
                 close_config(atn, next, closure, semantic_predicate);
             }
-            Transition::Action {
+            LexerTransition::Action {
                 target,
                 action_index,
                 rule_index,
@@ -1293,11 +1293,11 @@ fn close_config<P>(
                 }
                 close_config(atn, next, closure, semantic_predicate);
             }
-            Transition::Atom { .. }
-            | Transition::Range { .. }
-            | Transition::Set { .. }
-            | Transition::NotSet { .. }
-            | Transition::Wildcard { .. } => {}
+            LexerTransition::Atom { .. }
+            | LexerTransition::Range { .. }
+            | LexerTransition::Set { .. }
+            | LexerTransition::NotSet { .. }
+            | LexerTransition::Wildcard { .. } => {}
         }
     }
 
@@ -1317,7 +1317,7 @@ fn close_config<P>(
 /// Once such a path reaches the rule stop state, later same-rule configs should
 /// not continue to grow into a longer token. Greedy decisions still need all
 /// paths to remain available so longest-match selection can win.
-pub(super) fn prune_after_accepts(atn: &Atn, configs: Vec<LexerConfig>) -> Vec<LexerConfig> {
+pub(super) fn prune_after_accepts(atn: &LexerAtn, configs: Vec<LexerConfig>) -> Vec<LexerConfig> {
     let mut accepted_rules = BTreeSet::new();
     let mut pruned = Vec::with_capacity(configs.len());
     for config in configs {
@@ -1331,7 +1331,7 @@ pub(super) fn prune_after_accepts(atn: &Atn, configs: Vec<LexerConfig>) -> Vec<L
         let is_top_level_accept = config.stack.is_empty()
             && atn
                 .state(config.state)
-                .is_some_and(crate::atn::AtnState::is_rule_stop);
+                .is_some_and(crate::atn::LexerAtnState::is_rule_stop);
         if is_top_level_accept && config.passed_non_greedy {
             accepted_rules.insert(rule_index);
         }
@@ -1345,7 +1345,7 @@ pub(super) fn prune_after_accepts(atn: &Atn, configs: Vec<LexerConfig>) -> Vec<L
 /// ANTLR lexer priority is encoded by rule order. `match_token` already handles
 /// longest-match selection across input positions; within a single position the
 /// lower rule index wins.
-pub(super) fn best_accept(atn: &Atn, configs: &[LexerConfig]) -> Option<AcceptState> {
+pub(super) fn best_accept(atn: &LexerAtn, configs: &[LexerConfig]) -> Option<AcceptState> {
     configs
         .iter()
         .filter_map(|config| {
@@ -1364,7 +1364,7 @@ pub(super) fn best_accept(atn: &Atn, configs: &[LexerConfig]) -> Option<AcceptSt
 }
 
 /// Returns the token type predicted by an accepting lexer config set, if any.
-fn accept_prediction(atn: &Atn, configs: &[LexerConfig]) -> Option<i32> {
+fn accept_prediction(atn: &LexerAtn, configs: &[LexerConfig]) -> Option<i32> {
     best_accept(atn, configs)
         .and_then(|accept| atn.rule_to_token_type().get(accept.rule_index).copied())
 }
@@ -1445,7 +1445,7 @@ fn cached_configs_to_configs(
 
 /// Moves a lexer config to `state_number` and records the top-level lexer rule
 /// once the config leaves a mode start state.
-pub(super) fn set_config_state(atn: &Atn, config: &mut LexerConfig, state_number: usize) {
+pub(super) fn set_config_state(atn: &LexerAtn, config: &mut LexerConfig, state_number: usize) {
     config.state = state_number;
     if config.alt_rule_index.is_none() {
         config.alt_rule_index = atn.state(state_number).and_then(|state| state.rule_index);
@@ -1494,7 +1494,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::atn::AtnType;
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
     use crate::char_stream::InputStream;
     use crate::recognizer::RecognizerData;
@@ -1509,7 +1508,7 @@ mod tests {
         text: String,
     }
 
-    fn lex_one<I: CharStream>(lexer: &mut BaseLexer<I>, atn: &Atn) -> TokenSnapshot {
+    fn lex_one<I: CharStream>(lexer: &mut BaseLexer<I>, atn: &LexerAtn) -> TokenSnapshot {
         let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
         let mut sink = TokenSink::new(&mut store);
         let id = next_token(lexer, &mut sink, atn).expect("test token should fit");
@@ -1524,7 +1523,7 @@ mod tests {
 
     #[test]
     fn predicate_sensitive_lexer_state_is_not_replay_cached() {
-        let atn = Atn::new(AtnType::Lexer, 1);
+        let atn = LexerAtn::new(1);
         let data = RecognizerData::new(
             "T",
             Vocabulary::new([None, Some("T")], [None, Some("T")], [None::<&str>, None]),

--- a/src/atn/lexer_dfa.rs
+++ b/src/atn/lexer_dfa.rs
@@ -24,7 +24,7 @@ use crate::atn::lexer::{
     LexerConfig, best_accept, epsilon_closure, lexer_action_belongs_to_accept, prune_after_accepts,
     set_config_state,
 };
-use crate::atn::{Atn, Transition};
+use crate::atn::{LexerAtn, LexerTransition};
 use crate::int_stream::EOF;
 use crate::lexer::{LexerDfaActionKey, LexerDfaConfigKey, LexerDfaKey};
 use crate::prediction::PredictionFxHasher;
@@ -115,7 +115,7 @@ pub(super) struct CompiledLexerActionTrace {
 impl CompiledLexerDfa {
     /// Compiles every lexer mode of `atn` that has no semantic predicates and
     /// fits the state budget; the rest stay interpreter-matched.
-    pub fn compile(atn: &Atn) -> Self {
+    pub fn compile(atn: &LexerAtn) -> Self {
         let mut dfa = Self {
             mode_starts: Vec::new(),
             states: Vec::new(),
@@ -170,7 +170,7 @@ impl CompiledLexerDfa {
             .get(self.states[usize::from(state)].accept as usize)
     }
 
-    /// Transition target for a non-EOF symbol, or [`DEAD_STATE`].
+    /// `LexerTransition` target for a non-EOF symbol, or [`DEAD_STATE`].
     pub(super) fn char_target(&self, state: u16, symbol: i32) -> u16 {
         let compiled = &self.states[usize::from(state)];
         let code_point = symbol.cast_unsigned();
@@ -192,7 +192,7 @@ impl CompiledLexerDfa {
         }
     }
 
-    /// Transition target for the EOF symbol, or [`DEAD_STATE`].
+    /// `LexerTransition` target for the EOF symbol, or [`DEAD_STATE`].
     pub(super) fn eof_target(&self, state: u16) -> u16 {
         self.states[usize::from(state)].eof_target
     }
@@ -501,7 +501,7 @@ impl ModeBuild {
     /// state when the (input-offset-normalized) identity is new.
     /// [`ESCAPE_STATE`] means the state budget is exhausted and the edge must
     /// hand the token to the interpreter.
-    fn intern(&mut self, atn: &Atn, configs: Vec<LexerConfig>, step: usize) -> u16 {
+    fn intern(&mut self, atn: &LexerAtn, configs: Vec<LexerConfig>, step: usize) -> u16 {
         let key = LexerDfaKey::new(
             configs
                 .iter()
@@ -555,7 +555,11 @@ fn relative_config_key(config: &LexerConfig, step: usize) -> LexerDfaConfigKey {
 
 /// Computes the accept metadata for a DFA state from its config set, using
 /// the interpreter's own rule-priority selection.
-fn compiled_accept(atn: &Atn, configs: &[LexerConfig], step: usize) -> Option<CompiledLexerAccept> {
+fn compiled_accept(
+    atn: &LexerAtn,
+    configs: &[LexerConfig],
+    step: usize,
+) -> Option<CompiledLexerAccept> {
     let accept = best_accept(atn, configs)?;
     debug_assert!(
         accept.position == step,
@@ -579,7 +583,7 @@ fn compiled_accept(atn: &Atn, configs: &[LexerConfig], step: usize) -> Option<Co
 /// Runs subset construction for one mode; `None` leaves the whole mode to the
 /// interpreter (only when its very first closure already escapes).
 fn build_mode(
-    atn: &Atn,
+    atn: &LexerAtn,
     mode: usize,
     dfa: &mut CompiledLexerDfa,
     pools: &mut RowPools,
@@ -618,7 +622,7 @@ fn build_mode(
 /// `None` means the closure crossed a semantic predicate (which only the
 /// interpreter can evaluate) or entered a recursive lexer rule (nested
 /// comments never determinize), so the edge must escape.
-fn closed_configs(atn: &Atn, moved: Vec<LexerConfig>) -> Option<Vec<LexerConfig>> {
+fn closed_configs(atn: &LexerAtn, moved: Vec<LexerConfig>) -> Option<Vec<LexerConfig>> {
     let closure = epsilon_closure(atn, moved, &mut |_| true);
     if closure.has_semantic_context {
         return None;
@@ -644,7 +648,7 @@ fn closed_configs(atn: &Atn, moved: Vec<LexerConfig>) -> Option<Vec<LexerConfig>
 /// commands belong to itself, not the enclosing rule). Carrying them into
 /// DFA-state identity would mint a fresh state per input offset — rules that
 /// loop over comment/whitespace references would never determinize.
-fn prune_dead_action_traces(atn: &Atn, config: &mut LexerConfig) {
+fn prune_dead_action_traces(atn: &LexerAtn, config: &mut LexerConfig) {
     let Some(accept_rule) = config.alt_rule_index else {
         return;
     };
@@ -668,7 +672,7 @@ fn has_recursive_stack(config: &LexerConfig) -> bool {
 }
 
 /// Computes every outgoing edge of one interned DFA state.
-fn expand_state(atn: &Atn, build: &mut ModeBuild, local: usize) -> StateRows {
+fn expand_state(atn: &LexerAtn, build: &mut ModeBuild, local: usize) -> StateRows {
     let configs = build.configs[local].clone();
     let step = build.steps[local];
     let entries = consuming_entries(atn, &configs);
@@ -711,7 +715,10 @@ fn expand_state(atn: &Atn, build: &mut ModeBuild, local: usize) -> StateRows {
 }
 
 /// Lists each config's consuming transitions in the interpreter's move order.
-fn consuming_entries<'a>(atn: &'a Atn, configs: &[LexerConfig]) -> Vec<(usize, &'a Transition)> {
+fn consuming_entries<'a>(
+    atn: &'a LexerAtn,
+    configs: &[LexerConfig],
+) -> Vec<(usize, &'a LexerTransition)> {
     let mut entries = Vec::new();
     for (config_index, config) in configs.iter().enumerate() {
         let Some(state) = atn.state(config.state) else {
@@ -767,7 +774,7 @@ fn segment_mask_matrix(
 
 /// Materializes the code-point intervals a transition consumes, clamped to
 /// the valid character range (EOF is handled separately).
-fn transition_char_intervals(transition: &Transition) -> Vec<(i32, i32)> {
+fn transition_char_intervals(transition: &LexerTransition) -> Vec<(i32, i32)> {
     let mut intervals = Vec::new();
     let mut push_clamped = |low: i32, high: i32| {
         let low = low.max(MIN_CHAR_VALUE);
@@ -777,14 +784,14 @@ fn transition_char_intervals(transition: &Transition) -> Vec<(i32, i32)> {
         }
     };
     match transition {
-        Transition::Atom { label, .. } => push_clamped(*label, *label),
-        Transition::Range { start, stop, .. } => push_clamped(*start, *stop),
-        Transition::Set { set, .. } => {
+        LexerTransition::Atom { label, .. } => push_clamped(*label, *label),
+        LexerTransition::Range { start, stop, .. } => push_clamped(*start, *stop),
+        LexerTransition::Set { set, .. } => {
             for &(low, high) in set.ranges() {
                 push_clamped(low, high);
             }
         }
-        Transition::NotSet { set, .. } => {
+        LexerTransition::NotSet { set, .. } => {
             // `NotSet` matches the complement within the character range;
             // `IntervalSet` ranges are sorted and coalesced.
             let mut next = MIN_CHAR_VALUE;
@@ -796,7 +803,7 @@ fn transition_char_intervals(transition: &Transition) -> Vec<(i32, i32)> {
             }
             push_clamped(next, MAX_CHAR_VALUE);
         }
-        Transition::Wildcard { .. } => push_clamped(MIN_CHAR_VALUE, MAX_CHAR_VALUE),
+        LexerTransition::Wildcard { .. } => push_clamped(MIN_CHAR_VALUE, MAX_CHAR_VALUE),
         _ => {}
     }
     intervals
@@ -805,11 +812,11 @@ fn transition_char_intervals(transition: &Transition) -> Vec<(i32, i32)> {
 /// Advances the masked entries by one character and interns the result;
 /// closures that escape compile as [`ESCAPE_STATE`] edges.
 fn move_target(
-    atn: &Atn,
+    atn: &LexerAtn,
     build: &mut ModeBuild,
     configs: &[LexerConfig],
     step: usize,
-    entries: &[(usize, &Transition)],
+    entries: &[(usize, &LexerTransition)],
     mask: &[u64],
 ) -> u16 {
     let mut moved = Vec::new();
@@ -834,11 +841,11 @@ fn move_target(
 /// Advances the EOF-matching entries; EOF consumes no character, so the input
 /// offset stays put and the moved configs record `consumed_eof`.
 fn eof_move(
-    atn: &Atn,
+    atn: &LexerAtn,
     build: &mut ModeBuild,
     configs: &[LexerConfig],
     step: usize,
-    entries: &[(usize, &Transition)],
+    entries: &[(usize, &LexerTransition)],
 ) -> u16 {
     let mut moved = Vec::new();
     for (config_index, transition) in entries {
@@ -928,7 +935,7 @@ mod tests {
 
     fn compiled_token(
         lexer: &mut BaseLexer<InputStream>,
-        atn: &Atn,
+        atn: &LexerAtn,
         dfa: &CompiledLexerDfa,
     ) -> TokenSnapshot {
         let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
@@ -941,7 +948,7 @@ mod tests {
         }
     }
 
-    fn interpreted_token(lexer: &mut BaseLexer<InputStream>, atn: &Atn) -> TokenSnapshot {
+    fn interpreted_token(lexer: &mut BaseLexer<InputStream>, atn: &LexerAtn) -> TokenSnapshot {
         let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
         let mut sink = TokenSink::new(&mut store);
         let id = next_token(lexer, &mut sink, atn).expect("test token should fit");
@@ -970,7 +977,7 @@ mod tests {
     // explodes it to one integer per line (the cast/path elements defeat the
     // packed-list tactic) and destroys the mapping to the ANTLR ATN layout.
     #[rustfmt::skip]
-    fn two_rule_atn(with_predicate: bool) -> Atn {
+    fn two_rule_atn(with_predicate: bool) -> LexerAtn {
         let epsilon_or_predicate = if with_predicate { 4 } else { 1 };
         AtnDeserializer::new(&SerializedAtn::from_i32(&[
             4, 0, 2, // version, lexer, max token type
@@ -1014,7 +1021,7 @@ mod tests {
     // `two_rule_atn`). Pure literals keep rustfmt's packed layout today, but a
     // single cast/path element would explode it, so pin it defensively.
     #[rustfmt::skip]
-    fn wide_range_atn() -> Atn {
+    fn wide_range_atn() -> LexerAtn {
         AtnDeserializer::new(&SerializedAtn::from_i32(&[
             4, 0, 1, // version, lexer, max token type
             5, // states

--- a/src/atn/mod.rs
+++ b/src/atn/mod.rs
@@ -1,33 +1,25 @@
-//! Abstract Transition Network structures shared by generated lexers and
+//! Abstract Transition Network structures used by generated lexers and
 //! parsers.
 //!
-//! ANTLR serializes grammars into an ATN. Generated Rust code stores that
-//! serialized data in static metadata, while the runtime deserializes it into
-//! these compact Rust structures for simulation.
+//! Lexers deserialize ANTLR metadata into a graph because lexer simulation
+//! still mutates and inspects that shape. Parsers use the packed,
+//! index-addressed [`parser_atn::ParserAtn`] representation instead.
 
 pub mod lexer;
 pub mod lexer_dfa;
 pub mod parser;
+pub mod parser_atn;
 pub mod serialized;
 
-/// Distinguishes lexer ATNs from parser ATNs in serialized grammar metadata.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum AtnType {
-    Lexer,
-    Parser,
-}
-
-/// Deserialized ANTLR Abstract Transition Network.
+/// Deserialized lexer Abstract Transition Network.
 ///
 /// The structure keeps the state graph plus ANTLR side tables such as
-/// rule-to-start, rule-to-token, mode-to-start, decisions, and lexer actions.
-/// The side tables are part of the runtime contract because generated grammars
-/// should only need to provide metadata; simulation stays in this crate.
+/// rule-to-start, rule-to-token, mode-to-start, decisions, and actions. Parser
+/// ATNs never use this object-graph representation.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Atn {
-    grammar_type: AtnType,
+pub struct LexerAtn {
     max_token_type: i32,
-    states: Vec<AtnState>,
+    states: Vec<LexerAtnState>,
     rule_to_start_state: Vec<usize>,
     rule_to_stop_state: Vec<usize>,
     rule_to_token_type: Vec<i32>,
@@ -36,12 +28,11 @@ pub struct Atn {
     lexer_actions: Vec<LexerAction>,
 }
 
-impl Atn {
-    /// Creates an empty ATN with the grammar kind and maximum token type read
-    /// from the serialized header.
-    pub const fn new(grammar_type: AtnType, max_token_type: i32) -> Self {
+impl LexerAtn {
+    /// Creates an empty lexer ATN with the maximum token type read from the
+    /// serialized header.
+    pub const fn new(max_token_type: i32) -> Self {
         Self {
-            grammar_type,
             max_token_type,
             states: Vec::new(),
             rule_to_start_state: Vec::new(),
@@ -53,29 +44,25 @@ impl Atn {
         }
     }
 
-    pub const fn grammar_type(&self) -> AtnType {
-        self.grammar_type
-    }
-
     pub const fn max_token_type(&self) -> i32 {
         self.max_token_type
     }
 
-    pub fn states(&self) -> &[AtnState] {
+    pub fn states(&self) -> &[LexerAtnState] {
         &self.states
     }
 
-    pub fn state(&self, state_number: usize) -> Option<&AtnState> {
+    pub fn state(&self, state_number: usize) -> Option<&LexerAtnState> {
         self.states.get(state_number)
     }
 
-    pub fn state_mut(&mut self, state_number: usize) -> Option<&mut AtnState> {
+    pub fn state_mut(&mut self, state_number: usize) -> Option<&mut LexerAtnState> {
         self.states.get_mut(state_number)
     }
 
     /// Appends a state and returns the state number assigned by insertion
     /// order.
-    pub fn add_state(&mut self, state: AtnState) -> usize {
+    pub fn add_state(&mut self, state: LexerAtnState) -> usize {
         let index = self.states.len();
         self.states.push(state);
         index
@@ -137,7 +124,7 @@ impl Atn {
 /// representation stores those links as state numbers so the graph remains easy
 /// to clone and serialize in tests.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AtnState {
+pub struct LexerAtnState {
     pub state_number: usize,
     pub rule_index: Option<usize>,
     pub kind: AtnStateKind,
@@ -146,10 +133,10 @@ pub struct AtnState {
     pub non_greedy: bool,
     pub precedence_rule_decision: bool,
     pub left_recursive_rule: bool,
-    pub transitions: Vec<Transition>,
+    pub transitions: Vec<LexerTransition>,
 }
 
-impl AtnState {
+impl LexerAtnState {
     /// Creates an ATN state with no rule index and no outgoing transitions.
     pub const fn new(state_number: usize, kind: AtnStateKind) -> Self {
         Self {
@@ -175,7 +162,7 @@ impl AtnState {
     ///
     /// Transition order matters for alternatives and lexer priority, so the
     /// runtime preserves the order emitted by ANTLR.
-    pub fn add_transition(&mut self, transition: Transition) {
+    pub fn add_transition(&mut self, transition: LexerTransition) {
         self.transitions.push(transition);
     }
 
@@ -208,7 +195,7 @@ pub enum AtnStateKind {
 /// the current input symbol against an atom, range, set, negated set, or
 /// wildcard.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Transition {
+pub enum LexerTransition {
     Epsilon {
         target: usize,
     },
@@ -256,7 +243,7 @@ pub enum Transition {
     },
 }
 
-impl Transition {
+impl LexerTransition {
     /// Returns the target state number for this transition.
     pub const fn target(&self) -> usize {
         match self {

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -1,4 +1,9 @@
-use crate::atn::{Atn, AtnState, AtnStateKind, Transition};
+use crate::atn::AtnStateKind;
+use crate::atn::parser_atn::{
+    ParserAtn as Atn, ParserAtnState as AtnState, ParserTransition, ParserTransitionKind,
+};
+#[cfg(test)]
+use crate::atn::parser_atn::{ParserAtnBuilder, ParserTransitionSpec};
 use crate::dfa::{
     DfaStateBuilder, DfaStateId, NO_DFA_STATE, ParserDfa, ParserDfaStateView, ParserDfaStats,
 };
@@ -253,13 +258,12 @@ impl IntStream for LookaheadIntStream {
 fn initial_decision_dfas(atn: &Atn) -> Vec<ParserDfa> {
     atn.decision_to_state()
         .iter()
-        .copied()
         .enumerate()
         .map(|(decision, state)| {
             let mut dfa = ParserDfa::with_max_token_type(state, decision, atn.max_token_type());
             if atn
                 .state(state)
-                .is_some_and(|state| state.precedence_rule_decision)
+                .is_some_and(AtnState::precedence_rule_decision)
             {
                 dfa.set_precedence_dfa(true);
             }
@@ -688,7 +692,7 @@ impl<'a> ParserAtnSimulator<'a> {
         } = request;
         #[cfg(feature = "perf-counters")]
         crate::perf::record_adaptive_call(decision, force_full_context_retry);
-        let Some(&decision_state) = self.atn.decision_to_state().get(decision) else {
+        let Some(decision_state) = self.atn.decision_to_state().get(decision) else {
             return Err(ParserAtnSimulatorError::UnknownDecision(decision));
         };
         let start_index = input.index();
@@ -890,7 +894,7 @@ impl<'a> ParserAtnSimulator<'a> {
         if !self
             .atn
             .state(decision_state)
-            .is_some_and(|state| state.non_greedy)
+            .is_some_and(AtnState::non_greedy)
         {
             return None;
         }
@@ -957,7 +961,7 @@ impl<'a> ParserAtnSimulator<'a> {
 
     fn compute_start_state(
         &mut self,
-        decision_state: &AtnState,
+        decision_state: AtnState<'_>,
         precedence: i32,
         merge_cache: &mut PredictionWorkspace,
     ) -> AtnConfigSet {
@@ -972,7 +976,7 @@ impl<'a> ParserAtnSimulator<'a> {
 
     fn compute_start_state_with_context(
         &mut self,
-        decision_state: &AtnState,
+        decision_state: AtnState<'_>,
         full_context: bool,
         initial_context: ContextId,
         precedence: i32,
@@ -985,7 +989,7 @@ impl<'a> ParserAtnSimulator<'a> {
             collect_predicates: true,
             treat_eof_as_epsilon: false,
         };
-        for (index, transition) in decision_state.transitions.iter().enumerate() {
+        for (index, transition) in decision_state.transitions().iter().enumerate() {
             let alt = index + 1;
             let config = AtnConfig::new(
                 transition.target(),
@@ -1188,6 +1192,7 @@ impl<'a> ParserAtnSimulator<'a> {
     ) -> AtnConfigSet {
         let mut intermediate = AtnConfigSet::new_full_context(full_context);
         let mut skipped_stop_states = Vec::new();
+        let max_token_type = self.atn.max_token_type();
         for config in configs.configs() {
             let Some(state) = self.atn.state(config.state) else {
                 continue;
@@ -1198,8 +1203,8 @@ impl<'a> ParserAtnSimulator<'a> {
                 }
                 continue;
             }
-            for transition in &state.transitions {
-                if transition.matches(symbol, 1, self.atn.max_token_type()) {
+            for transition in &state.transitions() {
+                if transition.matches(symbol, 1, max_token_type) {
                     let target =
                         config.moved_to(transition.target(), config.context, &self.store.contexts);
                     intermediate.add(target, &mut self.store.contexts, merge_cache);
@@ -1331,6 +1336,7 @@ impl<'a> ParserAtnSimulator<'a> {
             collect_predicates,
             treat_eof_as_epsilon,
         } = params;
+        let max_token_type = self.atn.max_token_type();
         scratch.stack.clear();
         scratch.visited.clear();
         scratch.stack.push((config, collect_predicates));
@@ -1353,12 +1359,11 @@ impl<'a> ParserAtnSimulator<'a> {
             {
                 continue;
             }
-            let epsilon_only = !state.transitions.is_empty()
-                && state.transitions.iter().all(Transition::is_epsilon);
+            let epsilon_only = state.epsilon_only();
             if !epsilon_only {
                 configs.add(config.clone(), &mut self.store.contexts, merge_cache);
             }
-            for (index, transition) in state.transitions.iter().enumerate() {
+            for (index, transition) in state.transitions().iter().enumerate() {
                 if index == 0
                     && can_drop_left_recursive_loop_entry_edge(
                         self.atn,
@@ -1369,10 +1374,19 @@ impl<'a> ParserAtnSimulator<'a> {
                 {
                     continue;
                 }
-                if transition.is_epsilon() {
+                let transition_kind = transition.kind();
+                if matches!(
+                    transition_kind,
+                    ParserTransitionKind::Epsilon
+                        | ParserTransitionKind::Rule
+                        | ParserTransitionKind::Predicate
+                        | ParserTransitionKind::Action
+                        | ParserTransitionKind::Precedence
+                ) {
                     if let Some(mut target) = self.epsilon_target_config(
                         &config,
                         transition,
+                        transition_kind,
                         precedence,
                         collect_predicates,
                         configs.full_context(),
@@ -1385,11 +1399,11 @@ impl<'a> ParserAtnSimulator<'a> {
                         // crossed, so a predicate after an action is deferred to
                         // parse time rather than evaluated during prediction.
                         let target_collect_predicates =
-                            collect_predicates && !matches!(transition, Transition::Action { .. });
+                            collect_predicates && transition_kind != ParserTransitionKind::Action;
                         scratch.stack.push((target, target_collect_predicates));
                     }
                 } else if treat_eof_as_epsilon
-                    && transition.matches(TOKEN_EOF, 1, self.atn.max_token_type())
+                    && transition.matches_kind(transition_kind, TOKEN_EOF, 1, max_token_type)
                 {
                     scratch.stack.push((
                         config.moved_to(transition.target(), config.context, &self.store.contexts),
@@ -1443,47 +1457,47 @@ impl<'a> ParserAtnSimulator<'a> {
         handled_all_paths
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn epsilon_target_config(
         &mut self,
         config: &AtnConfig,
-        transition: &Transition,
+        transition: ParserTransition<'_>,
+        transition_kind: ParserTransitionKind,
         precedence: i32,
         collect_predicates: bool,
         full_context: bool,
     ) -> Option<AtnConfig> {
-        let semantic_context = match transition {
-            Transition::Predicate {
-                rule_index,
-                pred_index,
-                context_dependent,
-                ..
-            } if collect_predicates => SemanticContext::and(
+        let semantic_context = match transition_kind {
+            ParserTransitionKind::Predicate if collect_predicates => SemanticContext::and(
                 config.semantic_context.clone(),
                 SemanticContext::Predicate {
-                    rule_index: *rule_index,
-                    pred_index: *pred_index,
-                    context_dependent: *context_dependent,
+                    rule_index: transition.arg0() as usize,
+                    pred_index: transition.arg1() as usize,
+                    context_dependent: transition.arg2() != 0,
                 },
             ),
-            Transition::Precedence {
-                precedence: transition_precedence,
-                ..
-            } if collect_predicates && *transition_precedence < precedence => return None,
-            Transition::Precedence { precedence, .. } if collect_predicates && !full_context => {
+            ParserTransitionKind::Precedence
+                if collect_predicates
+                    && i32::from_le_bytes(transition.arg0().to_le_bytes()) < precedence =>
+            {
+                return None;
+            }
+            ParserTransitionKind::Precedence if collect_predicates && !full_context => {
                 SemanticContext::and(
                     config.semantic_context.clone(),
                     SemanticContext::Precedence {
-                        precedence: *precedence,
+                        precedence: i32::from_le_bytes(transition.arg0().to_le_bytes()),
                     },
                 )
             }
             _ => config.semantic_context.clone(),
         };
-        let context = match transition {
-            Transition::Rule { follow_state, .. } => {
-                self.store.contexts.singleton(config.context, *follow_state)
-            }
-            _ => config.context,
+        let context = if transition_kind == ParserTransitionKind::Rule {
+            self.store
+                .contexts
+                .singleton(config.context, transition.arg1() as usize)
+        } else {
+            config.context
         };
         let mut target = config.moved_to(transition.target(), context, &self.store.contexts);
         target.semantic_context = semantic_context;
@@ -1527,18 +1541,18 @@ impl<'a> ParserAtnSimulator<'a> {
 /// left-recursive rule under the current caller context.
 pub(crate) fn can_drop_left_recursive_loop_entry_edge(
     atn: &Atn,
-    state: &AtnState,
+    state: AtnState<'_>,
     contexts: &ContextArena,
     context: ContextId,
 ) -> bool {
-    if state.kind != AtnStateKind::StarLoopEntry
-        || !state.precedence_rule_decision
+    if state.kind() != AtnStateKind::StarLoopEntry
+        || !state.precedence_rule_decision()
         || contexts.is_empty(context)
         || contexts.has_empty_path(context)
     {
         return false;
     }
-    let Some(rule_index) = state.rule_index else {
+    let Some(rule_index) = state.rule_index() else {
         return false;
     };
     for index in 0..contexts.len(context) {
@@ -1548,15 +1562,15 @@ pub(crate) fn can_drop_left_recursive_loop_entry_edge(
         let Some(return_state) = atn.state(return_state_number) else {
             return false;
         };
-        if return_state.rule_index != Some(rule_index) {
+        if return_state.rule_index() != Some(rule_index) {
             return false;
         }
     }
     let Some(block_end_state_number) = state
-        .transitions
+        .transitions()
         .first()
         .and_then(|transition| atn.state(transition.target()))
-        .and_then(|decision_start| decision_start.end_state)
+        .and_then(AtnState::end_state)
     else {
         return false;
     };
@@ -1567,14 +1581,23 @@ pub(crate) fn can_drop_left_recursive_loop_entry_edge(
         let return_state = atn
             .state(return_state_number)
             .expect("return state checked above");
-        if return_state.state_number == block_end_state_number {
+        if return_state.state_number() == block_end_state_number {
             continue;
         }
-        if return_state.transitions.len() != 1 || !return_state.transitions[0].is_epsilon() {
+        if return_state.transitions().len() != 1
+            || !return_state
+                .transitions()
+                .first()
+                .is_some_and(ParserTransition::is_epsilon)
+        {
             return false;
         }
-        let return_target = return_state.transitions[0].target();
-        if return_state.kind == AtnStateKind::BlockEnd && return_target == state.state_number {
+        let return_target = return_state
+            .transitions()
+            .first()
+            .expect("single transition checked above")
+            .target();
+        if return_state.kind() == AtnStateKind::BlockEnd && return_target == state.state_number() {
             continue;
         }
         if return_target == block_end_state_number {
@@ -1583,10 +1606,16 @@ pub(crate) fn can_drop_left_recursive_loop_entry_edge(
         let Some(return_target_state) = atn.state(return_target) else {
             return false;
         };
-        if return_target_state.kind == AtnStateKind::BlockEnd
-            && return_target_state.transitions.len() == 1
-            && return_target_state.transitions[0].is_epsilon()
-            && return_target_state.transitions[0].target() == state.state_number
+        if return_target_state.kind() == AtnStateKind::BlockEnd
+            && return_target_state.transitions().len() == 1
+            && return_target_state
+                .transitions()
+                .first()
+                .is_some_and(ParserTransition::is_epsilon)
+            && return_target_state
+                .transitions()
+                .first()
+                .is_some_and(|transition| transition.target() == state.state_number())
         {
             continue;
         }
@@ -1637,7 +1666,11 @@ fn dfa_state_display(state: ParserDfaStateView<'_>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::atn::{AtnStateKind, AtnType};
+    use crate::atn::AtnStateKind;
+
+    fn finish_atn(builder: ParserAtnBuilder) -> Atn {
+        builder.finish().expect("valid packed parser ATN")
+    }
 
     #[test]
     fn union_decision_dfa_preserves_disjoint_coverage() {
@@ -1866,10 +1899,7 @@ mod tests {
 
     #[test]
     fn adaptive_predict_uses_precedence_dfa_start_states() {
-        let mut atn = two_token_decision_atn();
-        atn.state_mut(1)
-            .expect("decision state")
-            .precedence_rule_decision = true;
+        let atn = two_token_decision_atn_with_precedence(true);
         let mut simulator = ParserAtnSimulator::new(&atn);
 
         assert_eq!(
@@ -2010,19 +2040,25 @@ mod tests {
 
     #[test]
     fn sll_closure_follows_empty_context_rule_stop_exits() {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::RuleStop);
         add_state(&mut atn, 1, AtnStateKind::Basic);
         add_state(&mut atn, 2, AtnStateKind::Basic);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 1,
-            });
+            },
+        )
+        .expect("transition");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![0])
+            .expect("rule stop states");
+        let atn = finish_atn(atn);
 
         let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new_full_context(false);
@@ -2050,18 +2086,33 @@ mod tests {
 
     #[test]
     fn precedence_contexts_are_collected_only_for_start_closure() {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::Basic);
         add_state(&mut atn, 1, AtnStateKind::Basic);
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![1])
+            .expect("rule stop states");
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Precedence {
+                target: 1,
+                precedence: 2,
+            },
+        )
+        .expect("precedence transition");
+        let atn = finish_atn(atn);
+        let transition = atn
+            .state(0)
+            .expect("source state")
+            .transitions()
+            .first()
+            .expect("precedence transition");
         let mut simulator = ParserAtnSimulator::new(&atn);
-        let transition = Transition::Precedence {
-            target: 1,
-            precedence: 2,
-        };
         let config = AtnConfig::new(0, 1, EMPTY_CONTEXT, &simulator.store.contexts);
 
         let sll_start = simulator
-            .epsilon_target_config(&config, &transition, 1, true, false)
+            .epsilon_target_config(&config, transition, transition.kind(), 1, true, false)
             .expect("sll start transition");
         assert!(matches!(
             sll_start.semantic_context,
@@ -2069,18 +2120,18 @@ mod tests {
         ));
 
         let full_context_start = simulator
-            .epsilon_target_config(&config, &transition, 1, true, true)
+            .epsilon_target_config(&config, transition, transition.kind(), 1, true, true)
             .expect("full-context start transition");
         assert!(full_context_start.semantic_context.is_none());
 
         let reach = simulator
-            .epsilon_target_config(&config, &transition, 3, false, false)
+            .epsilon_target_config(&config, transition, transition.kind(), 3, false, false)
             .expect("reach transition");
         assert!(reach.semantic_context.is_none());
 
         assert!(
             simulator
-                .epsilon_target_config(&config, &transition, 3, true, false)
+                .epsilon_target_config(&config, transition, transition.kind(), 3, true, false)
                 .is_none()
         );
     }
@@ -2093,33 +2144,44 @@ mod tests {
         // config's semantic context — it is deferred to parse time (the
         // "action hides predicates" rule). Build `0 -Action-> 1 -Pred-> 2` and
         // assert the closure config carries NO semantic context.
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::Basic);
         add_state(&mut atn, 1, AtnStateKind::Basic);
         add_state(&mut atn, 2, AtnStateKind::Basic);
         add_state(&mut atn, 3, AtnStateKind::Basic);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Action {
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Action {
                 target: 1,
                 rule_index: 0,
                 action_index: Some(0),
                 context_dependent: false,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Predicate {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Predicate {
                 target: 2,
                 rule_index: 0,
                 pred_index: 0,
                 context_dependent: false,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
+            },
+        )
+        .expect("transition");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![3])
+            .expect("rule stop states");
+        let atn = finish_atn(atn);
 
         let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new();
@@ -2154,15 +2216,17 @@ mod tests {
         // IS collected (so the assertion above is about the action edge, not a
         // blanket failure to collect predicates).
         let direct_config = AtnConfig::new(1, 1, EMPTY_CONTEXT, &simulator.store.contexts);
+        let direct_transition = atn
+            .state(1)
+            .expect("predicate source")
+            .transitions()
+            .first()
+            .expect("predicate transition");
         let direct = simulator
             .epsilon_target_config(
                 &direct_config,
-                &Transition::Predicate {
-                    target: 2,
-                    rule_index: 0,
-                    pred_index: 0,
-                    context_dependent: false,
-                },
+                direct_transition,
+                direct_transition.kind(),
                 0,
                 true,
                 false,
@@ -2176,19 +2240,25 @@ mod tests {
 
     #[test]
     fn reach_set_skips_closure_for_unique_intermediate_alt() {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::Basic);
         add_state(&mut atn, 1, AtnStateKind::Basic);
         add_state(&mut atn, 2, AtnStateKind::Basic);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Atom {
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Atom {
                 target: 1,
                 label: 7,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
+            },
+        )
+        .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![2])
+            .expect("rule stop states");
+        let atn = finish_atn(atn);
 
         let mut simulator = ParserAtnSimulator::new(&atn);
         let mut configs = AtnConfigSet::new_full_context(false);
@@ -2268,7 +2338,11 @@ mod tests {
     }
 
     fn two_token_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 3);
+        two_token_decision_atn_with_precedence(false)
+    }
+
+    fn two_token_decision_atn_with_precedence(precedence: bool) -> Atn {
+        let mut atn = ParserAtnBuilder::new(3);
         add_state(&mut atn, 0, AtnStateKind::RuleStart);
         add_state(&mut atn, 1, AtnStateKind::BlockStart);
         add_state(&mut atn, 2, AtnStateKind::Basic);
@@ -2277,113 +2351,123 @@ mod tests {
         add_state(&mut atn, 5, AtnStateKind::Basic);
         add_state(&mut atn, 6, AtnStateKind::BlockEnd);
         add_state(&mut atn, 7, AtnStateKind::RuleStop);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![7]);
-        atn.add_decision_state(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![7])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        if precedence {
+            atn.set_precedence_rule_decision(1)
+                .expect("precedence decision state");
+        }
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Atom {
                 target: 6,
                 label: 2,
-            });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Atom {
                 target: 5,
                 label: 1,
-            });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Atom {
                 target: 6,
                 label: 3,
-            });
-        atn.state_mut(6)
-            .expect("state 6")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn optional_token_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::RuleStart);
         add_state(&mut atn, 1, AtnStateKind::BlockStart);
         add_state(&mut atn, 2, AtnStateKind::Basic);
         add_state(&mut atn, 3, AtnStateKind::BlockEnd);
         add_state(&mut atn, 4, AtnStateKind::RuleStop);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![4]);
-        atn.add_decision_state(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![4])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn non_greedy_optional_exit_first_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::RuleStart);
         add_state(&mut atn, 1, AtnStateKind::BlockStart);
         add_state(&mut atn, 2, AtnStateKind::BlockEnd);
         add_state(&mut atn, 3, AtnStateKind::Basic);
         add_state(&mut atn, 4, AtnStateKind::RuleStop);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![4]);
-        atn.add_decision_state(1);
-        atn.state_mut(1).expect("state 1").non_greedy = true;
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Atom {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![4])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.set_non_greedy(1).expect("non-greedy state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(2, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 1,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     fn ambiguous_single_token_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::RuleStart);
         add_state(&mut atn, 1, AtnStateKind::BlockStart);
         add_state(&mut atn, 2, AtnStateKind::Basic);
@@ -2392,73 +2476,81 @@ mod tests {
         add_state(&mut atn, 5, AtnStateKind::Basic);
         add_state(&mut atn, 6, AtnStateKind::BlockEnd);
         add_state(&mut atn, 7, AtnStateKind::RuleStop);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![7]);
-        atn.add_decision_state(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![7])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Atom {
                 target: 5,
                 label: 1,
-            });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(6)
-            .expect("state 6")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn prefix_alt_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 3);
+        let mut atn = ParserAtnBuilder::new(3);
         add_state(&mut atn, 0, AtnStateKind::BlockStart);
         add_state(&mut atn, 1, AtnStateKind::Basic);
         add_state(&mut atn, 2, AtnStateKind::RuleStop);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![2]);
-        atn.add_decision_state(0);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Atom {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![2])
+            .expect("rule stop states");
+        atn.add_decision_state(0).expect("decision state");
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 1,
-            });
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Atom {
                 target: 1,
                 label: 1,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 2,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     fn multiple_eof_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
+        let mut atn = ParserAtnBuilder::new(2);
         for state_number in 0..=10 {
             let kind = match state_number {
                 0 => AtnStateKind::RuleStart,
@@ -2469,91 +2561,104 @@ mod tests {
             };
             add_state(&mut atn, state_number, kind);
         }
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![10]);
-        atn.add_decision_state(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![10])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Atom {
                 target: 5,
                 label: 1,
-            });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Atom {
                 target: 6,
                 label: 2,
-            });
-        atn.state_mut(6)
-            .expect("state 6")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.state_mut(7)
-            .expect("state 7")
-            .add_transition(Transition::Epsilon { target: 8 });
-        atn.state_mut(8)
-            .expect("state 8")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_transition(7, ParserTransitionSpec::Epsilon { target: 8 })
+            .expect("transition");
+        atn.add_transition(
+            8,
+            ParserTransitionSpec::Atom {
                 target: 9,
                 label: TOKEN_EOF,
-            });
-        atn.state_mut(9)
-            .expect("state 9")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            9,
+            ParserTransitionSpec::Atom {
                 target: 10,
                 label: TOKEN_EOF,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     fn left_recursive_loop_entry_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         add_state(&mut atn, 0, AtnStateKind::RuleStart);
         add_state(&mut atn, 1, AtnStateKind::StarLoopEntry);
         add_state(&mut atn, 2, AtnStateKind::BlockStart);
         add_state(&mut atn, 3, AtnStateKind::BlockEnd);
         add_state(&mut atn, 4, AtnStateKind::Basic);
-        atn.add_state(AtnState::new(5, AtnStateKind::Basic).with_rule_index(1));
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(1))
+                .expect("state")
+                .index(),
+            5
+        );
         add_state(&mut atn, 6, AtnStateKind::LoopEnd);
         add_state(&mut atn, 7, AtnStateKind::RuleStop);
-        atn.state_mut(1)
-            .expect("loop entry")
-            .precedence_rule_decision = true;
-        atn.state_mut(2).expect("block start").end_state = Some(3);
-        atn.state_mut(1)
-            .expect("loop entry")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("loop entry")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(4)
-            .expect("same-rule return")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(5)
-            .expect("other-rule return")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn
+        atn.set_rule_to_start_state(vec![0, 5])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![7, 7])
+            .expect("rule stop states");
+        atn.set_precedence_rule_decision(1)
+            .expect("precedence decision state");
+        atn.set_end_state(2, 3).expect("block end state");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
-    fn add_state(atn: &mut Atn, state_number: usize, kind: AtnStateKind) {
-        atn.add_state(AtnState::new(state_number, kind).with_rule_index(0));
+    fn add_state(atn: &mut ParserAtnBuilder, state_number: usize, kind: AtnStateKind) {
+        assert_eq!(
+            atn.add_state(kind, Some(0)).expect("state").index(),
+            state_number
+        );
     }
 
     #[derive(Debug)]

--- a/src/atn/parser_atn.rs
+++ b/src/atn/parser_atn.rs
@@ -1,0 +1,2399 @@
+//! Packed, index-addressed parser ATN storage.
+//!
+//! Parser ATNs are immutable after generation/deserialization. Keeping their
+//! states and transitions in one validated word stream avoids the allocation
+//! and pointer-chasing costs of an owned object graph while still exposing
+//! borrowing semantic views to the simulator and diagnostics.
+
+// These accessors are scalar address calculations used throughout the parser's
+// innermost transition loops. Cross-crate generated parsers need them inlined.
+#![allow(clippy::inline_always)]
+
+use std::borrow::Cow;
+use std::fmt;
+use std::iter::FusedIterator;
+
+#[cfg(test)]
+use crate::token::TOKEN_EOF;
+
+use super::AtnStateKind;
+
+const PARSER_ATN_MAGIC: u32 = 0x5041_544e;
+const PARSER_ATN_FORMAT_VERSION: u32 = 1;
+const PARSER_ATN_MIN_FORMAT_VERSION: u32 = 1;
+const PARSER_ATN_MAX_FORMAT_VERSION: u32 = 1;
+const PARSER_ATN_BYTE_ORDER: u32 = 0x0102_0304;
+
+const HEADER_WORDS: usize = 26;
+const STATE_WORDS: usize = 7;
+const TRANSITION_WORDS: usize = 5;
+const SET_WORDS: usize = 2;
+
+const NO_INDEX: u32 = u32::MAX;
+
+const FLAG_NON_GREEDY: u32 = 1 << 0;
+const FLAG_PRECEDENCE_DECISION: u32 = 1 << 1;
+const FLAG_LEFT_RECURSIVE_RULE: u32 = 1 << 2;
+const FLAG_EPSILON_ONLY: u32 = 1 << 3;
+const FLAG_RULE_STOP: u32 = 1 << 4;
+const FLAG_HAS_CONSUMING: u32 = 1 << 5;
+const FLAG_HAS_SEMANTIC: u32 = 1 << 6;
+const STATE_FLAGS: u32 = FLAG_NON_GREEDY
+    | FLAG_PRECEDENCE_DECISION
+    | FLAG_LEFT_RECURSIVE_RULE
+    | FLAG_EPSILON_ONLY
+    | FLAG_RULE_STOP
+    | FLAG_HAS_CONSUMING
+    | FLAG_HAS_SEMANTIC;
+
+const HEADER_MAGIC: usize = 0;
+const HEADER_VERSION: usize = 1;
+const HEADER_BYTE_ORDER: usize = 2;
+const HEADER_SIZE: usize = 3;
+const HEADER_MAX_TOKEN_TYPE: usize = 4;
+const HEADER_STATE_COUNT: usize = 5;
+const HEADER_TRANSITION_COUNT: usize = 6;
+const HEADER_SET_COUNT: usize = 7;
+const HEADER_INTERVAL_COUNT: usize = 8;
+const HEADER_DECISION_COUNT: usize = 9;
+const HEADER_RULE_COUNT: usize = 10;
+const HEADER_STATES_OFFSET: usize = 11;
+const HEADER_TRANSITIONS_OFFSET: usize = 13;
+const HEADER_SETS_OFFSET: usize = 15;
+const HEADER_INTERVALS_OFFSET: usize = 17;
+const HEADER_DECISIONS_OFFSET: usize = 19;
+const HEADER_RULE_STARTS_OFFSET: usize = 21;
+const HEADER_RULE_STOPS_OFFSET: usize = 23;
+const HEADER_TOTAL_LEN: usize = 25;
+
+/// Checked compact identity for one parser ATN state.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AtnStateId(u32);
+
+impl AtnStateId {
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+
+    const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<usize> for AtnStateId {
+    type Error = ParserAtnError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        compact_id("parser ATN state", value).map(Self)
+    }
+}
+
+/// Checked compact identity for one parser ATN transition.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TransitionId(u32);
+
+impl TransitionId {
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+}
+
+impl TryFrom<usize> for TransitionId {
+    type Error = ParserAtnError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        compact_id("parser ATN transition", value).map(Self)
+    }
+}
+
+/// Checked compact identity for one shared interval set.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct ParserIntervalSetId(u32);
+
+impl ParserIntervalSetId {
+    pub const fn index(self) -> usize {
+        self.0 as usize
+    }
+
+    const fn raw(self) -> u32 {
+        self.0
+    }
+}
+
+impl TryFrom<usize> for ParserIntervalSetId {
+    type Error = ParserAtnError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        compact_id("parser ATN interval set", value).map(Self)
+    }
+}
+
+/// Failure while reading, validating, or constructing packed parser ATN data.
+#[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
+pub enum ParserAtnError {
+    #[error(
+        "generated parser ATN format version {found} is unsupported; \
+         this runtime requires generator/runtime format {minimum}..={maximum}"
+    )]
+    UnsupportedVersion {
+        found: u32,
+        minimum: u32,
+        maximum: u32,
+    },
+    #[error("invalid packed parser ATN: {0}")]
+    InvalidData(String),
+    #[error("{field} count/index {value} exceeds the compact u32 range")]
+    Overflow { field: &'static str, value: usize },
+}
+
+/// Storage and shape measurements for one packed parser ATN.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct ParserAtnStats {
+    pub states: usize,
+    pub transitions: usize,
+    pub interval_sets: usize,
+    pub interval_ranges: usize,
+    pub decisions: usize,
+    pub rules: usize,
+    pub packed_bytes: usize,
+}
+
+/// Immutable packed parser ATN.
+///
+/// Generated parsers borrow a static word stream directly. Deserialization of
+/// ordinary ANTLR v4 integer metadata produces the same layout in one owned
+/// allocation.
+pub struct ParserAtn {
+    words: Cow<'static, [u32]>,
+    words_address: usize,
+    layout: ParserAtnLayout,
+}
+
+impl Clone for ParserAtn {
+    fn clone(&self) -> Self {
+        let words = self.words.clone();
+        let words_address = words.as_ptr() as usize;
+        Self {
+            words,
+            words_address,
+            layout: self.layout,
+        }
+    }
+}
+
+impl PartialEq for ParserAtn {
+    fn eq(&self, other: &Self) -> bool {
+        self.words == other.words && self.layout == other.layout
+    }
+}
+
+impl Eq for ParserAtn {}
+
+impl fmt::Debug for ParserAtn {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ParserAtn")
+            .field("max_token_type", &self.max_token_type())
+            .field("stats", &self.stats())
+            .finish_non_exhaustive()
+    }
+}
+
+impl ParserAtn {
+    /// Validates and borrows generator-emitted packed data without allocating.
+    pub fn from_static(words: &'static [u32]) -> Result<Self, ParserAtnError> {
+        let layout = validate_packed(words)?;
+        Ok(Self {
+            words: Cow::Borrowed(words),
+            words_address: words.as_ptr() as usize,
+            layout,
+        })
+    }
+
+    /// Validates one owned packed stream.
+    pub fn from_owned(words: Vec<u32>) -> Result<Self, ParserAtnError> {
+        let layout = validate_packed(&words)?;
+        let words: Cow<'static, [u32]> = Cow::Owned(words);
+        let words_address = words.as_ptr() as usize;
+        Ok(Self {
+            words,
+            words_address,
+            layout,
+        })
+    }
+
+    /// Canonical generator/runtime format version carried by this ATN.
+    pub fn format_version(&self) -> u32 {
+        self.words[HEADER_VERSION]
+    }
+
+    #[inline(always)]
+    pub const fn max_token_type(&self) -> i32 {
+        self.layout.max_token_type
+    }
+
+    pub const fn state_count(&self) -> usize {
+        self.layout.state_count
+    }
+
+    pub const fn transition_count(&self) -> usize {
+        self.layout.transition_count
+    }
+
+    pub const fn decision_count(&self) -> usize {
+        self.layout.decisions.len
+    }
+
+    pub const fn rule_count(&self) -> usize {
+        self.layout.rule_starts.len
+    }
+
+    #[inline(always)]
+    pub fn state(&self, state_number: usize) -> Option<ParserAtnState<'_>> {
+        (state_number < self.state_count())
+            .then(|| ParserAtnState::new(self, AtnStateId(state_number as u32)))
+    }
+
+    #[inline(always)]
+    pub fn state_by_id(&self, id: AtnStateId) -> Option<ParserAtnState<'_>> {
+        (id.index() < self.state_count()).then(|| ParserAtnState::new(self, id))
+    }
+
+    pub const fn states(&self) -> ParserAtnStates<'_> {
+        ParserAtnStates {
+            atn: self,
+            next: 0,
+            end: self.state_count(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn transition(&self, id: TransitionId) -> Option<ParserTransition<'_>> {
+        (id.index() < self.transition_count()).then(|| ParserTransition::new(self, id))
+    }
+
+    pub const fn decision_to_state(&self) -> ParserStateIdTable<'_> {
+        ParserStateIdTable::new(self, self.layout.decisions)
+    }
+
+    pub const fn rule_to_start_state(&self) -> ParserStateIdTable<'_> {
+        ParserStateIdTable::new(self, self.layout.rule_starts)
+    }
+
+    pub const fn rule_to_stop_state(&self) -> ParserStateIdTable<'_> {
+        ParserStateIdTable::new(self, self.layout.rule_stops)
+    }
+
+    /// Returns the exact generator-emitted representation.
+    pub fn packed_words(&self) -> &[u32] {
+        &self.words
+    }
+
+    /// Stable backing-storage address used by thread-local grammar caches.
+    pub(crate) fn storage_identity(&self) -> (usize, usize) {
+        (self.words.as_ptr() as usize, self.words.len())
+    }
+
+    pub fn stats(&self) -> ParserAtnStats {
+        ParserAtnStats {
+            states: self.state_count(),
+            transitions: self.transition_count(),
+            interval_sets: self.layout.sets.len / SET_WORDS,
+            interval_ranges: self.layout.intervals.len / 2,
+            decisions: self.decision_count(),
+            rules: self.rule_count(),
+            packed_bytes: self.words.len() * size_of::<u32>(),
+        }
+    }
+
+    #[inline(always)]
+    fn word(&self, section: Section, record: usize, field: usize, width: usize) -> u32 {
+        self.packed_word(section.offset + record * width + field)
+    }
+
+    #[inline(always)]
+    fn interval_set(&self, id: ParserIntervalSetId) -> ParserIntervalSet<'_> {
+        let start = self.word(self.layout.sets, id.index(), 0, SET_WORDS) as usize;
+        let len = self.word(self.layout.sets, id.index(), 1, SET_WORDS) as usize;
+        ParserIntervalSet {
+            atn: self,
+            start,
+            len,
+        }
+    }
+
+    #[inline(always)]
+    fn packed_address(&self, index: usize) -> usize {
+        debug_assert!(index < self.words.len());
+        self.words_address + index * size_of::<u32>()
+    }
+
+    #[inline(always)]
+    #[allow(unsafe_code)]
+    fn packed_word(&self, index: usize) -> u32 {
+        debug_assert!(index < self.words.len());
+        // `words_address` is captured after the final backing allocation is in
+        // place. Parser ATNs are immutable, and every view index/range is
+        // validated before construction, so the allocation remains live and
+        // the read stays in bounds for the lifetime of `self`.
+        unsafe { *((self.words_address as *const u32).add(index)) }
+    }
+}
+
+/// Borrowing semantic view over one parser ATN state.
+#[derive(Clone, Copy)]
+pub struct ParserAtnState<'a> {
+    atn: &'a ParserAtn,
+    record_address: usize,
+}
+
+impl fmt::Debug for ParserAtnState<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("ParserAtnState")
+            .field("id", &self.id())
+            .field("kind", &self.kind())
+            .field("rule_index", &self.rule_index())
+            .field("transition_count", &self.transitions().len())
+            .finish()
+    }
+}
+
+impl<'a> ParserAtnState<'a> {
+    #[inline(always)]
+    fn new(atn: &'a ParserAtn, id: AtnStateId) -> Self {
+        Self {
+            atn,
+            record_address: atn.packed_address(atn.layout.states.offset + id.index() * STATE_WORDS),
+        }
+    }
+
+    pub const fn id(self) -> AtnStateId {
+        let word = (self.record_address - self.atn.words_address) / size_of::<u32>();
+        AtnStateId(((word - self.atn.layout.states.offset) / STATE_WORDS) as u32)
+    }
+
+    pub const fn state_number(self) -> usize {
+        self.id().index()
+    }
+
+    #[inline(always)]
+    pub fn kind(self) -> AtnStateKind {
+        decode_state_kind(self.word(0)).expect("packed parser ATN state kind was validated")
+    }
+
+    #[inline(always)]
+    pub fn rule_index(self) -> Option<usize> {
+        unpack_index(self.word(1))
+    }
+
+    #[inline(always)]
+    pub fn end_state(self) -> Option<usize> {
+        unpack_index(self.word(5))
+    }
+
+    #[inline(always)]
+    pub fn loop_back_state(self) -> Option<usize> {
+        unpack_index(self.word(6))
+    }
+
+    #[inline(always)]
+    pub fn non_greedy(self) -> bool {
+        self.flags() & FLAG_NON_GREEDY != 0
+    }
+
+    #[inline(always)]
+    pub fn precedence_rule_decision(self) -> bool {
+        self.flags() & FLAG_PRECEDENCE_DECISION != 0
+    }
+
+    #[inline(always)]
+    pub fn left_recursive_rule(self) -> bool {
+        self.flags() & FLAG_LEFT_RECURSIVE_RULE != 0
+    }
+
+    #[inline]
+    pub fn is_rule_stop(self) -> bool {
+        self.flags() & FLAG_RULE_STOP != 0
+    }
+
+    #[inline]
+    pub fn epsilon_only(self) -> bool {
+        self.flags() & FLAG_EPSILON_ONLY != 0
+    }
+
+    #[inline]
+    pub fn has_consuming_transition(self) -> bool {
+        self.flags() & FLAG_HAS_CONSUMING != 0
+    }
+
+    #[inline]
+    pub fn has_semantic_transition(self) -> bool {
+        self.flags() & FLAG_HAS_SEMANTIC != 0
+    }
+
+    #[inline(always)]
+    pub fn transitions(self) -> ParserTransitions<'a> {
+        let start = self.word(3) as usize;
+        ParserTransitions {
+            atn: self.atn,
+            record_address: self
+                .atn
+                .packed_address(self.atn.layout.transitions.offset + start * TRANSITION_WORDS),
+            len: self.word(4) as usize,
+        }
+    }
+
+    #[inline(always)]
+    fn flags(self) -> u32 {
+        self.word(2)
+    }
+
+    #[inline(always)]
+    #[allow(unsafe_code)]
+    fn word(self, field: usize) -> u32 {
+        debug_assert!(field < STATE_WORDS);
+        // The record address comes from the immutable validated state
+        // section, and `field` is constrained to the fixed record width.
+        unsafe { *((self.record_address as *const u32).add(field)) }
+    }
+}
+
+/// Borrowing range of transitions owned by the ATN's shared transition pool.
+#[derive(Clone, Copy, Debug)]
+pub struct ParserTransitions<'a> {
+    atn: &'a ParserAtn,
+    record_address: usize,
+    len: usize,
+}
+
+impl<'a> ParserTransitions<'a> {
+    pub const fn len(self) -> usize {
+        self.len
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    #[inline(always)]
+    pub fn get(self, index: usize) -> Option<ParserTransition<'a>> {
+        (index < self.len).then(|| ParserTransition {
+            atn: self.atn,
+            record_address: self.record_address + index * TRANSITION_WORDS * size_of::<u32>(),
+        })
+    }
+
+    #[inline(always)]
+    pub fn first(self) -> Option<ParserTransition<'a>> {
+        self.get(0)
+    }
+
+    #[inline]
+    pub fn last(self) -> Option<ParserTransition<'a>> {
+        self.len.checked_sub(1).and_then(|index| self.get(index))
+    }
+
+    pub const fn iter(self) -> ParserTransitionIter<'a> {
+        ParserTransitionIter {
+            atn: self.atn,
+            next_record_address: self.record_address,
+            remaining: self.len,
+        }
+    }
+}
+
+impl<'a> IntoIterator for ParserTransitions<'a> {
+    type Item = ParserTransition<'a>;
+    type IntoIter = ParserTransitionIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ParserTransitions<'a> {
+    type Item = ParserTransition<'a>;
+    type IntoIter = ParserTransitionIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over one state's contiguous transition range.
+#[derive(Clone, Debug)]
+pub struct ParserTransitionIter<'a> {
+    atn: &'a ParserAtn,
+    next_record_address: usize,
+    remaining: usize,
+}
+
+impl<'a> Iterator for ParserTransitionIter<'a> {
+    type Item = ParserTransition<'a>;
+
+    #[inline(always)]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.remaining == 0 {
+            return None;
+        }
+        let transition = ParserTransition {
+            atn: self.atn,
+            record_address: self.next_record_address,
+        };
+        self.next_record_address += TRANSITION_WORDS * size_of::<u32>();
+        self.remaining -= 1;
+        Some(transition)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.remaining, Some(self.remaining))
+    }
+}
+
+impl ExactSizeIterator for ParserTransitionIter<'_> {}
+impl FusedIterator for ParserTransitionIter<'_> {}
+
+/// Borrowing semantic view over one parser ATN transition.
+#[derive(Clone, Copy)]
+pub struct ParserTransition<'a> {
+    atn: &'a ParserAtn,
+    record_address: usize,
+}
+
+impl fmt::Debug for ParserTransition<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.data().fmt(formatter)
+    }
+}
+
+impl<'a> ParserTransition<'a> {
+    #[inline(always)]
+    fn new(atn: &'a ParserAtn, id: TransitionId) -> Self {
+        Self {
+            atn,
+            record_address: atn
+                .packed_address(atn.layout.transitions.offset + id.index() * TRANSITION_WORDS),
+        }
+    }
+
+    #[inline(always)]
+    pub const fn id(self) -> TransitionId {
+        let word = (self.record_address - self.atn.words_address) / size_of::<u32>();
+        TransitionId(((word - self.atn.layout.transitions.offset) / TRANSITION_WORDS) as u32)
+    }
+
+    #[inline(always)]
+    pub fn target_id(self) -> AtnStateId {
+        AtnStateId(self.word(1))
+    }
+
+    #[inline(always)]
+    pub fn target(self) -> usize {
+        self.target_id().index()
+    }
+
+    #[inline(always)]
+    pub fn kind(self) -> ParserTransitionKind {
+        decode_transition_kind(self.word(0))
+            .expect("packed parser ATN transition kind was validated")
+    }
+
+    #[inline(always)]
+    pub fn is_epsilon(self) -> bool {
+        matches!(
+            self.kind(),
+            ParserTransitionKind::Epsilon
+                | ParserTransitionKind::Rule
+                | ParserTransitionKind::Predicate
+                | ParserTransitionKind::Action
+                | ParserTransitionKind::Precedence
+        )
+    }
+
+    #[inline(always)]
+    pub fn is_action(self) -> bool {
+        self.kind() == ParserTransitionKind::Action
+    }
+
+    #[inline(always)]
+    pub fn matches(self, symbol: i32, min_vocabulary: i32, max_vocabulary: i32) -> bool {
+        self.matches_kind(self.kind(), symbol, min_vocabulary, max_vocabulary)
+    }
+
+    #[inline(always)]
+    pub(crate) fn matches_kind(
+        self,
+        kind: ParserTransitionKind,
+        symbol: i32,
+        min_vocabulary: i32,
+        max_vocabulary: i32,
+    ) -> bool {
+        match kind {
+            ParserTransitionKind::Atom => unpack_i32(self.arg0()) == symbol,
+            ParserTransitionKind::Range => {
+                (unpack_i32(self.arg0())..=unpack_i32(self.arg1())).contains(&symbol)
+            }
+            ParserTransitionKind::Set => self
+                .atn
+                .interval_set(ParserIntervalSetId(self.arg0()))
+                .contains(symbol),
+            ParserTransitionKind::NotSet => {
+                (min_vocabulary..=max_vocabulary).contains(&symbol)
+                    && !self
+                        .atn
+                        .interval_set(ParserIntervalSetId(self.arg0()))
+                        .contains(symbol)
+            }
+            ParserTransitionKind::Wildcard => (min_vocabulary..=max_vocabulary).contains(&symbol),
+            ParserTransitionKind::Epsilon
+            | ParserTransitionKind::Rule
+            | ParserTransitionKind::Predicate
+            | ParserTransitionKind::Action
+            | ParserTransitionKind::Precedence => false,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn arg0(self) -> u32 {
+        self.word(2)
+    }
+
+    #[inline(always)]
+    pub(crate) fn arg1(self) -> u32 {
+        self.word(3)
+    }
+
+    #[inline(always)]
+    pub(crate) fn arg2(self) -> u32 {
+        self.word(4)
+    }
+
+    #[inline(always)]
+    pub fn data(self) -> ParserTransitionData<'a> {
+        match decode_transition_kind(self.word(0))
+            .expect("packed parser ATN transition kind was validated")
+        {
+            ParserTransitionKind::Epsilon => ParserTransitionData::Epsilon {
+                target: self.word(1) as usize,
+            },
+            ParserTransitionKind::Atom => ParserTransitionData::Atom {
+                target: self.word(1) as usize,
+                label: unpack_i32(self.word(2)),
+            },
+            ParserTransitionKind::Range => ParserTransitionData::Range {
+                target: self.word(1) as usize,
+                start: unpack_i32(self.word(2)),
+                stop: unpack_i32(self.word(3)),
+            },
+            ParserTransitionKind::Set => ParserTransitionData::Set {
+                target: self.word(1) as usize,
+                set: self.atn.interval_set(ParserIntervalSetId(self.word(2))),
+            },
+            ParserTransitionKind::NotSet => ParserTransitionData::NotSet {
+                target: self.word(1) as usize,
+                set: self.atn.interval_set(ParserIntervalSetId(self.word(2))),
+            },
+            ParserTransitionKind::Wildcard => ParserTransitionData::Wildcard {
+                target: self.word(1) as usize,
+            },
+            ParserTransitionKind::Rule => ParserTransitionData::Rule {
+                target: self.word(1) as usize,
+                rule_index: self.word(2) as usize,
+                follow_state: self.word(3) as usize,
+                precedence: unpack_i32(self.word(4)),
+            },
+            ParserTransitionKind::Predicate => ParserTransitionData::Predicate {
+                target: self.word(1) as usize,
+                rule_index: self.word(2) as usize,
+                pred_index: self.word(3) as usize,
+                context_dependent: self.word(4) != 0,
+            },
+            ParserTransitionKind::Action => ParserTransitionData::Action {
+                target: self.word(1) as usize,
+                rule_index: self.word(2) as usize,
+                action_index: unpack_index(self.word(3)),
+                context_dependent: self.word(4) != 0,
+            },
+            ParserTransitionKind::Precedence => ParserTransitionData::Precedence {
+                target: self.word(1) as usize,
+                precedence: unpack_i32(self.word(2)),
+            },
+        }
+    }
+
+    #[inline(always)]
+    #[allow(unsafe_code)]
+    fn word(self, field: usize) -> u32 {
+        debug_assert!(field < TRANSITION_WORDS);
+        // The record address comes from the immutable validated transition
+        // section, and `field` is constrained to the fixed record width.
+        unsafe { *((self.record_address as *const u32).add(field)) }
+    }
+}
+
+/// Fixed transition tag stored in the packed transition table.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u8)]
+pub enum ParserTransitionKind {
+    Epsilon = 1,
+    Range = 2,
+    Rule = 3,
+    Predicate = 4,
+    Atom = 5,
+    Action = 6,
+    Set = 7,
+    NotSet = 8,
+    Wildcard = 9,
+    Precedence = 10,
+}
+
+/// Borrowing semantic payload for a packed parser transition.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParserTransitionData<'a> {
+    Epsilon {
+        target: usize,
+    },
+    Atom {
+        target: usize,
+        label: i32,
+    },
+    Range {
+        target: usize,
+        start: i32,
+        stop: i32,
+    },
+    Set {
+        target: usize,
+        set: ParserIntervalSet<'a>,
+    },
+    NotSet {
+        target: usize,
+        set: ParserIntervalSet<'a>,
+    },
+    Wildcard {
+        target: usize,
+    },
+    Rule {
+        target: usize,
+        rule_index: usize,
+        follow_state: usize,
+        precedence: i32,
+    },
+    Predicate {
+        target: usize,
+        rule_index: usize,
+        pred_index: usize,
+        context_dependent: bool,
+    },
+    Action {
+        target: usize,
+        rule_index: usize,
+        action_index: Option<usize>,
+        context_dependent: bool,
+    },
+    Precedence {
+        target: usize,
+        precedence: i32,
+    },
+}
+
+impl ParserTransitionData<'_> {
+    pub const fn target(self) -> usize {
+        match self {
+            Self::Epsilon { target }
+            | Self::Atom { target, .. }
+            | Self::Range { target, .. }
+            | Self::Set { target, .. }
+            | Self::NotSet { target, .. }
+            | Self::Wildcard { target }
+            | Self::Rule { target, .. }
+            | Self::Predicate { target, .. }
+            | Self::Action { target, .. }
+            | Self::Precedence { target, .. } => target,
+        }
+    }
+
+    pub const fn is_epsilon(self) -> bool {
+        matches!(
+            self,
+            Self::Epsilon { .. }
+                | Self::Rule { .. }
+                | Self::Predicate { .. }
+                | Self::Action { .. }
+                | Self::Precedence { .. }
+        )
+    }
+
+    pub const fn is_action(self) -> bool {
+        matches!(self, Self::Action { .. })
+    }
+
+    pub fn matches(self, symbol: i32, min_vocabulary: i32, max_vocabulary: i32) -> bool {
+        match self {
+            Self::Atom { label, .. } => label == symbol,
+            Self::Range { start, stop, .. } => (start..=stop).contains(&symbol),
+            Self::Set { set, .. } => set.contains(symbol),
+            Self::NotSet { set, .. } => {
+                (min_vocabulary..=max_vocabulary).contains(&symbol) && !set.contains(symbol)
+            }
+            Self::Wildcard { .. } => (min_vocabulary..=max_vocabulary).contains(&symbol),
+            Self::Epsilon { .. }
+            | Self::Rule { .. }
+            | Self::Predicate { .. }
+            | Self::Action { .. }
+            | Self::Precedence { .. } => false,
+        }
+    }
+}
+
+/// Borrowing view over one interval set in the shared interval pool.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct ParserIntervalSet<'a> {
+    atn: &'a ParserAtn,
+    start: usize,
+    len: usize,
+}
+
+impl fmt::Debug for ParserIntervalSet<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_list().entries(self.ranges()).finish()
+    }
+}
+
+impl<'a> ParserIntervalSet<'a> {
+    pub const fn is_empty(self) -> bool {
+        self.len == 0
+    }
+
+    #[inline(always)]
+    pub fn contains(self, value: i32) -> bool {
+        let mut low = 0;
+        let mut high = self.len;
+        while low < high {
+            let middle = low + (high - low) / 2;
+            if self.range_start(middle) <= value {
+                low = middle + 1;
+            } else {
+                high = middle;
+            }
+        }
+        low > 0 && self.range_stop(low - 1) >= value
+    }
+
+    pub const fn ranges(self) -> ParserIntervalRanges<'a> {
+        ParserIntervalRanges { set: self, next: 0 }
+    }
+
+    #[inline(always)]
+    fn range(self, index: usize) -> (i32, i32) {
+        (self.range_start(index), self.range_stop(index))
+    }
+
+    #[inline(always)]
+    fn range_start(self, index: usize) -> i32 {
+        let word = self.atn.layout.intervals.offset + (self.start + index) * 2;
+        unpack_i32(self.atn.packed_word(word))
+    }
+
+    #[inline(always)]
+    fn range_stop(self, index: usize) -> i32 {
+        let word = self.atn.layout.intervals.offset + (self.start + index) * 2 + 1;
+        unpack_i32(self.atn.packed_word(word))
+    }
+}
+
+/// Iterator over inclusive ranges in one shared parser interval set.
+#[derive(Clone, Debug)]
+pub struct ParserIntervalRanges<'a> {
+    set: ParserIntervalSet<'a>,
+    next: usize,
+}
+
+impl Iterator for ParserIntervalRanges<'_> {
+    type Item = (i32, i32);
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next >= self.set.len {
+            return None;
+        }
+        let range = self.set.range(self.next);
+        self.next += 1;
+        Some(range)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.set.len.saturating_sub(self.next);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for ParserIntervalRanges<'_> {}
+impl FusedIterator for ParserIntervalRanges<'_> {}
+
+/// Borrowing compact-ID side table with checked `usize` accessors.
+#[derive(Clone, Copy, Debug)]
+pub struct ParserStateIdTable<'a> {
+    atn: &'a ParserAtn,
+    section: Section,
+}
+
+impl<'a> ParserStateIdTable<'a> {
+    const fn new(atn: &'a ParserAtn, section: Section) -> Self {
+        Self { atn, section }
+    }
+
+    pub const fn len(self) -> usize {
+        self.section.len
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.section.len == 0
+    }
+
+    #[inline(always)]
+    pub fn get(self, index: usize) -> Option<usize> {
+        (index < self.len()).then(|| self.atn.packed_word(self.section.offset + index) as usize)
+    }
+
+    pub fn get_id(self, index: usize) -> Option<AtnStateId> {
+        self.get(index).map(|value| {
+            AtnStateId::try_from(value).expect("validated side-table state fits compact ID")
+        })
+    }
+
+    pub const fn iter(self) -> ParserStateIdIter<'a> {
+        ParserStateIdIter {
+            table: self,
+            next: 0,
+        }
+    }
+}
+
+impl<'a> IntoIterator for ParserStateIdTable<'a> {
+    type Item = usize;
+    type IntoIter = ParserStateIdIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over checked state indices in a parser ATN side table.
+#[derive(Clone, Debug)]
+pub struct ParserStateIdIter<'a> {
+    table: ParserStateIdTable<'a>,
+    next: usize,
+}
+
+impl Iterator for ParserStateIdIter<'_> {
+    type Item = usize;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        let value = self.table.get(self.next)?;
+        self.next += 1;
+        Some(value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.table.len().saturating_sub(self.next);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for ParserStateIdIter<'_> {}
+impl FusedIterator for ParserStateIdIter<'_> {}
+
+/// Iterator over every state in deterministic state-number order.
+#[derive(Clone, Debug)]
+pub struct ParserAtnStates<'a> {
+    atn: &'a ParserAtn,
+    next: usize,
+    end: usize,
+}
+
+impl<'a> Iterator for ParserAtnStates<'a> {
+    type Item = ParserAtnState<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next >= self.end {
+            return None;
+        }
+        let state = self.atn.state(self.next);
+        self.next += 1;
+        state
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.end.saturating_sub(self.next);
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for ParserAtnStates<'_> {}
+impl FusedIterator for ParserAtnStates<'_> {}
+
+/// Centralized construction API for packed parser ATNs.
+///
+/// States never own transition collections; edges are grouped into contiguous
+/// ranges only when the final packed stream is emitted.
+#[derive(Debug)]
+pub struct ParserAtnBuilder {
+    max_token_type: i32,
+    states: Vec<StateBuild>,
+    transitions: Vec<TransitionBuild>,
+    interval_sets: Vec<(u32, u32)>,
+    interval_ranges: Vec<(i32, i32)>,
+    decisions: Vec<AtnStateId>,
+    rule_starts: Vec<AtnStateId>,
+    rule_stops: Vec<AtnStateId>,
+}
+
+impl ParserAtnBuilder {
+    pub const fn new(max_token_type: i32) -> Self {
+        Self {
+            max_token_type,
+            states: Vec::new(),
+            transitions: Vec::new(),
+            interval_sets: Vec::new(),
+            interval_ranges: Vec::new(),
+            decisions: Vec::new(),
+            rule_starts: Vec::new(),
+            rule_stops: Vec::new(),
+        }
+    }
+
+    pub fn add_state(
+        &mut self,
+        kind: AtnStateKind,
+        rule_index: Option<usize>,
+    ) -> Result<AtnStateId, ParserAtnError> {
+        let id = AtnStateId::try_from(self.states.len())?;
+        let rule_index = pack_optional_index("parser ATN rule", rule_index)?;
+        self.states.push(StateBuild {
+            kind,
+            rule_index,
+            flags: u32::from(kind == AtnStateKind::RuleStop) * FLAG_RULE_STOP,
+            end_state: NO_INDEX,
+            loop_back_state: NO_INDEX,
+        });
+        Ok(id)
+    }
+
+    pub fn set_end_state(&mut self, state: usize, end_state: usize) -> Result<(), ParserAtnError> {
+        let end_state = self.checked_state(end_state, "block end state")?;
+        self.state_mut(state, "block start state")?.end_state = end_state.raw();
+        Ok(())
+    }
+
+    pub fn set_loop_back_state(
+        &mut self,
+        state: usize,
+        loop_back_state: usize,
+    ) -> Result<(), ParserAtnError> {
+        let loop_back_state = self.checked_state(loop_back_state, "loop back state")?;
+        self.state_mut(state, "loop end state")?.loop_back_state = loop_back_state.raw();
+        Ok(())
+    }
+
+    pub fn set_non_greedy(&mut self, state: usize) -> Result<(), ParserAtnError> {
+        self.state_mut(state, "non-greedy state")?.flags |= FLAG_NON_GREEDY;
+        Ok(())
+    }
+
+    pub fn set_left_recursive_rule(&mut self, state: usize) -> Result<(), ParserAtnError> {
+        self.state_mut(state, "precedence rule state")?.flags |= FLAG_LEFT_RECURSIVE_RULE;
+        Ok(())
+    }
+
+    pub fn set_precedence_rule_decision(&mut self, state: usize) -> Result<(), ParserAtnError> {
+        self.state_mut(state, "precedence decision state")?.flags |= FLAG_PRECEDENCE_DECISION;
+        Ok(())
+    }
+
+    pub fn add_interval_set(
+        &mut self,
+        ranges: impl IntoIterator<Item = (i32, i32)>,
+    ) -> Result<ParserIntervalSetId, ParserAtnError> {
+        let id = ParserIntervalSetId::try_from(self.interval_sets.len())?;
+        let start = compact_id("parser ATN interval start", self.interval_ranges.len())?;
+        let normalized = normalize_ranges(ranges);
+        let len = compact_id("parser ATN interval count", normalized.len())?;
+        self.interval_ranges.extend(normalized);
+        self.interval_sets.push((start, len));
+        Ok(id)
+    }
+
+    pub fn add_transition(
+        &mut self,
+        source: usize,
+        transition: ParserTransitionSpec,
+    ) -> Result<TransitionId, ParserAtnError> {
+        let source = self.checked_state(source, "transition source")?;
+        let record = self.transition_record(source, transition)?;
+        let id = TransitionId::try_from(self.transitions.len())?;
+        self.transitions.push(record);
+        Ok(id)
+    }
+
+    pub fn set_rule_to_start_state(&mut self, states: Vec<usize>) -> Result<(), ParserAtnError> {
+        self.rule_starts = self.checked_states(states, "rule start state")?;
+        Ok(())
+    }
+
+    pub fn set_rule_to_stop_state(&mut self, states: Vec<usize>) -> Result<(), ParserAtnError> {
+        self.rule_stops = self.checked_states(states, "rule stop state")?;
+        Ok(())
+    }
+
+    pub fn add_decision_state(&mut self, state: usize) -> Result<(), ParserAtnError> {
+        let state = self.checked_state(state, "decision state")?;
+        self.decisions.push(state);
+        Ok(())
+    }
+
+    pub fn state_kind(&self, state: usize) -> Option<AtnStateKind> {
+        self.states.get(state).map(|record| record.kind)
+    }
+
+    pub const fn state_count(&self) -> usize {
+        self.states.len()
+    }
+
+    pub fn state_rule_index(&self, state: usize) -> Option<usize> {
+        self.states
+            .get(state)
+            .and_then(|record| unpack_index(record.rule_index))
+    }
+
+    pub fn rule_stop_state(&self, rule: usize) -> Option<usize> {
+        self.rule_stops.get(rule).copied().map(AtnStateId::index)
+    }
+
+    pub fn transitions_from(
+        &self,
+        source: usize,
+    ) -> impl DoubleEndedIterator<Item = ParserTransitionSpec> + '_ {
+        self.transitions
+            .iter()
+            .filter(move |transition| transition.source.index() == source)
+            .map(TransitionBuild::spec)
+    }
+
+    pub fn finish(mut self) -> Result<ParserAtn, ParserAtnError> {
+        self.mark_precedence_decisions();
+        self.transitions.sort_by_key(|transition| transition.source);
+        let transition_ranges = self.transition_ranges()?;
+        self.precompute_state_flags(&transition_ranges);
+        let words = self.encode(&transition_ranges)?;
+        ParserAtn::from_owned(words)
+    }
+
+    fn state_mut(&mut self, state: usize, label: &str) -> Result<&mut StateBuild, ParserAtnError> {
+        self.states.get_mut(state).ok_or_else(|| {
+            ParserAtnError::InvalidData(format!("{label} {state} outside state list"))
+        })
+    }
+
+    fn checked_state(&self, state: usize, label: &str) -> Result<AtnStateId, ParserAtnError> {
+        let id = AtnStateId::try_from(state)?;
+        if state >= self.states.len() {
+            return Err(ParserAtnError::InvalidData(format!(
+                "{label} {state} outside state list"
+            )));
+        }
+        Ok(id)
+    }
+
+    fn checked_states(
+        &self,
+        states: Vec<usize>,
+        label: &str,
+    ) -> Result<Vec<AtnStateId>, ParserAtnError> {
+        states
+            .into_iter()
+            .map(|state| self.checked_state(state, label))
+            .collect()
+    }
+
+    fn transition_record(
+        &self,
+        source: AtnStateId,
+        spec: ParserTransitionSpec,
+    ) -> Result<TransitionBuild, ParserAtnError> {
+        let target = self.checked_state(spec.target(), "transition target")?;
+        let (kind, arg0, arg1, arg2) = match spec {
+            ParserTransitionSpec::Epsilon { .. } => (ParserTransitionKind::Epsilon, 0, 0, 0),
+            ParserTransitionSpec::Atom { label, .. } => {
+                (ParserTransitionKind::Atom, pack_i32(label), 0, 0)
+            }
+            ParserTransitionSpec::Range { start, stop, .. } => (
+                ParserTransitionKind::Range,
+                pack_i32(start),
+                pack_i32(stop),
+                0,
+            ),
+            ParserTransitionSpec::Set { set, .. } => {
+                self.checked_set(set)?;
+                (ParserTransitionKind::Set, set.raw(), 0, 0)
+            }
+            ParserTransitionSpec::NotSet { set, .. } => {
+                self.checked_set(set)?;
+                (ParserTransitionKind::NotSet, set.raw(), 0, 0)
+            }
+            ParserTransitionSpec::Wildcard { .. } => (ParserTransitionKind::Wildcard, 0, 0, 0),
+            ParserTransitionSpec::Rule {
+                rule_index,
+                follow_state,
+                precedence,
+                ..
+            } => (
+                ParserTransitionKind::Rule,
+                compact_id("rule transition rule", rule_index)?,
+                self.checked_state(follow_state, "rule follow state")?.raw(),
+                pack_i32(precedence),
+            ),
+            ParserTransitionSpec::Predicate {
+                rule_index,
+                pred_index,
+                context_dependent,
+                ..
+            } => (
+                ParserTransitionKind::Predicate,
+                compact_id("predicate rule", rule_index)?,
+                compact_id("predicate index", pred_index)?,
+                u32::from(context_dependent),
+            ),
+            ParserTransitionSpec::Action {
+                rule_index,
+                action_index,
+                context_dependent,
+                ..
+            } => (
+                ParserTransitionKind::Action,
+                compact_id("action rule", rule_index)?,
+                pack_optional_index("action", action_index)?,
+                u32::from(context_dependent),
+            ),
+            ParserTransitionSpec::Precedence { precedence, .. } => {
+                (ParserTransitionKind::Precedence, pack_i32(precedence), 0, 0)
+            }
+        };
+        Ok(TransitionBuild {
+            source,
+            kind,
+            target,
+            arg0,
+            arg1,
+            arg2,
+        })
+    }
+
+    fn checked_set(&self, set: ParserIntervalSetId) -> Result<(), ParserAtnError> {
+        if set.index() >= self.interval_sets.len() {
+            return Err(ParserAtnError::InvalidData(format!(
+                "interval set {} outside set list",
+                set.index()
+            )));
+        }
+        Ok(())
+    }
+
+    fn transition_ranges(&self) -> Result<Vec<(u32, u32)>, ParserAtnError> {
+        let mut ranges = vec![(0, 0); self.states.len()];
+        let mut cursor = 0;
+        for (state, range) in ranges.iter_mut().enumerate() {
+            let start = cursor;
+            while cursor < self.transitions.len()
+                && self.transitions[cursor].source.index() == state
+            {
+                cursor += 1;
+            }
+            *range = (
+                compact_id("state transition start", start)?,
+                compact_id("state transition count", cursor - start)?,
+            );
+        }
+        Ok(ranges)
+    }
+
+    fn precompute_state_flags(&mut self, ranges: &[(u32, u32)]) {
+        for (state, &(start, len)) in self.states.iter_mut().zip(ranges) {
+            let transitions = &self.transitions[start as usize..start as usize + len as usize];
+            if !transitions.is_empty()
+                && transitions
+                    .iter()
+                    .all(|transition| transition.kind.is_epsilon())
+            {
+                state.flags |= FLAG_EPSILON_ONLY;
+            }
+            if transitions
+                .iter()
+                .any(|transition| transition.kind.is_consuming())
+            {
+                state.flags |= FLAG_HAS_CONSUMING;
+            }
+            if transitions
+                .iter()
+                .any(|transition| transition.kind.is_semantic())
+            {
+                state.flags |= FLAG_HAS_SEMANTIC;
+            }
+        }
+    }
+
+    fn mark_precedence_decisions(&mut self) {
+        let candidates = (0..self.states.len())
+            .filter(|&state| self.is_precedence_decision(state))
+            .collect::<Vec<_>>();
+        for state in candidates {
+            self.states[state].flags |= FLAG_PRECEDENCE_DECISION;
+        }
+    }
+
+    fn is_precedence_decision(&self, state: usize) -> bool {
+        let record = &self.states[state];
+        if record.kind != AtnStateKind::StarLoopEntry {
+            return false;
+        }
+        let Some(rule_index) = unpack_index(record.rule_index) else {
+            return false;
+        };
+        let Some(rule_start) = self.rule_starts.get(rule_index) else {
+            return false;
+        };
+        if self.states[rule_start.index()].flags & FLAG_LEFT_RECURSIVE_RULE == 0 {
+            return false;
+        }
+        let Some(loop_end) = self.transitions_from(state).next_back() else {
+            return false;
+        };
+        let loop_end = loop_end.target();
+        if self.state_kind(loop_end) != Some(AtnStateKind::LoopEnd) {
+            return false;
+        }
+        self.transitions_from(loop_end)
+            .next()
+            .and_then(|transition| self.state_kind(transition.target()))
+            == Some(AtnStateKind::RuleStop)
+    }
+
+    fn encode(&self, transition_ranges: &[(u32, u32)]) -> Result<Vec<u32>, ParserAtnError> {
+        let layout = EncodedLayout::new(self)?;
+        let mut words = vec![0; layout.total_len];
+        self.encode_header(&mut words, layout);
+        self.encode_states(&mut words, layout.states, transition_ranges);
+        self.encode_transitions(&mut words, layout.transitions);
+        self.encode_sets(&mut words, layout.sets);
+        self.encode_intervals(&mut words, layout.intervals);
+        encode_ids(&mut words, layout.decisions, &self.decisions);
+        encode_ids(&mut words, layout.rule_starts, &self.rule_starts);
+        encode_ids(&mut words, layout.rule_stops, &self.rule_stops);
+        Ok(words)
+    }
+
+    fn encode_header(&self, words: &mut [u32], layout: EncodedLayout) {
+        words[HEADER_MAGIC] = PARSER_ATN_MAGIC;
+        words[HEADER_VERSION] = PARSER_ATN_FORMAT_VERSION;
+        words[HEADER_BYTE_ORDER] = PARSER_ATN_BYTE_ORDER;
+        words[HEADER_SIZE] = HEADER_WORDS as u32;
+        words[HEADER_MAX_TOKEN_TYPE] = pack_i32(self.max_token_type);
+        words[HEADER_STATE_COUNT] = self.states.len() as u32;
+        words[HEADER_TRANSITION_COUNT] = self.transitions.len() as u32;
+        words[HEADER_SET_COUNT] = self.interval_sets.len() as u32;
+        words[HEADER_INTERVAL_COUNT] = self.interval_ranges.len() as u32;
+        words[HEADER_DECISION_COUNT] = self.decisions.len() as u32;
+        words[HEADER_RULE_COUNT] = self.rule_starts.len() as u32;
+        write_section(words, HEADER_STATES_OFFSET, layout.states);
+        write_section(words, HEADER_TRANSITIONS_OFFSET, layout.transitions);
+        write_section(words, HEADER_SETS_OFFSET, layout.sets);
+        write_section(words, HEADER_INTERVALS_OFFSET, layout.intervals);
+        write_section(words, HEADER_DECISIONS_OFFSET, layout.decisions);
+        write_section(words, HEADER_RULE_STARTS_OFFSET, layout.rule_starts);
+        write_section(words, HEADER_RULE_STOPS_OFFSET, layout.rule_stops);
+        words[HEADER_TOTAL_LEN] = layout.total_len as u32;
+    }
+
+    fn encode_states(&self, words: &mut [u32], section: Section, transition_ranges: &[(u32, u32)]) {
+        for (index, (state, &(start, len))) in self.states.iter().zip(transition_ranges).enumerate()
+        {
+            let base = section.offset + index * STATE_WORDS;
+            words[base] = state_kind_word(state.kind);
+            words[base + 1] = state.rule_index;
+            words[base + 2] = state.flags;
+            words[base + 3] = start;
+            words[base + 4] = len;
+            words[base + 5] = state.end_state;
+            words[base + 6] = state.loop_back_state;
+        }
+    }
+
+    fn encode_transitions(&self, words: &mut [u32], section: Section) {
+        for (index, transition) in self.transitions.iter().enumerate() {
+            let base = section.offset + index * TRANSITION_WORDS;
+            words[base] = transition.kind as u32;
+            words[base + 1] = transition.target.raw();
+            words[base + 2] = transition.arg0;
+            words[base + 3] = transition.arg1;
+            words[base + 4] = transition.arg2;
+        }
+    }
+
+    fn encode_sets(&self, words: &mut [u32], section: Section) {
+        for (index, &(start, len)) in self.interval_sets.iter().enumerate() {
+            let base = section.offset + index * SET_WORDS;
+            words[base] = start;
+            words[base + 1] = len;
+        }
+    }
+
+    fn encode_intervals(&self, words: &mut [u32], section: Section) {
+        for (index, &(start, stop)) in self.interval_ranges.iter().enumerate() {
+            let base = section.offset + index * 2;
+            words[base] = pack_i32(start);
+            words[base + 1] = pack_i32(stop);
+        }
+    }
+}
+
+/// Transient semantic transition accepted by [`ParserAtnBuilder`].
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ParserTransitionSpec {
+    Epsilon {
+        target: usize,
+    },
+    Atom {
+        target: usize,
+        label: i32,
+    },
+    Range {
+        target: usize,
+        start: i32,
+        stop: i32,
+    },
+    Set {
+        target: usize,
+        set: ParserIntervalSetId,
+    },
+    NotSet {
+        target: usize,
+        set: ParserIntervalSetId,
+    },
+    Wildcard {
+        target: usize,
+    },
+    Rule {
+        target: usize,
+        rule_index: usize,
+        follow_state: usize,
+        precedence: i32,
+    },
+    Predicate {
+        target: usize,
+        rule_index: usize,
+        pred_index: usize,
+        context_dependent: bool,
+    },
+    Action {
+        target: usize,
+        rule_index: usize,
+        action_index: Option<usize>,
+        context_dependent: bool,
+    },
+    Precedence {
+        target: usize,
+        precedence: i32,
+    },
+}
+
+impl ParserTransitionSpec {
+    pub const fn target(self) -> usize {
+        match self {
+            Self::Epsilon { target }
+            | Self::Atom { target, .. }
+            | Self::Range { target, .. }
+            | Self::Set { target, .. }
+            | Self::NotSet { target, .. }
+            | Self::Wildcard { target }
+            | Self::Rule { target, .. }
+            | Self::Predicate { target, .. }
+            | Self::Action { target, .. }
+            | Self::Precedence { target, .. } => target,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ParserAtnLayout {
+    max_token_type: i32,
+    state_count: usize,
+    transition_count: usize,
+    states: Section,
+    transitions: Section,
+    sets: Section,
+    intervals: Section,
+    decisions: Section,
+    rule_starts: Section,
+    rule_stops: Section,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Section {
+    offset: usize,
+    len: usize,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct EncodedLayout {
+    states: Section,
+    transitions: Section,
+    sets: Section,
+    intervals: Section,
+    decisions: Section,
+    rule_starts: Section,
+    rule_stops: Section,
+    total_len: usize,
+}
+
+impl EncodedLayout {
+    fn new(builder: &ParserAtnBuilder) -> Result<Self, ParserAtnError> {
+        let mut cursor = HEADER_WORDS;
+        let states = next_section(&mut cursor, builder.states.len(), STATE_WORDS, "states")?;
+        let transitions = next_section(
+            &mut cursor,
+            builder.transitions.len(),
+            TRANSITION_WORDS,
+            "transitions",
+        )?;
+        let sets = next_section(
+            &mut cursor,
+            builder.interval_sets.len(),
+            SET_WORDS,
+            "interval sets",
+        )?;
+        let intervals = next_section(
+            &mut cursor,
+            builder.interval_ranges.len(),
+            2,
+            "interval ranges",
+        )?;
+        let decisions = next_section(&mut cursor, builder.decisions.len(), 1, "decisions")?;
+        let rule_starts = next_section(&mut cursor, builder.rule_starts.len(), 1, "rule starts")?;
+        let rule_stops = next_section(&mut cursor, builder.rule_stops.len(), 1, "rule stops")?;
+        compact_id("packed parser ATN word", cursor)?;
+        Ok(Self {
+            states,
+            transitions,
+            sets,
+            intervals,
+            decisions,
+            rule_starts,
+            rule_stops,
+            total_len: cursor,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+struct StateBuild {
+    kind: AtnStateKind,
+    rule_index: u32,
+    flags: u32,
+    end_state: u32,
+    loop_back_state: u32,
+}
+
+#[derive(Clone, Debug)]
+struct TransitionBuild {
+    source: AtnStateId,
+    kind: ParserTransitionKind,
+    target: AtnStateId,
+    arg0: u32,
+    arg1: u32,
+    arg2: u32,
+}
+
+impl TransitionBuild {
+    const fn spec(&self) -> ParserTransitionSpec {
+        let target = self.target.index();
+        match self.kind {
+            ParserTransitionKind::Epsilon => ParserTransitionSpec::Epsilon { target },
+            ParserTransitionKind::Atom => ParserTransitionSpec::Atom {
+                target,
+                label: unpack_i32(self.arg0),
+            },
+            ParserTransitionKind::Range => ParserTransitionSpec::Range {
+                target,
+                start: unpack_i32(self.arg0),
+                stop: unpack_i32(self.arg1),
+            },
+            ParserTransitionKind::Set => ParserTransitionSpec::Set {
+                target,
+                set: ParserIntervalSetId(self.arg0),
+            },
+            ParserTransitionKind::NotSet => ParserTransitionSpec::NotSet {
+                target,
+                set: ParserIntervalSetId(self.arg0),
+            },
+            ParserTransitionKind::Wildcard => ParserTransitionSpec::Wildcard { target },
+            ParserTransitionKind::Rule => ParserTransitionSpec::Rule {
+                target,
+                rule_index: self.arg0 as usize,
+                follow_state: self.arg1 as usize,
+                precedence: unpack_i32(self.arg2),
+            },
+            ParserTransitionKind::Predicate => ParserTransitionSpec::Predicate {
+                target,
+                rule_index: self.arg0 as usize,
+                pred_index: self.arg1 as usize,
+                context_dependent: self.arg2 != 0,
+            },
+            ParserTransitionKind::Action => ParserTransitionSpec::Action {
+                target,
+                rule_index: self.arg0 as usize,
+                action_index: unpack_index(self.arg1),
+                context_dependent: self.arg2 != 0,
+            },
+            ParserTransitionKind::Precedence => ParserTransitionSpec::Precedence {
+                target,
+                precedence: unpack_i32(self.arg0),
+            },
+        }
+    }
+}
+
+impl ParserTransitionKind {
+    const fn is_epsilon(self) -> bool {
+        matches!(
+            self,
+            Self::Epsilon | Self::Rule | Self::Predicate | Self::Action | Self::Precedence
+        )
+    }
+
+    const fn is_consuming(self) -> bool {
+        matches!(
+            self,
+            Self::Atom | Self::Range | Self::Set | Self::NotSet | Self::Wildcard
+        )
+    }
+
+    const fn is_semantic(self) -> bool {
+        matches!(self, Self::Predicate | Self::Action | Self::Precedence)
+    }
+}
+
+fn validate_packed(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
+    validate_header(words)?;
+    let layout = read_layout(words)?;
+    validate_sections(words, layout)?;
+    validate_states(words, layout)?;
+    validate_transitions(words, layout)?;
+    validate_state_flags(words, layout)?;
+    validate_sets(words, layout)?;
+    validate_side_tables(words, layout)?;
+    Ok(layout)
+}
+
+fn validate_header(words: &[u32]) -> Result<(), ParserAtnError> {
+    if words.len() < HEADER_WORDS {
+        return Err(ParserAtnError::InvalidData(format!(
+            "header has {} words; expected at least {HEADER_WORDS}",
+            words.len()
+        )));
+    }
+    if words[HEADER_MAGIC] != PARSER_ATN_MAGIC {
+        return Err(ParserAtnError::InvalidData(format!(
+            "magic 0x{:08x}; expected 0x{PARSER_ATN_MAGIC:08x}",
+            words[HEADER_MAGIC]
+        )));
+    }
+    let version = words[HEADER_VERSION];
+    if !(PARSER_ATN_MIN_FORMAT_VERSION..=PARSER_ATN_MAX_FORMAT_VERSION).contains(&version) {
+        return Err(ParserAtnError::UnsupportedVersion {
+            found: version,
+            minimum: PARSER_ATN_MIN_FORMAT_VERSION,
+            maximum: PARSER_ATN_MAX_FORMAT_VERSION,
+        });
+    }
+    if words[HEADER_BYTE_ORDER] != PARSER_ATN_BYTE_ORDER {
+        return Err(ParserAtnError::InvalidData(format!(
+            "byte-order marker 0x{:08x}; expected 0x{PARSER_ATN_BYTE_ORDER:08x}",
+            words[HEADER_BYTE_ORDER]
+        )));
+    }
+    if words[HEADER_SIZE] as usize != HEADER_WORDS {
+        return Err(ParserAtnError::InvalidData(format!(
+            "header length {}; expected {HEADER_WORDS}",
+            words[HEADER_SIZE]
+        )));
+    }
+    if words[HEADER_TOTAL_LEN] as usize != words.len() {
+        return Err(ParserAtnError::InvalidData(format!(
+            "declared total length {} does not match {} words",
+            words[HEADER_TOTAL_LEN],
+            words.len()
+        )));
+    }
+    Ok(())
+}
+
+fn read_layout(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
+    let states = read_section(words, HEADER_STATES_OFFSET)?;
+    let transitions = read_section(words, HEADER_TRANSITIONS_OFFSET)?;
+    let sets = read_section(words, HEADER_SETS_OFFSET)?;
+    let intervals = read_section(words, HEADER_INTERVALS_OFFSET)?;
+    let decisions = read_section(words, HEADER_DECISIONS_OFFSET)?;
+    let rule_starts = read_section(words, HEADER_RULE_STARTS_OFFSET)?;
+    let rule_stops = read_section(words, HEADER_RULE_STOPS_OFFSET)?;
+    let state_count = words[HEADER_STATE_COUNT] as usize;
+    let transition_count = words[HEADER_TRANSITION_COUNT] as usize;
+    expect_section_len("states", states, state_count, STATE_WORDS)?;
+    expect_section_len(
+        "transitions",
+        transitions,
+        transition_count,
+        TRANSITION_WORDS,
+    )?;
+    expect_section_len(
+        "interval sets",
+        sets,
+        words[HEADER_SET_COUNT] as usize,
+        SET_WORDS,
+    )?;
+    expect_section_len(
+        "intervals",
+        intervals,
+        words[HEADER_INTERVAL_COUNT] as usize,
+        2,
+    )?;
+    expect_section_len(
+        "decisions",
+        decisions,
+        words[HEADER_DECISION_COUNT] as usize,
+        1,
+    )?;
+    expect_section_len(
+        "rule starts",
+        rule_starts,
+        words[HEADER_RULE_COUNT] as usize,
+        1,
+    )?;
+    expect_section_len(
+        "rule stops",
+        rule_stops,
+        words[HEADER_RULE_COUNT] as usize,
+        1,
+    )?;
+    Ok(ParserAtnLayout {
+        max_token_type: unpack_i32(words[HEADER_MAX_TOKEN_TYPE]),
+        state_count,
+        transition_count,
+        states,
+        transitions,
+        sets,
+        intervals,
+        decisions,
+        rule_starts,
+        rule_stops,
+    })
+}
+
+fn validate_sections(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
+    let sections = [
+        ("states", layout.states),
+        ("transitions", layout.transitions),
+        ("sets", layout.sets),
+        ("intervals", layout.intervals),
+        ("decisions", layout.decisions),
+        ("rule starts", layout.rule_starts),
+        ("rule stops", layout.rule_stops),
+    ];
+    let mut expected_offset = HEADER_WORDS;
+    for (name, section) in sections {
+        if section.offset != expected_offset {
+            return Err(ParserAtnError::InvalidData(format!(
+                "{name} section starts at {}, expected {expected_offset}",
+                section.offset
+            )));
+        }
+        expected_offset = section_end(section, words.len(), name)?;
+    }
+    if expected_offset != words.len() {
+        return Err(ParserAtnError::InvalidData(format!(
+            "sections end at {expected_offset}, stream ends at {}",
+            words.len()
+        )));
+    }
+    Ok(())
+}
+
+fn validate_states(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
+    let mut transition_cursor = 0;
+    for state in 0..layout.state_count {
+        let base = layout.states.offset + state * STATE_WORDS;
+        decode_state_kind(words[base])?;
+        let flags = words[base + 2];
+        if flags & !STATE_FLAGS != 0 {
+            return Err(ParserAtnError::InvalidData(format!(
+                "state {state} has unknown flags 0x{:x}",
+                flags & !STATE_FLAGS
+            )));
+        }
+        validate_optional_index(words[base + 1], layout.rule_starts.len, "state rule index")?;
+        let transition_start = words[base + 3] as usize;
+        if transition_start != transition_cursor {
+            return Err(ParserAtnError::InvalidData(format!(
+                "state {state} transition range starts at {transition_start}, expected {transition_cursor}"
+            )));
+        }
+        validate_range(
+            words[base + 3],
+            words[base + 4],
+            layout.transition_count,
+            "state transition",
+        )?;
+        transition_cursor += words[base + 4] as usize;
+        validate_optional_index(words[base + 5], layout.state_count, "block end state")?;
+        validate_optional_index(words[base + 6], layout.state_count, "loop back state")?;
+    }
+    if transition_cursor != layout.transition_count {
+        return Err(ParserAtnError::InvalidData(format!(
+            "state transition ranges cover {transition_cursor} transitions; expected {}",
+            layout.transition_count
+        )));
+    }
+    Ok(())
+}
+
+fn validate_transitions(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
+    for transition in 0..layout.transition_count {
+        let base = layout.transitions.offset + transition * TRANSITION_WORDS;
+        let kind = decode_transition_kind(words[base])?;
+        validate_index(words[base + 1], layout.state_count, "transition target")?;
+        match kind {
+            ParserTransitionKind::Range => {
+                let start = unpack_i32(words[base + 2]);
+                let stop = unpack_i32(words[base + 3]);
+                if start > stop {
+                    return Err(ParserAtnError::InvalidData(format!(
+                        "transition {transition} range starts at {start} after stop {stop}"
+                    )));
+                }
+            }
+            ParserTransitionKind::Set | ParserTransitionKind::NotSet => {
+                validate_index(words[base + 2], layout.sets.len / SET_WORDS, "interval set")?;
+            }
+            ParserTransitionKind::Rule => {
+                validate_index(words[base + 2], layout.rule_starts.len, "rule index")?;
+                validate_index(words[base + 3], layout.state_count, "rule follow state")?;
+            }
+            ParserTransitionKind::Predicate => {
+                validate_index(words[base + 2], layout.rule_starts.len, "predicate rule")?;
+                validate_bool(words[base + 4], "predicate context-dependent flag")?;
+            }
+            ParserTransitionKind::Action => {
+                validate_index(words[base + 2], layout.rule_starts.len, "action rule")?;
+                validate_bool(words[base + 4], "action context-dependent flag")?;
+            }
+            ParserTransitionKind::Epsilon
+            | ParserTransitionKind::Atom
+            | ParserTransitionKind::Wildcard
+            | ParserTransitionKind::Precedence => {}
+        }
+    }
+    Ok(())
+}
+
+fn validate_state_flags(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
+    for state in 0..layout.state_count {
+        let base = layout.states.offset + state * STATE_WORDS;
+        let kind = decode_state_kind(words[base])?;
+        let start = words[base + 3] as usize;
+        let len = words[base + 4] as usize;
+        let mut all_epsilon = len != 0;
+        let mut has_consuming = false;
+        let mut has_semantic = false;
+        for transition in start..start + len {
+            let base = layout.transitions.offset + transition * TRANSITION_WORDS;
+            let kind = decode_transition_kind(words[base])
+                .expect("packed parser transition kind was already validated");
+            all_epsilon &= kind.is_epsilon();
+            has_consuming |= kind.is_consuming();
+            has_semantic |= kind.is_semantic();
+        }
+        let mut expected = u32::from(kind == AtnStateKind::RuleStop) * FLAG_RULE_STOP;
+        expected |= u32::from(all_epsilon) * FLAG_EPSILON_ONLY;
+        expected |= u32::from(has_consuming) * FLAG_HAS_CONSUMING;
+        expected |= u32::from(has_semantic) * FLAG_HAS_SEMANTIC;
+        let derived = words[base + 2]
+            & (FLAG_EPSILON_ONLY | FLAG_RULE_STOP | FLAG_HAS_CONSUMING | FLAG_HAS_SEMANTIC);
+        if derived != expected {
+            return Err(ParserAtnError::InvalidData(format!(
+                "state {state} has inconsistent precomputed flags 0x{derived:x}; expected 0x{expected:x}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn validate_sets(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
+    for set in 0..layout.sets.len / SET_WORDS {
+        let base = layout.sets.offset + set * SET_WORDS;
+        validate_range(
+            words[base],
+            words[base + 1],
+            layout.intervals.len / 2,
+            "interval set",
+        )?;
+        let start = words[base] as usize;
+        let len = words[base + 1] as usize;
+        let mut previous_stop: Option<i32> = None;
+        for interval in start..start + len {
+            let interval_base = layout.intervals.offset + interval * 2;
+            let range_start = unpack_i32(words[interval_base]);
+            let range_stop = unpack_i32(words[interval_base + 1]);
+            if range_start > range_stop {
+                return Err(ParserAtnError::InvalidData(format!(
+                    "interval {interval} starts at {range_start} after stop {range_stop}"
+                )));
+            }
+            if previous_stop.is_some_and(|stop| range_start <= stop.saturating_add(1)) {
+                return Err(ParserAtnError::InvalidData(format!(
+                    "interval set {set} is not sorted and coalesced"
+                )));
+            }
+            previous_stop = Some(range_stop);
+        }
+    }
+    Ok(())
+}
+
+fn validate_side_tables(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
+    for (name, section) in [
+        ("decision state", layout.decisions),
+        ("rule start state", layout.rule_starts),
+        ("rule stop state", layout.rule_stops),
+    ] {
+        for &state in &words[section.offset..section.offset + section.len] {
+            validate_index(state, layout.state_count, name)?;
+        }
+    }
+    Ok(())
+}
+
+#[inline(always)]
+fn decode_state_kind(value: u32) -> Result<AtnStateKind, ParserAtnError> {
+    let kind = match value {
+        0 => AtnStateKind::Invalid,
+        1 => AtnStateKind::Basic,
+        2 => AtnStateKind::RuleStart,
+        3 => AtnStateKind::BlockStart,
+        4 => AtnStateKind::PlusBlockStart,
+        5 => AtnStateKind::StarBlockStart,
+        6 => AtnStateKind::TokenStart,
+        7 => AtnStateKind::RuleStop,
+        8 => AtnStateKind::BlockEnd,
+        9 => AtnStateKind::StarLoopBack,
+        10 => AtnStateKind::StarLoopEntry,
+        11 => AtnStateKind::PlusLoopBack,
+        12 => AtnStateKind::LoopEnd,
+        other => {
+            return Err(ParserAtnError::InvalidData(format!(
+                "parser ATN state kind {other}"
+            )));
+        }
+    };
+    Ok(kind)
+}
+
+#[inline(always)]
+fn decode_transition_kind(value: u32) -> Result<ParserTransitionKind, ParserAtnError> {
+    let kind = match value {
+        1 => ParserTransitionKind::Epsilon,
+        2 => ParserTransitionKind::Range,
+        3 => ParserTransitionKind::Rule,
+        4 => ParserTransitionKind::Predicate,
+        5 => ParserTransitionKind::Atom,
+        6 => ParserTransitionKind::Action,
+        7 => ParserTransitionKind::Set,
+        8 => ParserTransitionKind::NotSet,
+        9 => ParserTransitionKind::Wildcard,
+        10 => ParserTransitionKind::Precedence,
+        other => {
+            return Err(ParserAtnError::InvalidData(format!(
+                "parser ATN transition kind {other}"
+            )));
+        }
+    };
+    Ok(kind)
+}
+
+const fn state_kind_word(kind: AtnStateKind) -> u32 {
+    match kind {
+        AtnStateKind::Invalid => 0,
+        AtnStateKind::Basic => 1,
+        AtnStateKind::RuleStart => 2,
+        AtnStateKind::BlockStart => 3,
+        AtnStateKind::PlusBlockStart => 4,
+        AtnStateKind::StarBlockStart => 5,
+        AtnStateKind::TokenStart => 6,
+        AtnStateKind::RuleStop => 7,
+        AtnStateKind::BlockEnd => 8,
+        AtnStateKind::StarLoopBack => 9,
+        AtnStateKind::StarLoopEntry => 10,
+        AtnStateKind::PlusLoopBack => 11,
+        AtnStateKind::LoopEnd => 12,
+    }
+}
+
+fn compact_id(field: &'static str, value: usize) -> Result<u32, ParserAtnError> {
+    u32::try_from(value).map_err(|_| ParserAtnError::Overflow { field, value })
+}
+
+fn pack_optional_index(field: &'static str, value: Option<usize>) -> Result<u32, ParserAtnError> {
+    match value {
+        Some(value) => {
+            let compact = compact_id(field, value)?;
+            if compact == NO_INDEX {
+                return Err(ParserAtnError::Overflow { field, value });
+            }
+            Ok(compact)
+        }
+        None => Ok(NO_INDEX),
+    }
+}
+
+const fn unpack_index(value: u32) -> Option<usize> {
+    if value == NO_INDEX {
+        None
+    } else {
+        Some(value as usize)
+    }
+}
+
+const fn pack_i32(value: i32) -> u32 {
+    u32::from_le_bytes(value.to_le_bytes())
+}
+
+const fn unpack_i32(value: u32) -> i32 {
+    i32::from_le_bytes(value.to_le_bytes())
+}
+
+fn normalize_ranges(ranges: impl IntoIterator<Item = (i32, i32)>) -> Vec<(i32, i32)> {
+    let mut ranges = ranges
+        .into_iter()
+        .map(|(start, stop)| {
+            if start <= stop {
+                (start, stop)
+            } else {
+                (stop, start)
+            }
+        })
+        .collect::<Vec<_>>();
+    ranges.sort_unstable();
+    let mut normalized: Vec<(i32, i32)> = Vec::with_capacity(ranges.len());
+    for (start, stop) in ranges {
+        if let Some((_, previous_stop)) = normalized.last_mut()
+            && start <= previous_stop.saturating_add(1)
+        {
+            *previous_stop = (*previous_stop).max(stop);
+            continue;
+        }
+        normalized.push((start, stop));
+    }
+    normalized
+}
+
+fn next_section(
+    cursor: &mut usize,
+    count: usize,
+    width: usize,
+    name: &str,
+) -> Result<Section, ParserAtnError> {
+    let len = count.checked_mul(width).ok_or_else(|| {
+        ParserAtnError::InvalidData(format!("{name} section length overflows usize"))
+    })?;
+    let section = Section {
+        offset: *cursor,
+        len,
+    };
+    *cursor = cursor.checked_add(len).ok_or_else(|| {
+        ParserAtnError::InvalidData(format!("{name} section end overflows usize"))
+    })?;
+    Ok(section)
+}
+
+fn write_section(words: &mut [u32], header_offset: usize, section: Section) {
+    words[header_offset] = section.offset as u32;
+    words[header_offset + 1] = section.len as u32;
+}
+
+fn encode_ids(words: &mut [u32], section: Section, ids: &[AtnStateId]) {
+    for (target, id) in words[section.offset..section.offset + section.len]
+        .iter_mut()
+        .zip(ids)
+    {
+        *target = id.raw();
+    }
+}
+
+fn read_section(words: &[u32], header_offset: usize) -> Result<Section, ParserAtnError> {
+    let offset = words[header_offset] as usize;
+    let len = words[header_offset + 1] as usize;
+    section_end(Section { offset, len }, words.len(), "declared")?;
+    Ok(Section { offset, len })
+}
+
+fn section_end(section: Section, total: usize, name: &str) -> Result<usize, ParserAtnError> {
+    let end = section.offset.checked_add(section.len).ok_or_else(|| {
+        ParserAtnError::InvalidData(format!("{name} section offset arithmetic overflow"))
+    })?;
+    if end > total {
+        return Err(ParserAtnError::InvalidData(format!(
+            "{name} section {0}..{end} exceeds stream length {total}",
+            section.offset
+        )));
+    }
+    Ok(end)
+}
+
+fn expect_section_len(
+    name: &str,
+    section: Section,
+    count: usize,
+    width: usize,
+) -> Result<(), ParserAtnError> {
+    let expected = count.checked_mul(width).ok_or_else(|| {
+        ParserAtnError::InvalidData(format!("{name} count/width multiplication overflow"))
+    })?;
+    if section.len != expected {
+        return Err(ParserAtnError::InvalidData(format!(
+            "{name} section has {} words; expected {expected}",
+            section.len
+        )));
+    }
+    Ok(())
+}
+
+fn validate_index(value: u32, count: usize, name: &str) -> Result<(), ParserAtnError> {
+    if value as usize >= count {
+        return Err(ParserAtnError::InvalidData(format!(
+            "{name} {value} outside 0..{count}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_optional_index(value: u32, count: usize, name: &str) -> Result<(), ParserAtnError> {
+    if value == NO_INDEX {
+        return Ok(());
+    }
+    validate_index(value, count, name)
+}
+
+fn validate_bool(value: u32, name: &str) -> Result<(), ParserAtnError> {
+    if value > 1 {
+        return Err(ParserAtnError::InvalidData(format!(
+            "{name} is {value}; expected 0 or 1"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_range(start: u32, len: u32, count: usize, name: &str) -> Result<(), ParserAtnError> {
+    let start = start as usize;
+    let len = len as usize;
+    let end = start
+        .checked_add(len)
+        .ok_or_else(|| ParserAtnError::InvalidData(format!("{name} range arithmetic overflow")))?;
+    if end > count {
+        return Err(ParserAtnError::InvalidData(format!(
+            "{name} range {start}..{end} exceeds count {count}"
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_atn() -> ParserAtn {
+        let mut builder = ParserAtnBuilder::new(9);
+        builder
+            .add_state(AtnStateKind::RuleStart, Some(0))
+            .expect("rule start");
+        builder
+            .add_state(AtnStateKind::RuleStop, Some(0))
+            .expect("rule stop");
+        builder
+            .set_rule_to_start_state(vec![0])
+            .expect("rule starts");
+        builder.set_rule_to_stop_state(vec![1]).expect("rule stops");
+        builder.add_decision_state(0).expect("decision");
+        builder
+            .add_transition(
+                0,
+                ParserTransitionSpec::Atom {
+                    target: 1,
+                    label: 7,
+                },
+            )
+            .expect("transition");
+        builder.finish().expect("packed parser ATN")
+    }
+
+    #[test]
+    fn packed_views_preserve_state_and_transition_semantics() {
+        let atn = sample_atn();
+        let start = atn.state(0).expect("start");
+        assert_eq!(start.kind(), AtnStateKind::RuleStart);
+        assert_eq!(start.rule_index(), Some(0));
+        assert!(start.has_consuming_transition());
+        let transition = start.transitions().first().expect("transition");
+        assert_eq!(
+            transition.data(),
+            ParserTransitionData::Atom {
+                target: 1,
+                label: 7
+            }
+        );
+        assert!(transition.matches(7, 1, 9));
+        assert!(!transition.matches(8, 1, 9));
+        assert_eq!(atn.rule_to_stop_state().get(0), Some(1));
+    }
+
+    #[test]
+    fn static_format_is_allocation_free_and_version_checked() {
+        let atn = sample_atn();
+        let words = Box::leak(atn.packed_words().to_vec().into_boxed_slice());
+        let borrowed = ParserAtn::from_static(words).expect("static packed ATN");
+        assert!(matches!(borrowed.words, Cow::Borrowed(_)));
+
+        let mut wrong_version = words.to_vec();
+        wrong_version[HEADER_VERSION] = PARSER_ATN_FORMAT_VERSION + 1;
+        assert_eq!(
+            ParserAtn::from_owned(wrong_version),
+            Err(ParserAtnError::UnsupportedVersion {
+                found: 2,
+                minimum: 1,
+                maximum: 1,
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_header_and_section_layout() {
+        let atn = sample_atn();
+        let cases = [
+            (HEADER_MAGIC, 0, "magic"),
+            (HEADER_BYTE_ORDER, 0x0403_0201, "byte-order marker"),
+            (HEADER_SIZE, 0, "header length"),
+            (HEADER_STATES_OFFSET, 0, "states section starts"),
+            (HEADER_STATES_OFFSET + 1, 0, "states section has 0 words"),
+            (HEADER_TOTAL_LEN, 0, "declared total length"),
+        ];
+        for (word, value, expected) in cases {
+            let mut words = atn.packed_words().to_vec();
+            words[word] = value;
+            let error = ParserAtn::from_owned(words).expect_err("invalid format must fail");
+            assert!(
+                error.to_string().contains(expected),
+                "{error} did not contain {expected:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_non_contiguous_state_transition_ranges() {
+        let atn = sample_atn();
+        let mut words = atn.packed_words().to_vec();
+        let second_state = atn.layout.states.offset + STATE_WORDS;
+        words[second_state + 3] = 0;
+        let error = ParserAtn::from_owned(words).expect_err("overlapping ranges must fail");
+        assert!(error.to_string().contains("transition range starts"));
+    }
+
+    #[test]
+    fn interval_sets_share_one_range_pool() {
+        let mut builder = ParserAtnBuilder::new(20);
+        builder
+            .add_state(AtnStateKind::RuleStart, Some(0))
+            .expect("start");
+        builder
+            .add_state(AtnStateKind::RuleStop, Some(0))
+            .expect("stop");
+        builder
+            .set_rule_to_start_state(vec![0])
+            .expect("rule starts");
+        builder.set_rule_to_stop_state(vec![1]).expect("rule stops");
+        let set = builder
+            .add_interval_set([(2, 4), (4, 8), (10, 10)])
+            .expect("set");
+        builder
+            .add_transition(0, ParserTransitionSpec::Set { target: 1, set })
+            .expect("set transition");
+        let atn = builder.finish().expect("ATN");
+        let transition = atn
+            .state(0)
+            .expect("start")
+            .transitions()
+            .first()
+            .expect("transition");
+        let ParserTransitionData::Set { set, .. } = transition.data() else {
+            panic!("expected set transition");
+        };
+        assert_eq!(set.ranges().collect::<Vec<_>>(), vec![(2, 8), (10, 10)]);
+        assert!(set.contains(7));
+        assert!(!set.contains(9));
+        assert_eq!(atn.stats().interval_ranges, 2);
+    }
+
+    #[test]
+    fn rejects_out_of_range_transition_target() {
+        let atn = sample_atn();
+        let mut words = atn.packed_words().to_vec();
+        let target = atn.layout.transitions.offset + 1;
+        words[target] = 99;
+        assert!(matches!(
+            ParserAtn::from_owned(words),
+            Err(ParserAtnError::InvalidData(message))
+                if message.contains("transition target")
+        ));
+    }
+
+    #[test]
+    fn eof_interval_is_preserved_as_signed_data() {
+        let mut builder = ParserAtnBuilder::new(3);
+        builder
+            .add_state(AtnStateKind::RuleStart, Some(0))
+            .expect("start");
+        builder
+            .add_state(AtnStateKind::RuleStop, Some(0))
+            .expect("stop");
+        builder
+            .set_rule_to_start_state(vec![0])
+            .expect("rule starts");
+        builder.set_rule_to_stop_state(vec![1]).expect("rule stops");
+        let set = builder
+            .add_interval_set([(TOKEN_EOF, TOKEN_EOF)])
+            .expect("set");
+        builder
+            .add_transition(0, ParserTransitionSpec::Set { target: 1, set })
+            .expect("transition");
+        let atn = builder.finish().expect("ATN");
+        let transition = atn
+            .state(0)
+            .expect("start")
+            .transitions()
+            .first()
+            .expect("transition");
+        assert!(transition.matches(TOKEN_EOF, 1, 3));
+    }
+}

--- a/src/atn/parser_atn.rs
+++ b/src/atn/parser_atn.rs
@@ -1387,7 +1387,7 @@ impl ParserAtnBuilder {
     fn encode(&self, transition_ranges: &[(u32, u32)]) -> Result<Vec<u32>, ParserAtnError> {
         let layout = EncodedLayout::new(self)?;
         let mut words = vec![0; layout.total_len];
-        self.encode_header(&mut words, layout);
+        self.encode_header(&mut words, layout)?;
         self.encode_states(&mut words, layout.states, transition_ranges);
         self.encode_transitions(&mut words, layout.transitions);
         self.encode_sets(&mut words, layout.sets);
@@ -1398,26 +1398,35 @@ impl ParserAtnBuilder {
         Ok(words)
     }
 
-    fn encode_header(&self, words: &mut [u32], layout: EncodedLayout) {
+    fn encode_header(
+        &self,
+        words: &mut [u32],
+        layout: EncodedLayout,
+    ) -> Result<(), ParserAtnError> {
         words[HEADER_MAGIC] = PARSER_ATN_MAGIC;
         words[HEADER_VERSION] = PARSER_ATN_FORMAT_VERSION;
         words[HEADER_BYTE_ORDER] = PARSER_ATN_BYTE_ORDER;
-        words[HEADER_SIZE] = HEADER_WORDS as u32;
+        words[HEADER_SIZE] = compact_id("parser ATN header size", HEADER_WORDS)?;
         words[HEADER_MAX_TOKEN_TYPE] = pack_i32(self.max_token_type);
-        words[HEADER_STATE_COUNT] = self.states.len() as u32;
-        words[HEADER_TRANSITION_COUNT] = self.transitions.len() as u32;
-        words[HEADER_SET_COUNT] = self.interval_sets.len() as u32;
-        words[HEADER_INTERVAL_COUNT] = self.interval_ranges.len() as u32;
-        words[HEADER_DECISION_COUNT] = self.decisions.len() as u32;
-        words[HEADER_RULE_COUNT] = self.rule_starts.len() as u32;
-        write_section(words, HEADER_STATES_OFFSET, layout.states);
-        write_section(words, HEADER_TRANSITIONS_OFFSET, layout.transitions);
-        write_section(words, HEADER_SETS_OFFSET, layout.sets);
-        write_section(words, HEADER_INTERVALS_OFFSET, layout.intervals);
-        write_section(words, HEADER_DECISIONS_OFFSET, layout.decisions);
-        write_section(words, HEADER_RULE_STARTS_OFFSET, layout.rule_starts);
-        write_section(words, HEADER_RULE_STOPS_OFFSET, layout.rule_stops);
-        words[HEADER_TOTAL_LEN] = layout.total_len as u32;
+        words[HEADER_STATE_COUNT] = compact_id("parser ATN state count", self.states.len())?;
+        words[HEADER_TRANSITION_COUNT] =
+            compact_id("parser ATN transition count", self.transitions.len())?;
+        words[HEADER_SET_COUNT] =
+            compact_id("parser ATN interval-set count", self.interval_sets.len())?;
+        words[HEADER_INTERVAL_COUNT] =
+            compact_id("parser ATN interval count", self.interval_ranges.len())?;
+        words[HEADER_DECISION_COUNT] =
+            compact_id("parser ATN decision count", self.decisions.len())?;
+        words[HEADER_RULE_COUNT] = compact_id("parser ATN rule count", self.rule_starts.len())?;
+        write_section(words, HEADER_STATES_OFFSET, layout.states)?;
+        write_section(words, HEADER_TRANSITIONS_OFFSET, layout.transitions)?;
+        write_section(words, HEADER_SETS_OFFSET, layout.sets)?;
+        write_section(words, HEADER_INTERVALS_OFFSET, layout.intervals)?;
+        write_section(words, HEADER_DECISIONS_OFFSET, layout.decisions)?;
+        write_section(words, HEADER_RULE_STARTS_OFFSET, layout.rule_starts)?;
+        write_section(words, HEADER_RULE_STOPS_OFFSET, layout.rule_stops)?;
+        words[HEADER_TOTAL_LEN] = compact_id("packed parser ATN word", layout.total_len)?;
+        Ok(())
     }
 
     fn encode_states(&self, words: &mut [u32], section: Section, transition_ranges: &[(u32, u32)]) {
@@ -2129,9 +2138,14 @@ fn next_section(
     Ok(section)
 }
 
-fn write_section(words: &mut [u32], header_offset: usize, section: Section) {
-    words[header_offset] = section.offset as u32;
-    words[header_offset + 1] = section.len as u32;
+fn write_section(
+    words: &mut [u32],
+    header_offset: usize,
+    section: Section,
+) -> Result<(), ParserAtnError> {
+    words[header_offset] = compact_id("parser ATN section offset", section.offset)?;
+    words[header_offset + 1] = compact_id("parser ATN section length", section.len)?;
+    Ok(())
 }
 
 fn encode_ids(words: &mut [u32], section: Section, ids: &[AtnStateId]) {
@@ -2284,6 +2298,45 @@ mod tests {
                 found: 2,
                 minimum: 1,
                 maximum: 1,
+            })
+        );
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn header_encoding_rejects_values_outside_u32() {
+        let builder = ParserAtnBuilder::new(0);
+        let section = Section {
+            offset: HEADER_WORDS,
+            len: 0,
+        };
+        let mut layout = EncodedLayout {
+            states: section,
+            transitions: section,
+            sets: section,
+            intervals: section,
+            decisions: section,
+            rule_starts: section,
+            rule_stops: section,
+            total_len: usize::MAX,
+        };
+        let mut words = [0; HEADER_WORDS];
+
+        assert_eq!(
+            builder.encode_header(&mut words, layout),
+            Err(ParserAtnError::Overflow {
+                field: "packed parser ATN word",
+                value: usize::MAX,
+            })
+        );
+
+        layout.states.offset = usize::MAX;
+        layout.total_len = HEADER_WORDS;
+        assert_eq!(
+            builder.encode_header(&mut words, layout),
+            Err(ParserAtnError::Overflow {
+                field: "parser ATN section offset",
+                value: usize::MAX,
             })
         );
     }

--- a/src/atn/serialized.rs
+++ b/src/atn/serialized.rs
@@ -1,6 +1,11 @@
 use std::borrow::Cow;
 
-use crate::atn::{Atn, AtnState, AtnStateKind, AtnType, IntervalSet, LexerAction, Transition};
+use crate::atn::parser_atn::{
+    ParserAtn, ParserAtnBuilder, ParserAtnError, ParserIntervalSetId, ParserTransitionSpec,
+};
+use crate::atn::{
+    AtnStateKind, IntervalSet, LexerAction, LexerAtn, LexerAtnState, LexerTransition,
+};
 use crate::errors::AntlrError;
 use crate::token::TOKEN_EOF;
 
@@ -57,15 +62,15 @@ impl<'a> AtnDeserializer<'a> {
         }
     }
 
-    /// Decodes the ANTLR v4 serialized ATN layout into runtime graph
-    /// structures.
+    /// Decodes an ANTLR v4 serialized lexer ATN into the lexer graph.
     ///
     /// The layout is order-sensitive: states come first, followed by non-greedy
     /// and precedence markers, rule tables, mode starts, interval sets, edges,
     /// decisions, and lexer actions. This method keeps ANTLR's side tables as
-    /// explicit vectors because the lexer/parser simulators need them without
-    /// depending on generated per-rule code.
-    pub fn deserialize(mut self) -> Result<Atn, AntlrError> {
+    /// explicit vectors because lexer simulation needs them without depending
+    /// on generated per-rule code. Parser input is rejected; use
+    /// [`Self::deserialize_parser`] for the packed parser representation.
+    pub fn deserialize(mut self) -> Result<LexerAtn, AntlrError> {
         let version = self.read("version")?;
         if version != SERIALIZED_VERSION {
             return Err(AntlrError::Unsupported(format!(
@@ -73,17 +78,21 @@ impl<'a> AtnDeserializer<'a> {
             )));
         }
 
-        let grammar_type = match self.read("grammar type")? {
-            0 => AtnType::Lexer,
-            1 => AtnType::Parser,
+        match self.read("grammar type")? {
+            0 => {}
+            1 => {
+                return Err(AntlrError::Unsupported(
+                    "parser ATNs require AtnDeserializer::deserialize_parser()".to_owned(),
+                ));
+            }
             other => {
                 return Err(AntlrError::Unsupported(format!(
                     "serialized ATN grammar type {other}"
                 )));
             }
-        };
+        }
         let max_token_type = self.read("max token type")?;
-        let mut atn = Atn::new(grammar_type, max_token_type);
+        let mut atn = LexerAtn::new(max_token_type);
 
         self.deserialize_states(&mut atn)?;
         self.deserialize_non_greedy_states(&mut atn)?;
@@ -93,27 +102,255 @@ impl<'a> AtnDeserializer<'a> {
         let sets = self.deserialize_sets()?;
         self.deserialize_edges(&mut atn, &sets)?;
         self.deserialize_decisions(&mut atn)?;
-        if grammar_type == AtnType::Lexer {
-            self.deserialize_lexer_actions(&mut atn)?;
-        }
+        self.deserialize_lexer_actions(&mut atn)?;
         mark_precedence_decisions(&mut atn);
 
         Ok(atn)
     }
 
+    /// Decodes parser metadata directly into the packed parser-only runtime
+    /// representation.
+    ///
+    /// No lexer object graph is constructed. Temporary state and edge records
+    /// live in centralized builder vectors, then become one validated
+    /// index-addressed word stream.
+    pub fn deserialize_parser(mut self) -> Result<ParserAtn, AntlrError> {
+        self.deserialize_parser_header()?;
+        let max_token_type = self.read("max token type")?;
+        let mut builder = ParserAtnBuilder::new(max_token_type);
+        self.deserialize_parser_states(&mut builder)?;
+        self.deserialize_parser_flags(&mut builder)?;
+        self.deserialize_parser_rules(&mut builder)?;
+        self.deserialize_parser_modes(&builder)?;
+        let sets = self.deserialize_parser_sets(&mut builder)?;
+        self.deserialize_parser_edges(&mut builder, &sets)?;
+        self.deserialize_parser_decisions(&mut builder)?;
+        if self.cursor != self.values.len() {
+            return Err(AntlrError::Unsupported(format!(
+                "serialized parser ATN has {} trailing values",
+                self.values.len() - self.cursor
+            )));
+        }
+        builder.finish().map_err(|error| parser_atn_error(&error))
+    }
+
+    fn deserialize_parser_header(&mut self) -> Result<(), AntlrError> {
+        let version = self.read("version")?;
+        if version != SERIALIZED_VERSION {
+            return Err(AntlrError::Unsupported(format!(
+                "serialized ATN version {version}; expected {SERIALIZED_VERSION}"
+            )));
+        }
+        let grammar_type = self.read("grammar type")?;
+        if grammar_type != 1 {
+            return Err(AntlrError::Unsupported(format!(
+                "serialized parser ATN has grammar type {grammar_type}; expected 1"
+            )));
+        }
+        Ok(())
+    }
+
+    fn deserialize_parser_states(
+        &mut self,
+        builder: &mut ParserAtnBuilder,
+    ) -> Result<(), AntlrError> {
+        let state_count = self.read_usize("state count")?;
+        let mut end_states = Vec::new();
+        let mut loop_back_states = Vec::new();
+        for _ in 0..state_count {
+            let kind = decode_state_kind(self.read("state type")?)?;
+            if kind == AtnStateKind::Invalid {
+                builder
+                    .add_state(kind, None)
+                    .map_err(|error| parser_atn_error(&error))?;
+                continue;
+            }
+            let raw_rule_index = self.read("rule index")?;
+            let rule_index = (raw_rule_index >= 0)
+                .then(|| read_index(raw_rule_index, "state rule index"))
+                .transpose()?;
+            let state = builder
+                .add_state(kind, rule_index)
+                .map_err(|error| parser_atn_error(&error))?
+                .index();
+            match kind {
+                AtnStateKind::LoopEnd => {
+                    let target = self.read_usize("loop back state")?;
+                    loop_back_states.push((state, target));
+                }
+                AtnStateKind::BlockStart
+                | AtnStateKind::PlusBlockStart
+                | AtnStateKind::StarBlockStart => {
+                    let target = self.read_usize("block end state")?;
+                    end_states.push((state, target));
+                }
+                _ => {}
+            }
+        }
+        for (state, target) in end_states {
+            builder
+                .set_end_state(state, target)
+                .map_err(|error| parser_atn_error(&error))?;
+        }
+        for (state, target) in loop_back_states {
+            builder
+                .set_loop_back_state(state, target)
+                .map_err(|error| parser_atn_error(&error))?;
+        }
+        Ok(())
+    }
+
+    fn deserialize_parser_flags(
+        &mut self,
+        builder: &mut ParserAtnBuilder,
+    ) -> Result<(), AntlrError> {
+        let non_greedy_count = self.read_usize("non-greedy state count")?;
+        for _ in 0..non_greedy_count {
+            let state = self.read_usize("non-greedy state")?;
+            builder
+                .set_non_greedy(state)
+                .map_err(|error| parser_atn_error(&error))?;
+        }
+        let precedence_count = self.read_usize("precedence state count")?;
+        for _ in 0..precedence_count {
+            let state = self.read_usize("precedence state")?;
+            builder
+                .set_left_recursive_rule(state)
+                .map_err(|error| parser_atn_error(&error))?;
+        }
+        Ok(())
+    }
+
+    fn deserialize_parser_rules(
+        &mut self,
+        builder: &mut ParserAtnBuilder,
+    ) -> Result<(), AntlrError> {
+        let rule_count = self.read_usize("rule count")?;
+        let mut starts = Vec::with_capacity(rule_count);
+        for _ in 0..rule_count {
+            starts.push(self.read_usize("rule start state")?);
+        }
+        let mut stops = vec![None; rule_count];
+        for state in 0..builder.state_count() {
+            let kind = builder
+                .state_kind(state)
+                .expect("state count bounds builder state lookup");
+            if kind != AtnStateKind::RuleStop {
+                continue;
+            }
+            let Some(rule_index) = builder.state_rule_index(state) else {
+                continue;
+            };
+            if let Some(stop) = stops.get_mut(rule_index) {
+                *stop = Some(state);
+            }
+        }
+        let stops = stops
+            .into_iter()
+            .enumerate()
+            .map(|(rule, stop)| {
+                stop.ok_or_else(|| {
+                    AntlrError::Unsupported(format!(
+                        "serialized parser ATN has no stop state for rule {rule}"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        builder
+            .set_rule_to_start_state(starts)
+            .map_err(|error| parser_atn_error(&error))?;
+        builder
+            .set_rule_to_stop_state(stops)
+            .map_err(|error| parser_atn_error(&error))?;
+        Ok(())
+    }
+
+    fn deserialize_parser_modes(&mut self, builder: &ParserAtnBuilder) -> Result<(), AntlrError> {
+        let mode_count = self.read_usize("mode count")?;
+        for _ in 0..mode_count {
+            let state = self.read_usize("mode start state")?;
+            if builder.state_kind(state).is_none() {
+                return Err(AntlrError::Unsupported(format!(
+                    "mode start state {state} outside state list"
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    fn deserialize_parser_sets(
+        &mut self,
+        builder: &mut ParserAtnBuilder,
+    ) -> Result<Vec<ParserIntervalSetId>, AntlrError> {
+        let set_count = self.read_usize("set count")?;
+        let mut sets = Vec::with_capacity(set_count);
+        for _ in 0..set_count {
+            let interval_count = self.read_usize("interval count")?;
+            let contains_eof = self.read("set contains EOF")? != 0;
+            let mut ranges = Vec::with_capacity(interval_count + usize::from(contains_eof));
+            if contains_eof {
+                ranges.push((TOKEN_EOF, TOKEN_EOF));
+            }
+            for _ in 0..interval_count {
+                ranges.push((self.read("interval start")?, self.read("interval stop")?));
+            }
+            sets.push(
+                builder
+                    .add_interval_set(ranges)
+                    .map_err(|error| parser_atn_error(&error))?,
+            );
+        }
+        Ok(sets)
+    }
+
+    fn deserialize_parser_edges(
+        &mut self,
+        builder: &mut ParserAtnBuilder,
+        sets: &[ParserIntervalSetId],
+    ) -> Result<(), AntlrError> {
+        let transition_count = self.read_usize("transition count")?;
+        for _ in 0..transition_count {
+            let source = self.read_usize("transition source")?;
+            let target = self.read_usize("transition target")?;
+            let kind = self.read("transition type")?;
+            let a = self.read("transition arg 1")?;
+            let b = self.read("transition arg 2")?;
+            let c = self.read("transition arg 3")?;
+            let transition = decode_parser_transition(target, kind, a, b, c, sets)?;
+            builder
+                .add_transition(source, transition)
+                .map_err(|error| parser_atn_error(&error))?;
+        }
+        add_parser_rule_return_edges(builder)
+    }
+
+    fn deserialize_parser_decisions(
+        &mut self,
+        builder: &mut ParserAtnBuilder,
+    ) -> Result<(), AntlrError> {
+        let decision_count = self.read_usize("decision count")?;
+        for _ in 0..decision_count {
+            let state = self.read_usize("decision state")?;
+            builder
+                .add_decision_state(state)
+                .map_err(|error| parser_atn_error(&error))?;
+        }
+        Ok(())
+    }
+
     /// Reads all serialized ATN states and preserves state-specific paired
     /// links such as block end states and loop-back states.
-    fn deserialize_states(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_states(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let state_count = self.read_usize("state count")?;
         for state_number in 0..state_count {
             let kind = decode_state_kind(self.read("state type")?)?;
             if kind == AtnStateKind::Invalid {
-                atn.add_state(AtnState::new(state_number, kind));
+                atn.add_state(LexerAtnState::new(state_number, kind));
                 continue;
             }
 
             let rule_index = self.read("rule index")?;
-            let mut state = AtnState::new(state_number, kind);
+            let mut state = LexerAtnState::new(state_number, kind);
             if rule_index >= 0 {
                 let rule_index = usize::try_from(rule_index).map_err(|_| {
                     AntlrError::Unsupported(format!("rule index cannot be negative: {rule_index}"))
@@ -140,7 +377,7 @@ impl<'a> AtnDeserializer<'a> {
 
     /// Marks lexer and parser decision states that ANTLR encoded as
     /// non-greedy.
-    fn deserialize_non_greedy_states(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_non_greedy_states(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let count = self.read_usize("non-greedy state count")?;
         for _ in 0..count {
             let state_number = self.read_usize("non-greedy state")?;
@@ -156,7 +393,7 @@ impl<'a> AtnDeserializer<'a> {
 
     /// Marks rule-start states that ANTLR generated for left-recursive
     /// precedence rules.
-    fn deserialize_precedence_states(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_precedence_states(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let count = self.read_usize("precedence state count")?;
         for _ in 0..count {
             let state_number = self.read_usize("precedence state")?;
@@ -172,15 +409,13 @@ impl<'a> AtnDeserializer<'a> {
 
     /// Decodes rule start states, lexer token types, and derived rule stop
     /// states.
-    fn deserialize_rules(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_rules(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let rule_count = self.read_usize("rule count")?;
         let mut starts = Vec::with_capacity(rule_count);
         let mut token_types = Vec::new();
         for _ in 0..rule_count {
             starts.push(self.read_usize("rule start state")?);
-            if atn.grammar_type() == AtnType::Lexer {
-                token_types.push(self.read("rule token type")?);
-            }
+            token_types.push(self.read("rule token type")?);
         }
 
         let mut stops = vec![usize::MAX; rule_count];
@@ -202,7 +437,7 @@ impl<'a> AtnDeserializer<'a> {
     }
 
     /// Decodes lexer mode entry states.
-    fn deserialize_modes(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_modes(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let mode_count = self.read_usize("mode count")?;
         for _ in 0..mode_count {
             atn.add_mode_start_state(self.read_usize("mode start state")?);
@@ -233,7 +468,11 @@ impl<'a> AtnDeserializer<'a> {
     }
 
     /// Decodes serialized edges and appends derived rule-return epsilon edges.
-    fn deserialize_edges(&mut self, atn: &mut Atn, sets: &[IntervalSet]) -> Result<(), AntlrError> {
+    fn deserialize_edges(
+        &mut self,
+        atn: &mut LexerAtn,
+        sets: &[IntervalSet],
+    ) -> Result<(), AntlrError> {
         let transition_count = self.read_usize("transition count")?;
         for _ in 0..transition_count {
             let src = self.read_usize("transition source")?;
@@ -254,7 +493,7 @@ impl<'a> AtnDeserializer<'a> {
         let mut return_edges = Vec::new();
         for state in atn.states() {
             for transition in &state.transitions {
-                let Transition::Rule {
+                let LexerTransition::Rule {
                     target,
                     follow_state,
                     ..
@@ -275,7 +514,7 @@ impl<'a> AtnDeserializer<'a> {
         }
         for (stop_state, follow_state) in return_edges {
             if let Some(state) = atn.state_mut(stop_state) {
-                state.add_transition(Transition::Epsilon {
+                state.add_transition(LexerTransition::Epsilon {
                     target: follow_state,
                 });
             }
@@ -285,7 +524,7 @@ impl<'a> AtnDeserializer<'a> {
     }
 
     /// Decodes parser/lexer decision entry states in decision-number order.
-    fn deserialize_decisions(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_decisions(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let decision_count = self.read_usize("decision count")?;
         for _ in 0..decision_count {
             atn.add_decision_state(self.read_usize("decision state")?);
@@ -295,7 +534,7 @@ impl<'a> AtnDeserializer<'a> {
 
     /// Decodes grammar-independent lexer actions referenced by action
     /// transitions.
-    fn deserialize_lexer_actions(&mut self, atn: &mut Atn) -> Result<(), AntlrError> {
+    fn deserialize_lexer_actions(&mut self, atn: &mut LexerAtn) -> Result<(), AntlrError> {
         let action_count = self.read_usize("lexer action count")?;
         let mut actions = Vec::with_capacity(action_count);
         for _ in 0..action_count {
@@ -355,37 +594,37 @@ fn decode_transition(
     b: i32,
     c: i32,
     sets: &[IntervalSet],
-) -> Result<Transition, AntlrError> {
+) -> Result<LexerTransition, AntlrError> {
     let transition = match kind {
-        1 => Transition::Epsilon { target },
-        2 => Transition::Range {
+        1 => LexerTransition::Epsilon { target },
+        2 => LexerTransition::Range {
             target,
             start: if c != 0 { TOKEN_EOF } else { a },
             stop: b,
         },
-        3 => Transition::Rule {
+        3 => LexerTransition::Rule {
             target: read_index(a, "rule transition target")?,
             rule_index: read_index(b, "rule transition rule index")?,
             follow_state: target,
             precedence: c,
         },
-        4 => Transition::Predicate {
+        4 => LexerTransition::Predicate {
             target,
             rule_index: read_index(a, "predicate rule index")?,
             pred_index: read_index(b, "predicate index")?,
             context_dependent: c != 0,
         },
-        5 => Transition::Atom {
+        5 => LexerTransition::Atom {
             target,
             label: if c != 0 { TOKEN_EOF } else { a },
         },
-        6 => Transition::Action {
+        6 => LexerTransition::Action {
             target,
             rule_index: read_index(a, "action rule index")?,
             action_index: usize::try_from(b).ok(),
             context_dependent: c != 0,
         },
-        7 => Transition::Set {
+        7 => LexerTransition::Set {
             target,
             set: sets
                 .get(read_index(a, "set transition set index")?)
@@ -394,7 +633,7 @@ fn decode_transition(
                     AntlrError::Unsupported(format!("set index {a} outside set list"))
                 })?,
         },
-        8 => Transition::NotSet {
+        8 => LexerTransition::NotSet {
             target,
             set: sets
                 .get(read_index(a, "not-set transition set index")?)
@@ -403,8 +642,8 @@ fn decode_transition(
                     AntlrError::Unsupported(format!("set index {a} outside set list"))
                 })?,
         },
-        9 => Transition::Wildcard { target },
-        10 => Transition::Precedence {
+        9 => LexerTransition::Wildcard { target },
+        10 => LexerTransition::Precedence {
             target,
             precedence: a,
         },
@@ -415,6 +654,118 @@ fn decode_transition(
         }
     };
     Ok(transition)
+}
+
+/// Converts one serialized parser edge directly into a packed-builder record.
+fn decode_parser_transition(
+    target: usize,
+    kind: i32,
+    a: i32,
+    b: i32,
+    c: i32,
+    sets: &[ParserIntervalSetId],
+) -> Result<ParserTransitionSpec, AntlrError> {
+    let transition = match kind {
+        1 => ParserTransitionSpec::Epsilon { target },
+        2 => ParserTransitionSpec::Range {
+            target,
+            start: if c != 0 { TOKEN_EOF } else { a },
+            stop: b,
+        },
+        3 => ParserTransitionSpec::Rule {
+            target: read_index(a, "rule transition target")?,
+            rule_index: read_index(b, "rule transition rule index")?,
+            follow_state: target,
+            precedence: c,
+        },
+        4 => ParserTransitionSpec::Predicate {
+            target,
+            rule_index: read_index(a, "predicate rule index")?,
+            pred_index: read_index(b, "predicate index")?,
+            context_dependent: c != 0,
+        },
+        5 => ParserTransitionSpec::Atom {
+            target,
+            label: if c != 0 { TOKEN_EOF } else { a },
+        },
+        6 => ParserTransitionSpec::Action {
+            target,
+            rule_index: read_index(a, "action rule index")?,
+            action_index: usize::try_from(b).ok(),
+            context_dependent: c != 0,
+        },
+        7 => ParserTransitionSpec::Set {
+            target,
+            set: parser_set_id(sets, a, "set transition")?,
+        },
+        8 => ParserTransitionSpec::NotSet {
+            target,
+            set: parser_set_id(sets, a, "not-set transition")?,
+        },
+        9 => ParserTransitionSpec::Wildcard { target },
+        10 => ParserTransitionSpec::Precedence {
+            target,
+            precedence: a,
+        },
+        other => {
+            return Err(AntlrError::Unsupported(format!(
+                "ATN transition type {other}"
+            )));
+        }
+    };
+    Ok(transition)
+}
+
+fn parser_set_id(
+    sets: &[ParserIntervalSetId],
+    value: i32,
+    label: &str,
+) -> Result<ParserIntervalSetId, AntlrError> {
+    let index = read_index(value, label)?;
+    sets.get(index).copied().ok_or_else(|| {
+        AntlrError::Unsupported(format!("{label} set index {value} outside set list"))
+    })
+}
+
+/// Adds ANTLR's derived epsilon returns without constructing per-state edge
+/// vectors. The builder keeps the original edge order for each stop state and
+/// appends these derived returns after serialized edges.
+fn add_parser_rule_return_edges(builder: &mut ParserAtnBuilder) -> Result<(), AntlrError> {
+    let mut return_edges = Vec::new();
+    for source in 0..builder.state_count() {
+        for transition in builder.transitions_from(source) {
+            let ParserTransitionSpec::Rule {
+                target,
+                follow_state,
+                ..
+            } = transition
+            else {
+                continue;
+            };
+            let Some(rule_index) = builder.state_rule_index(target) else {
+                continue;
+            };
+            let Some(stop_state) = builder.rule_stop_state(rule_index) else {
+                continue;
+            };
+            return_edges.push((stop_state, follow_state));
+        }
+    }
+    for (stop_state, follow_state) in return_edges {
+        builder
+            .add_transition(
+                stop_state,
+                ParserTransitionSpec::Epsilon {
+                    target: follow_state,
+                },
+            )
+            .map_err(|error| parser_atn_error(&error))?;
+    }
+    Ok(())
+}
+
+fn parser_atn_error(error: &ParserAtnError) -> AntlrError {
+    AntlrError::Unsupported(error.to_string())
 }
 
 /// Converts ANTLR's serialized lexer action ordinal and data operands into a
@@ -446,7 +797,7 @@ fn decode_lexer_action(
 }
 
 /// Marks star-loop entry states that are parser precedence decisions.
-fn mark_precedence_decisions(atn: &mut Atn) {
+fn mark_precedence_decisions(atn: &mut LexerAtn) {
     let mut decisions = Vec::new();
     for state in atn.states() {
         if state.kind != AtnStateKind::StarLoopEntry {
@@ -524,13 +875,26 @@ mod tests {
             0,
         ]);
         let atn = AtnDeserializer::new(&serialized)
-            .deserialize()
+            .deserialize_parser()
             .expect("artificial parser ATN should deserialize");
-        assert_eq!(atn.grammar_type(), AtnType::Parser);
         assert_eq!(atn.max_token_type(), 9);
         assert_eq!(atn.states().len(), 2);
-        assert_eq!(atn.rule_to_start_state(), &[0]);
-        assert_eq!(atn.rule_to_stop_state(), &[1]);
-        assert_eq!(atn.decision_to_state(), &[0]);
+        assert_eq!(atn.rule_to_start_state().iter().collect::<Vec<_>>(), [0]);
+        assert_eq!(atn.rule_to_stop_state().iter().collect::<Vec<_>>(), [1]);
+        assert_eq!(atn.decision_to_state().iter().collect::<Vec<_>>(), [0]);
+        assert_eq!(atn.stats().transitions, 1);
+    }
+
+    #[test]
+    fn graph_deserializer_rejects_parser_input() {
+        let serialized = SerializedAtn::from_i32(&[4, 1, 0]);
+        let error = AtnDeserializer::new(&serialized)
+            .deserialize()
+            .expect_err("parser input must not create a lexer graph");
+        assert!(
+            error
+                .to_string()
+                .contains("AtnDeserializer::deserialize_parser()")
+        );
     }
 }

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -7,8 +7,11 @@ use std::ops::AddAssign;
 use std::path::{Path, PathBuf};
 
 use antlr4_runtime::atn::lexer_dfa::CompiledLexerDfa;
+use antlr4_runtime::atn::parser_atn::{
+    ParserAtn, ParserAtnState, ParserTransition, ParserTransitionData,
+};
 use antlr4_runtime::atn::serialized::{AtnDeserializer, SerializedAtn};
-use antlr4_runtime::atn::{Atn, AtnStateKind, LexerAction, Transition};
+use antlr4_runtime::atn::{AtnStateKind, LexerAction, LexerTransition};
 use antlr4_runtime::token::TOKEN_EOF;
 
 #[path = "../bin_support/embedded.rs"]
@@ -947,7 +950,7 @@ fn collect_parser_semantics(
         .transpose()?
         .unwrap_or_default();
 
-    let predicate_coordinates = lexer_predicate_transitions(data)?;
+    let predicate_coordinates = parser_predicate_transitions(data)?;
     if !predicate_coordinates.is_empty() {
         let templates = grammar_source
             .map(|source| parser_predicate_templates(data, source, patterns))
@@ -2028,7 +2031,7 @@ fn render_lexer(
         r#"{generated_header}use antlr4_runtime::char_stream::CharStream;
 use antlr4_runtime::recognizer::RecognizerData;
 use antlr4_runtime::token::{{TokenId, TokenSink, TokenSource, TokenStoreError}};
-use antlr4_runtime::atn::Atn;
+use antlr4_runtime::atn::LexerAtn;
 use antlr4_runtime::atn::lexer_dfa::CompiledLexerDfa;
 use antlr4_runtime::atn::serialized::AtnDeserializer;
 use antlr4_runtime::{{BaseLexer, GeneratedLexer, GrammarMetadata, Lexer, Recognizer}};
@@ -2038,10 +2041,10 @@ use std::sync::OnceLock;
 {metadata}
 {typed_hook_adapter}
 
-static ATN_CELL: OnceLock<Atn> = OnceLock::new();
+static ATN_CELL: OnceLock<LexerAtn> = OnceLock::new();
 
 /// Deserializes and caches the grammar ATN for all lexer instances.
-fn atn() -> &'static Atn {{
+fn atn() -> &'static LexerAtn {{
     ATN_CELL.get_or_init(|| {{
         let serialized = metadata().serialized_atn();
         AtnDeserializer::new(&serialized)
@@ -2420,7 +2423,7 @@ struct GeneratedStepRenderContext<'a> {
 }
 
 struct GeneratedParserCompileContext<'a> {
-    atn: &'a Atn,
+    atn: &'a ParserAtn,
     decision_by_state: &'a [Option<usize>],
     rule_args: &'a [(usize, usize, RuleArgTemplate)],
     inline_action_states: &'a BTreeSet<usize>,
@@ -2508,7 +2511,7 @@ fn parser_generated_rules(
     require_generated_callees: bool,
 ) -> io::Result<Vec<Option<GeneratedParserRule>>> {
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let decision_by_state = decision_by_state(&atn);
     let context = GeneratedParserCompileContext {
@@ -2662,7 +2665,7 @@ fn parser_rule_callers_reaching(
         return Ok(BTreeSet::new());
     }
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     Ok(atn_rule_callers_reaching(
         &atn,
@@ -2672,7 +2675,7 @@ fn parser_rule_callers_reaching(
 }
 
 fn atn_rule_callers_reaching(
-    atn: &Atn,
+    atn: &ParserAtn,
     target_rules: &BTreeSet<usize>,
     rule_count: usize,
 ) -> BTreeSet<usize> {
@@ -2680,16 +2683,17 @@ fn atn_rule_callers_reaching(
     loop {
         let mut changed = false;
         for state in atn.states() {
-            let Some(caller_rule) = state.rule_index.filter(|index| *index < rule_count) else {
+            let Some(caller_rule) = state.rule_index().filter(|index| *index < rule_count) else {
                 continue;
             };
             if reaching.contains(&caller_rule) {
                 continue;
             }
-            let calls_reaching_rule = state.transitions.iter().any(|transition| {
+            let calls_reaching_rule = state.transitions().iter().any(|transition| {
                 matches!(
-                    transition,
-                    Transition::Rule { rule_index, .. } if reaching.contains(rule_index)
+                    transition.data(),
+                    ParserTransitionData::Rule { rule_index, .. }
+                        if reaching.contains(&rule_index)
                 )
             });
             if calls_reaching_rule {
@@ -3010,9 +3014,9 @@ fn generated_steps_call_disabled_rule(steps: &[GeneratedParserStep], enabled: &[
     })
 }
 
-fn decision_by_state(atn: &Atn) -> Vec<Option<usize>> {
-    let mut decision_by_state = vec![None; atn.states().len()];
-    for (decision, &state_number) in atn.decision_to_state().iter().enumerate() {
+fn decision_by_state(atn: &ParserAtn) -> Vec<Option<usize>> {
+    let mut decision_by_state = vec![None; atn.state_count()];
+    for (decision, state_number) in atn.decision_to_state().iter().enumerate() {
         if let Some(slot) = decision_by_state.get_mut(state_number) {
             *slot = Some(decision);
         }
@@ -3035,10 +3039,10 @@ struct GeneratedFirstSetCtx {
 
 fn generated_decision_fast_path<'a>(
     context: &GeneratedParserCompileContext<'_>,
-    state: &antlr4_runtime::atn::AtnState,
+    state: ParserAtnState<'_>,
     alts: impl IntoIterator<Item = (usize, &'a [GeneratedParserStep])>,
 ) -> Option<GeneratedDecisionFastPath> {
-    if state.precedence_rule_decision || state.non_greedy {
+    if state.precedence_rule_decision() || state.non_greedy() {
         return None;
     }
     let mut first_ctx = GeneratedFirstSetCtx::default();
@@ -3080,7 +3084,7 @@ fn generated_decision_fast_path<'a>(
 }
 
 fn generated_steps_first_set(
-    atn: &Atn,
+    atn: &ParserAtn,
     steps: &[GeneratedParserStep],
     ctx: &mut GeneratedFirstSetCtx,
 ) -> GeneratedLookSet {
@@ -3115,10 +3119,10 @@ fn generated_steps_first_set(
                 return first;
             }
             GeneratedParserStep::CallRule { rule_index, .. } => {
-                let Some(start) = atn.rule_to_start_state().get(*rule_index).copied() else {
+                let Some(start) = atn.rule_to_start_state().get(*rule_index) else {
                     return GeneratedLookSet::default();
                 };
-                let Some(stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                let Some(stop) = atn.rule_to_stop_state().get(*rule_index) else {
                     return GeneratedLookSet::default();
                 };
                 let child = generated_rule_first_set(atn, start, stop, ctx);
@@ -3151,7 +3155,7 @@ fn generated_steps_first_set(
 }
 
 fn generated_alt_steps_first_set(
-    atn: &Atn,
+    atn: &ParserAtn,
     alts: &[Vec<GeneratedParserStep>],
     ctx: &mut GeneratedFirstSetCtx,
 ) -> GeneratedLookSet {
@@ -3165,7 +3169,7 @@ fn generated_alt_steps_first_set(
 }
 
 fn generated_rule_first_set(
-    atn: &Atn,
+    atn: &ParserAtn,
     state_number: usize,
     rule_stop_state: usize,
     ctx: &mut GeneratedFirstSetCtx,
@@ -3197,7 +3201,7 @@ fn generated_rule_first_set(
 }
 
 fn generated_rule_first_set_inner(
-    atn: &Atn,
+    atn: &ParserAtn,
     state_number: usize,
     rule_stop_state: usize,
     ctx: &mut GeneratedFirstSetCtx,
@@ -3214,38 +3218,38 @@ fn generated_rule_first_set_inner(
     let Some(state) = atn.state(state_number) else {
         return;
     };
-    for transition in &state.transitions {
+    for transition in state.transitions() {
         let symbols = generated_transition_symbols(transition, atn.max_token_type());
         if !symbols.is_empty() {
             first.symbols.extend(symbols);
             continue;
         }
-        match transition {
-            Transition::Epsilon { target }
-            | Transition::Action { target, .. }
-            | Transition::Predicate { target, .. }
-            | Transition::Precedence { target, .. } => {
-                generated_rule_first_set_inner(atn, *target, rule_stop_state, ctx, visited, first);
+        match transition.data() {
+            ParserTransitionData::Epsilon { target }
+            | ParserTransitionData::Action { target, .. }
+            | ParserTransitionData::Predicate { target, .. }
+            | ParserTransitionData::Precedence { target, .. } => {
+                generated_rule_first_set_inner(atn, target, rule_stop_state, ctx, visited, first);
             }
-            Transition::Rule {
+            ParserTransitionData::Rule {
                 target,
                 rule_index,
                 follow_state,
                 ..
             } => {
-                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                let Some(child_stop) = atn.rule_to_stop_state().get(rule_index) else {
                     continue;
                 };
-                let child_key = (*target, child_stop);
+                let child_key = (target, child_stop);
                 if ctx.in_progress.contains(&child_key) && !ctx.cache.contains_key(&child_key) {
                     ctx.hit_cycle = true;
                 }
-                let child = generated_rule_first_set(atn, *target, child_stop, ctx);
+                let child = generated_rule_first_set(atn, target, child_stop, ctx);
                 first.symbols.extend(child.symbols);
                 if child.nullable {
                     generated_rule_first_set_inner(
                         atn,
-                        *follow_state,
+                        follow_state,
                         rule_stop_state,
                         ctx,
                         visited,
@@ -3253,40 +3257,43 @@ fn generated_rule_first_set_inner(
                     );
                 }
             }
-            Transition::Atom { .. }
-            | Transition::Range { .. }
-            | Transition::Set { .. }
-            | Transition::NotSet { .. }
-            | Transition::Wildcard { .. } => {}
+            ParserTransitionData::Atom { .. }
+            | ParserTransitionData::Range { .. }
+            | ParserTransitionData::Set { .. }
+            | ParserTransitionData::NotSet { .. }
+            | ParserTransitionData::Wildcard { .. } => {}
         }
     }
 }
 
-fn generated_transition_symbols(transition: &Transition, max_token_type: i32) -> BTreeSet<i32> {
+fn generated_transition_symbols(
+    transition: ParserTransition<'_>,
+    max_token_type: i32,
+) -> BTreeSet<i32> {
     let mut symbols = BTreeSet::new();
-    match transition {
-        Transition::Atom { label, .. } => {
-            symbols.insert(*label);
+    match transition.data() {
+        ParserTransitionData::Atom { label, .. } => {
+            symbols.insert(label);
         }
-        Transition::Range { start, stop, .. } => {
-            symbols.extend(*start..=*stop);
+        ParserTransitionData::Range { start, stop, .. } => {
+            symbols.extend(start..=stop);
         }
-        Transition::Set { set, .. } => {
+        ParserTransitionData::Set { set, .. } => {
             for (start, stop) in set.ranges() {
-                symbols.extend(*start..=*stop);
+                symbols.extend(start..=stop);
             }
         }
-        Transition::NotSet { set, .. } => {
+        ParserTransitionData::NotSet { set, .. } => {
             symbols.extend((1..=max_token_type).filter(|symbol| !set.contains(*symbol)));
         }
-        Transition::Wildcard { .. } => {
+        ParserTransitionData::Wildcard { .. } => {
             symbols.extend(1..=max_token_type);
         }
-        Transition::Epsilon { .. }
-        | Transition::Rule { .. }
-        | Transition::Predicate { .. }
-        | Transition::Action { .. }
-        | Transition::Precedence { .. } => {}
+        ParserTransitionData::Epsilon { .. }
+        | ParserTransitionData::Rule { .. }
+        | ParserTransitionData::Predicate { .. }
+        | ParserTransitionData::Action { .. }
+        | ParserTransitionData::Precedence { .. } => {}
     }
     symbols
 }
@@ -3302,26 +3309,26 @@ fn symbols_to_ranges(symbols: BTreeSet<i32>) -> Vec<(i32, i32)> {
     ranges
 }
 
-const fn state_tracks_alt_number(state: &antlr4_runtime::atn::AtnState) -> bool {
+fn state_tracks_alt_number(state: ParserAtnState<'_>) -> bool {
     matches!(
-        state.kind,
+        state.kind(),
         AtnStateKind::Basic
             | AtnStateKind::BlockStart
             | AtnStateKind::PlusBlockStart
             | AtnStateKind::StarBlockStart
             | AtnStateKind::StarLoopEntry
-    ) && !state.precedence_rule_decision
-        && state.transitions.len() > 1
+    ) && !state.precedence_rule_decision()
+        && state.transitions().len() > 1
 }
 
 fn compile_generated_parser_rule(
     context: &GeneratedParserCompileContext<'_>,
     rule_index: usize,
 ) -> Option<GeneratedParserRule> {
-    let entry_state = context.atn.rule_to_start_state().get(rule_index).copied()?;
-    let stop_state = context.atn.rule_to_stop_state().get(rule_index).copied()?;
+    let entry_state = context.atn.rule_to_start_state().get(rule_index)?;
+    let stop_state = context.atn.rule_to_stop_state().get(rule_index)?;
     let start = context.atn.state(entry_state)?;
-    if start.left_recursive_rule {
+    if start.left_recursive_rule() {
         return compile_generated_left_recursive_parser_rule(
             context,
             rule_index,
@@ -3380,11 +3387,11 @@ fn find_left_recursive_loop_entry(
     context: &GeneratedParserCompileContext<'_>,
     rule_index: usize,
 ) -> Option<usize> {
-    context.atn.states().iter().find_map(|state| {
-        (state.rule_index == Some(rule_index)
-            && state.kind == AtnStateKind::StarLoopEntry
-            && state.precedence_rule_decision)
-            .then_some(state.state_number)
+    context.atn.states().find_map(|state| {
+        (state.rule_index() == Some(rule_index)
+            && state.kind() == AtnStateKind::StarLoopEntry
+            && state.precedence_rule_decision())
+        .then_some(state.state_number())
     })
 }
 
@@ -3392,17 +3399,17 @@ fn compile_generated_left_recursive_loop(
     context: &GeneratedParserCompileContext<'_>,
     rule_index: usize,
     entry_state: usize,
-    state: &antlr4_runtime::atn::AtnState,
+    state: ParserAtnState<'_>,
     decision: usize,
 ) -> Option<(GeneratedParserStep, usize)> {
     let mut enter = None;
     let mut exit = None;
-    for (index, transition) in state.transitions.iter().enumerate() {
+    for (index, transition) in state.transitions().iter().enumerate() {
         let alt = index + 1;
         let target = transition.target();
         let target_state = context.atn.state(target)?;
-        if target_state.kind == AtnStateKind::LoopEnd {
-            exit = Some((alt, transition, target, target_state.loop_back_state?));
+        if target_state.kind() == AtnStateKind::LoopEnd {
+            exit = Some((alt, transition, target, target_state.loop_back_state()?));
         } else {
             enter = Some((alt, transition));
         }
@@ -3411,7 +3418,7 @@ fn compile_generated_left_recursive_loop(
     let (enter_alt, enter_transition) = enter?;
     let (exit_alt, exit_transition, exit_target, loop_back_state) = exit?;
     let (enter_step, enter_target) = compile_generated_parser_transition(
-        state.state_number,
+        state.state_number(),
         context.rule_args,
         enter_transition,
         generated_action_state_sets(context),
@@ -3430,7 +3437,7 @@ fn compile_generated_left_recursive_loop(
     }
 
     let (exit_step, _) = compile_generated_parser_transition(
-        state.state_number,
+        state.state_number(),
         context.rule_args,
         exit_transition,
         generated_action_state_sets(context),
@@ -3442,7 +3449,7 @@ fn compile_generated_left_recursive_loop(
 
     Some((
         GeneratedParserStep::LeftRecursiveLoop {
-            state: state.state_number,
+            state: state.state_number(),
             decision,
             enter_alt,
             exit_alt,
@@ -3476,8 +3483,8 @@ fn compile_generated_parser_path(
     {
         compile_generated_parser_decision_state(context, state, decision, stop_state, visited)?
     } else {
-        let transition = state.transitions.first()?;
-        if state.transitions.len() != 1 {
+        let transition = state.transitions().first()?;
+        if state.transitions().len() != 1 {
             return None;
         }
         let (step, target) = compile_generated_parser_transition(
@@ -3499,12 +3506,12 @@ fn compile_generated_parser_path(
 
 fn compile_generated_parser_decision_state(
     context: &GeneratedParserCompileContext<'_>,
-    state: &antlr4_runtime::atn::AtnState,
+    state: ParserAtnState<'_>,
     decision: usize,
     stop_state: usize,
     visited: &mut BTreeSet<usize>,
 ) -> Option<Vec<GeneratedParserStep>> {
-    match state.kind {
+    match state.kind() {
         AtnStateKind::BlockStart | AtnStateKind::PlusBlockStart | AtnStateKind::StarBlockStart => {
             compile_generated_parser_block_decision(context, state, decision, stop_state, visited)
         }
@@ -3520,16 +3527,16 @@ fn compile_generated_parser_decision_state(
 
 fn compile_generated_parser_block_decision(
     context: &GeneratedParserCompileContext<'_>,
-    state: &antlr4_runtime::atn::AtnState,
+    state: ParserAtnState<'_>,
     decision: usize,
     stop_state: usize,
     visited: &mut BTreeSet<usize>,
 ) -> Option<Vec<GeneratedParserStep>> {
-    let end_state = state.end_state?;
-    let mut alts = Vec::with_capacity(state.transitions.len());
-    for transition in &state.transitions {
+    let end_state = state.end_state()?;
+    let mut alts = Vec::with_capacity(state.transitions().len());
+    for transition in state.transitions() {
         let (step, target) = compile_generated_parser_transition(
-            state.state_number,
+            state.state_number(),
             context.rule_args,
             transition,
             generated_action_state_sets(context),
@@ -3547,11 +3554,11 @@ fn compile_generated_parser_block_decision(
     }
 
     let mut steps = vec![GeneratedParserStep::Decision {
-        state: state.state_number,
+        state: state.state_number(),
         decision,
         track_alt_number: state_tracks_alt_number(state),
         allow_semantic_context: alts.iter().any(|alt| steps_contain_predicate(alt)),
-        force_context: state.non_greedy,
+        force_context: state.non_greedy(),
         fast_path: generated_decision_fast_path(
             context,
             state,
@@ -3569,20 +3576,20 @@ fn compile_generated_parser_block_decision(
 
 fn compile_generated_parser_star_loop(
     context: &GeneratedParserCompileContext<'_>,
-    state: &antlr4_runtime::atn::AtnState,
+    state: ParserAtnState<'_>,
     decision: usize,
     stop_state: usize,
     visited: &mut BTreeSet<usize>,
 ) -> Option<Vec<GeneratedParserStep>> {
     let mut enter = None;
     let mut exit = None;
-    for (index, transition) in state.transitions.iter().enumerate() {
+    for (index, transition) in state.transitions().iter().enumerate() {
         let alt = index + 1;
         let target = transition.target();
         let target_state = context.atn.state(target)?;
-        let target_kind = target_state.kind;
+        let target_kind = target_state.kind();
         if target_kind == AtnStateKind::LoopEnd {
-            exit = Some((alt, transition, target_state.loop_back_state?));
+            exit = Some((alt, transition, target_state.loop_back_state()?));
         } else {
             enter = Some((alt, transition));
         }
@@ -3591,7 +3598,7 @@ fn compile_generated_parser_star_loop(
     let (enter_alt, enter_transition) = enter?;
     let (exit_alt, exit_transition, loop_back_state) = exit?;
     let (enter_step, enter_target) = compile_generated_parser_transition(
-        state.state_number,
+        state.state_number(),
         context.rule_args,
         enter_transition,
         generated_action_state_sets(context),
@@ -3610,7 +3617,7 @@ fn compile_generated_parser_star_loop(
     }
 
     let (exit_step, exit_target) = compile_generated_parser_transition(
-        state.state_number,
+        state.state_number(),
         context.rule_args,
         exit_transition,
         generated_action_state_sets(context),
@@ -3621,13 +3628,13 @@ fn compile_generated_parser_star_loop(
     }
 
     let mut steps = vec![GeneratedParserStep::StarLoop {
-        state: state.state_number,
+        state: state.state_number(),
         decision,
         enter_alt,
         exit_alt,
         track_alt_number: state_tracks_alt_number(state),
         allow_semantic_context: steps_contain_predicate(&body),
-        force_context: state.non_greedy,
+        force_context: state.non_greedy(),
         plus_loop: false,
         fast_path: None,
         body,
@@ -3643,18 +3650,18 @@ fn compile_generated_parser_star_loop(
 
 fn compile_generated_parser_plus_loop(
     context: &GeneratedParserCompileContext<'_>,
-    state: &antlr4_runtime::atn::AtnState,
+    state: ParserAtnState<'_>,
     decision: usize,
     stop_state: usize,
     visited: &mut BTreeSet<usize>,
 ) -> Option<Vec<GeneratedParserStep>> {
     let mut enter = None;
     let mut exit = None;
-    for (index, transition) in state.transitions.iter().enumerate() {
+    for (index, transition) in state.transitions().iter().enumerate() {
         let alt = index + 1;
         let target = transition.target();
         let target_state = context.atn.state(target)?;
-        if target_state.kind == AtnStateKind::LoopEnd {
+        if target_state.kind() == AtnStateKind::LoopEnd {
             exit = Some((alt, transition));
         } else {
             enter = Some((alt, transition));
@@ -3663,7 +3670,7 @@ fn compile_generated_parser_plus_loop(
 
     let (enter_alt, enter_transition) = enter?;
     let (enter_step, enter_target) = compile_generated_parser_transition(
-        state.state_number,
+        state.state_number(),
         context.rule_args,
         enter_transition,
         generated_action_state_sets(context),
@@ -3674,7 +3681,7 @@ fn compile_generated_parser_plus_loop(
     body.extend(compile_generated_parser_path(
         context,
         enter_target,
-        state.state_number,
+        state.state_number(),
         &mut body_visited,
     )?);
     if !steps_may_consume(&body) {
@@ -3683,7 +3690,7 @@ fn compile_generated_parser_plus_loop(
 
     let (exit_alt, exit_transition) = exit?;
     let (exit_step, exit_target) = compile_generated_parser_transition(
-        state.state_number,
+        state.state_number(),
         context.rule_args,
         exit_transition,
         generated_action_state_sets(context),
@@ -3694,13 +3701,13 @@ fn compile_generated_parser_plus_loop(
     }
 
     let mut steps = vec![GeneratedParserStep::StarLoop {
-        state: state.state_number,
+        state: state.state_number(),
         decision,
         enter_alt,
         exit_alt,
         track_alt_number: state_tracks_alt_number(state),
         allow_semantic_context: steps_contain_predicate(&body),
-        force_context: state.non_greedy,
+        force_context: state.non_greedy(),
         plus_loop: true,
         fast_path: None,
         body,
@@ -3811,51 +3818,51 @@ fn generated_rule_call_precedence(
 fn compile_generated_parser_transition(
     source_state: usize,
     rule_args: &[(usize, usize, RuleArgTemplate)],
-    transition: &Transition,
+    transition: ParserTransition<'_>,
     action_states: ActionStateSets<'_>,
     predicate_coordinates: PredicateCoordinateSets<'_>,
 ) -> Option<(Option<GeneratedParserStep>, usize)> {
-    match transition {
-        Transition::Epsilon { target } => Some((None, *target)),
-        Transition::Atom { target, label } => Some((
+    match transition.data() {
+        ParserTransitionData::Epsilon { target } => Some((None, target)),
+        ParserTransitionData::Atom { target, label } => Some((
             Some(GeneratedParserStep::MatchToken {
-                token_type: *label,
-                follow_state: *target,
+                token_type: label,
+                follow_state: target,
             }),
-            *target,
+            target,
         )),
-        Transition::Range {
+        ParserTransitionData::Range {
             target,
             start,
             stop,
         } => Some((
             Some(GeneratedParserStep::MatchSet {
-                intervals: vec![(*start, *stop)],
-                follow_state: *target,
+                intervals: vec![(start, stop)],
+                follow_state: target,
             }),
-            *target,
+            target,
         )),
-        Transition::Set { target, set } => Some((
+        ParserTransitionData::Set { target, set } => Some((
             Some(GeneratedParserStep::MatchSet {
-                intervals: set.ranges().to_vec(),
-                follow_state: *target,
+                intervals: set.ranges().collect(),
+                follow_state: target,
             }),
-            *target,
+            target,
         )),
-        Transition::NotSet { target, set } => Some((
+        ParserTransitionData::NotSet { target, set } => Some((
             Some(GeneratedParserStep::MatchNotSet {
-                intervals: set.ranges().to_vec(),
-                follow_state: *target,
+                intervals: set.ranges().collect(),
+                follow_state: target,
             }),
-            *target,
+            target,
         )),
-        Transition::Wildcard { target } => Some((
+        ParserTransitionData::Wildcard { target } => Some((
             Some(GeneratedParserStep::MatchWildcard {
-                follow_state: *target,
+                follow_state: target,
             }),
-            *target,
+            target,
         )),
-        Transition::Rule {
+        ParserTransitionData::Rule {
             rule_index,
             follow_state,
             precedence,
@@ -3863,62 +3870,62 @@ fn compile_generated_parser_transition(
         } => Some((
             Some(GeneratedParserStep::CallRule {
                 source_state,
-                rule_index: *rule_index,
+                rule_index,
                 precedence: generated_rule_call_precedence(
                     rule_args,
                     source_state,
-                    *rule_index,
-                    *precedence,
+                    rule_index,
+                    precedence,
                 )?,
             }),
-            *follow_state,
+            follow_state,
         )),
-        Transition::Action {
+        ParserTransitionData::Action {
             target, rule_index, ..
         } if action_states.generated.contains(&source_state) => Some((
             Some(GeneratedParserStep::Action {
                 source_state,
-                rule_index: *rule_index,
+                rule_index,
             }),
-            *target,
+            target,
         )),
-        Transition::Action {
+        ParserTransitionData::Action {
             target,
             action_index: None,
             ..
-        } if !action_states.all.contains(&source_state) => Some((None, *target)),
-        Transition::Predicate {
+        } if !action_states.all.contains(&source_state) => Some((None, target)),
+        ParserTransitionData::Predicate {
             target,
             rule_index,
             pred_index,
             ..
         } if predicate_coordinates
             .generated
-            .contains(&(*rule_index, *pred_index)) =>
+            .contains(&(rule_index, pred_index)) =>
         {
             Some((
                 Some(GeneratedParserStep::Predicate {
-                    rule_index: *rule_index,
-                    pred_index: *pred_index,
+                    rule_index,
+                    pred_index,
                 }),
-                *target,
+                target,
             ))
         }
-        Transition::Predicate {
+        ParserTransitionData::Predicate {
             rule_index,
             pred_index,
             ..
         } if predicate_coordinates
             .all
-            .contains(&(*rule_index, *pred_index)) =>
+            .contains(&(rule_index, pred_index)) =>
         {
             None
         }
-        Transition::Predicate { target, .. } => Some((None, *target)),
-        Transition::Precedence { target, precedence } => {
-            Some((Some(GeneratedParserStep::Precedence(*precedence)), *target))
+        ParserTransitionData::Predicate { target, .. } => Some((None, target)),
+        ParserTransitionData::Precedence { target, precedence } => {
+            Some((Some(GeneratedParserStep::Precedence(precedence)), target))
         }
-        Transition::Action { .. } => None,
+        ParserTransitionData::Action { .. } => None,
     }
 }
 
@@ -6026,7 +6033,7 @@ fn build_portable_local_data(
         out.required_generated_rules.insert(slot.rule_index);
     }
 
-    let coordinates = lexer_predicate_transitions(data)?;
+    let coordinates = parser_predicate_transitions(data)?;
     let mut predicate_index = 0;
     let mut offset = 0;
     while let Some(block) = next_predicate_action_block(source, offset) {
@@ -6093,10 +6100,10 @@ struct DecisionAltLook {
 /// output therefore only match Java when the generated routing agrees.
 fn tool_decision_analysis(data: &InterpData) -> io::Result<ToolDecisionAnalysis> {
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let mut analysis = ToolDecisionAnalysis::default();
-    for (decision, &state_number) in atn.decision_to_state().iter().enumerate() {
+    for (decision, state_number) in atn.decision_to_state().iter().enumerate() {
         let Some(state) = atn.state(state_number) else {
             continue;
         };
@@ -6104,12 +6111,12 @@ fn tool_decision_analysis(data: &InterpData) -> io::Result<ToolDecisionAnalysis>
         // precedence decisions, disjoint LOOK or not — Java always emits
         // `adaptivePredict` for them (a token switch would make a
         // non-greedy loop greedy).
-        if state.non_greedy || state.precedence_rule_decision {
+        if state.non_greedy() || state.precedence_rule_decision() {
             analysis.adaptive_decisions.insert(decision);
             continue;
         }
         let looks: Vec<DecisionAltLook> = state
-            .transitions
+            .transitions()
             .iter()
             .map(|transition| {
                 let mut look = DecisionAltLook::default();
@@ -6179,7 +6186,7 @@ fn decision_alt_looks_disjoint(looks: &[DecisionAltLook]) -> bool {
 }
 
 struct DecisionLookWalk<'a> {
-    atn: &'a Atn,
+    atn: &'a ParserAtn,
     /// Java's `lookBusy`: (state, calling context) pairs already expanded.
     busy: BTreeSet<(usize, Vec<usize>)>,
     /// Java's `calledRuleStack`: rules on the walk's invocation path, the
@@ -6200,47 +6207,49 @@ impl DecisionLookWalk<'_> {
         let Some(state) = self.atn.state(state_number) else {
             return;
         };
-        if state.kind == AtnStateKind::RuleStop {
+        if state.kind() == AtnStateKind::RuleStop {
             if let Some(return_state) = ctx.pop() {
                 let cleared = state
-                    .rule_index
+                    .rule_index()
                     .map(|rule| std::mem::replace(&mut self.called_rules[rule], false));
                 self.walk(return_state, ctx, look);
-                if let (Some(rule), Some(flag)) = (state.rule_index, cleared) {
+                if let (Some(rule), Some(flag)) = (state.rule_index(), cleared) {
                     self.called_rules[rule] = flag;
                 }
                 ctx.push(return_state);
                 return;
             }
-            if state.transitions.is_empty() {
+            if state.transitions().is_empty() {
                 // The walk escaped through a stop state with no call sites —
                 // the start rule's end, where the only lookahead is EOF.
                 look.symbols.insert(TOKEN_EOF);
                 return;
             }
         }
-        for transition in &state.transitions {
-            match transition {
-                Transition::Rule {
+        for transition in state.transitions() {
+            match transition.data() {
+                ParserTransitionData::Rule {
                     target,
                     rule_index,
                     follow_state,
                     ..
                 } => {
-                    if self.called_rules.get(*rule_index).copied().unwrap_or(true) {
+                    if self.called_rules.get(rule_index).copied().unwrap_or(true) {
                         continue;
                     }
-                    self.called_rules[*rule_index] = true;
-                    ctx.push(*follow_state);
-                    self.walk(*target, ctx, look);
+                    self.called_rules[rule_index] = true;
+                    ctx.push(follow_state);
+                    self.walk(target, ctx, look);
                     ctx.pop();
-                    self.called_rules[*rule_index] = false;
+                    self.called_rules[rule_index] = false;
                 }
-                Transition::Predicate { .. } | Transition::Precedence { .. } => {
+                ParserTransitionData::Predicate { .. }
+                | ParserTransitionData::Precedence { .. } => {
                     look.hit_pred = true;
                 }
-                Transition::Epsilon { target } | Transition::Action { target, .. } => {
-                    self.walk(*target, ctx, look);
+                ParserTransitionData::Epsilon { target }
+                | ParserTransitionData::Action { target, .. } => {
+                    self.walk(target, ctx, look);
                 }
                 _ => {
                     // Terminal edge: enumerate the vocabulary through the
@@ -6314,7 +6323,7 @@ fn build_embedded_parser_data(
     }
 
     // Predicates: same source walk/coordinate pairing as non-embedded mode.
-    let coordinates = lexer_predicate_transitions(data)?;
+    let coordinates = parser_predicate_transitions(data)?;
     let mut predicate_index = 0;
     let mut pred_offset = 0;
     while let Some(block) = next_predicate_action_block(source, pred_offset) {
@@ -6508,13 +6517,13 @@ fn embedded_rule_call_args(
     calls.sort_by_key(|(start, _, _)| *start);
 
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let mut rule_transitions = Vec::new();
     for state in atn.states() {
-        for transition in &state.transitions {
-            if let Transition::Rule { rule_index, .. } = transition {
-                rule_transitions.push((state.state_number, *rule_index));
+        for transition in state.transitions() {
+            if let ParserTransitionData::Rule { rule_index, .. } = transition.data() {
+                rule_transitions.push((state.state_number(), rule_index));
             }
         }
     }
@@ -7096,7 +7105,13 @@ fn render_parser_with_options(
     let empty_patterns = SemPatternFile::default();
     let patterns = options.patterns.unwrap_or(&empty_patterns);
     let type_name = rust_type_name(grammar_name);
-    let metadata = render_metadata(grammar_name, data);
+    let metadata = render_parser_metadata(grammar_name, data);
+    let parser_atn_data = render_u32_slice(
+        AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
+            .deserialize_parser()
+            .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?
+            .packed_words(),
+    );
     let token_constants = render_token_constants(data);
     let rule_constants = render_rule_constants(data);
     // Embedded mode: the grammar carries real Rust action/predicate bodies
@@ -7186,7 +7201,7 @@ fn render_parser_with_options(
     // inventory is read from the ATN even without grammar source.
     let predicate_coordinates =
         if grammar_source.is_some() || options.sem_unknown != SemUnknownPolicy::AssumeTrue {
-            lexer_predicate_transitions(data)?
+            parser_predicate_transitions(data)?
         } else {
             Vec::new()
         }
@@ -7329,8 +7344,7 @@ fn render_parser_with_options(
         r#"{generated_header}use antlr4_runtime::recognizer::RecognizerData;
 use antlr4_runtime::token::TokenSource;
 use antlr4_runtime::token_stream::CommonTokenStream;
-use antlr4_runtime::atn::Atn;
-use antlr4_runtime::atn::serialized::AtnDeserializer;
+use antlr4_runtime::atn::parser_atn::ParserAtn;
 use antlr4_runtime::{{BaseParser, GeneratedParser, GrammarMetadata, Parser, Recognizer}};
 use std::sync::OnceLock;
 {embedded_imports}
@@ -7343,16 +7357,20 @@ use std::sync::OnceLock;
 {embedded_attrs_structs}
 {embedded_module_items}
 
-static ATN_CELL: OnceLock<Atn> = OnceLock::new();
+static PARSER_ATN_DATA: &[u32] = &{parser_atn_data};
+static ATN_CELL: OnceLock<ParserAtn> = OnceLock::new();
 
-/// Deserializes and caches the grammar ATN for all parser instances.
-fn atn() -> &'static Atn {{
+/// Validates and caches the packed grammar ATN for all parser instances.
+fn atn() -> &'static ParserAtn {{
     ATN_CELL.get_or_init(|| {{
-        let serialized = metadata().serialized_atn();
-        AtnDeserializer::new(&serialized)
-            .deserialize()
-            .expect("generated parser contains a valid ANTLR serialized ATN")
+        ParserAtn::from_static(PARSER_ATN_DATA)
+            .unwrap_or_else(|error| panic!("generated parser ATN is incompatible with this runtime: {{error}}"))
     }})
+}}
+
+/// Borrows the validated packed parser ATN embedded in this module.
+pub fn parser_atn() -> &'static ParserAtn {{
+    atn()
 }}
 
 {parse_convenience}
@@ -7585,6 +7603,10 @@ where
 {{
     fn metadata() -> &'static GrammarMetadata {{
         metadata()
+    }}
+
+    fn parser_atn() -> &'static ParserAtn {{
+        parser_atn()
     }}
 }}
 
@@ -8105,7 +8127,7 @@ fn parser_predicate_templates_from_overrides(
     patterns: &SemPatternFile,
 ) -> io::Result<Vec<((usize, usize), PredicateTemplate)>> {
     let mut mapped = Vec::new();
-    for (rule_index, pred_index) in lexer_predicate_transitions(data)? {
+    for (rule_index, pred_index) in parser_predicate_transitions(data)? {
         if let Some(Some(template)) = patterns.coordinate_predicate_template(
             SemanticsKind::ParserPredicate,
             data.rule_names.get(rule_index).map(String::as_str),
@@ -8122,7 +8144,7 @@ fn parser_predicate_templates(
     grammar_source: &str,
     patterns: &SemPatternFile,
 ) -> io::Result<Vec<((usize, usize), PredicateTemplate)>> {
-    let predicates = lexer_predicate_transitions(data)?;
+    let predicates = parser_predicate_transitions(data)?;
     let mut mapped = Vec::new();
     let mut offset = 0;
     let mut predicate_index = 0;
@@ -8956,7 +8978,7 @@ fn lexer_predicate_transitions(data: &InterpData) -> io::Result<Vec<(usize, usiz
     let mut predicates = Vec::new();
     for state in atn.states() {
         for transition in &state.transitions {
-            if let Transition::Predicate {
+            if let LexerTransition::Predicate {
                 rule_index,
                 pred_index,
                 ..
@@ -8969,19 +8991,40 @@ fn lexer_predicate_transitions(data: &InterpData) -> io::Result<Vec<(usize, usiz
     Ok(predicates)
 }
 
+/// Reads the packed parser ATN to locate semantic predicate coordinates.
+fn parser_predicate_transitions(data: &InterpData) -> io::Result<Vec<(usize, usize)>> {
+    let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
+        .deserialize_parser()
+        .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
+    let mut predicates = Vec::new();
+    for state in atn.states() {
+        for transition in state.transitions() {
+            if let ParserTransitionData::Predicate {
+                rule_index,
+                pred_index,
+                ..
+            } = transition.data()
+            {
+                predicates.push((rule_index, pred_index));
+            }
+        }
+    }
+    Ok(predicates)
+}
+
 /// Reads the parser ATN to locate action-transition source states.
 fn parser_action_states(data: &InterpData) -> io::Result<Vec<usize>> {
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let mut states = Vec::new();
     for state in atn.states() {
         if state
-            .transitions
+            .transitions()
             .iter()
-            .any(|transition| matches!(transition, Transition::Action { .. }))
+            .any(|transition| matches!(transition.data(), ParserTransitionData::Action { .. }))
         {
-            states.push(state.state_number);
+            states.push(state.state_number());
         }
     }
     Ok(states)
@@ -8990,13 +9033,13 @@ fn parser_action_states(data: &InterpData) -> io::Result<Vec<usize>> {
 /// Reads the parser ATN action transitions keyed by source state.
 fn parser_action_state_rules(data: &InterpData) -> io::Result<BTreeMap<usize, usize>> {
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let mut states = BTreeMap::new();
     for state in atn.states() {
-        for transition in &state.transitions {
-            if let Transition::Action { rule_index, .. } = transition {
-                states.insert(state.state_number, *rule_index);
+        for transition in state.transitions() {
+            if let ParserTransitionData::Action { rule_index, .. } = transition.data() {
+                states.insert(state.state_number(), rule_index);
             }
         }
     }
@@ -9140,13 +9183,13 @@ fn parser_rule_args(
         return Ok(Vec::new());
     }
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     let mut rule_transitions = Vec::new();
     for state in atn.states() {
-        for transition in &state.transitions {
-            if let Transition::Rule { rule_index, .. } = transition {
-                rule_transitions.push((state.state_number, *rule_index));
+        for transition in state.transitions() {
+            if let ParserTransitionData::Rule { rule_index, .. } = transition.data() {
+                rule_transitions.push((state.state_number(), rule_index));
             }
         }
     }
@@ -9477,7 +9520,7 @@ fn render_parser_action_method(has_action_states: bool, noop_states: &BTreeSet<u
 
 fn likely_parser_entry_rule_indices(data: &InterpData) -> io::Result<Vec<usize>> {
     let atn = AtnDeserializer::new(&SerializedAtn::from_i32(&data.atn))
-        .deserialize()
+        .deserialize_parser()
         .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
     Ok(likely_parser_entry_rule_indices_from_atn(
         &atn,
@@ -9485,17 +9528,17 @@ fn likely_parser_entry_rule_indices(data: &InterpData) -> io::Result<Vec<usize>>
     ))
 }
 
-fn likely_parser_entry_rule_indices_from_atn(atn: &Atn, rule_count: usize) -> Vec<usize> {
+fn likely_parser_entry_rule_indices_from_atn(atn: &ParserAtn, rule_count: usize) -> Vec<usize> {
     let mut called_by_other_rule = vec![false; rule_count];
     for state in atn.states() {
-        for transition in &state.transitions {
-            let Transition::Rule { rule_index, .. } = transition else {
+        for transition in state.transitions() {
+            let ParserTransitionData::Rule { rule_index, .. } = transition.data() else {
                 continue;
             };
-            if *rule_index >= rule_count || state.rule_index == Some(*rule_index) {
+            if rule_index >= rule_count || state.rule_index() == Some(rule_index) {
                 continue;
             }
-            called_by_other_rule[*rule_index] = true;
+            called_by_other_rule[rule_index] = true;
         }
     }
     called_by_other_rule
@@ -9572,6 +9615,20 @@ fn render_parser_rustdoc(
 
 /// Renders static grammar metadata shared by generated lexers and parsers.
 fn render_metadata(grammar_name: &str, data: &InterpData) -> String {
+    render_metadata_with_atn(grammar_name, data, &data.atn)
+}
+
+/// Parser modules carry the versioned packed ATN separately, so retaining the
+/// legacy serialized integer stream in metadata would duplicate the artifact.
+fn render_parser_metadata(grammar_name: &str, data: &InterpData) -> String {
+    render_metadata_with_atn(grammar_name, data, &[])
+}
+
+fn render_metadata_with_atn(
+    grammar_name: &str,
+    data: &InterpData,
+    serialized_atn: &[i32],
+) -> String {
     format!(
         "pub static METADATA: GrammarMetadata = GrammarMetadata::new(\n    \"{}\",\n    &{},\n    &{},\n    &{},\n    &{},\n    &{},\n    &{},\n    &{},\n);\n\npub fn metadata() -> &'static GrammarMetadata {{\n    &METADATA\n}}\n\npub fn rule_names() -> &'static [&'static str] {{\n    METADATA.rule_names()\n}}\n",
         rust_string(grammar_name),
@@ -9581,7 +9638,7 @@ fn render_metadata(grammar_name: &str, data: &InterpData) -> String {
         render_empty_option_str_slice(max_len(&data.literal_names, &data.symbolic_names)),
         render_str_slice(&data.channel_names),
         render_str_slice(&data.mode_names),
-        render_i32_slice(&data.atn)
+        render_i32_slice(serialized_atn)
     )
 }
 
@@ -9652,6 +9709,16 @@ fn render_i32_slice(values: &[i32]) -> String {
     let items = values
         .iter()
         .map(i32::to_string)
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!("[{items}]")
+}
+
+/// Renders a versioned packed parser ATN word stream.
+fn render_u32_slice(values: &[u32]) -> String {
+    let items = values
+        .iter()
+        .map(u32::to_string)
         .collect::<Vec<_>>()
         .join(", ");
     format!("[{items}]")
@@ -9941,7 +10008,7 @@ fn parser_typed_hook_mappings(
     let Some(grammar_source) = grammar_source else {
         return Ok(Vec::new());
     };
-    let coordinates = lexer_predicate_transitions(data)?;
+    let coordinates = parser_predicate_transitions(data)?;
     let mut mappings = Vec::new();
     let mut offset = 0;
     let mut predicate_index = 0;
@@ -10495,7 +10562,7 @@ fn grammar_name_from_path(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use antlr4_runtime::atn::{AtnState, AtnType, IntervalSet};
+    use antlr4_runtime::atn::parser_atn::{ParserAtnBuilder, ParserTransitionSpec};
 
     #[test]
     fn parses_interp_sections() {
@@ -10605,6 +10672,21 @@ atn:
     }
 
     #[test]
+    fn generated_parser_embeds_only_versioned_packed_atn_data() {
+        let rendered =
+            render_parser("TParser", &minimal_parser_data(), None).expect("parser should render");
+
+        assert!(rendered.contains("static PARSER_ATN_DATA: &[u32]"));
+        assert!(rendered.contains("static ATN_CELL: OnceLock<ParserAtn>"));
+        assert!(rendered.contains("ParserAtn::from_static(PARSER_ATN_DATA)"));
+        assert!(rendered.contains("generated parser ATN is incompatible with this runtime"));
+        assert!(rendered.contains("pub fn parser_atn() -> &'static ParserAtn"));
+        assert!(rendered.contains("fn parser_atn() -> &'static ParserAtn"));
+        assert!(!rendered.contains("AtnDeserializer"));
+        assert!(!rendered.contains("SerializedAtn"));
+    }
+
+    #[test]
     fn parser_rule_method_names_reserve_token_stream_accessors() {
         let rule_names = vec![
             "tokenStream".to_owned(),
@@ -10628,7 +10710,7 @@ atn:
     fn generated_modules_start_with_file_level_header() {
         let lexer = render_lexer(
             "TLexer",
-            &minimal_parser_data(),
+            &predicate_lexer_data(),
             None,
             false,
             SemUnknownPolicy::default(),
@@ -10660,7 +10742,7 @@ atn:
     }
 
     fn compile_test_parser_rule(
-        atn: &Atn,
+        atn: &ParserAtn,
         rule_index: usize,
         inline_action_states: &BTreeSet<usize>,
     ) -> Option<GeneratedParserRule> {
@@ -10680,6 +10762,40 @@ atn:
             generated_predicate_coordinates: &generated_predicate_coordinates,
         };
         compile_generated_parser_rule(&context, rule_index)
+    }
+
+    fn finish_atn(builder: ParserAtnBuilder) -> ParserAtn {
+        builder.finish().expect("valid packed parser ATN")
+    }
+
+    fn transition_atn(
+        make_transition: impl FnOnce(&mut ParserAtnBuilder) -> ParserTransitionSpec,
+    ) -> ParserAtn {
+        let mut builder = ParserAtnBuilder::new(10);
+        for _ in 0..10 {
+            builder
+                .add_state(AtnStateKind::Basic, Some(0))
+                .expect("state");
+        }
+        builder
+            .set_rule_to_start_state(vec![0, 0, 0])
+            .expect("rule start states");
+        builder
+            .set_rule_to_stop_state(vec![9, 9, 9])
+            .expect("rule stop states");
+        let transition = make_transition(&mut builder);
+        builder
+            .add_transition(0, transition)
+            .expect("test transition");
+        finish_atn(builder)
+    }
+
+    fn only_transition(atn: &ParserAtn) -> ParserTransition<'_> {
+        atn.state(0)
+            .expect("transition source")
+            .transitions()
+            .first()
+            .expect("test transition")
     }
 
     fn mt(token_type: i32, follow_state: usize) -> GeneratedParserStep {
@@ -11272,16 +11388,17 @@ atn:
 
     #[test]
     fn compiles_token_set_transitions() {
-        let range = Transition::Range {
+        let range_atn = transition_atn(|_| ParserTransitionSpec::Range {
             target: 7,
             start: 2,
             stop: 4,
-        };
+        });
+        let range = only_transition(&range_atn);
         assert_eq!(
             compile_generated_parser_transition(
                 3,
                 &[],
-                &range,
+                range,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11295,15 +11412,16 @@ atn:
             Some((Some(ms(vec![(2, 4)], 7)), 7))
         );
 
-        let mut set = IntervalSet::new();
-        set.add(1);
-        set.add_range(5, 6);
-        let set_transition = Transition::Set { target: 8, set };
+        let set_atn = transition_atn(|builder| {
+            let set = builder.add_interval_set([(1, 1), (5, 6)]).expect("set");
+            ParserTransitionSpec::Set { target: 8, set }
+        });
+        let set_transition = only_transition(&set_atn);
         assert_eq!(
             compile_generated_parser_transition(
                 3,
                 &[],
-                &set_transition,
+                set_transition,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11317,17 +11435,16 @@ atn:
             Some((Some(ms(vec![(1, 1), (5, 6)], 8)), 8))
         );
 
-        let mut not_set = IntervalSet::new();
-        not_set.add(1);
-        let not_set_transition = Transition::NotSet {
-            target: 9,
-            set: not_set,
-        };
+        let not_set_atn = transition_atn(|builder| {
+            let set = builder.add_interval_set([(1, 1)]).expect("set");
+            ParserTransitionSpec::NotSet { target: 9, set }
+        });
+        let not_set_transition = only_transition(&not_set_atn);
         assert_eq!(
             compile_generated_parser_transition(
                 3,
                 &[],
-                &not_set_transition,
+                not_set_transition,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11344,17 +11461,18 @@ atn:
 
     #[test]
     fn compiles_generated_action_transitions_only_for_allowed_states() {
-        let action = Transition::Action {
+        let action_atn = transition_atn(|_| ParserTransitionSpec::Action {
             target: 8,
             rule_index: 2,
             action_index: Some(0),
             context_dependent: false,
-        };
+        });
+        let action = only_transition(&action_atn);
         assert_eq!(
             compile_generated_parser_transition(
                 4,
                 &[],
-                &action,
+                action,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11374,7 +11492,7 @@ atn:
             compile_generated_parser_transition(
                 4,
                 &[],
-                &action,
+                action,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &generated_action_states,
@@ -11397,18 +11515,19 @@ atn:
 
     #[test]
     fn compiles_rule_call_precedence_from_rule_args() {
-        let rule = Transition::Rule {
+        let rule_atn = transition_atn(|_| ParserTransitionSpec::Rule {
             target: 1,
             rule_index: 2,
             follow_state: 8,
             precedence: 0,
-        };
+        });
+        let rule = only_transition(&rule_atn);
 
         assert_eq!(
             compile_generated_parser_transition(
                 4,
                 &[(4, 2, RuleArgTemplate::Literal(6))],
-                &rule,
+                rule,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11433,7 +11552,7 @@ atn:
             compile_generated_parser_transition(
                 4,
                 &[(4, 2, RuleArgTemplate::InheritLocal)],
-                &rule,
+                rule,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11495,17 +11614,18 @@ atn:
 
     #[test]
     fn compiles_synthetic_noop_action_transitions_as_epsilon() {
-        let action = Transition::Action {
+        let action_atn = transition_atn(|_| ParserTransitionSpec::Action {
             target: 8,
             rule_index: 2,
             action_index: None,
             context_dependent: false,
-        };
+        });
+        let action = only_transition(&action_atn);
         assert_eq!(
             compile_generated_parser_transition(
                 4,
                 &[],
-                &action,
+                action,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11522,19 +11642,20 @@ atn:
 
     #[test]
     fn rejects_known_non_inline_noop_action_transitions() {
-        let action = Transition::Action {
+        let action_atn = transition_atn(|_| ParserTransitionSpec::Action {
             target: 8,
             rule_index: 2,
             action_index: None,
             context_dependent: false,
-        };
+        });
+        let action = only_transition(&action_atn);
         let mut action_states = BTreeSet::new();
         action_states.insert(4);
         assert_eq!(
             compile_generated_parser_transition(
                 4,
                 &[],
-                &action,
+                action,
                 ActionStateSets {
                     all: &action_states,
                     generated: &BTreeSet::new(),
@@ -11551,18 +11672,19 @@ atn:
 
     #[test]
     fn compiles_parser_predicates_as_viable_when_no_metadata_is_active() {
-        let predicate = Transition::Predicate {
+        let predicate_atn = transition_atn(|_| ParserTransitionSpec::Predicate {
             target: 8,
             rule_index: 2,
             pred_index: 1,
             context_dependent: false,
-        };
+        });
+        let predicate = only_transition(&predicate_atn);
 
         assert_eq!(
             compile_generated_parser_transition(
                 4,
                 &[],
-                &predicate,
+                predicate,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11579,12 +11701,13 @@ atn:
 
     #[test]
     fn compiles_generated_parser_predicate_transitions() {
-        let predicate = Transition::Predicate {
+        let predicate_atn = transition_atn(|_| ParserTransitionSpec::Predicate {
             target: 8,
             rule_index: 2,
             pred_index: 1,
             context_dependent: false,
-        };
+        });
+        let predicate = only_transition(&predicate_atn);
         let mut predicates = BTreeSet::new();
         predicates.insert((2, 1));
         let generated_predicates = predicates.clone();
@@ -11593,7 +11716,7 @@ atn:
             compile_generated_parser_transition(
                 4,
                 &[],
-                &predicate,
+                predicate,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -11698,12 +11821,13 @@ atn:
 
     #[test]
     fn rejects_known_parser_predicates_without_generated_metadata() {
-        let predicate = Transition::Predicate {
+        let predicate_atn = transition_atn(|_| ParserTransitionSpec::Predicate {
             target: 8,
             rule_index: 2,
             pred_index: 1,
             context_dependent: false,
-        };
+        });
+        let predicate = only_transition(&predicate_atn);
         let mut predicates = BTreeSet::new();
         predicates.insert((2, 1));
 
@@ -11711,7 +11835,7 @@ atn:
             compile_generated_parser_transition(
                 4,
                 &[],
-                &predicate,
+                predicate,
                 ActionStateSets {
                     all: &BTreeSet::new(),
                     generated: &BTreeSet::new(),
@@ -13312,333 +13436,600 @@ ID: [a-z]+ { customJava(); };
         assert_eq!(summary, format!("{}...", "a".repeat(95)));
     }
 
-    fn linear_rule_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+    fn linear_rule_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 1,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: TOKEN_EOF,
-            });
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![3]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![3])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
-    fn block_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        let mut decision = AtnState::new(1, AtnStateKind::BlockStart).with_rule_index(0);
-        decision.end_state = Some(4);
-        atn.add_state(decision);
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::BlockEnd).with_rule_index(0));
-        atn.add_state(AtnState::new(5, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+    fn block_decision_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockEnd, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        atn.set_end_state(1, 4).expect("block end state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 2,
-            });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.add_decision_state(1);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![5]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_decision_state(1).expect("decision state");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![5])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
-    fn star_loop_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::StarLoopEntry).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        let mut loop_end = AtnState::new(3, AtnStateKind::LoopEnd).with_rule_index(0);
-        loop_end.loop_back_state = Some(4);
-        atn.add_state(loop_end);
-        atn.add_state(AtnState::new(4, AtnStateKind::StarLoopBack).with_rule_index(0));
-        atn.add_state(AtnState::new(5, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+    fn star_loop_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::StarLoopEntry, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::LoopEnd, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::StarLoopBack, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        atn.set_loop_back_state(3, 4).expect("loop back state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 1,
-            });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.add_decision_state(1);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![5]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_decision_state(1).expect("decision state");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![5])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
-    fn plus_loop_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        let mut plus_start = AtnState::new(1, AtnStateKind::PlusBlockStart).with_rule_index(0);
-        plus_start.end_state = Some(3);
-        atn.add_state(plus_start);
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::BlockEnd).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::PlusLoopBack).with_rule_index(0));
-        let mut loop_end = AtnState::new(5, AtnStateKind::LoopEnd).with_rule_index(0);
-        loop_end.loop_back_state = Some(4);
-        atn.add_state(loop_end);
-        atn.add_state(AtnState::new(6, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+    fn plus_loop_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::PlusBlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockEnd, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::PlusLoopBack, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::LoopEnd, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            6
+        );
+        atn.set_end_state(1, 3).expect("block end state");
+        atn.set_loop_back_state(5, 4).expect("loop back state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.add_decision_state(4);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![6]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_decision_state(4).expect("decision state");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![6])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
-    fn plus_block_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        let mut plus_start = AtnState::new(1, AtnStateKind::PlusBlockStart).with_rule_index(0);
-        plus_start.end_state = Some(4);
-        atn.add_state(plus_start);
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::BlockEnd).with_rule_index(0));
-        atn.add_state(AtnState::new(5, AtnStateKind::PlusLoopBack).with_rule_index(0));
-        let mut loop_end = AtnState::new(6, AtnStateKind::LoopEnd).with_rule_index(0);
-        loop_end.loop_back_state = Some(5);
-        atn.add_state(loop_end);
-        atn.add_state(AtnState::new(7, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+    fn plus_block_decision_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::PlusBlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockEnd, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::PlusLoopBack, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::LoopEnd, Some(0))
+                .expect("state")
+                .index(),
+            6
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            7
+        );
+        atn.set_end_state(1, 4).expect("block end state");
+        atn.set_loop_back_state(6, 5).expect("loop back state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 1,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 2,
-            });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(6)
-            .expect("state 6")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.add_decision_state(1);
-        atn.add_decision_state(5);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![7]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_decision_state(5).expect("decision state");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![7])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
-    fn left_recursive_rule_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        let mut start = AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0);
-        start.left_recursive_rule = true;
-        atn.add_state(start);
-        atn.add_state(AtnState::new(1, AtnStateKind::Basic).with_rule_index(0));
-        let mut loop_entry = AtnState::new(2, AtnStateKind::StarLoopEntry).with_rule_index(0);
-        loop_entry.precedence_rule_decision = true;
-        atn.add_state(loop_entry);
-        let mut block_start = AtnState::new(3, AtnStateKind::StarBlockStart).with_rule_index(0);
-        block_start.end_state = Some(6);
-        atn.add_state(block_start);
-        atn.add_state(AtnState::new(4, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(5, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(6, AtnStateKind::BlockEnd).with_rule_index(0));
-        let mut loop_end = AtnState::new(7, AtnStateKind::LoopEnd).with_rule_index(0);
-        loop_end.loop_back_state = Some(8);
-        atn.add_state(loop_end);
-        atn.add_state(AtnState::new(8, AtnStateKind::StarLoopBack).with_rule_index(0));
-        atn.add_state(AtnState::new(9, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.add_state(AtnState::new(10, AtnStateKind::Basic).with_rule_index(0));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+    fn left_recursive_rule_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::StarLoopEntry, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::StarBlockStart, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockEnd, Some(0))
+                .expect("state")
+                .index(),
+            6
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::LoopEnd, Some(0))
+                .expect("state")
+                .index(),
+            7
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::StarLoopBack, Some(0))
+                .expect("state")
+                .index(),
+            8
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            9
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            10
+        );
+        atn.set_left_recursive_rule(0)
+            .expect("left-recursive rule start");
+        atn.set_precedence_rule_decision(2)
+            .expect("precedence decision");
+        atn.set_end_state(3, 6).expect("block end state");
+        atn.set_loop_back_state(7, 8).expect("loop back state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 1,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Epsilon { target: 3 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Precedence {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(2, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
+        atn.add_transition(2, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Precedence {
                 target: 5,
                 precedence: 2,
-            });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Atom {
                 target: 10,
                 label: 2,
-            });
-        atn.state_mut(10)
-            .expect("state 10")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            10,
+            ParserTransitionSpec::Rule {
                 target: 0,
                 rule_index: 0,
                 follow_state: 6,
                 precedence: 3,
-            });
-        atn.state_mut(6)
-            .expect("state 6")
-            .add_transition(Transition::Epsilon { target: 8 });
-        atn.state_mut(8)
-            .expect("state 8")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(7)
-            .expect("state 7")
-            .add_transition(Transition::Epsilon { target: 9 });
-        atn.add_decision_state(2);
-        atn.add_decision_state(3);
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![9]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 8 })
+            .expect("transition");
+        atn.add_transition(8, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(7, ParserTransitionSpec::Epsilon { target: 9 })
+            .expect("transition");
+        atn.add_decision_state(2).expect("decision state");
+        atn.add_decision_state(3).expect("decision state");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![9])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
-    fn entry_candidate_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::RuleStart).with_rule_index(1));
-        atn.add_state(AtnState::new(4, AtnStateKind::RuleStop).with_rule_index(1));
-        atn.add_state(AtnState::new(5, AtnStateKind::RuleStart).with_rule_index(2));
-        atn.add_state(AtnState::new(6, AtnStateKind::RuleStop).with_rule_index(2));
-        atn.add_state(AtnState::new(7, AtnStateKind::Basic).with_rule_index(2));
-        atn.add_state(AtnState::new(8, AtnStateKind::RuleStart).with_rule_index(3));
-        atn.add_state(AtnState::new(9, AtnStateKind::RuleStop).with_rule_index(3));
-        atn.add_state(AtnState::new(10, AtnStateKind::Basic).with_rule_index(3));
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Rule {
+    fn entry_candidate_atn() -> ParserAtn {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(1))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(1))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(2))
+                .expect("state")
+                .index(),
+            5
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(2))
+                .expect("state")
+                .index(),
+            6
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(2))
+                .expect("state")
+                .index(),
+            7
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(3))
+                .expect("state")
+                .index(),
+            8
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(3))
+                .expect("state")
+                .index(),
+            9
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(3))
+                .expect("state")
+                .index(),
+            10
+        );
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Rule {
                 target: 3,
                 rule_index: 1,
                 follow_state: 2,
                 precedence: 0,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(2, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Rule {
                 target: 3,
                 rule_index: 1,
                 follow_state: 7,
                 precedence: 0,
-            });
-        atn.state_mut(7)
-            .expect("state 7")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(8)
-            .expect("state 8")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(7, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(
+            8,
+            ParserTransitionSpec::Rule {
                 target: 8,
                 rule_index: 3,
                 follow_state: 10,
                 precedence: 0,
-            });
-        atn.state_mut(10)
-            .expect("state 10")
-            .add_transition(Transition::Epsilon { target: 9 });
-        atn.set_rule_to_start_state(vec![0, 3, 5, 8]);
-        atn.set_rule_to_stop_state(vec![1, 4, 6, 9]);
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(10, ParserTransitionSpec::Epsilon { target: 9 })
+            .expect("transition");
+        atn.set_rule_to_start_state(vec![0, 3, 5, 8])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![1, 4, 6, 9])
+            .expect("rule stop states");
+        finish_atn(atn)
     }
 
     fn minimal_parser_data() -> InterpData {
@@ -13765,6 +14156,42 @@ ID: [a-z]+ { customJava(); };
                 1, 2, 5, 1, 0, 0, // atom A
                 2, 3, 1, 0, 0, 0, // epsilon
                 0, // decisions
+            ],
+        }
+    }
+
+    /// Lexer `.interp` fixture with one semantic-predicate transition at
+    /// coordinate `(rule 0, pred 0)`.
+    fn predicate_lexer_data() -> InterpData {
+        InterpData {
+            literal_names: vec![None, Some("'a'".to_owned())],
+            symbolic_names: vec![None, Some("A".to_owned())],
+            rule_names: vec!["A".to_owned()],
+            channel_names: vec!["DEFAULT_TOKEN_CHANNEL".to_owned()],
+            mode_names: vec!["DEFAULT_MODE".to_owned()],
+            atn: vec![
+                4, 0, 1, // version, lexer grammar, max token type
+                5, // states
+                6, -1, // state 0: mode token start
+                2, 0, // state 1: rule start
+                1, 0, // state 2: predicate source
+                1, 0, // state 3: token source
+                7, 0, // state 4: rule stop
+                0, // non-greedy states
+                0, // precedence states
+                1, // rules
+                1, 1, // rule 0 start and token type
+                1, // modes
+                0, // mode 0 start
+                0, // sets
+                4, // transitions
+                0, 1, 1, 0, 0, 0, // epsilon to rule start
+                1, 2, 4, 0, 0, 0, // predicate rule 0 pred 0
+                2, 3, 5, 1, 0, 0, // atom A
+                3, 4, 1, 0, 0, 0, // epsilon to stop
+                1, // decisions
+                0, // mode start decision
+                0, // lexer actions
             ],
         }
     }
@@ -14895,7 +15322,7 @@ ID : [a-z]+ ;\n";
     fn lexer_assume_false_policy_renders_failing_predicate_hook() {
         let module = render_lexer(
             "SLexer",
-            &predicate_parser_data(),
+            &predicate_lexer_data(),
             None,
             false,
             SemUnknownPolicy::AssumeFalse,
@@ -14916,7 +15343,7 @@ ID : [a-z]+ ;\n";
         .expect("pattern file parses");
         let module = render_lexer(
             "SLexer",
-            &predicate_parser_data(),
+            &predicate_lexer_data(),
             None,
             false,
             SemUnknownPolicy::AssumeTrue,
@@ -14941,7 +15368,7 @@ ID : [a-z]+ ;\n";
         .expect("pattern file parses");
         let module = render_lexer(
             "SLexer",
-            &predicate_parser_data(),
+            &predicate_lexer_data(),
             None,
             false,
             SemUnknownPolicy::AssumeTrue,
@@ -14997,7 +15424,7 @@ ID : [a-z]+ ;\n";
     fn lexer_hook_policy_routes_uncovered_predicates_to_owned_hooks() {
         let module = render_lexer(
             "SLexer",
-            &predicate_parser_data(),
+            &predicate_lexer_data(),
             None,
             false,
             SemUnknownPolicy::Hook,
@@ -15067,7 +15494,7 @@ ID : [a-z]+ ;\n";
     fn lexer_default_policy_keeps_compiled_token_path() {
         let module = render_lexer(
             "SLexer",
-            &predicate_parser_data(),
+            &predicate_lexer_data(),
             None,
             false,
             SemUnknownPolicy::AssumeTrue,

--- a/src/generated.rs
+++ b/src/generated.rs
@@ -1,3 +1,4 @@
+use crate::atn::parser_atn::ParserAtn;
 use crate::atn::serialized::SerializedAtn;
 use crate::vocabulary::Vocabulary;
 
@@ -75,6 +76,9 @@ pub trait GeneratedLexer {
 
 pub trait GeneratedParser {
     fn metadata() -> &'static GrammarMetadata;
+
+    /// Borrows the validated packed ATN embedded by the matching generator.
+    fn parser_atn() -> &'static ParserAtn;
 }
 
 #[cfg(test)]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap};
 use std::hash::BuildHasherDefault;
 use std::rc::Rc;
 
-use crate::atn::Atn;
+use crate::atn::LexerAtn;
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
 use crate::prediction::PredictionFxHasher;
@@ -433,14 +433,14 @@ where
     ///
     /// Generated lexers create a fresh instance per parse; without sharing,
     /// every instance relearns the same DFA through ATN simulation. The shared
-    /// cache is keyed by the generated lexer's `&'static Atn` identity and
+    /// cache is keyed by the generated lexer's `&'static LexerAtn` identity and
     /// holds only input-independent data, so it stays valid across inputs.
     /// The `showDFA` edge trace lives in the cache too, so it reports the
     /// accumulated DFA — the same view the reference runtimes print from
     /// their static shared DFA.
     #[must_use]
-    pub fn with_shared_dfa(mut self, atn: &'static Atn) -> Self {
-        let ptr: *const Atn = atn;
+    pub fn with_shared_dfa(mut self, atn: &'static LexerAtn) -> Self {
+        let ptr: *const LexerAtn = atn;
         let key = ptr as usize;
         self.dfa_cache = SHARED_LEXER_DFA_CACHES
             .with(|caches| Rc::clone(caches.borrow_mut().entry(key).or_insert_with(Rc::default)));

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -72,10 +72,16 @@ type FxHashMap<K, V> = HashMap<K, V, FxBuildHasher>;
 #[allow(clippy::disallowed_types)]
 type FxHashSet<K> = HashSet<K, FxBuildHasher>;
 
+use crate::atn::AtnStateKind;
 use crate::atn::parser::{
     ParserAtnPrediction, ParserAtnPredictionDiagnosticKind, ParserAtnSimulator,
 };
-use crate::atn::{Atn, AtnState, AtnStateKind, Transition};
+use crate::atn::parser_atn::{
+    ParserAtn as Atn, ParserAtnState as AtnState, ParserTransition,
+    ParserTransitionData as Transition, ParserTransitionKind,
+};
+#[cfg(test)]
+use crate::atn::parser_atn::{ParserAtnBuilder, ParserTransitionSpec};
 use crate::char_stream::CharStream;
 use crate::errors::AntlrError;
 use crate::int_stream::IntStream;
@@ -1823,7 +1829,12 @@ struct NoViableAlternative {
 impl ExpectedTokens {
     /// Records the expected symbols for the farthest token index reached by any
     /// failed ATN path.
-    fn record_transition(&mut self, index: usize, transition: &Transition, max_token_type: i32) {
+    fn record_transition(
+        &mut self,
+        index: usize,
+        transition: ParserTransition<'_>,
+        max_token_type: i32,
+    ) {
         let symbols = transition_expected_symbols(transition, max_token_type);
         match self.index {
             Some(current) if index < current => {}
@@ -1987,9 +1998,12 @@ fn token_bit_symbol(slot: usize) -> Option<i32> {
 
 /// Converts one consuming transition into the token types that would satisfy it
 /// for diagnostic reporting.
-fn transition_expected_symbols(transition: &Transition, max_token_type: i32) -> BTreeSet<i32> {
+fn transition_expected_symbols(
+    transition: ParserTransition<'_>,
+    max_token_type: i32,
+) -> BTreeSet<i32> {
     let mut symbols = BTreeSet::new();
-    match transition {
+    match &transition.data() {
         Transition::Atom { label, .. } => {
             symbols.insert(*label);
         }
@@ -1998,7 +2012,7 @@ fn transition_expected_symbols(transition: &Transition, max_token_type: i32) -> 
         }
         Transition::Set { set, .. } => {
             for (start, stop) in set.ranges() {
-                symbols.extend(*start..=*stop);
+                symbols.extend(start..=stop);
             }
         }
         Transition::NotSet { set, .. } => {
@@ -2016,9 +2030,12 @@ fn transition_expected_symbols(transition: &Transition, max_token_type: i32) -> 
     symbols
 }
 
-fn transition_expected_token_set(transition: &Transition, max_token_type: i32) -> TokenBitSet {
+fn transition_expected_token_set(
+    transition: ParserTransition<'_>,
+    max_token_type: i32,
+) -> TokenBitSet {
     let mut symbols = TokenBitSet::default();
-    match transition {
+    match &transition.data() {
         Transition::Atom { label, .. } => {
             symbols.insert(*label);
         }
@@ -2027,7 +2044,7 @@ fn transition_expected_token_set(transition: &Transition, max_token_type: i32) -
         }
         Transition::Set { set, .. } => {
             for (start, stop) in set.ranges() {
-                symbols.extend_range(*start, *stop);
+                symbols.extend_range(start, stop);
             }
         }
         Transition::NotSet { set, .. } => {
@@ -2059,7 +2076,7 @@ fn state_expected_symbols(atn: &Atn, state_number: usize) -> BTreeSet<i32> {
         let Some(state) = atn.state(current) else {
             continue;
         };
-        for transition in &state.transitions {
+        for transition in &state.transitions() {
             let transition_symbols = transition_expected_symbols(transition, atn.max_token_type());
             if transition_symbols.is_empty() {
                 if transition.is_epsilon() {
@@ -2084,7 +2101,7 @@ fn state_expected_token_set(atn: &Atn, state_number: usize) -> TokenBitSet {
         let Some(state) = atn.state(current) else {
             continue;
         };
-        for transition in &state.transitions {
+        for transition in &state.transitions() {
             let transition_symbols =
                 transition_expected_token_set(transition, atn.max_token_type());
             if transition_symbols.is_empty() {
@@ -2100,10 +2117,10 @@ fn state_expected_token_set(atn: &Atn, state_number: usize) -> TokenBitSet {
 }
 
 fn state_can_reach_rule_stop(atn: &Atn, state_number: usize) -> bool {
-    let Some(rule_index) = atn.state(state_number).and_then(|state| state.rule_index) else {
+    let Some(rule_index) = atn.state(state_number).and_then(AtnState::rule_index) else {
         return false;
     };
-    let Some(&stop_state) = atn.rule_to_stop_state().get(rule_index) else {
+    let Some(stop_state) = atn.rule_to_stop_state().get(rule_index) else {
         return false;
     };
     epsilon_reaches_state(atn, state_number, stop_state)
@@ -2124,10 +2141,10 @@ fn epsilon_reaches_state(atn: &Atn, start: usize, target: usize) -> bool {
         };
         stack.extend(
             state
-                .transitions
+                .transitions()
                 .iter()
                 .filter(|transition| transition.is_epsilon())
-                .map(Transition::target),
+                .map(ParserTransition::target),
         );
     }
     false
@@ -2204,10 +2221,11 @@ struct SharedAtnCacheKey {
 
 impl SharedAtnCacheKey {
     fn for_atn(atn: &Atn) -> Self {
+        let (states, state_count) = atn.storage_identity();
         Self {
             atn: std::ptr::from_ref::<Atn>(atn) as usize,
-            states: atn.states().as_ptr() as usize,
-            state_count: atn.states().len(),
+            states,
+            state_count,
             max_token_type: atn.max_token_type(),
         }
     }
@@ -2325,11 +2343,11 @@ fn rule_first_set_cached(
 /// prunes transitions whose look-1 cannot accept the current lookahead.
 fn transition_first_set(
     atn: &Atn,
-    transition: &Transition,
+    transition: ParserTransition<'_>,
     rule_stop_state: usize,
     cache: &mut FirstSetCache,
 ) -> TransitionLookSet {
-    match transition {
+    match &transition.data() {
         Transition::Atom { label, .. } => {
             let mut symbols = TokenBitSet::default();
             symbols.insert(*label);
@@ -2349,7 +2367,7 @@ fn transition_first_set(
         Transition::Set { set, .. } => {
             let mut symbols = TokenBitSet::default();
             for (start, stop) in set.ranges() {
-                symbols.extend_range(*start, *stop);
+                symbols.extend_range(start, stop);
             }
             TransitionLookSet {
                 symbols,
@@ -2391,7 +2409,7 @@ fn transition_first_set(
             follow_state,
             ..
         } => {
-            let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+            let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index) else {
                 return TransitionLookSet::default();
             };
             let child = rule_first_set(atn, *target, child_stop, cache);
@@ -2483,7 +2501,7 @@ fn ll1_greedy_alt(entry: &DecisionLookahead, symbol: i32, non_greedy: bool) -> O
 }
 
 fn should_skip_via_lookahead(
-    transition: &Transition,
+    transition_kind: ParserTransitionKind,
     transition_index: usize,
     lookahead_filter: Option<&(i32, Rc<DecisionLookahead>)>,
     index: usize,
@@ -2491,12 +2509,12 @@ fn should_skip_via_lookahead(
     expected: &mut ExpectedTokens,
 ) -> bool {
     let prune_non_consuming = matches!(
-        transition,
-        Transition::Epsilon { .. }
-            | Transition::Action { .. }
-            | Transition::Predicate { .. }
-            | Transition::Rule { .. }
-            | Transition::Precedence { .. }
+        transition_kind,
+        ParserTransitionKind::Epsilon
+            | ParserTransitionKind::Action
+            | ParserTransitionKind::Predicate
+            | ParserTransitionKind::Rule
+            | ParserTransitionKind::Precedence
     );
     if !prune_non_consuming {
         return false;
@@ -2581,13 +2599,13 @@ fn rule_first_set_inner(
     let Some(state) = atn.state(state_number) else {
         return;
     };
-    for transition in &state.transitions {
+    for transition in &state.transitions() {
         let transition_symbols = transition_expected_symbols(transition, atn.max_token_type());
         if !transition_symbols.is_empty() {
             first.symbols.extend_iter(transition_symbols);
             continue;
         }
-        match transition {
+        match &transition.data() {
             Transition::Epsilon { target }
             | Transition::Action { target, .. }
             | Transition::Predicate { target, .. }
@@ -2600,7 +2618,7 @@ fn rule_first_set_inner(
                 follow_state,
                 ..
             } => {
-                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index) else {
                     continue;
                 };
                 let child_key = (*target, child_stop);
@@ -2655,10 +2673,10 @@ fn state_sync_symbols_inner(
     let Some(state) = atn.state(state_number) else {
         return;
     };
-    for transition in &state.transitions {
+    for transition in &state.transitions() {
         let transition_symbols = transition_expected_symbols(transition, atn.max_token_type());
         if transition_symbols.is_empty() {
-            match transition {
+            match &transition.data() {
                 Transition::Rule { target, .. }
                 | Transition::Epsilon { target }
                 | Transition::Action { target, .. }
@@ -2748,71 +2766,76 @@ fn state_is_nullable_with_precedence_cached(
     let saved_hit_cycle = ctx.hit_cycle;
     ctx.hit_cycle = false;
     let nullable = atn.state(state_number).is_some_and(|state| {
-        state.transitions.iter().any(|transition| match transition {
-            Transition::Rule {
-                target,
-                rule_index,
-                follow_state,
-                precedence: rule_precedence,
-            } => {
-                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
-                    return false;
-                };
-                state_is_nullable_with_precedence_cached(
-                    atn,
-                    *target,
-                    child_stop,
-                    *rule_precedence,
-                    allow_predicates,
-                    ctx,
-                ) && state_is_nullable_with_precedence_cached(
-                    atn,
-                    *follow_state,
-                    stop_state_number,
-                    precedence,
-                    allow_predicates,
-                    ctx,
-                )
-            }
-            Transition::Epsilon { target } | Transition::Action { target, .. } => {
-                state_is_nullable_with_precedence_cached(
-                    atn,
-                    *target,
-                    stop_state_number,
-                    precedence,
-                    allow_predicates,
-                    ctx,
-                )
-            }
-            Transition::Predicate { target, .. } if allow_predicates => {
-                state_is_nullable_with_precedence_cached(
-                    atn,
-                    *target,
-                    stop_state_number,
-                    precedence,
-                    allow_predicates,
-                    ctx,
-                )
-            }
-            Transition::Precedence {
-                target,
-                precedence: transition_precedence,
-            } if *transition_precedence >= precedence => state_is_nullable_with_precedence_cached(
-                atn,
-                *target,
-                stop_state_number,
-                precedence,
-                allow_predicates,
-                ctx,
-            ),
-            Transition::Atom { .. }
-            | Transition::Range { .. }
-            | Transition::Set { .. }
-            | Transition::NotSet { .. }
-            | Transition::Wildcard { .. }
-            | Transition::Predicate { .. }
-            | Transition::Precedence { .. } => false,
-        })
+        state
+            .transitions()
+            .iter()
+            .any(|transition| match &transition.data() {
+                Transition::Rule {
+                    target,
+                    rule_index,
+                    follow_state,
+                    precedence: rule_precedence,
+                } => {
+                    let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index) else {
+                        return false;
+                    };
+                    state_is_nullable_with_precedence_cached(
+                        atn,
+                        *target,
+                        child_stop,
+                        *rule_precedence,
+                        allow_predicates,
+                        ctx,
+                    ) && state_is_nullable_with_precedence_cached(
+                        atn,
+                        *follow_state,
+                        stop_state_number,
+                        precedence,
+                        allow_predicates,
+                        ctx,
+                    )
+                }
+                Transition::Epsilon { target } | Transition::Action { target, .. } => {
+                    state_is_nullable_with_precedence_cached(
+                        atn,
+                        *target,
+                        stop_state_number,
+                        precedence,
+                        allow_predicates,
+                        ctx,
+                    )
+                }
+                Transition::Predicate { target, .. } if allow_predicates => {
+                    state_is_nullable_with_precedence_cached(
+                        atn,
+                        *target,
+                        stop_state_number,
+                        precedence,
+                        allow_predicates,
+                        ctx,
+                    )
+                }
+                Transition::Precedence {
+                    target,
+                    precedence: transition_precedence,
+                } if *transition_precedence >= precedence => {
+                    state_is_nullable_with_precedence_cached(
+                        atn,
+                        *target,
+                        stop_state_number,
+                        precedence,
+                        allow_predicates,
+                        ctx,
+                    )
+                }
+                Transition::Atom { .. }
+                | Transition::Range { .. }
+                | Transition::Set { .. }
+                | Transition::NotSet { .. }
+                | Transition::Wildcard { .. }
+                | Transition::Predicate { .. }
+                | Transition::Precedence { .. } => false,
+            })
     });
     ctx.in_progress.remove(&key);
     if !ctx.hit_cycle {
@@ -2840,7 +2863,7 @@ fn state_can_reach_symbol_with_precedence(
         return OperatorSymbolReachability::None;
     };
     let mut reachability = OperatorSymbolReachability::None;
-    for transition in &state.transitions {
+    for transition in &state.transitions() {
         if transition.matches(request.symbol, 1, atn.max_token_type()) {
             if request.predicate_dependent {
                 reachability = OperatorSymbolReachability::PredicateDependent;
@@ -2848,7 +2871,7 @@ fn state_can_reach_symbol_with_precedence(
             }
             return OperatorSymbolReachability::Unconditional;
         }
-        let transition_reachability = match transition {
+        let transition_reachability = match &transition.data() {
             Transition::Rule {
                 target,
                 rule_index,
@@ -2868,7 +2891,7 @@ fn state_can_reach_symbol_with_precedence(
                 if result == OperatorSymbolReachability::Unconditional {
                     return result;
                 }
-                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index) else {
                     continue;
                 };
                 if state_is_nullable_with_precedence(
@@ -2905,7 +2928,7 @@ fn state_can_reach_symbol_with_precedence(
             | Transition::Action { target, .. }
             | Transition::Precedence { target, .. } => {
                 if matches!(
-                    transition,
+                    &transition.data(),
                     Transition::Precedence {
                         precedence: transition_precedence,
                         ..
@@ -2953,11 +2976,11 @@ fn left_recursive_operator_lookahead(
         in_progress: BTreeSet::new(),
         hit_cycle: false,
     };
-    for transition in &state.transitions {
+    for transition in &state.transitions() {
         let target = transition.target();
         if atn
             .state(target)
-            .is_some_and(|state| state.kind == AtnStateKind::LoopEnd)
+            .is_some_and(|state| state.kind() == AtnStateKind::LoopEnd)
         {
             continue;
         }
@@ -3037,12 +3060,12 @@ fn state_before_stop_lookahead_inner(
     let Some(state) = atn.state(state_number) else {
         return;
     };
-    if state.kind == AtnStateKind::RuleStop {
+    if state.kind() == AtnStateKind::RuleStop {
         lookahead.reaches_context_boundary = true;
         return;
     }
-    for transition in &state.transitions {
-        match transition {
+    for transition in &state.transitions() {
+        match &transition.data() {
             Transition::Epsilon { target }
             | Transition::Action { target, .. }
             | Transition::Predicate { target, .. }
@@ -3062,7 +3085,7 @@ fn state_before_stop_lookahead_inner(
                 follow_state,
                 ..
             } => {
-                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied() else {
+                let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index) else {
                     continue;
                 };
                 let child = rule_first_set(atn, *target, child_stop, first_set_cache);
@@ -3115,15 +3138,15 @@ fn caller_context_can_match_symbol_before_state(
 /// failed consuming transition is nested under block or loop epsilon edges.
 fn next_recovery_context(
     atn: &Atn,
-    state: &AtnState,
+    state: AtnState<'_>,
     inherited: &BTreeSet<i32>,
     inherited_state: Option<usize>,
 ) -> (BTreeSet<i32>, Option<usize>) {
-    let state_symbols = state_expected_symbols(atn, state.state_number);
-    if state.transitions.len() > 1 && !state_symbols.is_empty() {
+    let state_symbols = state_expected_symbols(atn, state.state_number());
+    if state.transitions().len() > 1 && !state_symbols.is_empty() {
         let mut symbols = state_symbols;
         symbols.extend(inherited.iter().copied());
-        return (symbols, Some(state.state_number));
+        return (symbols, Some(state.state_number()));
     }
     (inherited.clone(), inherited_state)
 }
@@ -3144,7 +3167,7 @@ fn recovery_expected_symbols(
 fn fast_next_recovery_context<S, H>(
     parser: &mut BaseParser<S, H>,
     atn: &Atn,
-    state: &AtnState,
+    state: AtnState<'_>,
     inherited: &Rc<BTreeSet<i32>>,
     inherited_state: Option<usize>,
 ) -> (Rc<BTreeSet<i32>>, Option<usize>)
@@ -3152,24 +3175,24 @@ where
     S: TokenSource,
     H: SemanticHooks,
 {
-    if state.transitions.len() <= 1 {
+    if state.transitions().len() <= 1 {
         return (Rc::clone(inherited), inherited_state);
     }
-    let state_symbols = parser.cached_state_expected_symbols(atn, state.state_number);
+    let state_symbols = parser.cached_state_expected_symbols(atn, state.state_number());
     if state_symbols.is_empty() {
         return (Rc::clone(inherited), inherited_state);
     }
     if inherited.is_empty() {
-        return (state_symbols, Some(state.state_number));
+        return (state_symbols, Some(state.state_number()));
     }
     if Rc::ptr_eq(&state_symbols, inherited) {
-        return (state_symbols, Some(state.state_number));
+        return (state_symbols, Some(state.state_number()));
     }
     let mut combined = (*state_symbols).clone();
     combined.extend(inherited.iter().copied());
     (
         parser.intern_recovery_symbols(combined),
-        Some(state.state_number),
+        Some(state.state_number()),
     )
 }
 
@@ -3384,10 +3407,10 @@ fn stop_outcome(
 fn atn_has_observable_action_transitions(atn: &Atn) -> bool {
     with_shared_atn_caches(atn, |cache| {
         *cache.observable_action_transitions.get_or_insert_with(|| {
-            atn.states().iter().any(|state| {
-                state.transitions.iter().any(|transition| {
+            atn.states().any(|state| {
+                state.transitions().iter().any(|transition| {
                     matches!(
-                        transition,
+                        &transition.data(),
                         Transition::Action {
                             action_index: Some(_),
                             ..
@@ -3402,11 +3425,11 @@ fn atn_has_observable_action_transitions(atn: &Atn) -> bool {
 fn atn_has_predicate_transitions(atn: &Atn) -> bool {
     with_shared_atn_caches(atn, |cache| {
         *cache.predicate_transitions.get_or_insert_with(|| {
-            atn.states().iter().any(|state| {
+            atn.states().any(|state| {
                 state
-                    .transitions
+                    .transitions()
                     .iter()
-                    .any(|transition| matches!(transition, Transition::Predicate { .. }))
+                    .any(|transition| matches!(&transition.data(), Transition::Predicate { .. }))
             })
         })
     })
@@ -3550,7 +3573,7 @@ impl Hash for FastRecognizeKey {
 
 struct FastRecoveryRequest<'a, 'b> {
     atn: &'a Atn,
-    transition: &'a Transition,
+    transition: ParserTransition<'a>,
     expected_symbols: Rc<BTreeSet<i32>>,
     target: usize,
     request: FastRecognizeRequest,
@@ -3580,7 +3603,7 @@ struct FastChildRuleFailureRecoveryRequest<'a> {
 
 struct RecoveryRequest<'a, 'b> {
     atn: &'a Atn,
-    transition: &'a Transition,
+    transition: ParserTransition<'a>,
     expected_symbols: BTreeSet<i32>,
     target: usize,
     request: RecognizeRequest<'a>,
@@ -4130,11 +4153,11 @@ where
         let Some(decision) = atn
             .decision_to_state()
             .iter()
-            .position(|candidate| *candidate == state_number)
+            .position(|candidate| candidate == state_number)
         else {
             return;
         };
-        let Some(rule_index) = atn.state(state_number).and_then(|state| state.rule_index) else {
+        let Some(rule_index) = atn.state(state_number).and_then(AtnState::rule_index) else {
             return;
         };
         let rule_name = self
@@ -4182,11 +4205,11 @@ where
         let Some(decision) = atn
             .decision_to_state()
             .iter()
-            .position(|candidate| *candidate == state_number)
+            .position(|candidate| candidate == state_number)
         else {
             return;
         };
-        let Some(rule_index) = atn.state(state_number).and_then(|state| state.rule_index) else {
+        let Some(rule_index) = atn.state(state_number).and_then(AtnState::rule_index) else {
             return;
         };
         let rule_name = self
@@ -4698,11 +4721,12 @@ where
             };
             let Some(Transition::Rule { follow_state, .. }) = atn
                 .state(state_number)
-                .and_then(|state| state.transitions.first())
+                .and_then(|state| state.transitions().first())
+                .map(ParserTransition::data)
             else {
                 return None;
             };
-            Some(*follow_state)
+            Some(follow_state)
         })
     }
 
@@ -5143,10 +5167,10 @@ where
         let Some(state) = atn.state(state_number) else {
             return Ok(Vec::new());
         };
-        let Some(rule_index) = state.rule_index else {
+        let Some(rule_index) = state.rule_index() else {
             return Ok(Vec::new());
         };
-        let Some(rule_stop) = atn.rule_to_stop_state().get(rule_index).copied() else {
+        let Some(rule_stop) = atn.rule_to_stop_state().get(rule_index) else {
             return Ok(Vec::new());
         };
         let entry = self.cached_decision_lookahead(atn, state, rule_stop);
@@ -5199,7 +5223,7 @@ where
         // and leave recovery to the rule.
         //
         // The generated loop always presents the loop-ENTRY state to this method on
-        // every pass, so `state.kind` cannot distinguish entry from back; the caller
+        // every pass, so `state.kind()` cannot distinguish entry from back; the caller
         // passes `loop_back` (false on a `*` loop's first sync / on a block, true once
         // an iteration has been taken, and true on a `+` loop's first sync since its
         // mandatory first element is iteration 1). Treating a loop entry as a
@@ -5296,15 +5320,15 @@ where
         state_number: usize,
     ) -> Option<ParserAtnPrediction> {
         let state = atn.state(state_number)?;
-        if state.precedence_rule_decision {
+        if state.precedence_rule_decision() {
             return None;
         }
         let rule_stop = state
-            .rule_index
-            .and_then(|rule_index| atn.rule_to_stop_state().get(rule_index).copied())?;
+            .rule_index()
+            .and_then(|rule_index| atn.rule_to_stop_state().get(rule_index))?;
         let symbol = self.la(1);
         let entry = self.cached_decision_lookahead(atn, state, rule_stop);
-        ll1_greedy_alt(&entry, symbol, state.non_greedy).map(|alt| ParserAtnPrediction {
+        ll1_greedy_alt(&entry, symbol, state.non_greedy()).map(|alt| ParserAtnPrediction {
             alt: alt + 1,
             requires_full_context: false,
             has_semantic_context: false,
@@ -5321,11 +5345,12 @@ where
             };
             let Some(Transition::Rule { follow_state, .. }) = atn
                 .state(state_number)
-                .and_then(|state| state.transitions.first())
+                .and_then(|state| state.transitions().first())
+                .map(ParserTransition::data)
             else {
                 continue;
             };
-            let return_state = *follow_state;
+            let return_state = follow_state;
             expected.extend(self.cached_state_expected_symbols(atn, return_state).iter());
             if !self.cached_state_can_reach_rule_stop(atn, return_state) {
                 return expected;
@@ -5344,11 +5369,11 @@ where
             };
             let Some(Transition::Rule { follow_state, .. }) = atn
                 .state(state_number)
-                .and_then(|state| state.transitions.first())
+                .and_then(|state| state.transitions().first())
+                .map(ParserTransition::data)
             else {
                 continue;
             };
-            let follow_state = *follow_state;
             expected.extend_from(&self.cached_state_expected_token_set(atn, follow_state));
             if !self.cached_state_can_reach_rule_stop(atn, follow_state) {
                 return expected;
@@ -5376,11 +5401,11 @@ where
             };
             let Some(Transition::Rule { follow_state, .. }) = atn
                 .state(state_number)
-                .and_then(|state| state.transitions.first())
+                .and_then(|state| state.transitions().first())
+                .map(ParserTransition::data)
             else {
                 continue;
             };
-            let follow_state = *follow_state;
             if self
                 .cached_state_expected_token_set(atn, follow_state)
                 .contains(symbol)
@@ -5512,7 +5537,7 @@ where
         self.reset_recognition_arena();
         let tree_checkpoint = self.tree.checkpoint();
         let mut decision_by_state = vec![None; atn.states().len()];
-        for (decision, &state_number) in atn.decision_to_state().iter().enumerate() {
+        for (decision, state_number) in atn.decision_to_state().iter().enumerate() {
             if let Some(slot) = decision_by_state.get_mut(state_number) {
                 *slot = Some(decision);
             }
@@ -5567,17 +5592,12 @@ where
         rule_index: usize,
         precedence: i32,
     ) -> Result<ParseTree, AntlrError> {
-        let start_state = atn
-            .rule_to_start_state()
-            .get(rule_index)
-            .copied()
-            .ok_or_else(|| {
-                AntlrError::Unsupported(format!("rule {rule_index} has no start state"))
-            })?;
+        let start_state = atn.rule_to_start_state().get(rule_index).ok_or_else(|| {
+            AntlrError::Unsupported(format!("rule {rule_index} has no start state"))
+        })?;
         let stop_state = atn
             .rule_to_stop_state()
             .get(rule_index)
-            .copied()
             .filter(|state| *state != usize::MAX)
             .ok_or_else(|| {
                 AntlrError::Unsupported(format!("rule {rule_index} has no stop state"))
@@ -5712,8 +5732,8 @@ where
     fn pending_invoking_follow_state(&self, atn: &Atn) -> Option<usize> {
         let invoking_state = self.pending_invoking_states.last().copied()?;
         let state_number = usize::try_from(invoking_state).ok()?;
-        match atn.state(state_number)?.transitions.first()? {
-            Transition::Rule { follow_state, .. } => Some(*follow_state),
+        match atn.state(state_number)?.transitions().first()?.data() {
+            Transition::Rule { follow_state, .. } => Some(follow_state),
             _ => None,
         }
     }
@@ -6095,17 +6115,12 @@ where
         // only the hits it records itself (so the fail-loud check below reflects
         // this rule), and the parent's prior hits are merged back afterward.
         let prior_unknown_predicate_hits = std::mem::take(&mut self.unknown_predicate_hits);
-        let start_state = atn
-            .rule_to_start_state()
-            .get(rule_index)
-            .copied()
-            .ok_or_else(|| {
-                AntlrError::Unsupported(format!("rule {rule_index} has no start state"))
-            })?;
+        let start_state = atn.rule_to_start_state().get(rule_index).ok_or_else(|| {
+            AntlrError::Unsupported(format!("rule {rule_index} has no start state"))
+        })?;
         let stop_state = atn
             .rule_to_stop_state()
             .get(rule_index)
-            .copied()
             .filter(|state| *state != usize::MAX)
             .ok_or_else(|| {
                 AntlrError::Unsupported(format!("rule {rule_index} has no stop state"))
@@ -6401,7 +6416,7 @@ where
     /// satisfies the failed consuming transition.
     fn single_token_deletion(
         &mut self,
-        transition: &Transition,
+        transition: ParserTransition<'_>,
         index: usize,
         max_token_type: i32,
         expected_symbols: &BTreeSet<i32>,
@@ -6486,7 +6501,7 @@ where
     /// transition target at the same input index.
     fn single_token_insertion(
         &mut self,
-        transition: &Transition,
+        transition: ParserTransition<'_>,
         index: usize,
         max_token_type: i32,
         expected_symbols: &BTreeSet<i32>,
@@ -6784,6 +6799,7 @@ where
             recovery_symbols,
             recovery_state,
         } = request;
+        let max_token_type = atn.max_token_type();
         // Walk straight-line epsilon chains in a loop instead of recursing
         // into `recognize_state_fast` for each intermediate state. ATN
         // serialization places long sequences of `BasicBlock` epsilon
@@ -6826,31 +6842,32 @@ where
             let Some(state) = atn.state(state_number) else {
                 return Vec::new();
             };
-            if state.transitions.len() == 1
-                && !starts_prediction_decision(state)
-                && !state.precedence_rule_decision
-            {
-                match &state.transitions[0] {
-                    Transition::Epsilon { target }
-                    | Transition::Predicate { target, .. }
-                    | Transition::Action { target, .. }
-                        if left_recursive_boundary(atn, state, *target).is_none() =>
+            let transitions = state.transitions();
+            if transitions.len() == 1 && !state.precedence_rule_decision() {
+                let transition = transitions
+                    .first()
+                    .expect("single transition checked above");
+                let transition_kind = transition.kind();
+                let target = transition.target();
+                match transition_kind {
+                    ParserTransitionKind::Epsilon
+                    | ParserTransitionKind::Predicate
+                    | ParserTransitionKind::Action
+                        if left_recursive_boundary(atn, state, target).is_none() =>
                     {
                         #[cfg(feature = "perf-counters")]
                         perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
-                        state_number = *target;
+                        state_number = target;
                         depth += 1;
                         continue;
                     }
-                    Transition::Precedence {
-                        target,
-                        precedence: transition_precedence,
-                    } if *transition_precedence >= precedence
-                        && left_recursive_boundary(atn, state, *target).is_none() =>
+                    ParserTransitionKind::Precedence
+                        if packed_i32(transition.arg0()) >= precedence
+                            && left_recursive_boundary(atn, state, target).is_none() =>
                     {
                         #[cfg(feature = "perf-counters")]
                         perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
-                        state_number = *target;
+                        state_number = target;
                         depth += 1;
                         continue;
                     }
@@ -6863,16 +6880,15 @@ where
                     // a Token node, and return. Skip pass 2 (recovery
                     // enabled): there the failure branch matters and the
                     // existing recursive code records expected symbols.
-                    Transition::Atom { target, .. }
-                    | Transition::Range { target, .. }
-                    | Transition::Set { target, .. }
-                    | Transition::NotSet { target, .. }
-                    | Transition::Wildcard { target, .. }
+                    ParserTransitionKind::Atom
+                    | ParserTransitionKind::Range
+                    | ParserTransitionKind::Set
+                    | ParserTransitionKind::NotSet
+                    | ParserTransitionKind::Wildcard
                         if !self.fast_recovery_enabled =>
                     {
                         let symbol = self.token_type_at(index);
-                        let transition = &state.transitions[0];
-                        if transition.matches(symbol, 1, atn.max_token_type()) {
+                        if transition.matches_kind(transition_kind, symbol, 1, max_token_type) {
                             #[cfg(feature = "perf-counters")]
                             perf_counters::inc(&perf_counters::ATOM_RANGE_TRANSITIONS, 1);
                             if self.fast_token_nodes_enabled {
@@ -6880,7 +6896,7 @@ where
                             }
                             inline_consumed_eof |= symbol == TOKEN_EOF;
                             index = self.consume_index(index, symbol);
-                            state_number = *target;
+                            state_number = target;
                             depth += 1;
                             continue;
                         }
@@ -6899,7 +6915,8 @@ where
         let Some(state) = atn.state(state_number) else {
             return Vec::new();
         };
-        let transition_count = state.transitions.len();
+        let transitions = state.transitions();
+        let transition_count = transitions.len();
         let memo_lookup_enabled = self.fast_recovery_enabled || transition_count > 1;
         // In pass 1 (`fast_recovery_enabled == false`) the recovery-related
         // fields and the rule/decision boundary indices are pure plumbing —
@@ -6974,7 +6991,7 @@ where
         // guard because an otherwise non-nullable loop body can recover as an
         // empty child at EOF and re-enter the loop at the same token.
         let needs_cycle_guard = if self.fast_recovery_enabled {
-            state.transitions.iter().any(Transition::is_epsilon)
+            transitions.iter().any(ParserTransition::is_epsilon)
         } else {
             transition_count > 1 && self.state_can_reenter_without_consuming(atn, state_number)
         };
@@ -6983,7 +7000,12 @@ where
             perf_counters::inc(&perf_counters::MULTI_TRANS_BODY, 1);
         } else {
             perf_counters::inc(&perf_counters::SINGLE_TRANS_BODY, 1);
-            match &state.transitions[0] {
+            match state
+                .transitions()
+                .first()
+                .expect("single-transition path requires one transition")
+                .data()
+            {
                 Transition::Rule { .. } => {
                     perf_counters::inc(&perf_counters::SINGLE_TRANS_RULE, 1);
                 }
@@ -7009,7 +7031,7 @@ where
         } else {
             false
         };
-        let next_decision_start_index = if starts_prediction_decision(state) {
+        let next_decision_start_index = if starts_prediction_decision(state, transition_count) {
             Some(index)
         } else {
             decision_start_index
@@ -7038,15 +7060,14 @@ where
         //   * left-recursive precedence loops (the precedence transition's
         //     gating is dynamic),
         //   * states with too few alternatives to benefit.
-        let transition_count = state.transitions.len();
         let lookahead_filter = if transition_count > 1
             && self.fast_first_set_prefilter
-            && !state.precedence_rule_decision
-            && (!self.fast_recovery_enabled || state.kind != AtnStateKind::RuleStart)
+            && !state.precedence_rule_decision()
+            && (!self.fast_recovery_enabled || state.kind() != AtnStateKind::RuleStart)
         {
             state
-                .rule_index
-                .and_then(|rule_index| atn.rule_to_stop_state().get(rule_index).copied())
+                .rule_index()
+                .and_then(|rule_index| atn.rule_to_stop_state().get(rule_index))
                 .map(|rule_stop| {
                     let symbol = self.token_type_at(index);
                     let entry = self.cached_decision_lookahead(atn, state, rule_stop);
@@ -7066,7 +7087,7 @@ where
         let ll1_only_alt: Option<usize> = if transition_count > 1
             && let Some((symbol, entry)) = lookahead_filter.as_ref()
         {
-            let key = (state.state_number, *symbol);
+            let key = (state.state_number(), *symbol);
             if let Some(&cached) = self.ll1_decision_cache.get(&key) {
                 cached
             } else {
@@ -7084,34 +7105,39 @@ where
         // reserving one slot avoids a reallocation while keeping the
         // unused-slot waste at one element.
         let mut outcomes: Vec<FastRecognizeOutcome> = Vec::with_capacity(transition_count.min(2));
-        for (transition_index, transition) in state.transitions.iter().enumerate() {
+        for (transition_index, transition) in transitions.iter().enumerate() {
             if let Some(alt) = ll1_only_alt {
                 // LL(1) determinism: skip every alt except the chosen one.
                 if alt != transition_index {
                     continue;
                 }
-            } else if should_skip_via_lookahead(
-                transition,
-                transition_index,
-                lookahead_filter,
-                index,
-                self.fast_recovery_enabled,
-                expected,
-            ) {
+            }
+            let transition_kind = transition.kind();
+            if ll1_only_alt.is_none()
+                && should_skip_via_lookahead(
+                    transition_kind,
+                    transition_index,
+                    lookahead_filter,
+                    index,
+                    self.fast_recovery_enabled,
+                    expected,
+                )
+            {
                 continue;
             }
-            match transition {
-                Transition::Epsilon { target }
-                | Transition::Predicate { target, .. }
-                | Transition::Action { target, .. } => {
+            let target = transition.target();
+            match transition_kind {
+                ParserTransitionKind::Epsilon
+                | ParserTransitionKind::Predicate
+                | ParserTransitionKind::Action => {
                     #[cfg(feature = "perf-counters")]
                     perf_counters::inc(&perf_counters::EPSILON_TRANSITIONS, 1);
-                    let boundary = left_recursive_boundary(atn, state, *target);
+                    let boundary = left_recursive_boundary(atn, state, target);
                     outcomes.extend(
                         self.recognize_state_fast(
                             atn,
                             FastRecognizeRequest {
-                                state_number: *target,
+                                state_number: target,
                                 stop_state,
                                 index,
                                 rule_start_index,
@@ -7135,17 +7161,15 @@ where
                         }),
                     );
                 }
-                Transition::Precedence {
-                    target,
-                    precedence: transition_precedence,
-                } => {
-                    if *transition_precedence >= precedence {
-                        let boundary = left_recursive_boundary(atn, state, *target);
+                ParserTransitionKind::Precedence => {
+                    let transition_precedence = packed_i32(transition.arg0());
+                    if transition_precedence >= precedence {
+                        let boundary = left_recursive_boundary(atn, state, target);
                         outcomes.extend(
                             self.recognize_state_fast(
                                 atn,
                                 FastRecognizeRequest {
-                                    state_number: *target,
+                                    state_number: target,
                                     stop_state,
                                     index,
                                     rule_start_index,
@@ -7170,17 +7194,13 @@ where
                         );
                     }
                 }
-                Transition::Rule {
-                    target,
-                    rule_index,
-                    follow_state,
-                    precedence: rule_precedence,
-                    ..
-                } => {
+                ParserTransitionKind::Rule => {
+                    let rule_index = transition.arg0() as usize;
+                    let follow_state = transition.arg1() as usize;
+                    let rule_precedence = packed_i32(transition.arg2());
                     #[cfg(feature = "perf-counters")]
                     perf_counters::inc(&perf_counters::RULE_TRANSITIONS, 1);
-                    let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied()
-                    else {
+                    let Some(child_stop) = atn.rule_to_stop_state().get(rule_index) else {
                         continue;
                     };
                     // Lookahead-based pruning. The recognizer would otherwise
@@ -7208,7 +7228,7 @@ where
                         // the cache when the FIRST-set walk hit a cycle, so
                         // we cannot assume the entry is in the cache after
                         // computing it.
-                        let first = self.cached_rule_first_set(atn, *target, child_stop);
+                        let first = self.cached_rule_first_set(atn, target, child_stop);
                         if should_skip_rule_via_first_set(
                             &first,
                             symbol,
@@ -7224,12 +7244,12 @@ where
                     let mut children = self.recognize_state_fast(
                         atn,
                         FastRecognizeRequest {
-                            state_number: *target,
+                            state_number: target,
                             stop_state: child_stop,
                             index,
                             rule_start_index: index,
                             decision_start_index: None,
-                            precedence: *rule_precedence,
+                            precedence: rule_precedence,
                             depth: depth + 1,
                             recovery_symbols: Rc::clone(&epsilon_recovery_symbols),
                             recovery_state: epsilon_recovery_state,
@@ -7242,9 +7262,9 @@ where
                         children = self.fast_child_rule_failure_recovery_outcomes(
                             FastChildRuleFailureRecoveryRequest {
                                 atn,
-                                rule_index: *rule_index,
+                                rule_index,
                                 start_index: index,
-                                follow_state: *follow_state,
+                                follow_state,
                                 stop_state,
                                 expected,
                             },
@@ -7266,7 +7286,7 @@ where
                         let follow_outcomes = self.recognize_state_fast(
                             atn,
                             FastRecognizeRequest {
-                                state_number: *follow_state,
+                                state_number: follow_state,
                                 stop_state,
                                 index: child_index,
                                 rule_start_index,
@@ -7286,7 +7306,7 @@ where
                         let child_stop_index =
                             self.rule_stop_token_index(child_index, child_consumed_eof);
                         let child_node = self.arena_rule_node(ArenaRuleSpec {
-                            rule_index: *rule_index,
+                            rule_index,
                             invoking_state: invoking_state_number(state_number),
                             alt_number: 0,
                             start_index: index,
@@ -7309,22 +7329,22 @@ where
                         }));
                     }
                 }
-                Transition::Atom { target, .. }
-                | Transition::Range { target, .. }
-                | Transition::Set { target, .. }
-                | Transition::NotSet { target, .. }
-                | Transition::Wildcard { target, .. } => {
+                ParserTransitionKind::Atom
+                | ParserTransitionKind::Range
+                | ParserTransitionKind::Set
+                | ParserTransitionKind::NotSet
+                | ParserTransitionKind::Wildcard => {
                     #[cfg(feature = "perf-counters")]
                     perf_counters::inc(&perf_counters::ATOM_RANGE_TRANSITIONS, 1);
                     let symbol = self.token_type_at(index);
-                    if transition.matches(symbol, 1, atn.max_token_type()) {
+                    if transition.matches_kind(transition_kind, symbol, 1, max_token_type) {
                         let next_index = self.consume_index(index, symbol);
                         let empty_recovery = self.empty_recovery_symbols();
                         outcomes.extend(
                             self.recognize_state_fast(
                                 atn,
                                 FastRecognizeRequest {
-                                    state_number: *target,
+                                    state_number: target,
                                     stop_state,
                                     index: next_index,
                                     rule_start_index,
@@ -7362,14 +7382,14 @@ where
                         let expected_symbols = fast_recovery_expected_symbols(
                             self,
                             atn,
-                            state.state_number,
+                            state.state_number(),
                             &recovery_symbols,
                         );
                         if expected_symbols.contains(&symbol) {
                             continue;
                         }
                         {
-                            expected.record_transition(index, transition, atn.max_token_type());
+                            expected.record_transition(index, transition, max_token_type);
                             record_no_viable_if_ambiguous(
                                 expected,
                                 next_decision_start_index,
@@ -7380,7 +7400,7 @@ where
                                     atn,
                                     transition,
                                     expected_symbols: Rc::clone(&expected_symbols),
-                                    target: *target,
+                                    target,
                                     request: FastRecognizeRequest {
                                         state_number,
                                         stop_state,
@@ -7403,7 +7423,7 @@ where
                                         atn,
                                         transition,
                                         expected_symbols: Rc::clone(&expected_symbols),
-                                        target: *target,
+                                        target,
                                         request: FastRecognizeRequest {
                                             state_number,
                                             stop_state,
@@ -7936,7 +7956,9 @@ where
             visiting.remove(&visit_key);
             return Vec::new();
         };
-        let next_decision_start_index = if starts_prediction_decision(state) {
+        let transitions = state.transitions();
+        let transition_count = transitions.len();
+        let next_decision_start_index = if starts_prediction_decision(state, transition_count) {
             Some(index)
         } else {
             decision_start_index
@@ -7944,13 +7966,20 @@ where
         let (epsilon_recovery_symbols, epsilon_recovery_state) =
             next_recovery_context(atn, state, &recovery_symbols, recovery_state);
         let mut outcomes = Vec::new();
-        for (transition_index, transition) in state.transitions.iter().enumerate() {
-            let decision = transition_decision(atn, state, transition_index, predicates);
-            let next_alt_number =
-                next_alt_number(state, transition_index, rule_alt_number, track_alt_numbers);
-            match transition {
+        for (transition_index, transition) in transitions.iter().enumerate() {
+            let decision =
+                transition_decision(atn, state, transition_count, transition_index, predicates);
+            let next_alt_number = next_alt_number(
+                state,
+                transition_count,
+                transition_index,
+                rule_alt_number,
+                track_alt_numbers,
+            );
+            let transition_data = transition.data();
+            match &transition_data {
                 Transition::Epsilon { target } | Transition::Action { target, .. } => {
-                    let action_rule_index = match transition {
+                    let action_rule_index = match &transition_data {
                         Transition::Action { rule_index, .. } => Some(*rule_index),
                         _ => None,
                     };
@@ -8111,8 +8140,7 @@ where
                     precedence: rule_precedence,
                     ..
                 } => {
-                    let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied()
-                    else {
+                    let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index) else {
                         continue;
                     };
                     let child_local_int_arg =
@@ -8249,7 +8277,7 @@ where
                 | Transition::NotSet { target, .. }
                 | Transition::Wildcard { target, .. } => {
                     let symbol = self.token_type_at(index);
-                    if transition.matches(symbol, 1, atn.max_token_type()) {
+                    if transition_data.matches(symbol, 1, atn.max_token_type()) {
                         let next_index = self.consume_index(index, symbol);
                         outcomes.extend(
                             self.recognize_state(
@@ -8292,7 +8320,7 @@ where
                         );
                     } else {
                         let expected_symbols =
-                            recovery_expected_symbols(atn, state.state_number, &recovery_symbols);
+                            recovery_expected_symbols(atn, state.state_number(), &recovery_symbols);
                         if expected_symbols.contains(&symbol) {
                             continue;
                         }
@@ -8586,7 +8614,7 @@ where
     fn cached_decision_lookahead(
         &mut self,
         atn: &Atn,
-        state: &AtnState,
+        state: AtnState<'_>,
         rule_stop_state: usize,
     ) -> Rc<DecisionLookahead> {
         // Hit the parser-instance cache first. Decision lookahead is purely
@@ -8595,17 +8623,17 @@ where
         // SHARED_ATN_CACHES — which on multi-trans-heavy grammars (C# does
         // ~58K multi-trans visits per parse) shows up as RefCell borrow and
         // hashmap-entry overhead in profiles.
-        if let Some(cached) = self.decision_lookahead_cache.get(&state.state_number) {
+        if let Some(cached) = self.decision_lookahead_cache.get(&state.state_number()) {
             return Rc::clone(cached);
         }
         let entry = with_shared_atn_caches(atn, |cache| {
-            if let Some(cached) = cache.decision_lookahead.get(&state.state_number) {
+            if let Some(cached) = cache.decision_lookahead.get(&state.state_number()) {
                 return Rc::clone(cached);
             }
             let mut entry = DecisionLookahead {
-                transitions: Vec::with_capacity(state.transitions.len()),
+                transitions: Vec::with_capacity(state.transitions().len()),
             };
-            for transition in &state.transitions {
+            for transition in &state.transitions() {
                 entry.transitions.push(transition_first_set(
                     atn,
                     transition,
@@ -8616,11 +8644,11 @@ where
             let entry = Rc::new(entry);
             cache
                 .decision_lookahead
-                .insert(state.state_number, Rc::clone(&entry));
+                .insert(state.state_number(), Rc::clone(&entry));
             entry
         });
         self.decision_lookahead_cache
-            .insert(state.state_number, Rc::clone(&entry));
+            .insert(state.state_number(), Rc::clone(&entry));
         entry
     }
 
@@ -8675,35 +8703,31 @@ where
         let Some(state) = atn.state(state_number) else {
             return false;
         };
-        for transition in &state.transitions {
-            match transition {
-                Transition::Atom { .. }
-                | Transition::Range { .. }
-                | Transition::Set { .. }
-                | Transition::NotSet { .. }
-                | Transition::Wildcard { .. } => {}
-                Transition::Rule {
-                    target,
-                    rule_index,
-                    follow_state,
-                    ..
-                } => {
-                    if *target == target_state
-                        || self.empty_path_reaches_state(atn, *target, target_state, visited)
+        for transition in &state.transitions() {
+            let kind = transition.kind();
+            let target = transition.target();
+            match kind {
+                ParserTransitionKind::Atom
+                | ParserTransitionKind::Range
+                | ParserTransitionKind::Set
+                | ParserTransitionKind::NotSet
+                | ParserTransitionKind::Wildcard => {}
+                ParserTransitionKind::Rule => {
+                    let rule_index = transition.arg0() as usize;
+                    let follow_state = transition.arg1() as usize;
+                    if target == target_state
+                        || self.empty_path_reaches_state(atn, target, target_state, visited)
                     {
                         return true;
                     }
-                    let Some(child_stop) = atn.rule_to_stop_state().get(*rule_index).copied()
-                    else {
+                    let Some(child_stop) = atn.rule_to_stop_state().get(rule_index) else {
                         continue;
                     };
-                    if self
-                        .cached_rule_first_set(atn, *target, child_stop)
-                        .nullable
-                        && (*follow_state == target_state
+                    if self.cached_rule_first_set(atn, target, child_stop).nullable
+                        && (follow_state == target_state
                             || self.empty_path_reaches_state(
                                 atn,
-                                *follow_state,
+                                follow_state,
                                 target_state,
                                 visited,
                             ))
@@ -8711,12 +8735,12 @@ where
                         return true;
                     }
                 }
-                Transition::Epsilon { target }
-                | Transition::Predicate { target, .. }
-                | Transition::Action { target, .. }
-                | Transition::Precedence { target, .. } => {
-                    if *target == target_state
-                        || self.empty_path_reaches_state(atn, *target, target_state, visited)
+                ParserTransitionKind::Epsilon
+                | ParserTransitionKind::Predicate
+                | ParserTransitionKind::Action
+                | ParserTransitionKind::Precedence => {
+                    if target == target_state
+                        || self.empty_path_reaches_state(atn, target, target_state, visited)
                     {
                         return true;
                     }
@@ -9486,21 +9510,21 @@ where
     fn record_prediction_diagnostics(
         &mut self,
         atn: &Atn,
-        state: &AtnState,
+        state: AtnState<'_>,
         start_index: usize,
         outcomes: &[RecognizeOutcome],
     ) {
-        if !self.report_diagnostic_errors || state.transitions.len() < 2 {
+        if !self.report_diagnostic_errors || state.transitions().len() < 2 {
             return;
         }
         let Some(decision) = atn
             .decision_to_state()
             .iter()
-            .position(|state_number| *state_number == state.state_number)
+            .position(|state_number| state_number == state.state_number())
         else {
             return;
         };
-        let Some(rule_index) = state.rule_index else {
+        let Some(rule_index) = state.rule_index() else {
             return;
         };
         let mut alts_by_end = BTreeMap::<usize, BTreeSet<usize>>::new();
@@ -9617,7 +9641,7 @@ where
     }
 }
 
-impl<S, H> DirectAdaptiveParser<'_, '_, S, H>
+impl<'atn, S, H> DirectAdaptiveParser<'atn, '_, S, H>
 where
     S: TokenSource,
     H: SemanticHooks,
@@ -9628,14 +9652,14 @@ where
         invoking_state: isize,
         precedence: i32,
     ) -> DirectAdaptiveParseResult<ParseTree> {
-        let start_state = *self.atn.rule_to_start_state().get(rule_index).ok_or(
+        let start_state = self.atn.rule_to_start_state().get(rule_index).ok_or(
             DirectAdaptiveParseControl::Fallback(DirectAdaptiveFallback::MissingAtn),
         )?;
-        let stop_state = *self
+        let stop_state = self
             .atn
             .rule_to_stop_state()
             .get(rule_index)
-            .filter(|state| **state != usize::MAX)
+            .filter(|state| *state != usize::MAX)
             .ok_or(DirectAdaptiveParseControl::Fallback(
                 DirectAdaptiveFallback::MissingAtn,
             ))?;
@@ -9654,7 +9678,7 @@ where
                     DirectAdaptiveFallback::LeftRecursiveBoundary,
                 ));
             }
-            match transition {
+            match transition.data() {
                 Transition::Epsilon { target } => {
                     state_number = target;
                 }
@@ -9690,7 +9714,7 @@ where
                 | Transition::Set { .. }
                 | Transition::NotSet { .. }
                 | Transition::Wildcard { .. } => {
-                    let (matched_eof, child) = self.consume_transition(&transition)?;
+                    let (matched_eof, child) = self.consume_transition(transition)?;
                     consumed_eof |= matched_eof;
                     if let Some(child) = child {
                         self.parser.tree.add_child(&mut context, child);
@@ -9733,7 +9757,7 @@ where
         &mut self,
         state_number: usize,
         precedence: i32,
-    ) -> DirectAdaptiveParseResult<(Transition, Option<usize>)> {
+    ) -> DirectAdaptiveParseResult<(ParserTransition<'atn>, Option<usize>)> {
         let state = self
             .atn
             .state(state_number)
@@ -9746,11 +9770,11 @@ where
             ));
         }
         let transition_index =
-            self.transition_index(state_number, state.transitions.len(), precedence)?;
-        let transition = state.transitions.get(transition_index).cloned().ok_or(
+            self.transition_index(state_number, state.transitions().len(), precedence)?;
+        let transition = state.transitions().get(transition_index).ok_or(
             DirectAdaptiveParseControl::Fallback(DirectAdaptiveFallback::NoTransition),
         )?;
-        let boundary = match &transition {
+        let boundary = match &transition.data() {
             Transition::Epsilon { target } | Transition::Precedence { target, .. } => {
                 left_recursive_boundary(self.atn, state, *target)
             }
@@ -9818,12 +9842,12 @@ where
             .ok_or(DirectAdaptiveParseControl::Fallback(
                 DirectAdaptiveFallback::MissingAtn,
             ))?;
-        if state.precedence_rule_decision {
+        if state.precedence_rule_decision() {
             return Ok(None);
         }
         let Some(rule_stop) = state
-            .rule_index
-            .and_then(|rule_index| self.atn.rule_to_stop_state().get(rule_index).copied())
+            .rule_index()
+            .and_then(|rule_index| self.atn.rule_to_stop_state().get(rule_index))
         else {
             return Ok(None);
         };
@@ -9831,12 +9855,15 @@ where
         let entry = self
             .parser
             .cached_decision_lookahead(self.atn, state, rule_stop);
-        Ok(ll1_greedy_alt(&entry, symbol, state.non_greedy).filter(|alt| *alt < transition_count))
+        Ok(
+            ll1_greedy_alt(&entry, symbol, state.non_greedy())
+                .filter(|alt| *alt < transition_count),
+        )
     }
 
     fn consume_transition(
         &mut self,
-        transition: &Transition,
+        transition: ParserTransition<'_>,
     ) -> DirectAdaptiveParseResult<(bool, Option<ParseTree>)> {
         let symbol = self.parser.input.la_token(1);
         if !transition.matches(symbol, 1, self.atn.max_token_type()) {
@@ -9865,15 +9892,15 @@ where
 
 /// Detects the loop edge where ANTLR would call `pushNewRecursionContext` for a
 /// transformed left-recursive rule.
-fn left_recursive_boundary(atn: &Atn, state: &AtnState, target: usize) -> Option<usize> {
-    if !state.precedence_rule_decision {
+fn left_recursive_boundary(atn: &Atn, state: AtnState<'_>, target: usize) -> Option<usize> {
+    if !state.precedence_rule_decision() {
         return None;
     }
     let target_state = atn.state(target)?;
-    if target_state.kind == AtnStateKind::LoopEnd {
+    if target_state.kind() == AtnStateKind::LoopEnd {
         return None;
     }
-    state.rule_index
+    state.rule_index()
 }
 
 /// Selects the first outer alternative observed for a rule path.
@@ -9882,23 +9909,24 @@ fn left_recursive_boundary(atn: &Atn, state: &AtnState, target: usize) -> Option
 /// outer decision. The metadata recognizer only needs this when a generated
 /// grammar opts into that target template; otherwise the value remains `0` and
 /// parse-tree rendering is unchanged.
-const fn next_alt_number(
-    state: &AtnState,
+fn next_alt_number(
+    state: AtnState<'_>,
+    transition_count: usize,
     transition_index: usize,
     current_alt_number: usize,
     track_alt_numbers: bool,
 ) -> usize {
-    if !track_alt_numbers || current_alt_number != 0 || state.transitions.len() <= 1 {
+    if !track_alt_numbers || current_alt_number != 0 || transition_count <= 1 {
         return current_alt_number;
     }
     if matches!(
-        state.kind,
+        state.kind(),
         AtnStateKind::Basic
             | AtnStateKind::BlockStart
             | AtnStateKind::PlusBlockStart
             | AtnStateKind::StarBlockStart
             | AtnStateKind::StarLoopEntry
-    ) && !state.precedence_rule_decision
+    ) && !state.precedence_rule_decision()
     {
         return transition_index + 1;
     }
@@ -9909,6 +9937,10 @@ const fn next_alt_number(
 /// ANTLR parse-tree contexts, saturating only for impossible platform widths.
 fn invoking_state_number(state_number: usize) -> isize {
     isize::try_from(state_number).unwrap_or(isize::MAX)
+}
+
+const fn packed_i32(value: u32) -> i32 {
+    i32::from_le_bytes(value.to_le_bytes())
 }
 
 fn direct_precedence(precedence: i32) -> usize {
@@ -10046,14 +10078,14 @@ fn is_caller_follow_boundary_gap_text(text: &str) -> bool {
 /// Returns whether `state` belongs to an ANTLR-transformed left-recursive rule.
 /// Inline insertion in those precedence loops can synthesize a missing operand
 /// before an operator and then block the legitimate loop-exit path.
-fn state_is_left_recursive_rule(atn: &Atn, state: &AtnState) -> bool {
-    let Some(rule_index) = state.rule_index else {
+fn state_is_left_recursive_rule(atn: &Atn, state: AtnState<'_>) -> bool {
+    let Some(rule_index) = state.rule_index() else {
         return false;
     };
     atn.rule_to_start_state()
         .get(rule_index)
-        .and_then(|state_number| atn.state(*state_number))
-        .is_some_and(|rule_start| rule_start.left_recursive_rule)
+        .and_then(|state_number| atn.state(state_number))
+        .is_some_and(AtnState::left_recursive_rule)
 }
 
 /// Picks the better of two `parse_atn_rule` passes (with and without the
@@ -10211,12 +10243,13 @@ fn select_best_outcome(
 /// prediction simulator.
 fn transition_decision(
     atn: &Atn,
-    state: &AtnState,
+    state: AtnState<'_>,
+    transition_count: usize,
     transition_index: usize,
     predicates: &[(usize, usize, ParserPredicate)],
 ) -> Option<usize> {
-    if state.transitions.len() <= 1
-        || state.precedence_rule_decision
+    if transition_count <= 1
+        || state.precedence_rule_decision()
         || decision_reaches_unsupported_predicate(atn, state, predicates)
     {
         return None;
@@ -10229,10 +10262,10 @@ fn transition_decision(
 /// Loop entry/back states are continuations of the surrounding adaptive
 /// prediction; resetting at those states would turn LL-star failures back into
 /// ordinary mismatches.
-const fn starts_prediction_decision(state: &AtnState) -> bool {
-    state.transitions.len() > 1
+fn starts_prediction_decision(state: AtnState<'_>, transition_count: usize) -> bool {
+    transition_count > 1
         && !matches!(
-            state.kind,
+            state.kind(),
             AtnStateKind::PlusLoopBack | AtnStateKind::StarLoopBack | AtnStateKind::StarLoopEntry
         )
 }
@@ -10299,10 +10332,10 @@ fn restore_expected(
 /// translate. Static alternative order is unsafe for those context predicates.
 fn decision_reaches_unsupported_predicate(
     atn: &Atn,
-    state: &AtnState,
+    state: AtnState<'_>,
     predicates: &[(usize, usize, ParserPredicate)],
 ) -> bool {
-    state.transitions.iter().any(|transition| {
+    state.transitions().iter().any(|transition| {
         transition_reaches_unsupported_predicate(atn, transition, predicates, &mut BTreeSet::new())
     })
 }
@@ -10310,11 +10343,11 @@ fn decision_reaches_unsupported_predicate(
 /// Walks epsilon-like edges from one transition to find unsupported predicates.
 fn transition_reaches_unsupported_predicate(
     atn: &Atn,
-    transition: &Transition,
+    transition: ParserTransition<'_>,
     predicates: &[(usize, usize, ParserPredicate)],
     visited: &mut BTreeSet<usize>,
 ) -> bool {
-    match transition {
+    match &transition.data() {
         Transition::Predicate {
             rule_index,
             pred_index,
@@ -10349,7 +10382,7 @@ fn state_reaches_unsupported_predicate(
     let Some(state) = atn.state(state_number) else {
         return false;
     };
-    state.transitions.iter().any(|transition| {
+    state.transitions().iter().any(|transition| {
         transition_reaches_unsupported_predicate(atn, transition, predicates, visited)
     })
 }
@@ -10560,8 +10593,6 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::atn::AtnType;
-    use crate::atn::IntervalSet;
     use crate::atn::parser::{
         ParserAtnPredictionDiagnostic, ParserAtnPredictionDiagnosticKind, ParserAtnSimulator,
     };
@@ -10744,60 +10775,121 @@ mod tests {
         )
     }
 
+    fn finish_atn(builder: ParserAtnBuilder) -> Atn {
+        builder.finish().expect("valid packed parser ATN")
+    }
+
     fn left_recursive_loop_with_caller_follow_atn(caller_symbol: i32) -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        let mut callee_start = AtnState::new(3, AtnStateKind::RuleStart).with_rule_index(1);
-        callee_start.left_recursive_rule = true;
-        atn.add_state(callee_start);
-        let mut loop_entry = AtnState::new(4, AtnStateKind::StarLoopEntry).with_rule_index(1);
-        loop_entry.precedence_rule_decision = true;
-        atn.add_state(loop_entry);
-        atn.add_state(AtnState::new(5, AtnStateKind::Basic).with_rule_index(1));
-        atn.add_state(AtnState::new(6, AtnStateKind::Basic).with_rule_index(1));
-        atn.add_state(AtnState::new(7, AtnStateKind::LoopEnd).with_rule_index(1));
-        atn.add_state(AtnState::new(8, AtnStateKind::RuleStop).with_rule_index(1));
-        atn.add_state(AtnState::new(9, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0, 3]);
-        atn.set_rule_to_stop_state(vec![9, 8]);
-        atn.state_mut(1)
-            .expect("caller invoking state")
-            .add_transition(Transition::Rule {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(1))
+                .expect("state")
+                .index(),
+            3
+        );
+        atn.set_left_recursive_rule(3)
+            .expect("left-recursive rule start");
+        assert_eq!(
+            atn.add_state(AtnStateKind::StarLoopEntry, Some(1))
+                .expect("state")
+                .index(),
+            4
+        );
+        atn.set_precedence_rule_decision(4)
+            .expect("precedence decision");
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(1))
+                .expect("state")
+                .index(),
+            5
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(1))
+                .expect("state")
+                .index(),
+            6
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::LoopEnd, Some(1))
+                .expect("state")
+                .index(),
+            7
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(1))
+                .expect("state")
+                .index(),
+            8
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            9
+        );
+        atn.set_rule_to_start_state(vec![0, 3])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![9, 8])
+            .expect("rule stop states");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Rule {
                 target: 3,
                 rule_index: 1,
                 follow_state: 2,
                 precedence: 0,
-            });
-        atn.state_mut(2)
-            .expect("caller follow")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 9,
                 label: caller_symbol,
-            });
-        atn.state_mut(4)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(4)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.state_mut(5)
-            .expect("precedence predicate")
-            .add_transition(Transition::Precedence {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Precedence {
                 target: 6,
                 precedence: 1,
-            });
-        atn.state_mut(6)
-            .expect("operator token")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            6,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 1,
-            });
-        atn.state_mut(7)
-            .expect("loop exit")
-            .add_transition(Transition::Epsilon { target: 8 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(7, ParserTransitionSpec::Epsilon { target: 8 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn parser_inside_left_recursive_callee(symbol: i32) -> BaseParser<Source> {
@@ -10819,7 +10911,7 @@ mod tests {
     }
 
     fn left_recursive_loop_with_nullable_operator_prefix_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
+        let mut atn = ParserAtnBuilder::new(2);
         for (state, kind, rule) in [
             (0, AtnStateKind::RuleStart, 0),
             (1, AtnStateKind::StarLoopEntry, 0),
@@ -10832,59 +10924,69 @@ mod tests {
             (8, AtnStateKind::RuleStop, 1),
             (9, AtnStateKind::Basic, 1),
         ] {
-            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            assert_eq!(
+                atn.add_state(kind, Some(rule)).expect("state").index(),
+                state
+            );
             if state == 0 {
-                atn_state.left_recursive_rule = true;
+                atn.set_left_recursive_rule(state)
+                    .expect("left-recursive rule start");
             } else if state == 1 {
-                atn_state.precedence_rule_decision = true;
+                atn.set_precedence_rule_decision(state)
+                    .expect("precedence decision");
             }
-            atn.add_state(atn_state);
         }
-        atn.set_rule_to_start_state(vec![0, 7]);
-        atn.set_rule_to_stop_state(vec![6, 8]);
-        atn.state_mut(1)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(2)
-            .expect("precedence predicate")
-            .add_transition(Transition::Precedence {
+        atn.set_rule_to_start_state(vec![0, 7])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![6, 8])
+            .expect("rule stop states");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Precedence {
                 target: 3,
                 precedence: 3,
-            });
-        atn.state_mut(3)
-            .expect("nullable operator prefix")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Rule {
                 target: 7,
                 rule_index: 1,
                 follow_state: 4,
                 precedence: 0,
-            });
-        atn.state_mut(4)
-            .expect("operator token")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Atom {
                 target: 1,
                 label: 1,
-            });
-        atn.state_mut(5)
-            .expect("loop exit")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(7)
-            .expect("nullable operator prefix")
-            .add_transition(Transition::Precedence {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(
+            7,
+            ParserTransitionSpec::Precedence {
                 target: 9,
                 precedence: 1,
-            });
-        atn.state_mut(9)
-            .expect("nullable operator prefix")
-            .add_transition(Transition::Epsilon { target: 8 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(9, ParserTransitionSpec::Epsilon { target: 8 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn left_recursive_loop_with_predicate_guarded_operator_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
+        let mut atn = ParserAtnBuilder::new(2);
         for (state, kind) in [
             (0, AtnStateKind::RuleStart),
             (1, AtnStateKind::StarLoopEntry),
@@ -10894,50 +10996,56 @@ mod tests {
             (5, AtnStateKind::LoopEnd),
             (6, AtnStateKind::RuleStop),
         ] {
-            let mut atn_state = AtnState::new(state, kind).with_rule_index(0);
+            assert_eq!(atn.add_state(kind, Some(0)).expect("state").index(), state);
             if state == 0 {
-                atn_state.left_recursive_rule = true;
+                atn.set_left_recursive_rule(state)
+                    .expect("left-recursive rule start");
             } else if state == 1 {
-                atn_state.precedence_rule_decision = true;
+                atn.set_precedence_rule_decision(state)
+                    .expect("precedence decision");
             }
-            atn.add_state(atn_state);
         }
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![6]);
-        atn.state_mut(1)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(1)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(2)
-            .expect("precedence predicate")
-            .add_transition(Transition::Precedence {
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![6])
+            .expect("rule stop states");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Precedence {
                 target: 3,
                 precedence: 1,
-            });
-        atn.state_mut(3)
-            .expect("semantic predicate")
-            .add_transition(Transition::Predicate {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Predicate {
                 target: 4,
                 rule_index: 0,
                 pred_index: 0,
                 context_dependent: false,
-            });
-        atn.state_mut(4)
-            .expect("operator token")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Atom {
                 target: 1,
                 label: 1,
-            });
-        atn.state_mut(5)
-            .expect("loop exit")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn left_recursive_loop_with_nullable_follow_call_atn(caller_symbol: i32) -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
+        let mut atn = ParserAtnBuilder::new(2);
         for (state, kind, rule) in [
             (0, AtnStateKind::RuleStart, 0),
             (1, AtnStateKind::Basic, 0),
@@ -10953,70 +11061,81 @@ mod tests {
             (11, AtnStateKind::RuleStart, 2),
             (12, AtnStateKind::RuleStop, 2),
         ] {
-            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            assert_eq!(
+                atn.add_state(kind, Some(rule)).expect("state").index(),
+                state
+            );
             if state == 5 {
-                atn_state.left_recursive_rule = true;
+                atn.set_left_recursive_rule(state)
+                    .expect("left-recursive rule start");
             } else if state == 6 {
-                atn_state.precedence_rule_decision = true;
+                atn.set_precedence_rule_decision(state)
+                    .expect("precedence decision");
             }
-            atn.add_state(atn_state);
         }
-        atn.set_rule_to_start_state(vec![0, 5, 11]);
-        atn.set_rule_to_stop_state(vec![4, 10, 12]);
-        atn.state_mut(0)
-            .expect("caller start")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("caller invoking state")
-            .add_transition(Transition::Rule {
+        atn.set_rule_to_start_state(vec![0, 5, 11])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![4, 10, 12])
+            .expect("rule stop states");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Rule {
                 target: 5,
                 rule_index: 1,
                 follow_state: 2,
                 precedence: 0,
-            });
-        atn.state_mut(2)
-            .expect("nullable child invocation")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Rule {
                 target: 11,
                 rule_index: 2,
                 follow_state: 3,
                 precedence: 0,
-            });
-        atn.state_mut(3)
-            .expect("caller follow")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: caller_symbol,
-            });
-        atn.state_mut(6)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.state_mut(6)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 9 });
-        atn.state_mut(7)
-            .expect("precedence predicate")
-            .add_transition(Transition::Precedence {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 9 })
+            .expect("transition");
+        atn.add_transition(
+            7,
+            ParserTransitionSpec::Precedence {
                 target: 8,
                 precedence: 1,
-            });
-        atn.state_mut(8)
-            .expect("operator token")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            8,
+            ParserTransitionSpec::Atom {
                 target: 6,
                 label: 1,
-            });
-        atn.state_mut(9)
-            .expect("loop exit")
-            .add_transition(Transition::Epsilon { target: 10 });
-        atn.state_mut(11)
-            .expect("nullable child")
-            .add_transition(Transition::Epsilon { target: 12 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(9, ParserTransitionSpec::Epsilon { target: 10 })
+            .expect("transition");
+        atn.add_transition(11, ParserTransitionSpec::Epsilon { target: 12 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn left_recursive_loop_with_nullable_parent_return_atn(caller_symbol: i32) -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
+        let mut atn = ParserAtnBuilder::new(2);
         for (state, kind, rule) in [
             (0, AtnStateKind::RuleStart, 0),
             (1, AtnStateKind::Basic, 0),
@@ -11033,73 +11152,83 @@ mod tests {
             (12, AtnStateKind::LoopEnd, 2),
             (13, AtnStateKind::RuleStop, 2),
         ] {
-            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            assert_eq!(
+                atn.add_state(kind, Some(rule)).expect("state").index(),
+                state
+            );
             if state == 8 {
-                atn_state.left_recursive_rule = true;
+                atn.set_left_recursive_rule(state)
+                    .expect("left-recursive rule start");
             } else if state == 9 {
-                atn_state.precedence_rule_decision = true;
+                atn.set_precedence_rule_decision(state)
+                    .expect("precedence decision");
             }
-            atn.add_state(atn_state);
         }
-        atn.set_rule_to_start_state(vec![0, 4, 8]);
-        atn.set_rule_to_stop_state(vec![3, 7, 13]);
-        atn.state_mut(0)
-            .expect("parent start")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("parent invocation")
-            .add_transition(Transition::Rule {
+        atn.set_rule_to_start_state(vec![0, 4, 8])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![3, 7, 13])
+            .expect("rule stop states");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Rule {
                 target: 4,
                 rule_index: 1,
                 follow_state: 2,
                 precedence: 0,
-            });
-        atn.state_mut(2)
-            .expect("parent follow")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: caller_symbol,
-            });
-        atn.state_mut(4)
-            .expect("caller start")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(5)
-            .expect("caller invocation")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Rule {
                 target: 8,
                 rule_index: 2,
                 follow_state: 6,
                 precedence: 0,
-            });
-        atn.state_mut(6)
-            .expect("nullable caller return")
-            .add_transition(Transition::Epsilon { target: 7 });
-        atn.state_mut(9)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 10 });
-        atn.state_mut(9)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 12 });
-        atn.state_mut(10)
-            .expect("precedence predicate")
-            .add_transition(Transition::Precedence {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
+            .expect("transition");
+        atn.add_transition(9, ParserTransitionSpec::Epsilon { target: 10 })
+            .expect("transition");
+        atn.add_transition(9, ParserTransitionSpec::Epsilon { target: 12 })
+            .expect("transition");
+        atn.add_transition(
+            10,
+            ParserTransitionSpec::Precedence {
                 target: 11,
                 precedence: 1,
-            });
-        atn.state_mut(11)
-            .expect("operator token")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            11,
+            ParserTransitionSpec::Atom {
                 target: 9,
                 label: 1,
-            });
-        atn.state_mut(12)
-            .expect("loop exit")
-            .add_transition(Transition::Epsilon { target: 13 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(12, ParserTransitionSpec::Epsilon { target: 13 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn left_recursive_loop_with_recursive_operand_return_atn(caller_symbol: i32) -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
+        let mut atn = ParserAtnBuilder::new(2);
         for (state, kind, rule) in [
             (0, AtnStateKind::RuleStart, 0),
             (1, AtnStateKind::Basic, 0),
@@ -11114,66 +11243,77 @@ mod tests {
             (10, AtnStateKind::LoopEnd, 1),
             (11, AtnStateKind::RuleStop, 1),
         ] {
-            let mut atn_state = AtnState::new(state, kind).with_rule_index(rule);
+            assert_eq!(
+                atn.add_state(kind, Some(rule)).expect("state").index(),
+                state
+            );
             if state == 4 {
-                atn_state.left_recursive_rule = true;
+                atn.set_left_recursive_rule(state)
+                    .expect("left-recursive rule start");
             } else if state == 5 {
-                atn_state.precedence_rule_decision = true;
+                atn.set_precedence_rule_decision(state)
+                    .expect("precedence decision");
             }
-            atn.add_state(atn_state);
         }
-        atn.set_rule_to_start_state(vec![0, 4]);
-        atn.set_rule_to_stop_state(vec![3, 11]);
-        atn.state_mut(0)
-            .expect("caller start")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("caller invocation")
-            .add_transition(Transition::Rule {
+        atn.set_rule_to_start_state(vec![0, 4])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![3, 11])
+            .expect("rule stop states");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Rule {
                 target: 4,
                 rule_index: 1,
                 follow_state: 2,
                 precedence: 0,
-            });
-        atn.state_mut(2)
-            .expect("caller follow")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: caller_symbol,
-            });
-        atn.state_mut(5)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 6 });
-        atn.state_mut(5)
-            .expect("precedence loop")
-            .add_transition(Transition::Epsilon { target: 10 });
-        atn.state_mut(6)
-            .expect("precedence predicate")
-            .add_transition(Transition::Precedence {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 10 })
+            .expect("transition");
+        atn.add_transition(
+            6,
+            ParserTransitionSpec::Precedence {
                 target: 7,
                 precedence: 1,
-            });
-        atn.state_mut(7)
-            .expect("operator token")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            7,
+            ParserTransitionSpec::Atom {
                 target: 8,
                 label: 1,
-            });
-        atn.state_mut(8)
-            .expect("recursive operand")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            8,
+            ParserTransitionSpec::Rule {
                 target: 4,
                 rule_index: 1,
                 follow_state: 9,
                 precedence: 2,
-            });
-        atn.state_mut(9)
-            .expect("recursive operand follow")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(10)
-            .expect("loop exit")
-            .add_transition(Transition::Epsilon { target: 11 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(9, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(10, ParserTransitionSpec::Epsilon { target: 11 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     #[test]
@@ -11363,7 +11503,7 @@ mod tests {
             1, 2, 5, -1, 0, 0, // match EOF
             0, // decisions
         ]))
-        .deserialize()
+        .deserialize_parser()
         .expect("artificial parser ATN should deserialize")
     }
 
@@ -11385,7 +11525,7 @@ mod tests {
             1, 2, 6, 0, 0, 0, // parser action
             0, // decisions
         ]))
-        .deserialize()
+        .deserialize_parser()
         .expect("artificial parser ATN should deserialize")
     }
 
@@ -11409,88 +11549,156 @@ mod tests {
             2, 3, 5, -1, 0, 0, // match EOF
             0, // decisions
         ]))
-        .deserialize()
+        .deserialize_parser()
         .expect("artificial no-op action ATN should deserialize")
     }
 
     fn two_alt_decision_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::BlockStart).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::BlockEnd).with_rule_index(0));
-        atn.add_state(AtnState::new(5, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![5]);
-        atn.add_decision_state(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockEnd, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![5])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 1,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 2,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(2, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     /// ATN for `start : (A)? B EOF ;` (A=1, B=2, C=3, max token type 3).
     /// State 1 is the nullable optional-block decision; its sync set is {A, B}.
     fn optional_then_b_eof_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 3);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::BlockStart).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(5, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![5]);
-        atn.add_decision_state(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
+        let mut atn = ParserAtnBuilder::new(3);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![5])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
         // Optional block: match A then fall through, or skip straight to state 3.
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 1,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 3 });
+            },
+        )
+        .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 3 })
+            .expect("transition");
         // Match B, then EOF.
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Atom {
+        atn.add_transition(
+            3,
+            ParserTransitionSpec::Atom {
                 target: 4,
                 label: 2,
-            });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            4,
+            ParserTransitionSpec::Atom {
                 target: 5,
                 label: TOKEN_EOF,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     #[test]
@@ -11557,7 +11765,7 @@ mod tests {
             0, 0, 5, 3, 1, 0, 0, 0, 5, 6, 1, 0, 0, 0, 6, 8, 1, 0, 0, 0, 7, 5, 1, 0, 0, 0, 8, 9, 5,
             0, 0, 1, 9, 1, 1, 0, 0, 0, 1, 5,
         ]))
-        .deserialize()
+        .deserialize_parser()
         .expect("star-loop-then-EOF ATN should deserialize")
     }
 
@@ -11567,62 +11775,112 @@ mod tests {
     /// `+` loop must not treat that zero-width child as a successful iteration
     /// and then re-enter the loop at the same token index.
     fn plus_loop_with_recovering_body_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        let mut loop_start = AtnState::new(1, AtnStateKind::PlusBlockStart).with_rule_index(0);
-        loop_start.end_state = Some(3);
-        atn.add_state(loop_start);
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::BlockEnd).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::PlusLoopBack).with_rule_index(0));
-        let mut loop_end = AtnState::new(5, AtnStateKind::LoopEnd).with_rule_index(0);
-        loop_end.loop_back_state = Some(4);
-        atn.add_state(loop_end);
-        atn.add_state(AtnState::new(6, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.add_state(AtnState::new(7, AtnStateKind::RuleStart).with_rule_index(1));
-        atn.add_state(AtnState::new(8, AtnStateKind::Basic).with_rule_index(1));
-        atn.add_state(AtnState::new(9, AtnStateKind::RuleStop).with_rule_index(1));
-        atn.set_rule_to_start_state(vec![0, 7]);
-        atn.set_rule_to_stop_state(vec![6, 9]);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Epsilon { target: 2 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Rule {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::PlusBlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockEnd, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::PlusLoopBack, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::LoopEnd, Some(0))
+                .expect("state")
+                .index(),
+            5
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            6
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(1))
+                .expect("state")
+                .index(),
+            7
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(1))
+                .expect("state")
+                .index(),
+            8
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(1))
+                .expect("state")
+                .index(),
+            9
+        );
+        atn.set_rule_to_start_state(vec![0, 7])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![6, 9])
+            .expect("rule stop states");
+        atn.set_end_state(1, 3).expect("block end state");
+        atn.set_loop_back_state(5, 4).expect("loop back state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Rule {
                 target: 7,
                 rule_index: 1,
                 follow_state: 3,
                 precedence: 0,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(4)
-            .expect("state 4")
-            .add_transition(Transition::Epsilon { target: 5 });
-        atn.state_mut(5)
-            .expect("state 5")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(4, ParserTransitionSpec::Epsilon { target: 5 })
+            .expect("transition");
+        atn.add_transition(
+            5,
+            ParserTransitionSpec::Atom {
                 target: 6,
                 label: 2,
-            });
-        atn.state_mut(7)
-            .expect("state 7")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            7,
+            ParserTransitionSpec::Atom {
                 target: 8,
                 label: 1,
-            });
-        atn.state_mut(8)
-            .expect("state 8")
-            .add_transition(Transition::Epsilon { target: 9 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(8, ParserTransitionSpec::Epsilon { target: 9 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     #[test]
@@ -11734,42 +11992,74 @@ mod tests {
     }
 
     fn predicate_after_token_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![4]);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Atom {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            4
+        );
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![4])
+            .expect("rule stop states");
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Atom {
                 target: 1,
                 label: 1,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Predicate {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Predicate {
                 target: 2,
                 rule_index: 0,
                 pred_index: 0,
                 context_dependent: false,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: 2,
-            });
-        atn.state_mut(3)
-            .expect("state 3")
-            .add_transition(Transition::Epsilon { target: 4 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(3, ParserTransitionSpec::Epsilon { target: 4 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn nested_nullable_context_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
+        let mut atn = ParserAtnBuilder::new(1);
         for state_number in 0..=20 {
             let kind = match state_number {
                 0 | 10 | 16 => AtnStateKind::RuleStart,
@@ -11781,104 +12071,182 @@ mod tests {
                 10..=15 => 1,
                 _ => 2,
             };
-            atn.add_state(AtnState::new(state_number, kind).with_rule_index(rule_index));
+            assert_eq!(
+                atn.add_state(kind, Some(rule_index))
+                    .expect("state")
+                    .index(),
+                state_number
+            );
         }
-        atn.set_rule_to_start_state(vec![0, 10, 16]);
-        atn.set_rule_to_stop_state(vec![9, 15, 20]);
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Rule {
+        atn.set_rule_to_start_state(vec![0, 10, 16])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![9, 15, 20])
+            .expect("rule stop states");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Rule {
                 target: 10,
                 rule_index: 1,
                 follow_state: 8,
                 precedence: 0,
-            });
-        atn.state_mut(8)
-            .expect("state 8")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            8,
+            ParserTransitionSpec::Atom {
                 target: 9,
                 label: 1,
-            });
-        atn.state_mut(8)
-            .expect("state 8")
-            .add_transition(Transition::Epsilon { target: 9 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Rule {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(8, ParserTransitionSpec::Epsilon { target: 9 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Rule {
                 target: 16,
                 rule_index: 2,
                 follow_state: 14,
                 precedence: 0,
-            });
-        atn.state_mut(14)
-            .expect("state 14")
-            .add_transition(Transition::Epsilon { target: 15 });
-        atn
+            },
+        )
+        .expect("transition");
+        atn.add_transition(14, ParserTransitionSpec::Epsilon { target: 15 })
+            .expect("transition");
+        finish_atn(atn)
     }
 
     fn generated_match_recovery_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.add_state(AtnState::new(3, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.add_state(AtnState::new(4, AtnStateKind::RuleStart).with_rule_index(1));
-        atn.add_state(AtnState::new(5, AtnStateKind::RuleStop).with_rule_index(1));
-        atn.set_rule_to_start_state(vec![0, 4]);
-        atn.set_rule_to_stop_state(vec![3, 5]);
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Rule {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            3
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(1))
+                .expect("state")
+                .index(),
+            4
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(1))
+                .expect("state")
+                .index(),
+            5
+        );
+        atn.set_rule_to_start_state(vec![0, 4])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![3, 5])
+            .expect("rule stop states");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Rule {
                 target: 4,
                 rule_index: 1,
                 follow_state: 2,
                 precedence: 0,
-            });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 3,
                 label: TOKEN_EOF,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     fn complement_set_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![1]);
-        let mut excluded = IntervalSet::new();
-        excluded.add(1);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::NotSet {
+        let mut atn = ParserAtnBuilder::new(1);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![1])
+            .expect("rule stop states");
+        let excluded = atn.add_interval_set([(1, 1)]).expect("excluded set");
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::NotSet {
                 target: 1,
                 set: excluded,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     /// ATN for `start : . EOF ;`: a wildcard whose follow state explicitly matches
     /// EOF. State 0 (`RuleStart`) -wildcard-> 2 -EOF-> 1 (`RuleStop`).
     fn wildcard_then_eof_atn() -> Atn {
-        let mut atn = Atn::new(AtnType::Parser, 1);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::Basic).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![1]);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Wildcard { target: 2 });
-        atn.state_mut(2)
-            .expect("state 2")
-            .add_transition(Transition::Atom {
+        let mut atn = ParserAtnBuilder::new(1);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::Basic, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![1])
+            .expect("rule stop states");
+        atn.add_transition(0, ParserTransitionSpec::Wildcard { target: 2 })
+            .expect("transition");
+        atn.add_transition(
+            2,
+            ParserTransitionSpec::Atom {
                 target: 1,
                 label: TOKEN_EOF,
-            });
-        atn
+            },
+        )
+        .expect("transition");
+        finish_atn(atn)
     }
 
     #[test]
@@ -12545,27 +12913,48 @@ mod tests {
 
     #[test]
     fn clean_empty_multi_alt_outcomes_are_memoized() {
-        let mut atn = Atn::new(AtnType::Parser, 2);
-        atn.add_state(AtnState::new(0, AtnStateKind::RuleStart).with_rule_index(0));
-        atn.add_state(AtnState::new(1, AtnStateKind::BlockStart).with_rule_index(0));
-        atn.add_state(AtnState::new(2, AtnStateKind::RuleStop).with_rule_index(0));
-        atn.set_rule_to_start_state(vec![0]);
-        atn.set_rule_to_stop_state(vec![2]);
-        atn.state_mut(0)
-            .expect("state 0")
-            .add_transition(Transition::Epsilon { target: 1 });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+        let mut atn = ParserAtnBuilder::new(2);
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStart, Some(0))
+                .expect("state")
+                .index(),
+            0
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::BlockStart, Some(0))
+                .expect("state")
+                .index(),
+            1
+        );
+        assert_eq!(
+            atn.add_state(AtnStateKind::RuleStop, Some(0))
+                .expect("state")
+                .index(),
+            2
+        );
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![2])
+            .expect("rule stop states");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 1,
-            });
-        atn.state_mut(1)
-            .expect("state 1")
-            .add_transition(Transition::Atom {
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Atom {
                 target: 2,
                 label: 2,
-            });
+            },
+        )
+        .expect("transition");
+        let atn = finish_atn(atn);
 
         let mut parser = mini_parser(vec![TestToken::eof("parser-test", 0, 1, 0)]);
         parser.fast_recovery_enabled = false;


### PR DESCRIPTION
Closes #87

## Summary

- Replace the parser ATN object graph with one validated, versioned packed word stream using compact state/transition IDs, contiguous transition ranges, and pooled interval data.
- Compile parser ATNs in `antlr4-rust-gen` and embed the packed representation directly in generated parsers, with clear format/version validation and no compatibility fallback.
- Adapt parser simulation and generated rule recognition to borrowing state/transition views, including hot-path scalar dispatch and interval-set lookup optimizations.
- Keep lexer graph simulation separate under the explicit `LexerAtn`, `LexerAtnState`, and `LexerTransition` names.
- Document the breaking regeneration requirement, migration path, and benchmark evidence.

## Impact

Generated parsers must be regenerated with the matching generator/runtime release. Older generated parsers do not contain the packed format and are intentionally source- and data-incompatible.

Across Kotlin, C#, Java, and Trino parser ATNs, construction allocations fall from 11,702 to zero and retained ATN storage falls from 3,450,664 bytes to 590,444 bytes (82.9%). Validation is approximately 3.5-4x faster. The generated artifact grows by 2.4% for the four-grammar benchmark executable.

Warm end-to-end parsing is neutral to slightly faster overall, and interleaved checks found no confirmed protected fixture regression above 2%. The final normal-mode hot-path refinement made Kotlin 2.32% faster than the pre-refinement packed build.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test --locked --all-targets --all-features` (340 passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- Kotlin parity against `antlr4-python3-runtime` (9/9 parse trees match)
- ANTLR runtime testsuite (356 passed, 0 failed, 1 documented skip)
- Same-machine protected-language warm/cold, construction, allocation, resident-size, and artifact-size benchmarks recorded in `docs/issue-87-parser-atn-benchmark.md`