### PR TITLE
Add generic lexer lifecycle extension contract

### DIFF
--- a/.conformance-review/Rust.test.stg
+++ b/.conformance-review/Rust.test.stg
@@ -160,110 +160,12 @@ fn Property(&self) -> bool {
 
 ParserPropertyCall(p, call) ::= "<p>.<call>"
 
-PositionAdjustingLexerDef() ::= <<
-struct PositionAdjustingLexerATNSimulator {
-    base: LexerATNSimulator,
-}
+// The Rust conformance harness supplies this behavior through
+// SemanticHooks::lexer_after_accept, exercising the public lifecycle contract
+// instead of injecting a target-specific superclass.
+PositionAdjustingLexerDef() ::= ""
 
-impl PositionAdjustingLexerATNSimulator {
-    fn new(
-        atn: Arc\<ATN>,
-        decision_to_dfa: Arc\<Vec\<DFA>\>,
-        shared_context_cache: Arc\<PredictionContextCache>,
-    ) -> Self {
-        Self {
-            base: LexerATNSimulator::new(atn, decision_to_dfa, shared_context_cache),
-        }
-    }
-
-    fn reset_accept_position(
-        &mut self,
-        input: &mut dyn CharStream,
-        index: isize,
-        line: isize,
-        char_position_in_line: isize,
-    ) {
-        input.seek(index);
-        self.base.set_line(line);
-        self.base.set_char_position_in_line(char_position_in_line);
-        self.base.consume(input);
-    }
-}
->>
-
-PositionAdjustingLexer() ::= <<
-
-fn next_token(&mut self) -> Box\<dyn Token> {
-    if !self.interpreter().is::\<PositionAdjustingLexerATNSimulator>() {
-        let sim = PositionAdjustingLexerATNSimulator::new(
-            self.atn(),
-            self.decision_to_dfa(),
-            self.shared_context_cache(),
-        );
-        self.set_interpreter(Box::new(sim));
-    }
-    self.base_next_token()
-}
-
-fn emit(&mut self) -> Box\<dyn Token> {
-    match self.token_type() {
-        Self::TOKENS => {
-            self.handle_accept_position_for_keyword("tokens");
-        }
-        Self::LABEL => {
-            self.handle_accept_position_for_identifier();
-        }
-        _ => {}
-    }
-    self.base_emit()
-}
-
-fn handle_accept_position_for_identifier(&mut self) -> bool {
-    let token_text = self.text();
-    let mut identifier_length = 0usize;
-    let chars: Vec\<char> = token_text.chars().collect();
-    while identifier_length \< chars.len() && Self::is_identifier_char(chars[identifier_length]) {
-        identifier_length += 1;
-    }
-
-    let identifier_length = identifier_length as isize;
-    if self.input().index() > self.token_start_char_index() + identifier_length {
-        let offset = identifier_length - 1;
-        let (input, index, line, column) = (
-            self.input_mut(),
-            self.token_start_char_index() + offset,
-            self.token_start_line(),
-            self.token_start_char_position_in_line() + offset,
-        );
-        self.interpreter_as::\<PositionAdjustingLexerATNSimulator>()
-            .reset_accept_position(input, index, line, column);
-        return true;
-    }
-    false
-}
-
-fn handle_accept_position_for_keyword(&mut self, keyword: &str) -> bool {
-    let keyword_len = keyword.chars().count() as isize;
-    if self.input().index() > self.token_start_char_index() + keyword_len {
-        let offset = keyword_len - 1;
-        let (input, index, line, column) = (
-            self.input_mut(),
-            self.token_start_char_index() + offset,
-            self.token_start_line(),
-            self.token_start_char_position_in_line() + offset,
-        );
-        self.interpreter_as::\<PositionAdjustingLexerATNSimulator>()
-            .reset_accept_position(input, index, line, column);
-        return true;
-    }
-    false
-}
-
-fn is_identifier_char(c: char) -> bool {
-    c.is_alphanumeric() || c == '_'
-}
-
->>
+PositionAdjustingLexer() ::= ""
 
 BasicListener(X) ::= <<
 @parser::members {

--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ form.
   compilation of serialized parser ATNs into packed runtime tables.
 - Supports lexer and parser execution through generated Rust wrappers.
 - Supports real split lexer/parser grammars, including Kotlin smoke builds.
-- Passes every supported upstream ANTLR runtime-testsuite descriptor discovered
-  by the harness: `356 passed, 0 failed, 1 skipped, 356 run`.
+- Passes every upstream ANTLR runtime-testsuite descriptor discovered by the
+  harness: `357 passed, 0 failed, 0 skipped, 357 run`.
 - Licensed under BSD-3-Clause for compatibility with ANTLR's runtime licensing
   pattern and downstream open-source applications.
 
@@ -267,6 +267,22 @@ arbitrary grammar-embedded snippets. The boundary is:
   grammar-author source, is a runtime no-op, and is exempt from the `error`
   gate — only actions the author actually wrote in the grammar can fail it.
 
+When `--grammar` is present, the same manifest inventories top-level grammar
+options. Options already represented by ANTLR metadata (`tokenVocab` and
+`caseInsensitive`) are recorded without a warning. Target extension options
+such as `superClass` and `contextSuperClass` warn because the Rust backend
+cannot inherit their target-language implementation automatically. If
+caller-owned Rust hooks provide that behavior, acknowledge the exact option:
+
+```bash
+antlr4-rust-gen --lexer L.interp --grammar L.g4 \
+    --option-hook superClass=MyLexerBase --out-dir src/generated
+```
+
+Acknowledged options have the `hooked` disposition. Unacknowledged target
+options have the `unsupported` disposition and make
+`--require-full-semantics` fail.
+
 Unknown coordinates are governed by `--sem-unknown`:
 
 ```bash
@@ -312,6 +328,16 @@ mutators. Actions can also queue a prefix token and advance the current token
 start, allowing one lexer match to return multiple tokens while each
 `TokenSource::next_token` call still appends exactly one token.
 
+Lexer behavior that has no ATN action/predicate coordinate uses
+`LexerLifecycleCtx`. A hook may implement `lexer_before_token`,
+`lexer_after_accept`, `lexer_reset`, and the existing
+`lexer_token_emitted` observer. The post-accept callback runs after portable
+and custom actions but before the token span is emitted, including for rules
+with no semantic transition. Generated lexers expose `reset()` to clear
+runtime-owned pending tokens and invoke extension-owned cleanup. Lexers built
+with `new()` retain the direct compiled-DFA path; `with_hooks()` opts into the
+lifecycle dispatch path.
+
 Generated lexers also own optional hook state and emit typed lexer adapters
 when a semantic pattern maps lexer helper calls to hooks. The official
 grammars-v4 JavaScript and TypeScript grammars are complete examples, including
@@ -319,8 +345,9 @@ checked-in Rust lexer/parser base modules and strict build commands; see
 [`docs/javascript-build.md`](docs/javascript-build.md) and
 [`docs/typescript-build.md`](docs/typescript-build.md).
 
-Use `--require-full-semantics` in CI when every coordinate must be either
-translated or explicitly hooked; policy fallbacks fail generation.
+Use `--require-full-semantics` in CI when every coordinate and target extension
+option must be either translated, metadata-backed, or explicitly hooked;
+policy fallbacks and unsupported options fail generation.
 
 #### Embedded target-language actions are not portable — including in official ANTLR
 

--- a/docs/javascript-build.md
+++ b/docs/javascript-build.md
@@ -60,6 +60,7 @@ cargo run --locked --release --bin antlr4-rust-gen -- \
   --lexer "$BUILD/interp/JavaScriptLexer.interp" \
   --grammar "$GRAMMAR/JavaScriptLexer.g4" \
   --sem-patterns patterns/javascript.toml \
+  --option-hook superClass=JavaScriptLexerBase \
   --sem-unknown error \
   --require-full-semantics \
   --out-dir "$BUILD/lexer"
@@ -68,6 +69,7 @@ cargo run --locked --release --bin antlr4-rust-gen -- \
   --parser "$BUILD/interp/JavaScriptParser.interp" \
   --grammar "$GRAMMAR/JavaScriptParser.g4" \
   --sem-patterns patterns/javascript.toml \
+  --option-hook superClass=JavaScriptParserBase \
   --sem-unknown error \
   --require-full-semantics \
   --out-dir "$BUILD/parser"
@@ -77,6 +79,8 @@ This deliberately does not use `--allow-unsupported-lexer-actions`: every
 authored coordinate is translated or routed to a typed Rust hook. It also does
 not use `--require-generated-parser`; rules outside the current direct compiler
 use the faithful runtime ATN interpreter, including the same semantic hooks.
+The `--option-hook` acknowledgements record that the checked-in Rust base-hook
+modules supply the grammars' superclass behavior.
 
 Copy these files into an application crate:
 

--- a/docs/runtime-testsuite.md
+++ b/docs/runtime-testsuite.md
@@ -92,7 +92,7 @@ Supported now:
 - lexer DFA dump output for the predicate-sensitive `SemPredEvalLexer`
   `showDFA` fixtures,
 - lexer accept-position adjustment for the upstream `PositionAdjustingLexer`
-  target template,
+  through the same generic post-accept lifecycle hook available to callers,
 - parser `@init {<BuildParseTrees()>}` and `notBuildParseTree` descriptors,
 - parser `predictionMode=LL` and `predictionMode=SLL` descriptors modeled by
   the metadata recognizer,

--- a/docs/typescript-build.md
+++ b/docs/typescript-build.md
@@ -57,6 +57,7 @@ cargo run --locked --release --bin antlr4-rust-gen -- \
   --lexer "$BUILD/interp/TypeScriptLexer.interp" \
   --grammar "$GRAMMAR/TypeScriptLexer.g4" \
   --sem-patterns patterns/javascript.toml \
+  --option-hook superClass=TypeScriptLexerBase \
   --sem-unknown error \
   --require-full-semantics \
   --out-dir "$BUILD/lexer"
@@ -65,6 +66,7 @@ cargo run --locked --release --bin antlr4-rust-gen -- \
   --parser "$BUILD/interp/TypeScriptParser.interp" \
   --grammar "$GRAMMAR/TypeScriptParser.g4" \
   --sem-patterns patterns/javascript.toml \
+  --option-hook superClass=TypeScriptParserBase \
   --sem-unknown error \
   --require-full-semantics \
   --out-dir "$BUILD/parser"
@@ -74,6 +76,8 @@ Every authored action and predicate is either translated or routed to a typed
 hook. Do not pass `--allow-unsupported-lexer-actions`: the TypeScript base needs
 all template, brace, strict-mode, regex, and token-lookaround helpers to retain
 the official grammar's behavior.
+The `--option-hook` acknowledgements record that those Rust hooks supply the
+otherwise target-specific superclass behavior.
 
 Copy these files into an application crate:
 

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -8,8 +8,8 @@ use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
 use crate::lexer::{
     BaseLexer, Lexer, LexerCustomAction, LexerDfaActionKey, LexerDfaCachedAccept,
-    LexerDfaCachedState, LexerDfaCachedTransition, LexerDfaConfigKey, LexerDfaKey, LexerPredicate,
-    LexerSemCtx,
+    LexerDfaCachedState, LexerDfaCachedTransition, LexerDfaConfigKey, LexerDfaKey,
+    LexerLifecycleCtx, LexerPredicate, LexerSemCtx,
 };
 use crate::parser::{SemanticHooks, UnknownSemanticPolicy};
 use crate::prediction::PredictionFxHasher;
@@ -145,9 +145,9 @@ where
 /// Runs one lexer-token match and lets generated code adjust the final accept
 /// position before the token is emitted.
 ///
-/// ANTLR target templates such as `PositionAdjustingLexer` use this to accept
-/// a long disambiguating token path but emit only the prefix, leaving the
-/// remaining characters for the next token.
+/// Generated lexer extensions use this to accept a long disambiguating token
+/// path but emit only a prefix, leaving the remaining characters for the next
+/// token.
 pub fn next_token_with_accept_adjuster<I, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
@@ -212,6 +212,7 @@ where
         atn,
         &mut custom_action,
         &mut semantic_predicate,
+        &mut |_| {},
         &mut accept_adjuster,
         LexerMatchStrategy {
             compiled: None,
@@ -271,6 +272,38 @@ where
         .lexer_sempred(&mut ctx, predicate.rule_index(), predicate.pred_index())
 }
 
+fn dispatch_lexer_before_token_hook<I, H>(hooks: &RefCell<&mut H>, lexer: &mut BaseLexer<I>)
+where
+    I: CharStream,
+    H: SemanticHooks,
+{
+    let mut ctx = LexerLifecycleCtx::new(lexer, None);
+    hooks.borrow_mut().lexer_before_token(&mut ctx);
+}
+
+fn dispatch_lexer_after_accept_hook<I, H>(
+    hooks: &RefCell<&mut H>,
+    lexer: &mut BaseLexer<I>,
+    accept_position: usize,
+) where
+    I: CharStream,
+    H: SemanticHooks,
+{
+    let mut ctx = LexerLifecycleCtx::new(lexer, Some(accept_position));
+    hooks.borrow_mut().lexer_after_accept(&mut ctx);
+}
+
+/// Resets a base lexer and its caller-owned lifecycle state for reuse.
+pub fn reset_with_semantic_hooks<I, H>(lexer: &mut BaseLexer<I>, hooks: &mut H)
+where
+    I: CharStream,
+    H: SemanticHooks,
+{
+    lexer.reset();
+    let mut ctx = LexerLifecycleCtx::new(lexer, None);
+    hooks.lexer_reset(&mut ctx);
+}
+
 /// Runs one lexer-token match with a shared [`SemanticHooks`] object.
 ///
 /// This is the trait-based facade over the historical lexer closure hooks.
@@ -288,15 +321,24 @@ where
     H: SemanticHooks,
 {
     let hooks = RefCell::new(hooks);
-    let token = next_token_with_hooks(
+    let token = next_token_with_hooks_impl(
         lexer,
         sink,
         atn,
-        |lexer, action| {
+        &mut |lexer, action| {
             let _ = dispatch_lexer_action_hook(&hooks, lexer, action);
         },
-        |lexer, predicate| dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true),
-        |_, _, _| {},
+        &mut |lexer, predicate| {
+            dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true)
+        },
+        &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
+        &mut |lexer, _, accept_position| {
+            dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
+        },
+        LexerMatchStrategy {
+            compiled: None,
+            use_cache: false,
+        },
     );
     let token = token?;
     hooks.borrow_mut().lexer_token_emitted(
@@ -326,6 +368,7 @@ where
         atn,
         &mut |_, _| {},
         &mut |_, _| true,
+        &mut |_| {},
         &mut |_, _, _| {},
         LexerMatchStrategy {
             compiled: Some(dfa),
@@ -361,6 +404,7 @@ where
         atn,
         &mut custom_action,
         &mut semantic_predicate,
+        &mut |_| {},
         &mut accept_adjuster,
         LexerMatchStrategy {
             compiled: Some(dfa),
@@ -383,16 +427,24 @@ where
     H: SemanticHooks,
 {
     let hooks = RefCell::new(hooks);
-    let token = next_token_compiled_with_hooks(
+    let token = next_token_with_hooks_impl(
         lexer,
         sink,
         atn,
-        dfa,
-        |lexer, action| {
+        &mut |lexer, action| {
             let _ = dispatch_lexer_action_hook(&hooks, lexer, action);
         },
-        |lexer, predicate| dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true),
-        |_, _, _| {},
+        &mut |lexer, predicate| {
+            dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true)
+        },
+        &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
+        &mut |lexer, _, accept_position| {
+            dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
+        },
+        LexerMatchStrategy {
+            compiled: Some(dfa),
+            use_cache: false,
+        },
     );
     let token = token?;
     hooks.borrow_mut().lexer_token_emitted(
@@ -418,7 +470,7 @@ pub fn next_token_with_semantic_dispatch<I, H, A, P, E>(
     mut generated_action: A,
     mut generated_predicate: P,
     unknown_policy: UnknownSemanticPolicy,
-    accept_adjuster: E,
+    mut accept_adjuster: E,
 ) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
@@ -428,11 +480,11 @@ where
     E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     let hooks = RefCell::new(hooks);
-    let token = next_token_with_hooks(
+    let token = next_token_with_hooks_impl(
         lexer,
         sink,
         atn,
-        |lexer, action| {
+        &mut |lexer, action| {
             if !generated_action(lexer, action)
                 && !dispatch_lexer_action_hook(&hooks, lexer, action)
                 && unknown_policy == UnknownSemanticPolicy::Error
@@ -444,7 +496,7 @@ where
                 lexer.record_semantic_error(true, rule, index);
             }
         },
-        |lexer, predicate| {
+        &mut |lexer, predicate| {
             generated_predicate(lexer, predicate)
                 .or_else(|| dispatch_lexer_predicate_hook(&hooks, lexer, predicate))
                 .unwrap_or_else(|| match unknown_policy {
@@ -460,7 +512,15 @@ where
                     }
                 })
         },
-        accept_adjuster,
+        &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
+        &mut |lexer, token_type, accept_position| {
+            accept_adjuster(lexer, token_type, accept_position);
+            dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
+        },
+        LexerMatchStrategy {
+            compiled: None,
+            use_cache: false,
+        },
     );
     let token = token?;
     hooks.borrow_mut().lexer_token_emitted(
@@ -481,7 +541,7 @@ pub fn next_token_compiled_with_semantic_dispatch<I, H, A, P, E>(
     mut generated_action: A,
     mut generated_predicate: P,
     unknown_policy: UnknownSemanticPolicy,
-    accept_adjuster: E,
+    mut accept_adjuster: E,
 ) -> Result<TokenId, TokenStoreError>
 where
     I: CharStream,
@@ -491,12 +551,11 @@ where
     E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
     let hooks = RefCell::new(hooks);
-    let token = next_token_compiled_with_hooks(
+    let token = next_token_with_hooks_impl(
         lexer,
         sink,
         atn,
-        dfa,
-        |lexer, action| {
+        &mut |lexer, action| {
             if !generated_action(lexer, action)
                 && !dispatch_lexer_action_hook(&hooks, lexer, action)
                 && unknown_policy == UnknownSemanticPolicy::Error
@@ -508,7 +567,7 @@ where
                 lexer.record_semantic_error(true, rule, index);
             }
         },
-        |lexer, predicate| {
+        &mut |lexer, predicate| {
             generated_predicate(lexer, predicate)
                 .or_else(|| dispatch_lexer_predicate_hook(&hooks, lexer, predicate))
                 .unwrap_or_else(|| match unknown_policy {
@@ -524,7 +583,15 @@ where
                     }
                 })
         },
-        accept_adjuster,
+        &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
+        &mut |lexer, token_type, accept_position| {
+            accept_adjuster(lexer, token_type, accept_position);
+            dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
+        },
+        LexerMatchStrategy {
+            compiled: Some(dfa),
+            use_cache: false,
+        },
     );
     let token = token?;
     hooks.borrow_mut().lexer_token_emitted(
@@ -554,6 +621,7 @@ where
         atn,
         &mut custom_action,
         &mut semantic_predicate,
+        &mut |_| {},
         &mut accept_adjuster,
         LexerMatchStrategy {
             compiled: None,
@@ -601,12 +669,13 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn next_token_with_hooks_impl<I, A, P, E>(
+fn next_token_with_hooks_impl<I, A, P, B, E>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
     atn: &LexerAtn,
     custom_action: &mut A,
     semantic_predicate: &mut P,
+    before_token: &mut B,
     accept_adjuster: &mut E,
     strategy: LexerMatchStrategy<'_>,
 ) -> Result<TokenId, TokenStoreError>
@@ -614,14 +683,16 @@ where
     I: CharStream,
     A: FnMut(&mut BaseLexer<I>, LexerCustomAction),
     P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
+    B: FnMut(&mut BaseLexer<I>),
     E: FnMut(&mut BaseLexer<I>, i32, usize),
 {
-    if let Some(token) = lexer.emit_pending_token(sink)? {
-        return Ok(token);
-    }
-
     let mut continuing_more = false;
     loop {
+        before_token(lexer);
+        if let Some(token) = lexer.emit_pending_token(sink)? {
+            return Ok(token);
+        }
+
         if lexer.hit_eof() {
             return lexer.emit_eof_or_pending(sink);
         }
@@ -691,6 +762,14 @@ where
         }
 
         accept_adjuster(lexer, token_type, accept.position);
+        let token_type = lexer.token_type();
+        if token_type == crate::lexer::SKIP || token_type == crate::lexer::MORE {
+            if accept.consumed_eof || lexer.input().index() != accept.position {
+                refresh_hit_eof(lexer);
+            }
+            continuing_more = token_type == crate::lexer::MORE;
+            continue;
+        }
         let emit_position = lexer.input().index();
         let hit_eof = if accept.consumed_eof || emit_position != accept.position {
             refresh_hit_eof(lexer)
@@ -1632,6 +1711,54 @@ mod tests {
         atn
     }
 
+    fn lifecycle_rewind_atn() -> LexerAtn {
+        let mut atn = LexerAtn::new(2);
+        for (state_number, kind, rule_index) in [
+            (0, AtnStateKind::TokenStart, None),
+            (1, AtnStateKind::RuleStart, Some(0)),
+            (2, AtnStateKind::Basic, Some(0)),
+            (3, AtnStateKind::RuleStop, Some(0)),
+            (4, AtnStateKind::RuleStart, Some(1)),
+            (5, AtnStateKind::RuleStop, Some(1)),
+        ] {
+            let mut state = LexerAtnState::new(state_number, kind);
+            if let Some(rule_index) = rule_index {
+                state = state.with_rule_index(rule_index);
+            }
+            atn.add_state(state);
+        }
+        atn.state_mut(0)
+            .expect("token start")
+            .add_transition(LexerTransition::Epsilon { target: 1 });
+        atn.state_mut(0)
+            .expect("token start")
+            .add_transition(LexerTransition::Epsilon { target: 4 });
+        atn.state_mut(1)
+            .expect("long rule start")
+            .add_transition(LexerTransition::Atom {
+                target: 2,
+                label: 'a' as i32,
+            });
+        atn.state_mut(2)
+            .expect("long rule body")
+            .add_transition(LexerTransition::Atom {
+                target: 3,
+                label: 'b' as i32,
+            });
+        atn.state_mut(4)
+            .expect("suffix rule start")
+            .add_transition(LexerTransition::Atom {
+                target: 5,
+                label: 'b' as i32,
+            });
+        atn.set_rule_to_start_state(vec![1, 4]);
+        atn.set_rule_to_stop_state(vec![3, 5]);
+        atn.set_rule_to_token_type(vec![1, 2]);
+        atn.add_mode_start_state(0);
+        atn.add_decision_state(0);
+        atn
+    }
+
     fn lex_one<I: CharStream>(lexer: &mut BaseLexer<I>, atn: &LexerAtn) -> TokenSnapshot {
         let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
         let mut sink = TokenSink::new(&mut store);
@@ -1647,6 +1774,7 @@ mod tests {
 
     #[derive(Debug, Default)]
     struct FunctionTokenHooks {
+        accepted: Vec<(i32, i32, String)>,
         emitted: Vec<(i32, i32, String)>,
     }
 
@@ -1667,6 +1795,14 @@ mod tests {
             assert_eq!(ctx.la(1), '(' as i32);
             assert!(ctx.set_type(7));
             true
+        }
+
+        fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.accepted
+                .push((ctx.token_type(), ctx.channel(), ctx.token_text()));
         }
 
         fn lexer_token_emitted(&mut self, token: TokenView<'_>) {
@@ -1697,15 +1833,24 @@ mod tests {
         assert_eq!(token.channel(), HIDDEN_CHANNEL);
         assert_eq!(token.text(), "count \t");
         assert_eq!(lexer.la(1), '(' as i32);
+        assert_eq!(hooks.accepted, [(7, HIDDEN_CHANNEL, "count \t".to_owned())]);
         assert_eq!(hooks.emitted, [(7, HIDDEN_CHANNEL, "count \t".to_owned())]);
     }
 
     #[derive(Debug, Default)]
     struct DotSplitHooks {
+        before_pending_counts: Vec<usize>,
         emitted_types: Vec<i32>,
     }
 
     impl SemanticHooks for DotSplitHooks {
+        fn lexer_before_token<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.before_pending_counts.push(ctx.pending_token_count());
+        }
+
         fn lexer_action<I>(
             &mut self,
             ctx: &mut LexerSemCtx<'_, I>,
@@ -1781,6 +1926,7 @@ mod tests {
             sink.view(eof).expect("EOF token should exist").token_type(),
             TOKEN_EOF
         );
+        assert_eq!(hooks.before_pending_counts, [0, 1, 0]);
         assert_eq!(hooks.emitted_types, [1, 2, TOKEN_EOF]);
     }
 
@@ -1835,6 +1981,251 @@ mod tests {
             TOKEN_EOF
         );
         assert_eq!(hooks.action_count, 1);
+    }
+
+    #[derive(Debug, Default)]
+    struct LifecycleRecordingHooks {
+        events: Vec<String>,
+    }
+
+    impl SemanticHooks for LifecycleRecordingHooks {
+        fn lexer_before_token<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.events.push(format!(
+                "before:{}:{}",
+                ctx.input_position(),
+                ctx.pending_token_count()
+            ));
+        }
+
+        fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.events.push(format!(
+                "accept:{}:{}",
+                ctx.token_type(),
+                ctx.accepted_text().expect("accepted callback has text")
+            ));
+            if ctx.token_type() == 1 {
+                ctx.reset_accept_position(ctx.token_start() + 1);
+            }
+        }
+
+        fn lexer_token_emitted(&mut self, token: TokenView<'_>) {
+            self.events
+                .push(format!("emit:{}:{}", token.token_type(), token.text()));
+        }
+    }
+
+    fn lifecycle_tokens(compiled: bool) -> (Vec<(i32, String)>, Vec<String>) {
+        let atn = lifecycle_rewind_atn();
+        let dfa = CompiledLexerDfa::compile(&atn);
+        let mut lexer = BaseLexer::new(InputStream::new("ab"), recognizer_data());
+        let mut hooks = LifecycleRecordingHooks::default();
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let mut ids = Vec::new();
+        for _ in 0..3 {
+            let id = if compiled {
+                next_token_compiled_with_semantic_hooks(
+                    &mut lexer, &mut sink, &atn, &dfa, &mut hooks,
+                )
+            } else {
+                next_token_with_semantic_hooks(&mut lexer, &mut sink, &atn, &mut hooks)
+            }
+            .expect("lifecycle token should fit");
+            ids.push(id);
+        }
+        let tokens = ids
+            .into_iter()
+            .map(|id| {
+                let token = sink.view(id).expect("lifecycle token should exist");
+                (token.token_type(), token.text().to_owned())
+            })
+            .collect();
+        (tokens, hooks.events)
+    }
+
+    #[test]
+    fn lifecycle_post_accept_runs_without_actions_and_matches_compiled_order() {
+        let interpreted = lifecycle_tokens(false);
+        let compiled = lifecycle_tokens(true);
+
+        assert_eq!(interpreted, compiled);
+        assert_eq!(
+            interpreted.0,
+            [
+                (1, "a".to_owned()),
+                (2, "b".to_owned()),
+                (TOKEN_EOF, "<EOF>".to_owned()),
+            ]
+        );
+        assert_eq!(
+            interpreted.1,
+            [
+                "before:0:0",
+                "accept:1:ab",
+                "emit:1:a",
+                "before:1:0",
+                "accept:2:b",
+                "emit:2:b",
+                "before:2:0",
+                "emit:-1:<EOF>",
+            ]
+        );
+    }
+
+    #[derive(Debug, Default)]
+    struct MoreAfterAcceptHooks {
+        events: Vec<String>,
+    }
+
+    impl SemanticHooks for MoreAfterAcceptHooks {
+        fn lexer_before_token<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.events.push(format!("before:{}", ctx.input_position()));
+        }
+
+        fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.events.push(format!(
+                "accept:{}:{}",
+                ctx.token_type(),
+                ctx.accepted_text().expect("accepted callback has text")
+            ));
+            if ctx.token_type() == 1 {
+                ctx.more();
+            }
+        }
+
+        fn lexer_token_emitted(&mut self, token: TokenView<'_>) {
+            self.events
+                .push(format!("emit:{}:{}", token.token_type(), token.text()));
+        }
+    }
+
+    fn lifecycle_more_token(compiled: bool) -> ((i32, String), Vec<String>) {
+        let atn = lifecycle_rewind_atn();
+        let dfa = CompiledLexerDfa::compile(&atn);
+        let mut lexer = BaseLexer::new(InputStream::new("abb"), recognizer_data());
+        let mut hooks = MoreAfterAcceptHooks::default();
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let id = if compiled {
+            next_token_compiled_with_semantic_hooks(&mut lexer, &mut sink, &atn, &dfa, &mut hooks)
+        } else {
+            next_token_with_semantic_hooks(&mut lexer, &mut sink, &atn, &mut hooks)
+        }
+        .expect("combined lifecycle token should fit");
+        let token = sink
+            .view(id)
+            .expect("combined lifecycle token should exist");
+        ((token.token_type(), token.text().to_owned()), hooks.events)
+    }
+
+    #[test]
+    fn lifecycle_post_accept_more_composes_with_the_next_match() {
+        let interpreted = lifecycle_more_token(false);
+        let compiled = lifecycle_more_token(true);
+
+        assert_eq!(interpreted, compiled);
+        assert_eq!(interpreted.0, (2, "abb".to_owned()));
+        assert_eq!(
+            interpreted.1,
+            [
+                "before:0",
+                "accept:1:ab",
+                "before:2",
+                "accept:2:abb",
+                "emit:2:abb",
+            ]
+        );
+    }
+
+    #[derive(Debug, Default)]
+    struct ResettableSplitHooks {
+        transient: bool,
+        reset_count: usize,
+    }
+
+    impl SemanticHooks for ResettableSplitHooks {
+        fn lexer_action<I>(
+            &mut self,
+            ctx: &mut LexerSemCtx<'_, I>,
+            _action: LexerCustomAction,
+        ) -> bool
+        where
+            I: CharStream,
+        {
+            let start = ctx.token_start();
+            assert!(ctx.enqueue_token(1, start));
+            assert!(ctx.set_token_start(start + 1));
+            self.transient = true;
+            true
+        }
+
+        fn lexer_reset<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            assert_eq!(ctx.input_position(), 0);
+            assert_eq!(ctx.pending_token_count(), 0);
+            assert_eq!(ctx.mode(), crate::lexer::DEFAULT_MODE);
+            assert_eq!(ctx.token_type(), INVALID_TOKEN_TYPE);
+            assert_eq!(ctx.channel(), DEFAULT_CHANNEL);
+            assert_eq!((ctx.line(), ctx.column()), (1, 0));
+            assert_eq!(ctx.token_start(), 0);
+            self.transient = false;
+            self.reset_count += 1;
+        }
+    }
+
+    #[test]
+    fn lifecycle_reset_clears_pending_tokens_and_extension_state() {
+        let atn = trailing_action_atn(
+            &['.', 'x'],
+            2,
+            vec![LexerAction::Custom {
+                rule_index: 0,
+                action_index: 0,
+            }],
+        );
+        let dfa = CompiledLexerDfa::compile(&atn);
+        let mut lexer = BaseLexer::new(InputStream::new(".x"), recognizer_data());
+        let mut hooks = ResettableSplitHooks::default();
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+
+        let first =
+            next_token_compiled_with_semantic_hooks(&mut lexer, &mut sink, &atn, &dfa, &mut hooks)
+                .expect("queued prefix should fit");
+        assert_eq!(sink.view(first).expect("prefix exists").text(), ".");
+        assert!(hooks.transient);
+
+        lexer.push_mode(7);
+        lexer.set_channel(HIDDEN_CHANNEL);
+        lexer.set_hit_eof(true);
+        reset_with_semantic_hooks(&mut lexer, &mut hooks);
+        assert!(!hooks.transient);
+        assert_eq!(hooks.reset_count, 1);
+
+        let after_reset =
+            next_token_compiled_with_semantic_hooks(&mut lexer, &mut sink, &atn, &dfa, &mut hooks)
+                .expect("prefix after reset should fit");
+        assert_eq!(
+            sink.view(after_reset)
+                .expect("post-reset prefix exists")
+                .text(),
+            ".",
+            "the stale queued suffix must not survive reset"
+        );
     }
 
     #[test]

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -214,6 +214,7 @@ where
         &mut semantic_predicate,
         &mut |_| {},
         &mut accept_adjuster,
+        &mut |_, _| {},
         LexerMatchStrategy {
             compiled: None,
             use_cache: false,
@@ -332,7 +333,8 @@ where
             dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true)
         },
         &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
-        &mut |lexer, _, accept_position| {
+        &mut |_, _, _| {},
+        &mut |lexer, accept_position| {
             dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
         },
         LexerMatchStrategy {
@@ -370,6 +372,7 @@ where
         &mut |_, _| true,
         &mut |_| {},
         &mut |_, _, _| {},
+        &mut |_, _| {},
         LexerMatchStrategy {
             compiled: Some(dfa),
             use_cache: true,
@@ -406,6 +409,7 @@ where
         &mut semantic_predicate,
         &mut |_| {},
         &mut accept_adjuster,
+        &mut |_, _| {},
         LexerMatchStrategy {
             compiled: Some(dfa),
             use_cache: false,
@@ -438,7 +442,8 @@ where
             dispatch_lexer_predicate_hook(&hooks, lexer, predicate).unwrap_or(true)
         },
         &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
-        &mut |lexer, _, accept_position| {
+        &mut |_, _, _| {},
+        &mut |lexer, accept_position| {
             dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
         },
         LexerMatchStrategy {
@@ -513,8 +518,8 @@ where
                 })
         },
         &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
-        &mut |lexer, token_type, accept_position| {
-            accept_adjuster(lexer, token_type, accept_position);
+        &mut accept_adjuster,
+        &mut |lexer, accept_position| {
             dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
         },
         LexerMatchStrategy {
@@ -584,8 +589,8 @@ where
                 })
         },
         &mut |lexer| dispatch_lexer_before_token_hook(&hooks, lexer),
-        &mut |lexer, token_type, accept_position| {
-            accept_adjuster(lexer, token_type, accept_position);
+        &mut accept_adjuster,
+        &mut |lexer, accept_position| {
             dispatch_lexer_after_accept_hook(&hooks, lexer, accept_position);
         },
         LexerMatchStrategy {
@@ -623,6 +628,7 @@ where
         &mut semantic_predicate,
         &mut |_| {},
         &mut accept_adjuster,
+        &mut |_, _| {},
         LexerMatchStrategy {
             compiled: None,
             use_cache: true,
@@ -669,7 +675,7 @@ where
 }
 
 #[allow(clippy::too_many_arguments)]
-fn next_token_with_hooks_impl<I, A, P, B, E>(
+fn next_token_with_hooks_impl<I, A, P, B, E, L>(
     lexer: &mut BaseLexer<I>,
     sink: &mut TokenSink<'_>,
     atn: &LexerAtn,
@@ -677,6 +683,7 @@ fn next_token_with_hooks_impl<I, A, P, B, E>(
     semantic_predicate: &mut P,
     before_token: &mut B,
     accept_adjuster: &mut E,
+    after_accept: &mut L,
     strategy: LexerMatchStrategy<'_>,
 ) -> Result<TokenId, TokenStoreError>
 where
@@ -685,12 +692,15 @@ where
     P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
     B: FnMut(&mut BaseLexer<I>),
     E: FnMut(&mut BaseLexer<I>, i32, usize),
+    L: FnMut(&mut BaseLexer<I>, usize),
 {
     let mut continuing_more = false;
     loop {
         before_token(lexer);
-        if let Some(token) = lexer.emit_pending_token(sink)? {
-            return Ok(token);
+        if !continuing_more {
+            if let Some(token) = lexer.emit_pending_token(sink)? {
+                return Ok(token);
+            }
         }
 
         if lexer.hit_eof() {
@@ -752,16 +762,20 @@ where
             }
         }
 
-        let token_type = lexer.token_type();
-        if token_type == crate::lexer::SKIP || token_type == crate::lexer::MORE {
-            if accept.consumed_eof || lexer.input().index() != accept.position {
-                refresh_hit_eof(lexer);
+        let action_token_type = lexer.token_type();
+        if action_token_type == crate::lexer::SKIP || action_token_type == crate::lexer::MORE {
+            after_accept(lexer, accept.position);
+            let lifecycle_token_type = lexer.token_type();
+            if lifecycle_token_type != crate::lexer::SKIP
+                && lifecycle_token_type != crate::lexer::MORE
+            {
+                accept_adjuster(lexer, lifecycle_token_type, accept.position);
             }
-            continuing_more = token_type == crate::lexer::MORE;
-            continue;
+        } else {
+            accept_adjuster(lexer, action_token_type, accept.position);
+            after_accept(lexer, accept.position);
         }
 
-        accept_adjuster(lexer, token_type, accept.position);
         let token_type = lexer.token_type();
         if token_type == crate::lexer::SKIP || token_type == crate::lexer::MORE {
             if accept.consumed_eof || lexer.input().index() != accept.position {
@@ -1759,6 +1773,72 @@ mod tests {
         atn
     }
 
+    fn custom_control_action_atn(control_action: LexerAction) -> LexerAtn {
+        let mut atn = LexerAtn::new(8);
+        for (state_number, kind, rule_index) in [
+            (0, AtnStateKind::TokenStart, None),
+            (1, AtnStateKind::RuleStart, Some(0)),
+            (2, AtnStateKind::Basic, Some(0)),
+            (3, AtnStateKind::Basic, Some(0)),
+            (4, AtnStateKind::RuleStop, Some(0)),
+            (5, AtnStateKind::RuleStart, Some(1)),
+            (6, AtnStateKind::RuleStop, Some(1)),
+        ] {
+            let mut state = LexerAtnState::new(state_number, kind);
+            if let Some(rule_index) = rule_index {
+                state = state.with_rule_index(rule_index);
+            }
+            atn.add_state(state);
+        }
+        atn.state_mut(0)
+            .expect("token start")
+            .add_transition(LexerTransition::Epsilon { target: 1 });
+        atn.state_mut(0)
+            .expect("token start")
+            .add_transition(LexerTransition::Epsilon { target: 5 });
+        atn.state_mut(1)
+            .expect("first rule start")
+            .add_transition(LexerTransition::Atom {
+                target: 2,
+                label: 'a' as i32,
+            });
+        atn.state_mut(2)
+            .expect("custom action")
+            .add_transition(LexerTransition::Action {
+                target: 3,
+                rule_index: 0,
+                action_index: Some(0),
+                context_dependent: false,
+            });
+        atn.state_mut(3)
+            .expect("control action")
+            .add_transition(LexerTransition::Action {
+                target: 4,
+                rule_index: 0,
+                action_index: Some(1),
+                context_dependent: false,
+            });
+        atn.state_mut(5)
+            .expect("suffix rule start")
+            .add_transition(LexerTransition::Atom {
+                target: 6,
+                label: 'b' as i32,
+            });
+        atn.set_rule_to_start_state(vec![1, 5]);
+        atn.set_rule_to_stop_state(vec![4, 6]);
+        atn.set_rule_to_token_type(vec![1, 2]);
+        atn.add_mode_start_state(0);
+        atn.add_decision_state(0);
+        atn.set_lexer_actions(vec![
+            LexerAction::Custom {
+                rule_index: 0,
+                action_index: 0,
+            },
+            control_action,
+        ]);
+        atn
+    }
+
     fn lex_one<I: CharStream>(lexer: &mut BaseLexer<I>, atn: &LexerAtn) -> TokenSnapshot {
         let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
         let mut sink = TokenSink::new(&mut store);
@@ -2147,6 +2227,188 @@ mod tests {
                 "emit:2:abb",
             ]
         );
+    }
+
+    #[derive(Debug, Default)]
+    struct QueueDuringMoreHooks {
+        before: Vec<(usize, usize)>,
+    }
+
+    type QueuedMoreToken = (i32, usize, usize, String);
+    type BeforeTokenState = (usize, usize);
+
+    impl SemanticHooks for QueueDuringMoreHooks {
+        fn lexer_before_token<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.before
+                .push((ctx.input_position(), ctx.pending_token_count()));
+        }
+
+        fn lexer_action<I>(
+            &mut self,
+            ctx: &mut LexerSemCtx<'_, I>,
+            _action: LexerCustomAction,
+        ) -> bool
+        where
+            I: CharStream,
+        {
+            assert_eq!(ctx.text_so_far(), "a");
+            assert!(ctx.enqueue_token(7, ctx.token_start()));
+            true
+        }
+    }
+
+    fn queued_more_tokens(compiled: bool) -> (Vec<QueuedMoreToken>, Vec<BeforeTokenState>) {
+        let atn = custom_control_action_atn(LexerAction::More);
+        let dfa = CompiledLexerDfa::compile(&atn);
+        let mut lexer = BaseLexer::new(InputStream::new("ab"), recognizer_data());
+        let mut hooks = QueueDuringMoreHooks::default();
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let mut ids = Vec::new();
+        for _ in 0..2 {
+            let id = if compiled {
+                next_token_compiled_with_semantic_hooks(
+                    &mut lexer, &mut sink, &atn, &dfa, &mut hooks,
+                )
+            } else {
+                next_token_with_semantic_hooks(&mut lexer, &mut sink, &atn, &mut hooks)
+            }
+            .expect("queued MORE token should fit");
+            ids.push(id);
+        }
+        let tokens = ids
+            .into_iter()
+            .map(|id| {
+                let token = sink.view(id).expect("queued MORE token should exist");
+                (
+                    token.token_type(),
+                    token.start(),
+                    token.stop(),
+                    token.text().to_owned(),
+                )
+            })
+            .collect();
+        (tokens, hooks.before)
+    }
+
+    #[test]
+    fn queued_token_waits_for_more_chain_to_finish() {
+        let interpreted = queued_more_tokens(false);
+        let compiled = queued_more_tokens(true);
+
+        assert_eq!(interpreted, compiled);
+        assert_eq!(
+            interpreted.0,
+            [(7, 0, 0, "a".to_owned()), (2, 0, 1, "ab".to_owned()),]
+        );
+        assert_eq!(interpreted.1, [(0, 0), (1, 1), (2, 1)]);
+    }
+
+    #[derive(Debug, Default)]
+    struct OverrideControlActionHooks {
+        events: Vec<String>,
+    }
+
+    impl SemanticHooks for OverrideControlActionHooks {
+        fn lexer_action<I>(
+            &mut self,
+            ctx: &mut LexerSemCtx<'_, I>,
+            _action: LexerCustomAction,
+        ) -> bool
+        where
+            I: CharStream,
+        {
+            self.events.push(format!("action:{}", ctx.text_so_far()));
+            true
+        }
+
+        fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+        where
+            I: CharStream,
+        {
+            self.events.push(format!(
+                "accept:{}:{}",
+                ctx.token_type(),
+                ctx.accepted_text().expect("accepted callback has text")
+            ));
+            if ctx.token_type() == crate::lexer::SKIP || ctx.token_type() == crate::lexer::MORE {
+                ctx.set_type(8);
+            }
+        }
+
+        fn lexer_token_emitted(&mut self, token: TokenView<'_>) {
+            self.events
+                .push(format!("emit:{}:{}", token.token_type(), token.text()));
+        }
+    }
+
+    fn overridden_control_action_tokens(
+        control_action: LexerAction,
+        compiled: bool,
+    ) -> (Vec<(i32, String)>, Vec<String>) {
+        let atn = custom_control_action_atn(control_action);
+        let dfa = CompiledLexerDfa::compile(&atn);
+        let mut lexer = BaseLexer::new(InputStream::new("ab"), recognizer_data());
+        let mut hooks = OverrideControlActionHooks::default();
+        let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
+        let mut sink = TokenSink::new(&mut store);
+        let mut ids = Vec::new();
+        for _ in 0..3 {
+            let id = if compiled {
+                next_token_compiled_with_semantic_hooks(
+                    &mut lexer, &mut sink, &atn, &dfa, &mut hooks,
+                )
+            } else {
+                next_token_with_semantic_hooks(&mut lexer, &mut sink, &atn, &mut hooks)
+            }
+            .expect("overridden control-action token should fit");
+            ids.push(id);
+        }
+        let tokens = ids
+            .into_iter()
+            .map(|id| {
+                let token = sink
+                    .view(id)
+                    .expect("overridden control-action token should exist");
+                (token.token_type(), token.text().to_owned())
+            })
+            .collect();
+        (tokens, hooks.events)
+    }
+
+    #[test]
+    fn lifecycle_post_accept_can_override_skip_and_more_actions() {
+        for (control_action, control_type) in [
+            (LexerAction::Skip, crate::lexer::SKIP),
+            (LexerAction::More, crate::lexer::MORE),
+        ] {
+            let interpreted = overridden_control_action_tokens(control_action.clone(), false);
+            let compiled = overridden_control_action_tokens(control_action, true);
+
+            assert_eq!(interpreted, compiled);
+            assert_eq!(
+                interpreted.0,
+                [
+                    (8, "a".to_owned()),
+                    (2, "b".to_owned()),
+                    (TOKEN_EOF, "<EOF>".to_owned()),
+                ]
+            );
+            assert_eq!(
+                interpreted.1,
+                [
+                    "action:a".to_owned(),
+                    format!("accept:{control_type}:a"),
+                    "emit:8:a".to_owned(),
+                    "accept:2:b".to_owned(),
+                    "emit:2:b".to_owned(),
+                    "emit:-1:<EOF>".to_owned(),
+                ]
+            );
+        }
     }
 
     #[derive(Debug, Default)]

--- a/src/bin/antlr4-runtime-testsuite.rs
+++ b/src/bin/antlr4-runtime-testsuite.rs
@@ -733,9 +733,6 @@ fn unsupported_reason(descriptor: &Descriptor) -> Option<&'static str> {
     if !descriptor.flags.is_empty() && !runtime_flags_supported(descriptor) {
         return Some("diagnostic/profile/DFA flags are not implemented in the Rust harness yet");
     }
-    if descriptor.id() == "LexerExec/PositionAdjustingLexer" {
-        return Some("lexer subclass method overrides are not supported yet");
-    }
     if descriptor.is_parser() || descriptor.is_lexer() {
         return None;
     }
@@ -1073,6 +1070,9 @@ fn smoke_main(descriptor: &Descriptor) -> String {
     if descriptor.is_parser() {
         return parser_smoke_main(descriptor);
     }
+    if descriptor.id() == "LexerExec/PositionAdjustingLexer" {
+        return position_adjusting_lexer_smoke_main(descriptor);
+    }
     let module_name = module_name(&descriptor.grammar_name);
     let type_name = rust_type_name(&descriptor.grammar_name);
     let show_dfa = descriptor.flags.trim() == "showDFA";
@@ -1091,6 +1091,68 @@ fn smoke_main(descriptor: &Descriptor) -> String {
     };
     format!(
         "pub mod generated {{\n    pub mod {module_name};\n}}\n\nuse antlr4_runtime::{{CommonTokenStream, InputStream{token_source_import}}};\nuse generated::{module_name}::{type_name};\n\nfn main() {{\n    {lexer_binding} = {type_name}::new(InputStream::new(\"{}\"));\n{force_interpreted}    let mut tokens = CommonTokenStream::new(lexer);\n    tokens.fill();\n    for error in tokens.drain_source_errors() {{\n        eprintln!(\"line {{}}:{{}} {{}}\", error.line, error.column, error.message);\n    }}\n    for token in tokens.tokens() {{\n        println!(\"{{token}}\");\n    }}\n{dfa_dump}}}\n",
+        rust_string(&descriptor.input)
+    )
+}
+
+/// Supplies the descriptor's target-specific superclass behavior through the
+/// public, grammar-agnostic lexer lifecycle contract.
+fn position_adjusting_lexer_smoke_main(descriptor: &Descriptor) -> String {
+    let module_name = module_name(&descriptor.grammar_name);
+    let type_name = rust_type_name(&descriptor.grammar_name);
+    format!(
+        r#"pub mod generated {{
+    pub mod {module_name};
+}}
+
+use antlr4_runtime::{{
+    CharStream, CommonTokenStream, InputStream, LexerLifecycleCtx, SemanticHooks,
+}};
+use generated::{module_name}::{{LABEL, TOKENS, {type_name}}};
+
+#[derive(Clone, Copy, Debug, Default)]
+struct PositionAdjustingHooks;
+
+impl SemanticHooks for PositionAdjustingHooks {{
+    fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+    where
+        I: CharStream,
+    {{
+        let prefix_length = match ctx.token_type() {{
+            TOKENS => "tokens".chars().count(),
+            LABEL => ctx
+                .accepted_text()
+                .expect("post-accept callback has accepted text")
+                .chars()
+                .take_while(|ch| ch.is_alphanumeric() || *ch == '_')
+                .count(),
+            _ => return,
+        }};
+        let target = ctx.token_start().saturating_add(prefix_length);
+        if ctx
+            .accept_position()
+            .is_some_and(|accept_position| accept_position > target)
+        {{
+            ctx.reset_accept_position(target);
+        }}
+    }}
+}}
+
+fn main() {{
+    let lexer = {type_name}::with_hooks(
+        InputStream::new("{}"),
+        PositionAdjustingHooks,
+    );
+    let mut tokens = CommonTokenStream::new(lexer);
+    tokens.fill();
+    for error in tokens.drain_source_errors() {{
+        eprintln!("line {{}}:{{}} {{}}", error.line, error.column, error.message);
+    }}
+    for token in tokens.tokens() {{
+        println!("{{token}}");
+    }}
+}}
+"#,
         rust_string(&descriptor.input)
     )
 }

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -60,7 +60,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Some(arg) = args_iter.next() {
         match arg.as_str() {
             "--lexer" | "--parser" | "--lexer-name" | "--parser-name" | "--grammar"
-            | "--out-dir" | "--sem-patterns" | "--actions" | "--sem-unknown" => {
+            | "--out-dir" | "--sem-patterns" | "--actions" | "--sem-unknown" | "--option-hook" => {
                 let _ = args_iter.next();
             }
             "--help" | "-h" => {
@@ -79,6 +79,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .as_deref()
         .map(fs::read_to_string)
         .transpose()?;
+    let grammar_options = grammar_source
+        .as_deref()
+        .map(|source| collect_grammar_options(source, &args.option_hooks))
+        .transpose()?
+        .unwrap_or_default();
+    emit_grammar_option_warnings(&grammar_options)?;
+    enforce_require_full_options(args.require_full_semantics, &grammar_options)?;
     let mut manifest_grammars: Vec<(&'static str, String, Vec<SemanticsEntry>)> = Vec::new();
 
     if let Some(lexer) = args.lexer {
@@ -154,7 +161,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         manifest_grammars.push(("parser", grammar_name, entries));
     }
 
-    write_semantics_manifest(&args.out_dir, args.sem_unknown, &manifest_grammars)?;
+    write_semantics_manifest(
+        &args.out_dir,
+        args.sem_unknown,
+        &grammar_options,
+        &manifest_grammars,
+    )?;
     Ok(())
 }
 
@@ -287,6 +299,59 @@ impl SemanticsDisposition {
             Self::Ignored => "ignored",
             Self::Synthetic => "synthetic",
         }
+    }
+}
+
+/// How the Rust backend treats one top-level ANTLR grammar option.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum GrammarOptionDisposition {
+    /// The ANTLR tool encoded the option's behavior into `.interp` metadata.
+    Metadata,
+    /// The option affects the upstream tool invocation, not Rust runtime
+    /// behavior.
+    ToolHandled,
+    /// Caller-owned Rust hooks explicitly provide the target behavior.
+    Hooked,
+    /// The option is legal ANTLR syntax but its target behavior is not
+    /// automatically implemented by the Rust backend.
+    Unsupported,
+}
+
+impl GrammarOptionDisposition {
+    const fn manifest_name(self) -> &'static str {
+        match self {
+            Self::Metadata => "metadata",
+            Self::ToolHandled => "tool-handled",
+            Self::Hooked => "hooked",
+            Self::Unsupported => "unsupported",
+        }
+    }
+}
+
+/// One source-level grammar option inventoried from `--grammar`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct GrammarOptionEntry {
+    key: String,
+    value: String,
+    line: usize,
+    column: usize,
+    disposition: GrammarOptionDisposition,
+}
+
+impl GrammarOptionEntry {
+    fn assignment(&self) -> String {
+        format!("{}={}", self.key, self.value)
+    }
+
+    fn describe_unsupported(&self) -> String {
+        format!(
+            "unsupported grammar option: {} at {}:{} is accepted by ANTLR but is not \
+             automatically implemented by antlr4-rust-gen; target-specific behavior may be \
+             missing (see #98)",
+            self.assignment(),
+            self.line,
+            self.column
+        )
     }
 }
 
@@ -816,6 +881,66 @@ fn enforce_require_full_semantics(require: bool, entries: &[SemanticsEntry]) -> 
     Err(io::Error::new(io::ErrorKind::InvalidData, message))
 }
 
+fn emit_grammar_option_warnings(entries: &[GrammarOptionEntry]) -> io::Result<()> {
+    let mut stderr = io::stderr().lock();
+    for entry in entries
+        .iter()
+        .filter(|entry| entry.disposition == GrammarOptionDisposition::Unsupported)
+    {
+        writeln!(stderr, "warning: {}", entry.describe_unsupported())?;
+    }
+    Ok(())
+}
+
+fn enforce_require_full_options(require: bool, entries: &[GrammarOptionEntry]) -> io::Result<()> {
+    if !require {
+        return Ok(());
+    }
+    let unsupported = entries
+        .iter()
+        .filter(|entry| entry.disposition == GrammarOptionDisposition::Unsupported)
+        .collect::<Vec<_>>();
+    if unsupported.is_empty() {
+        return Ok(());
+    }
+    let mut message = String::new();
+    for entry in &unsupported {
+        message.push_str(&entry.describe_unsupported());
+        message.push('\n');
+    }
+    let _ = write!(
+        message,
+        "--require-full-semantics: {} grammar option(s) require caller-owned target behavior; \
+         acknowledge implemented behavior with --option-hook KEY=VALUE",
+        unsupported.len()
+    );
+    Err(io::Error::new(io::ErrorKind::InvalidData, message))
+}
+
+fn normalize_option_hook(value: &str) -> Result<String, String> {
+    let Some((key, option_value)) = value.split_once('=') else {
+        return Err(format!(
+            "--option-hook requires KEY=VALUE; got {value:?}\n\n{}",
+            usage()
+        ));
+    };
+    let key = key.trim();
+    let option_value = option_value.trim();
+    let mut key_chars = key.chars();
+    if !key_chars
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphabetic())
+        || !key_chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+        || option_value.is_empty()
+    {
+        return Err(format!(
+            "--option-hook requires KEY=VALUE; got {value:?}\n\n{}",
+            usage()
+        ));
+    }
+    Ok(format!("{key}={option_value}"))
+}
+
 /// Inventories every custom-action and predicate coordinate in a lexer
 /// `.interp`, mirroring the pairing rules `render_lexer` uses so manifest
 /// dispositions match what the generated module will do.
@@ -1162,34 +1287,199 @@ fn line_column(source: &str, offset: usize) -> (usize, usize) {
     (line, column)
 }
 
+/// Inventories top-level `options { ... }` assignments from grammar source.
+///
+/// Rule-level options are excluded by requiring `options` to be the first
+/// identifier after the previous grammar statement boundary.
+fn collect_grammar_options(
+    source: &str,
+    option_hooks: &BTreeSet<String>,
+) -> io::Result<Vec<GrammarOptionEntry>> {
+    let mut entries = Vec::new();
+    let mut offset = 0;
+    while let Some(open_brace) = templates::find_significant_open_brace(source, offset) {
+        let close_brace = matching_grammar_block(source, open_brace).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("unterminated grammar block at byte {open_brace}"),
+            )
+        })?;
+        offset = close_brace + 1;
+        if !is_options_block(source, open_brace) {
+            continue;
+        }
+        let statement_start = statement_start_before(source, open_brace);
+        if rule_header_start_identifier(&source[statement_start..open_brace]) != Some("options") {
+            continue;
+        }
+        collect_grammar_option_block(
+            source,
+            open_brace + 1,
+            close_brace,
+            option_hooks,
+            &mut entries,
+        );
+    }
+    Ok(entries)
+}
+
+fn matching_grammar_block(source: &str, open_brace: usize) -> Option<usize> {
+    let mut cursor = templates::GrammarSourceCursor::new(source, open_brace + 1);
+    let mut nested = 0_usize;
+    while let Some((index, ch)) = cursor.next_significant() {
+        match ch {
+            '{' => nested += 1,
+            '}' if nested == 0 => return Some(index),
+            '}' => nested -= 1,
+            _ => {}
+        }
+    }
+    None
+}
+
+fn collect_grammar_option_block(
+    source: &str,
+    body_start: usize,
+    body_stop: usize,
+    option_hooks: &BTreeSet<String>,
+    entries: &mut Vec<GrammarOptionEntry>,
+) {
+    let body = &source[body_start..body_stop];
+    let mut cursor = templates::GrammarSourceCursor::new(body, 0);
+    let mut assignment_start = 0;
+    while let Some((index, ch)) = cursor.next_significant() {
+        if ch == ';' {
+            collect_grammar_option_assignment(
+                source,
+                body_start,
+                &body[assignment_start..index],
+                assignment_start,
+                option_hooks,
+                entries,
+            );
+            assignment_start = index + 1;
+        }
+    }
+    collect_grammar_option_assignment(
+        source,
+        body_start,
+        &body[assignment_start..],
+        assignment_start,
+        option_hooks,
+        entries,
+    );
+}
+
+fn collect_grammar_option_assignment(
+    source: &str,
+    body_start: usize,
+    assignment: &str,
+    assignment_offset: usize,
+    option_hooks: &BTreeSet<String>,
+    entries: &mut Vec<GrammarOptionEntry>,
+) {
+    let mut cursor = templates::GrammarSourceCursor::new(assignment, 0);
+    let mut first = None;
+    while let Some((index, ch)) = cursor.next_significant() {
+        if !ch.is_ascii_whitespace() {
+            first = Some((index, ch));
+            break;
+        }
+    }
+    let Some((key_start, first)) = first else {
+        return;
+    };
+    if first != '_' && !first.is_ascii_alphabetic() {
+        return;
+    }
+    let mut key_stop = key_start + first.len_utf8();
+    while assignment[key_stop..]
+        .chars()
+        .next()
+        .is_some_and(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+    {
+        key_stop += assignment[key_stop..]
+            .chars()
+            .next()
+            .map_or(0, char::len_utf8);
+    }
+    cursor.seek(key_stop);
+    let mut equals = None;
+    while let Some((index, ch)) = cursor.next_significant() {
+        if ch == '=' {
+            equals = Some(index);
+            break;
+        }
+    }
+    let Some(equals) = equals else {
+        return;
+    };
+    let key = assignment[key_start..key_stop].to_owned();
+    let value = assignment[equals + 1..].trim().to_owned();
+    if value.is_empty() {
+        return;
+    }
+    let absolute_key = body_start + assignment_offset + key_start;
+    let (line, column) = line_column(source, absolute_key);
+    let assignment = format!("{key}={value}");
+    let disposition = match key.as_str() {
+        "tokenVocab" | "caseInsensitive" => GrammarOptionDisposition::Metadata,
+        "language" => GrammarOptionDisposition::ToolHandled,
+        _ if option_hooks.contains(&assignment) => GrammarOptionDisposition::Hooked,
+        _ => GrammarOptionDisposition::Unsupported,
+    };
+    entries.push(GrammarOptionEntry {
+        key,
+        value,
+        line,
+        column,
+        disposition,
+    });
+}
+
 /// Writes the `semantics.json` compatibility manifest next to the generated
 /// modules. The manifest lists every semantic coordinate and how generation
 /// disposed of it, making the supported/unsupported boundary inspectable.
 fn write_semantics_manifest(
     out_dir: &Path,
     policy: SemUnknownPolicy,
+    options: &[GrammarOptionEntry],
     grammars: &[(&'static str, String, Vec<SemanticsEntry>)],
 ) -> io::Result<()> {
     fs::write(
         out_dir.join("semantics.json"),
-        render_semantics_manifest(policy, grammars),
+        render_semantics_manifest(policy, options, grammars),
     )
 }
 
 fn render_semantics_manifest(
     policy: SemUnknownPolicy,
+    options: &[GrammarOptionEntry],
     grammars: &[(&'static str, String, Vec<SemanticsEntry>)],
 ) -> String {
     const DEPRECATION_NOTE: &str = "unknown coordinates currently default to assume-true; \
                                     a future minor release changes the default to error";
     let mut out = String::new();
-    out.push_str("{\n  \"version\": 1,\n");
+    out.push_str("{\n  \"version\": 2,\n");
     let _ = writeln!(
         out,
         "  \"policy\": {},",
         json_string(policy.manifest_name())
     );
     let _ = writeln!(out, "  \"note\": {},", json_string(DEPRECATION_NOTE));
+    out.push_str("  \"options\": [");
+    for (position, option) in options.iter().enumerate() {
+        if position > 0 {
+            out.push(',');
+        }
+        out.push_str("\n    ");
+        write_grammar_option_entry(&mut out, option);
+    }
+    if options.is_empty() {
+        out.push_str("],\n");
+    } else {
+        out.push_str("\n  ],\n");
+    }
     out.push_str("  \"grammars\": [");
     for (grammar_position, (kind, name, entries)) in grammars.iter().enumerate() {
         if grammar_position > 0 {
@@ -1218,6 +1508,20 @@ fn render_semantics_manifest(
         out.push_str("\n  ]\n}\n");
     }
     out
+}
+
+fn write_grammar_option_entry(out: &mut String, entry: &GrammarOptionEntry) {
+    out.push('{');
+    let _ = write!(out, "\"name\": {}", json_string(&entry.key));
+    let _ = write!(out, ", \"value\": {}", json_string(&entry.value));
+    let _ = write!(out, ", \"line\": {}", entry.line);
+    let _ = write!(out, ", \"column\": {}", entry.column);
+    let _ = write!(
+        out,
+        ", \"disposition\": {}",
+        json_string(entry.disposition.manifest_name())
+    );
+    out.push('}');
 }
 
 fn write_semantics_entry(out: &mut String, entry: &SemanticsEntry) {
@@ -1560,6 +1864,7 @@ struct Args {
     sem_unknown: SemUnknownPolicy,
     sem_patterns: SemPatternFile,
     require_full_semantics: bool,
+    option_hooks: BTreeSet<String>,
     /// `--actions embedded`: the grammar contains real Rust action/predicate
     /// bodies (rendered through a `.test.stg`); splice them verbatim after
     /// `$`-attribute translation instead of recognizing template markup.
@@ -1587,6 +1892,7 @@ impl Args {
         let mut sem_unknown = SemUnknownPolicy::default();
         let mut sem_patterns = SemPatternFile::default();
         let mut require_full_semantics = false;
+        let mut option_hooks = BTreeSet::new();
 
         let mut iter = env::args().skip(1);
         while let Some(arg) = iter.next() {
@@ -1605,6 +1911,10 @@ impl Args {
                             .map_err(|error| format!("failed to load --sem-patterns: {error}"))?;
                 }
                 "--require-full-semantics" => require_full_semantics = true,
+                "--option-hook" => {
+                    let value = next_arg(&mut iter, "--option-hook")?;
+                    option_hooks.insert(normalize_option_hook(&value)?);
+                }
                 "--actions" => {
                     let value = next_arg(&mut iter, "--actions")?;
                     match value.as_str() {
@@ -1645,6 +1955,7 @@ impl Args {
             sem_unknown,
             sem_patterns,
             require_full_semantics,
+            option_hooks,
             embedded_actions,
         })
     }
@@ -1673,7 +1984,8 @@ Options:
   --sem-unknown error|hook|assume-true|assume-false
                                    Choose unsupported semantic predicate policy
   --sem-patterns FILE              Load semantic helper patterns
-  --require-full-semantics         Fail if any semantic coordinate is unsupported
+  --option-hook KEY=VALUE          Acknowledge an option implemented by caller hooks
+  --require-full-semantics         Fail if any semantic coordinate or option is unsupported
   -h, --help                       Print this help"
         .to_owned()
 }
@@ -1907,8 +2219,6 @@ fn render_lexer(
     let unknown_predicates_assume_false = sem_unknown == SemUnknownPolicy::AssumeFalse
         && predicates.is_empty()
         && !lexer_predicate_transitions(data)?.is_empty();
-    let adjusts_accept_position =
-        template_grammar_source.is_some_and(uses_position_adjusting_lexer);
     let lexer_dfa_data = compiled_lexer_dfa_words(data);
     let lexer_typed_hook_mappings = if embedded {
         Vec::new()
@@ -1959,11 +2269,6 @@ fn render_lexer(
     } else {
         render_lexer_predicate_method(&predicates, sem_unknown)
     };
-    let accept_adjust_method = if adjusts_accept_position {
-        render_position_adjusting_lexer_methods()
-    } else {
-        String::new()
-    };
     let has_predicate_dispatch = if embedded {
         !embedded_lexer_predicates.is_empty()
     } else {
@@ -1976,30 +2281,22 @@ fn render_lexer(
             "antlr4_runtime::UnknownSemanticPolicy::Error"
         }
     };
+    let semantic_action = if has_action_dispatch {
+        "Self::run_action"
+    } else {
+        "|_, _| false"
+    };
+    let semantic_predicate = if has_predicate_dispatch {
+        "Self::run_predicate"
+    } else {
+        "|_, _| None"
+    };
+    let lifecycle_next_token_call = format!(
+        "antlr4_runtime::atn::lexer::next_token_compiled_with_semantic_dispatch(&mut self.base, sink, atn(), lexer_dfa(), &mut self.hooks, {semantic_action}, {semantic_predicate}, {lexer_unknown_policy}, |_, _, _| {{}})"
+    );
     let next_token_call = if has_semantic_hooks {
-        let action = if has_action_dispatch {
-            "Self::run_action"
-        } else {
-            "|_, _| false"
-        };
-        let predicate = if has_predicate_dispatch {
-            "Self::run_predicate"
-        } else {
-            "|_, _| None"
-        };
-        let adjuster = if adjusts_accept_position {
-            "Self::adjust_accept_position"
-        } else {
-            "|_, _, _| {}"
-        };
-        format!(
-            "antlr4_runtime::atn::lexer::next_token_compiled_with_semantic_dispatch(&mut self.base, sink, atn(), lexer_dfa(), &mut self.hooks, {action}, {predicate}, {lexer_unknown_policy}, {adjuster})"
-        )
-    } else if !has_action_dispatch
-        && !has_predicate_dispatch
-        && !adjusts_accept_position
-        && !unknown_predicates_assume_false
-    {
+        lifecycle_next_token_call.clone()
+    } else if !has_action_dispatch && !has_predicate_dispatch && !unknown_predicates_assume_false {
         "antlr4_runtime::atn::lexer::next_token_compiled(&mut self.base, sink, atn(), lexer_dfa())"
             .to_owned()
     } else {
@@ -2015,13 +2312,15 @@ fn render_lexer(
         } else {
             "|_, _| true"
         };
-        let adjuster = if adjusts_accept_position {
-            "Self::adjust_accept_position"
-        } else {
-            "|_, _, _| {}"
-        };
         format!(
-            "antlr4_runtime::atn::lexer::next_token_compiled_with_hooks(&mut self.base, sink, atn(), lexer_dfa(), {action}, {predicate}, {adjuster})"
+            "antlr4_runtime::atn::lexer::next_token_compiled_with_hooks(&mut self.base, sink, atn(), lexer_dfa(), {action}, {predicate}, |_, _, _| {{}})"
+        )
+    };
+    let next_token_call = if has_semantic_hooks {
+        next_token_call
+    } else {
+        format!(
+            "if H::ENABLES_LEXER_LIFECYCLE {{\n            {lifecycle_next_token_call}\n        }} else {{\n            {next_token_call}\n        }}"
         )
     };
     let generated_header = GENERATED_MODULE_HEADER;
@@ -2114,9 +2413,20 @@ where
         self.base.set_force_interpreted(force_interpreted);
     }}
 
+    /// Resets this lexer and any caller-owned lifecycle state for reuse.
+    pub fn reset(&mut self) {{
+        if H::ENABLES_LEXER_LIFECYCLE {{
+            antlr4_runtime::atn::lexer::reset_with_semantic_hooks(
+                &mut self.base,
+                &mut self.hooks,
+            );
+        }} else {{
+            self.base.reset();
+        }}
+    }}
+
 {action_method}
 {predicate_method}
-{accept_adjust_method}
 }}
 
 {typed_lexer_constructor}
@@ -8622,10 +8932,6 @@ fn uses_alt_number_contexts(source: &str) -> bool {
     source.contains("<TreeNodeWithAltNumField") || source.contains("contextSuperClass")
 }
 
-fn uses_position_adjusting_lexer(source: &str) -> bool {
-    source.contains("<PositionAdjustingLexer()")
-}
-
 /// Reads the rule name at the *start* of a rule header, i.e. the first
 /// identifier after skipping leading `@name {...}` clauses, comments, and
 /// `<...>` templates, and an optional `fragment` keyword. Stops before rule
@@ -9286,57 +9592,6 @@ fn literal_rule_arg_calls(
         .into_iter()
         .map(|(_, rule_index, value)| (rule_index, value))
         .collect()
-}
-
-/// Emits the helper methods for ANTLR's `PositionAdjustingLexer` runtime-test
-/// target template.
-///
-/// The template accepts a longer lexer path for keywords and labels, then emits
-/// only the keyword or identifier prefix. Resetting the accept position leaves
-/// delimiters such as `{`, `=`, and `+=` available for the next token.
-fn render_position_adjusting_lexer_methods() -> String {
-    r#"
-    fn adjust_accept_position(base: &mut BaseLexer<I>, token_type: i32, accept_position: usize) {
-        match token_type {
-            TOKENS => Self::adjust_accept_position_for_keyword(base, accept_position, "tokens"),
-            LABEL => Self::adjust_accept_position_for_identifier(base, accept_position),
-            _ => {}
-        }
-    }
-
-    fn adjust_accept_position_for_identifier(base: &mut BaseLexer<I>, accept_position: usize) {
-        let identifier_length = base
-            .token_text_until(accept_position)
-            .chars()
-            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '_')
-            .count();
-        Self::reset_accept_position_after_prefix(base, accept_position, identifier_length);
-    }
-
-    fn adjust_accept_position_for_keyword(
-        base: &mut BaseLexer<I>,
-        accept_position: usize,
-        keyword: &str,
-    ) {
-        Self::reset_accept_position_after_prefix(
-            base,
-            accept_position,
-            keyword.chars().count(),
-        );
-    }
-
-    fn reset_accept_position_after_prefix(
-        base: &mut BaseLexer<I>,
-        accept_position: usize,
-        prefix_length: usize,
-    ) {
-        let target = base.token_start().saturating_add(prefix_length);
-        if accept_position > target {
-            base.reset_accept_position(target);
-        }
-    }
-"#
-    .to_owned()
 }
 
 /// Emits the generated lexer action dispatcher for grammar-specific custom
@@ -13473,6 +13728,7 @@ ID: [a-z]+ { customJava(); };
         );
         let manifest = render_semantics_manifest(
             SemUnknownPolicy::AssumeTrue,
+            &[],
             &[("lexer", "L".to_owned(), entries)],
         );
         assert_eq!(manifest.matches("\"kind\": \"lexer-action\"").count(), 2);
@@ -15095,10 +15351,12 @@ ID : [a-z]+ ;\n";
         .expect("collection should succeed");
         let manifest = render_semantics_manifest(
             SemUnknownPolicy::AssumeTrue,
+            &[],
             &[("parser", "SParser".to_owned(), entries)],
         );
 
-        assert!(manifest.contains("\"version\": 1"));
+        assert!(manifest.contains("\"version\": 2"));
+        assert!(manifest.contains("\"options\": []"));
         assert!(manifest.contains("\"policy\": \"assume-true\""));
         assert!(manifest.contains("\"kind\": \"parser\""));
         assert!(manifest.contains("\"name\": \"SParser\""));
@@ -15166,6 +15424,7 @@ ID : [a-z]+ ;\n";
     fn semantics_manifest_renders_empty_inventory() {
         let manifest = render_semantics_manifest(
             SemUnknownPolicy::AssumeTrue,
+            &[],
             &[("parser", "SParser".to_owned(), Vec::new())],
         );
 
@@ -15632,6 +15891,10 @@ ID : [a-z]+ ;\n";
         .expect("lexer should render");
 
         assert!(module.contains("next_token_compiled(&mut self.base, sink, atn(), lexer_dfa())"));
+        assert!(module.contains("if H::ENABLES_LEXER_LIFECYCLE"));
+        assert!(module.contains("next_token_compiled_with_semantic_dispatch"));
+        assert!(module.contains("pub fn reset(&mut self)"));
+        assert!(module.contains("reset_with_semantic_hooks"));
         assert!(module.contains(
             "fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError>"
         ));
@@ -15640,6 +15903,103 @@ ID : [a-z]+ ;\n";
         ));
         assert!(!module.contains("CommonToken"));
         assert!(!module.contains("TokenFactory"));
+    }
+
+    #[test]
+    fn grammar_options_inventory_distinguishes_metadata_and_target_behavior() {
+        let source = "\
+lexer grammar L;
+options {
+  tokenVocab = Shared;
+  caseInsensitive = true;
+  superClass = BaseLexer;
+}
+A options { caseInsensitive = false; } : 'a';
+";
+        let options_open = templates::find_significant_open_brace(source, 0)
+            .expect("grammar options block should be structurally visible");
+        assert!(is_options_block(source, options_open));
+        let statement_start = statement_start_before(source, options_open);
+        assert_eq!(
+            rule_header_start_identifier(&source[statement_start..options_open]),
+            Some("options")
+        );
+
+        let options = collect_grammar_options(source, &BTreeSet::new())
+            .expect("top-level grammar options should parse");
+
+        assert_eq!(
+            options,
+            [
+                GrammarOptionEntry {
+                    key: "tokenVocab".to_owned(),
+                    value: "Shared".to_owned(),
+                    line: 3,
+                    column: 2,
+                    disposition: GrammarOptionDisposition::Metadata,
+                },
+                GrammarOptionEntry {
+                    key: "caseInsensitive".to_owned(),
+                    value: "true".to_owned(),
+                    line: 4,
+                    column: 2,
+                    disposition: GrammarOptionDisposition::Metadata,
+                },
+                GrammarOptionEntry {
+                    key: "superClass".to_owned(),
+                    value: "BaseLexer".to_owned(),
+                    line: 5,
+                    column: 2,
+                    disposition: GrammarOptionDisposition::Unsupported,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn grammar_option_hook_acknowledgement_satisfies_strict_mode() {
+        let source = "lexer grammar L;\noptions { superClass = BaseLexer; }\nA: 'a';\n";
+        let hooks = BTreeSet::from(["superClass=BaseLexer".to_owned()]);
+        let options =
+            collect_grammar_options(source, &hooks).expect("acknowledged option should parse");
+
+        assert_eq!(options.len(), 1);
+        assert_eq!(options[0].disposition, GrammarOptionDisposition::Hooked);
+        enforce_require_full_options(true, &options)
+            .expect("hooked options are explicitly implemented");
+
+        let manifest = render_semantics_manifest(SemUnknownPolicy::AssumeTrue, &options, &[]);
+        assert!(manifest.contains("\"name\": \"superClass\""));
+        assert!(manifest.contains("\"value\": \"BaseLexer\""));
+        assert!(manifest.contains("\"disposition\": \"hooked\""));
+    }
+
+    #[test]
+    fn strict_mode_rejects_unacknowledged_target_options() {
+        let source = "parser grammar P;\noptions { contextSuperClass = RuleNode; }\ns: EOF;\n";
+        let options = collect_grammar_options(source, &BTreeSet::new())
+            .expect("unsupported option should still be inventoried");
+
+        let error = enforce_require_full_options(true, &options)
+            .expect_err("strict mode should reject an unsupported target option");
+        assert!(
+            error
+                .to_string()
+                .contains("unsupported grammar option: contextSuperClass=RuleNode at 2:10")
+        );
+        assert!(error.to_string().contains("--option-hook KEY=VALUE"));
+    }
+
+    #[test]
+    fn option_hook_requires_an_exact_assignment() {
+        assert_eq!(
+            normalize_option_hook(" superClass = BaseLexer ")
+                .expect("valid hook assignment should normalize"),
+            "superClass=BaseLexer"
+        );
+        assert!(normalize_option_hook("superClass").is_err());
+        assert!(normalize_option_hook("=BaseLexer").is_err());
+        assert!(normalize_option_hook("superClass=").is_err());
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -381,6 +381,184 @@ where
     }
 }
 
+/// Mutable lexer state exposed at lifecycle boundaries that have no ATN
+/// semantic coordinate.
+///
+/// The context is used before a token request starts matching, after an
+/// accepted path has applied its actions but before emission, and while a
+/// lexer is reset for reuse. [`Self::accept_position`] is present only at the
+/// post-accept boundary.
+#[derive(Debug)]
+pub struct LexerLifecycleCtx<'a, I>
+where
+    I: CharStream,
+{
+    lexer: &'a mut BaseLexer<I>,
+    accept_position: Option<usize>,
+}
+
+impl<'a, I> LexerLifecycleCtx<'a, I>
+where
+    I: CharStream,
+{
+    pub(crate) const fn new(lexer: &'a mut BaseLexer<I>, accept_position: Option<usize>) -> Self {
+        Self {
+            lexer,
+            accept_position,
+        }
+    }
+
+    /// Original input boundary selected by the accepted ATN path.
+    ///
+    /// A post-accept hook may move the committed cursor away from this
+    /// boundary with [`Self::reset_accept_position`].
+    #[must_use]
+    pub const fn accept_position(&self) -> Option<usize> {
+        self.accept_position
+    }
+
+    /// Current committed input position.
+    #[must_use]
+    pub fn input_position(&self) -> usize {
+        self.lexer.input().index()
+    }
+
+    /// Current lexer mode.
+    #[must_use]
+    pub const fn mode(&self) -> i32 {
+        self.lexer.mode
+    }
+
+    /// Current source line.
+    #[must_use]
+    pub const fn line(&self) -> usize {
+        self.lexer.line()
+    }
+
+    /// Current source column.
+    #[must_use]
+    pub const fn column(&self) -> usize {
+        self.lexer.column()
+    }
+
+    /// Absolute source index where the current token begins.
+    #[must_use]
+    pub const fn token_start(&self) -> usize {
+        self.lexer.token_start()
+    }
+
+    /// Source line captured at the current token start.
+    #[must_use]
+    pub const fn token_start_line(&self) -> usize {
+        self.lexer.token_start_line()
+    }
+
+    /// Source column captured at the current token start.
+    #[must_use]
+    pub const fn token_start_column(&self) -> usize {
+        self.lexer.token_start_column()
+    }
+
+    /// Pending type of the token being matched.
+    #[must_use]
+    pub const fn token_type(&self) -> i32 {
+        self.lexer.token_type()
+    }
+
+    /// Pending channel of the token being matched.
+    #[must_use]
+    pub const fn channel(&self) -> i32 {
+        self.lexer.channel()
+    }
+
+    /// Number of tokens waiting to be returned before another ATN match.
+    #[must_use]
+    pub fn pending_token_count(&self) -> usize {
+        self.lexer.pending_tokens.len()
+    }
+
+    /// Text from the current token start through the committed input cursor.
+    #[must_use]
+    pub fn token_text(&self) -> String {
+        self.lexer.token_text()
+    }
+
+    /// Text selected by the original accepted ATN path.
+    ///
+    /// Returns `None` outside the post-accept callback.
+    #[must_use]
+    pub fn accepted_text(&self) -> Option<String> {
+        self.accept_position
+            .map(|position| self.lexer.token_text_until(position))
+    }
+
+    /// Character at a one-based lookahead/lookbehind offset from the
+    /// committed input cursor.
+    pub fn la(&mut self, offset: isize) -> i32 {
+        self.lexer.la(offset)
+    }
+
+    /// Consumes one input character and updates source position tracking.
+    pub fn consume(&mut self) {
+        self.lexer.consume_char();
+    }
+
+    /// Overrides the pending emitted token type.
+    pub const fn set_type(&mut self, token_type: i32) {
+        self.lexer.set_type(token_type);
+    }
+
+    /// Overrides the pending emitted token channel.
+    pub const fn set_channel(&mut self, channel: i32) {
+        self.lexer.set_channel(channel);
+    }
+
+    /// Marks the current match as skipped.
+    pub const fn skip(&mut self) {
+        self.lexer.skip();
+    }
+
+    /// Extends the current token with another lexer-rule match.
+    pub const fn more(&mut self) {
+        self.lexer.more();
+    }
+
+    /// Repositions the committed accept cursor.
+    pub fn reset_accept_position(&mut self, index: usize) {
+        self.lexer.reset_accept_position(index);
+    }
+
+    /// Moves the current token start forward within the committed match.
+    pub fn set_token_start(&mut self, index: usize) -> bool {
+        self.lexer.set_token_start(index)
+    }
+
+    /// Queues an additional token on the current channel.
+    pub fn enqueue_token(&mut self, token_type: i32, stop: usize) {
+        self.enqueue_token_with_channel(token_type, self.channel(), stop);
+    }
+
+    /// Queues an additional token on an explicit channel.
+    pub fn enqueue_token_with_channel(&mut self, token_type: i32, channel: i32, stop: usize) {
+        self.lexer.enqueue_token(token_type, channel, stop, None);
+    }
+
+    /// Sets the current lexer mode.
+    pub fn set_mode(&mut self, mode: i32) {
+        self.lexer.set_mode(mode);
+    }
+
+    /// Pushes the current mode and switches to `mode`.
+    pub fn push_mode(&mut self, mode: i32) {
+        self.lexer.push_mode(mode);
+    }
+
+    /// Pops the mode stack, restoring the previous mode.
+    pub fn pop_mode(&mut self) -> Option<i32> {
+        self.lexer.pop_mode()
+    }
+}
+
 pub trait Lexer: Recognizer {
     fn mode(&self) -> i32;
     fn set_mode(&mut self, mode: i32);
@@ -563,6 +741,29 @@ where
             pending_tokens: VecDeque::new(),
             dfa_cache: Rc::new(RefCell::new(LexerDfaCache::default())),
         }
+    }
+
+    /// Resets runtime-owned lexer state so this instance can consume its input
+    /// again from the beginning.
+    ///
+    /// Learned DFA tables and configuration such as forced interpretation are
+    /// retained. Token-production state, diagnostics, pending tokens, modes,
+    /// and source position are cleared.
+    pub fn reset(&mut self) {
+        self.input.seek(0);
+        self.mode = DEFAULT_MODE;
+        self.mode_stack.clear();
+        self.token_type = INVALID_TOKEN_TYPE;
+        self.channel = DEFAULT_CHANNEL;
+        self.token_start = 0;
+        self.token_start_line = 1;
+        self.token_start_column = 0;
+        self.line = 1;
+        self.column = 0;
+        self.hit_eof = false;
+        self.errors.get_mut().clear();
+        self.semantic_error_coordinates.get_mut().clear();
+        self.pending_tokens.clear();
     }
 
     /// Switches this lexer to the thread-shared learned DFA for `atn`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,9 @@ pub use dfa::{DfaStateId, DfaTransition, ParserDfa, ParserDfaStateView, ParserDf
 pub use errors::{AntlrError, ConsoleErrorListener, ErrorListener};
 pub use generated::{GeneratedLexer, GeneratedParser, GrammarMetadata};
 pub use int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
-pub use lexer::{BaseLexer, Lexer, LexerCustomAction, LexerMode, LexerPredicate, LexerSemCtx};
+pub use lexer::{
+    BaseLexer, Lexer, LexerCustomAction, LexerLifecycleCtx, LexerMode, LexerPredicate, LexerSemCtx,
+};
 pub use parser::{
     BailErrorStrategy, BaseParser, ExpectedTokenSet, NoSemanticHooks, Parser, ParserAction,
     ParserMemberAction, ParserPredicate, ParserReturnAction, ParserRuleArg, ParserRuntimeOptions,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -85,7 +85,7 @@ use crate::atn::parser_atn::{ParserAtnBuilder, ParserTransitionSpec};
 use crate::char_stream::CharStream;
 use crate::errors::AntlrError;
 use crate::int_stream::IntStream;
-use crate::lexer::{LexerCustomAction, LexerSemCtx};
+use crate::lexer::{LexerCustomAction, LexerLifecycleCtx, LexerSemCtx};
 use crate::recognizer::{Recognizer, RecognizerData};
 use crate::semir::{self, AStmt, ArithOp, CmpOp, ExprId, HookId, PExpr, SemIr, StmtId};
 use crate::token::{
@@ -502,6 +502,14 @@ where
 /// to the configured [`UnknownSemanticPolicy`]. Predicate hooks may run during
 /// speculative prediction and must be replay-safe.
 pub trait SemanticHooks {
+    /// Whether generated lexers should route lifecycle callbacks through this
+    /// hook object.
+    ///
+    /// User hook implementations opt in by default. [`NoSemanticHooks`]
+    /// overrides this to keep generated lexers on the direct no-extension
+    /// token path.
+    const ENABLES_LEXER_LIFECYCLE: bool = true;
+
     /// Whether this hook object may observe parser predicate transitions.
     ///
     /// Custom hooks default to conservative predicate handling so the fast
@@ -561,6 +569,40 @@ pub trait SemanticHooks {
         false
     }
 
+    /// Runs after runtime-owned lexer state has been reset for reuse.
+    ///
+    /// Implementations should clear extension-owned transient state here.
+    fn lexer_reset<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+    where
+        I: CharStream,
+    {
+        let _ = ctx;
+    }
+
+    /// Runs before the runtime returns a queued token or starts a new ATN
+    /// token match.
+    ///
+    /// The callback also runs between internal `skip`/`more` matches, so it
+    /// observes every point where another ATN match may start.
+    fn lexer_before_token<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+    where
+        I: CharStream,
+    {
+        let _ = ctx;
+    }
+
+    /// Runs after the accepted path's portable and custom actions, but before
+    /// the token span is finalized and emitted.
+    ///
+    /// This callback has no synthetic ATN coordinate. It therefore also runs
+    /// for accepted rules that contain no action or predicate.
+    fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)
+    where
+        I: CharStream,
+    {
+        let _ = ctx;
+    }
+
     /// Observes a token after committed lexer actions and portable commands
     /// have run and the token has been emitted, immediately before it is
     /// returned to the token stream.
@@ -578,6 +620,8 @@ pub trait SemanticHooks {
 pub struct NoSemanticHooks;
 
 impl SemanticHooks for NoSemanticHooks {
+    const ENABLES_LEXER_LIFECYCLE: bool = false;
+
     fn observes_parser_predicates(&self) -> bool {
         false
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -594,6 +594,9 @@ pub trait SemanticHooks {
     /// Runs after the accepted path's portable and custom actions, but before
     /// the token span is finalized and emitted.
     ///
+    /// Accepted paths that selected `skip` or `more` are included, and the hook
+    /// may observe or override that pending token type.
+    ///
     /// This callback has no synthetic ATN coordinate. It therefore also runs
     /// for accepted rules that contain no action or predicate.
     fn lexer_after_accept<I>(&mut self, ctx: &mut LexerLifecycleCtx<'_, I>)

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1,4 +1,7 @@
+use std::fs;
+use std::path::PathBuf;
 use std::process::{Command, Output};
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn run_antlr4_rust_gen(args: &[&str]) -> Output {
     Command::new(env!("CARGO_BIN_EXE_antlr4-rust-gen"))
@@ -9,6 +12,17 @@ fn run_antlr4_rust_gen(args: &[&str]) -> Output {
 
 fn utf8(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("process output should be UTF-8")
+}
+
+fn temporary_grammar_path() -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system clock should follow the Unix epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "antlr4-rust-gen-options-{}-{nonce}.g4",
+        std::process::id()
+    ))
 }
 
 #[test]
@@ -29,6 +43,7 @@ fn long_help_exits_successfully_on_stdout() {
         "{stdout}"
     );
     assert!(stdout.contains("  --lexer Lexer.interp"), "{stdout}");
+    assert!(stdout.contains("  --option-hook KEY=VALUE"), "{stdout}");
     assert!(stdout.contains("  -h, --help"), "{stdout}");
 }
 
@@ -75,4 +90,66 @@ fn unknown_arguments_still_report_usage_on_stderr() {
     let stderr = utf8(&output.stderr);
     assert!(stderr.contains("unknown argument --bogus"));
     assert!(stderr.contains("Usage: antlr4-rust-gen"));
+}
+
+#[test]
+fn option_hook_requires_a_key_value_assignment() {
+    let output = run_antlr4_rust_gen(&["--option-hook", "superClass"]);
+
+    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stdout), "");
+    let stderr = utf8(&output.stderr);
+    assert!(stderr.contains("--option-hook requires KEY=VALUE"));
+    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+}
+
+#[test]
+fn unsupported_grammar_options_warn_and_exact_hooks_acknowledge_them() {
+    let grammar = temporary_grammar_path();
+    fs::write(
+        &grammar,
+        "lexer grammar L;\noptions { superClass = MyLexerBase; }\nA: 'a';\n",
+    )
+    .expect("temporary grammar should be writable");
+    let missing_interp = grammar.with_extension("missing.interp");
+    let grammar = grammar
+        .to_str()
+        .expect("temporary grammar path should be UTF-8");
+    let missing_interp = missing_interp
+        .to_str()
+        .expect("temporary interp path should be UTF-8");
+
+    let unsupported = run_antlr4_rust_gen(&[
+        "--lexer",
+        missing_interp,
+        "--grammar",
+        grammar,
+        "--require-full-semantics",
+    ]);
+    assert!(!unsupported.status.success());
+    let stderr = utf8(&unsupported.stderr);
+    assert!(
+        stderr.contains("warning: unsupported grammar option: superClass=MyLexerBase at 2:10"),
+        "{stderr}"
+    );
+    assert!(stderr.contains("--option-hook KEY=VALUE"), "{stderr}");
+
+    let acknowledged = run_antlr4_rust_gen(&[
+        "--lexer",
+        missing_interp,
+        "--grammar",
+        grammar,
+        "--option-hook",
+        "superClass=MyLexerBase",
+        "--require-full-semantics",
+    ]);
+    assert!(!acknowledged.status.success());
+    let stderr = utf8(&acknowledged.stderr);
+    assert!(!stderr.contains("unsupported grammar option"), "{stderr}");
+    assert!(
+        !stderr.contains("require caller-owned target behavior"),
+        "{stderr}"
+    );
+
+    fs::remove_file(grammar).expect("temporary grammar should be removable");
 }

--- a/tests/javascript-parity/run.sh
+++ b/tests/javascript-parity/run.sh
@@ -58,6 +58,7 @@ cargo run --quiet --locked --release --manifest-path "$REPO_ROOT/Cargo.toml" \
     --lexer "$WORK_DIR/interp/JavaScriptLexer.interp" \
     --grammar "$WORK_DIR/grammar/JavaScriptLexer.g4" \
     --sem-patterns "$REPO_ROOT/patterns/javascript.toml" \
+    --option-hook superClass=JavaScriptLexerBase \
     --sem-unknown error --require-full-semantics \
     --out-dir "$WORK_DIR/rust-lexer"
 cargo run --quiet --locked --release --manifest-path "$REPO_ROOT/Cargo.toml" \
@@ -65,6 +66,7 @@ cargo run --quiet --locked --release --manifest-path "$REPO_ROOT/Cargo.toml" \
     --parser "$WORK_DIR/interp/JavaScriptParser.interp" \
     --grammar "$WORK_DIR/grammar/JavaScriptParser.g4" \
     --sem-patterns "$REPO_ROOT/patterns/javascript.toml" \
+    --option-hook superClass=JavaScriptParserBase \
     --sem-unknown error --require-full-semantics \
     --out-dir "$WORK_DIR/rust-parser"
 

--- a/tests/typescript-parity/run.sh
+++ b/tests/typescript-parity/run.sh
@@ -49,6 +49,7 @@ cargo run --quiet --locked --release --manifest-path "$REPO_ROOT/Cargo.toml" \
     --lexer "$WORK_DIR/java-gen/TypeScriptLexer.interp" \
     --grammar "$WORK_DIR/grammar/TypeScriptLexer.g4" \
     --sem-patterns "$REPO_ROOT/patterns/javascript.toml" \
+    --option-hook superClass=TypeScriptLexerBase \
     --sem-unknown error --require-full-semantics \
     --out-dir "$WORK_DIR/rust-lexer"
 cargo run --quiet --locked --release --manifest-path "$REPO_ROOT/Cargo.toml" \
@@ -56,6 +57,7 @@ cargo run --quiet --locked --release --manifest-path "$REPO_ROOT/Cargo.toml" \
     --parser "$WORK_DIR/java-gen/TypeScriptParser.interp" \
     --grammar "$WORK_DIR/grammar/TypeScriptParser.g4" \
     --sem-patterns "$REPO_ROOT/patterns/javascript.toml" \
+    --option-hook superClass=TypeScriptParserBase \
     --sem-unknown error --require-full-semantics \
     --out-dir "$WORK_DIR/rust-parser"
 


### PR DESCRIPTION
## Summary

- add grammar-agnostic lexer lifecycle hooks for reset, pre-token, post-accept/pre-emission, and existing post-emission observation across interpreted and compiled lexer paths
- preserve the direct compiled-DFA path for default generated lexers while allowing caller-owned hooks to compose with actions, predicates, pending tokens, `skip`, `more`, and accept-position rewinds
- execute `LexerExec/PositionAdjustingLexer` through the public lifecycle contract and remove the final runtime-testsuite skip
- inventory top-level grammar options in `semantics.json`, warn for unsupported target-extension options, and support exact `--option-hook KEY=VALUE` acknowledgements under `--require-full-semantics`

Closes #98.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --doc --all-features`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite`
  - `357 passed, 0 failed, 0 skipped, 357 run`
- `tests/javascript-parity/run.sh ...`
  - all 6 snippets matched Python tokens and parse trees
- `tests/typescript-parity/run.sh ...`
  - all 5 snippets matched Java tokens and parse trees
- same-machine generated-only parse benchmark against `origin/main` across 17 Kotlin, C#, Java, and Trino fixtures
  - repository comparator passed at the `1.15x` threshold
  - overall head/base geometric mean: `0.996x`