### PR TITLE
Accelerate lexer fallback and parser deduplication

### DIFF
--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -1263,8 +1263,8 @@ where
     let mut active = prune_after_accepts(atn, closure.configs);
     update_best_accept(atn, &active, &mut best);
 
-    while !active.is_empty() {
-        let active_position = active[0].position;
+    while let Some(config) = active.first() {
+        let active_position = config.position;
         debug_assert!(
             active
                 .iter()

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -669,7 +669,9 @@ where
         match match_token_compiled(lexer, dfa, start_state, start) {
             CompiledMatch::Complete(result) => return result,
             CompiledMatch::Resume(resume) => {
-                return match_token_from_continuation(lexer, atn, resume, semantic_predicate);
+                if compiled_resume_matches_atn(atn, start, &resume) {
+                    return match_token_from_continuation(lexer, atn, resume, semantic_predicate);
+                }
             }
             CompiledMatch::Restart => {}
         }
@@ -1078,6 +1080,29 @@ struct CompiledResume<'a> {
     position: usize,
     best: Option<AcceptState>,
     error_stop: usize,
+}
+
+fn compiled_resume_matches_atn(atn: &LexerAtn, start: usize, resume: &CompiledResume<'_>) -> bool {
+    let Some(consumed) = resume.position.checked_sub(start) else {
+        return false;
+    };
+    let rule_count = atn.rule_to_token_type().len();
+    !resume.continuation.configs.is_empty()
+        && resume.continuation.configs.iter().all(|config| {
+            atn.state(config.state).is_some()
+                && config
+                    .alt_rule_index
+                    .is_some_and(|rule_index| rule_index < rule_count)
+                && config
+                    .stack
+                    .iter()
+                    .all(|&state_number| atn.state(state_number).is_some())
+                && config.actions.iter().all(|action| {
+                    action.action_index < atn.lexer_actions().len()
+                        && action.rule_index < rule_count
+                        && action.behind <= consumed
+                })
+        })
 }
 
 /// Matches one token by walking the ahead-of-time compiled lexer DFA.
@@ -1795,6 +1820,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::atn::lexer_dfa::{CompiledLexerActionTrace, CompiledLexerConfig};
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
     use crate::atn::{LexerAtnState, LexerTransition};
     use crate::char_stream::InputStream;
@@ -2881,6 +2907,71 @@ mod tests {
             assert_eq!((token.start, token.stop), (0, 3), "{strategy:?}");
             assert_eq!(token.text, "/**/", "{strategy:?}");
         }
+    }
+
+    #[test]
+    fn compiled_resume_rejects_untrusted_continuation_payloads() {
+        let atn = trailing_action_atn(&['a'], 1, vec![LexerAction::Skip]);
+        let valid_config = CompiledLexerConfig {
+            state: 2,
+            consumed_eof: false,
+            alt_rule_index: Some(0),
+            passed_non_greedy: false,
+            stack: Vec::new(),
+            actions: vec![CompiledLexerActionTrace {
+                action_index: 0,
+                rule_index: 0,
+                behind: 0,
+            }],
+        };
+        let valid = |config| CompiledLexerContinuation {
+            configs: vec![config],
+        };
+        let matches = |continuation: &CompiledLexerContinuation| {
+            compiled_resume_matches_atn(
+                &atn,
+                4,
+                &CompiledResume {
+                    continuation,
+                    position: 5,
+                    best: None,
+                    error_stop: 5,
+                },
+            )
+        };
+
+        assert!(matches(&valid(valid_config.clone())));
+        assert!(!matches(&CompiledLexerContinuation {
+            configs: Vec::new(),
+        }));
+
+        let mut invalid = valid_config.clone();
+        invalid.state = usize::MAX;
+        assert!(!matches(&valid(invalid)));
+
+        let mut invalid = valid_config.clone();
+        invalid.alt_rule_index = None;
+        assert!(!matches(&valid(invalid)));
+
+        let mut invalid = valid_config.clone();
+        invalid.alt_rule_index = Some(1);
+        assert!(!matches(&valid(invalid)));
+
+        let mut invalid = valid_config.clone();
+        invalid.stack.push(usize::MAX);
+        assert!(!matches(&valid(invalid)));
+
+        let mut invalid = valid_config.clone();
+        invalid.actions[0].action_index = 1;
+        assert!(!matches(&valid(invalid)));
+
+        let mut invalid = valid_config.clone();
+        invalid.actions[0].rule_index = 1;
+        assert!(!matches(&valid(invalid)));
+
+        let mut invalid = valid_config;
+        invalid.actions[0].behind = 2;
+        assert!(!matches(&valid(invalid)));
     }
 
     #[test]

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -2,7 +2,9 @@ use std::cell::RefCell;
 use std::collections::HashSet;
 use std::hash::BuildHasherDefault;
 
-use crate::atn::lexer_dfa::{CompiledLexerAccept, CompiledLexerDfa, DEAD_STATE, ESCAPE_STATE};
+use crate::atn::lexer_dfa::{
+    CompiledLexerAccept, CompiledLexerContinuation, CompiledLexerDfa, DEAD_STATE, ESCAPE_STATE,
+};
 use crate::atn::{AtnStateKind, LexerAction, LexerAtn, LexerTransition};
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
@@ -663,9 +665,14 @@ where
     if let Some(dfa) = strategy.compiled
         && !lexer.force_interpreted()
         && let Some(start_state) = dfa.mode_start(mode)
-        && let Some(result) = match_token_compiled(lexer, dfa, start_state, start)
     {
-        return result;
+        match match_token_compiled(lexer, dfa, start_state, start) {
+            CompiledMatch::Complete(result) => return result,
+            CompiledMatch::Resume(resume) => {
+                return match_token_from_continuation(lexer, atn, resume, semantic_predicate);
+            }
+            CompiledMatch::Restart => {}
+        }
     }
     if strategy.use_cache {
         match_token_cached(lexer, atn, mode, start, semantic_predicate)
@@ -863,16 +870,19 @@ where
     let mut best = best_accept(atn, &active);
     let mut error_stop = start;
     while !active.is_empty() {
+        let position = active[0].position;
+        debug_assert!(
+            active.iter().all(|config| config.position == position),
+            "lexer ATN configs must advance through the input in lockstep"
+        );
+        let symbol = symbol_at(lexer, position);
+        if symbol != EOF {
+            error_stop = error_stop.max(position.saturating_add(1));
+        }
         let mut next = Vec::new();
         let source_dfa_state = dfa_state;
         let source_has_semantic_context = dfa_state_has_semantic_context;
-        let mut edge_symbol = None;
         for config in active {
-            let symbol = symbol_at(lexer, config.position);
-            if symbol != EOF {
-                error_stop = error_stop.max(config.position.saturating_add(1));
-                edge_symbol = Some(symbol);
-            }
             let Some(state) = atn.state(config.state) else {
                 continue;
             };
@@ -904,7 +914,7 @@ where
             );
             dfa_state_has_semantic_context = target_has_semantic_context;
             if !suppress_edge {
-                if let Some(symbol) = edge_symbol {
+                if symbol != EOF {
                     lexer.record_lexer_dfa_edge(source_dfa_state, symbol, dfa_state);
                 }
             }
@@ -1057,20 +1067,33 @@ where
 /// (including grammars whose chains never terminate).
 const MAX_COMPILED_EOF_EDGES: u32 = 8;
 
+enum CompiledMatch<'a> {
+    Complete(MatchResult),
+    Resume(CompiledResume<'a>),
+    Restart,
+}
+
+struct CompiledResume<'a> {
+    continuation: &'a CompiledLexerContinuation,
+    position: usize,
+    best: Option<AcceptState>,
+    error_stop: usize,
+}
+
 /// Matches one token by walking the ahead-of-time compiled lexer DFA.
 ///
 /// The walk reproduces the interpreter's longest-match selection: remember
 /// the best accept seen so far, advance until the table has no transition,
 /// then return the remembered accept — or a recognition error spanning every
 /// character the walk looked at, exactly like `match_token`. Reaching an
-/// escape edge (semantic predicate, recursive lexer rule, state budget)
-/// returns `None`, and the caller re-matches the token with the interpreter.
-fn match_token_compiled<I>(
+/// escape edge resumes the interpreter from its narrowed configs when present;
+/// budget-only escapes restart from the token boundary.
+fn match_token_compiled<'a, I>(
     lexer: &mut BaseLexer<I>,
-    dfa: &CompiledLexerDfa,
+    dfa: &'a CompiledLexerDfa,
     start_state: u16,
     start: usize,
-) -> Option<MatchResult>
+) -> CompiledMatch<'a>
 where
     I: CharStream,
 {
@@ -1080,12 +1103,12 @@ where
     match_token_compiled_generic(lexer, dfa, start_state, start)
 }
 
-fn match_token_compiled_ascii(
+fn match_token_compiled_ascii<'a>(
     input: &[u8],
-    dfa: &CompiledLexerDfa,
+    dfa: &'a CompiledLexerDfa,
     start_state: u16,
     start: usize,
-) -> Option<MatchResult> {
+) -> CompiledMatch<'a> {
     let mut state = start_state;
     let mut position = start;
     let mut best: Option<AcceptState> = None;
@@ -1108,18 +1131,30 @@ fn match_token_compiled_ascii(
         } else {
             eof_edges += 1;
             if eof_edges > MAX_COMPILED_EOF_EDGES {
-                break None;
+                break CompiledMatch::Restart;
             }
             (dfa.eof_target(state), true)
         };
         if target == DEAD_STATE {
-            break Some(best.map_or(
+            break CompiledMatch::Complete(best.map_or(
                 MatchResult::NoViableAlt { stop: error_stop },
                 MatchResult::Accept,
             ));
         }
         if target == ESCAPE_STATE {
-            break None;
+            let continuation = if at_eof {
+                dfa.eof_continuation(state)
+            } else {
+                dfa.char_continuation(state, i32::from(input[position]))
+            };
+            break continuation.map_or(CompiledMatch::Restart, |continuation| {
+                CompiledMatch::Resume(CompiledResume {
+                    continuation,
+                    position: position + usize::from(!at_eof),
+                    best,
+                    error_stop,
+                })
+            });
         }
         if !at_eof {
             position += 1;
@@ -1131,12 +1166,12 @@ fn match_token_compiled_ascii(
     result
 }
 
-fn match_token_compiled_generic<I>(
+fn match_token_compiled_generic<'a, I>(
     lexer: &mut BaseLexer<I>,
-    dfa: &CompiledLexerDfa,
+    dfa: &'a CompiledLexerDfa,
     start_state: u16,
     start: usize,
-) -> Option<MatchResult>
+) -> CompiledMatch<'a>
 where
     I: CharStream,
 {
@@ -1153,7 +1188,7 @@ where
         let target = if symbol == EOF {
             eof_edges += 1;
             if eof_edges > MAX_COMPILED_EOF_EDGES {
-                return None;
+                return CompiledMatch::Restart;
             }
             dfa.eof_target(state)
         } else {
@@ -1164,17 +1199,125 @@ where
             break;
         }
         if target == ESCAPE_STATE {
-            return None;
+            let continuation = if symbol == EOF {
+                dfa.eof_continuation(state)
+            } else {
+                dfa.char_continuation(state, symbol)
+            };
+            return continuation.map_or(CompiledMatch::Restart, |continuation| {
+                CompiledMatch::Resume(CompiledResume {
+                    continuation,
+                    position: position + usize::from(symbol != EOF),
+                    best,
+                    error_stop,
+                })
+            });
         }
         if symbol != EOF {
             position += 1;
         }
         state = target;
     }
-    Some(best.map_or(
+    CompiledMatch::Complete(best.map_or(
         MatchResult::NoViableAlt { stop: error_stop },
         MatchResult::Accept,
     ))
+}
+
+fn match_token_from_continuation<I, P>(
+    lexer: &mut BaseLexer<I>,
+    atn: &LexerAtn,
+    resume: CompiledResume<'_>,
+    semantic_predicate: &mut P,
+) -> MatchResult
+where
+    I: CharStream,
+    P: FnMut(&BaseLexer<I>, LexerPredicate) -> bool,
+{
+    let CompiledResume {
+        continuation,
+        position,
+        mut best,
+        mut error_stop,
+    } = resume;
+    let moved = continuation.configs.iter().map(|config| LexerConfig {
+        state: config.state,
+        position,
+        consumed_eof: config.consumed_eof,
+        alt_rule_index: config.alt_rule_index,
+        passed_non_greedy: config.passed_non_greedy,
+        stack: config.stack.clone(),
+        actions: config
+            .actions
+            .iter()
+            .map(|action| LexerActionTrace {
+                action_index: action.action_index,
+                position: position.saturating_sub(action.behind),
+                rule_index: action.rule_index,
+            })
+            .collect(),
+    });
+    let closure = epsilon_closure(atn, moved, &mut |predicate| {
+        semantic_predicate(lexer, predicate)
+    });
+    let mut active = prune_after_accepts(atn, closure.configs);
+    update_best_accept(atn, &active, &mut best);
+
+    while !active.is_empty() {
+        let active_position = active[0].position;
+        debug_assert!(
+            active
+                .iter()
+                .all(|config| config.position == active_position),
+            "lexer ATN configs must advance through the input in lockstep"
+        );
+        let symbol = symbol_at(lexer, active_position);
+        if symbol != EOF {
+            error_stop = error_stop.max(active_position.saturating_add(1));
+        }
+        let mut next = Vec::new();
+        for config in active {
+            let Some(state) = atn.state(config.state) else {
+                continue;
+            };
+            for transition in &state.transitions {
+                if !transition.matches(symbol, MIN_CHAR_VALUE, MAX_CHAR_VALUE) {
+                    continue;
+                }
+                let mut advanced = config.clone();
+                set_config_state(atn, &mut advanced, transition.target());
+                if symbol == EOF {
+                    advanced.consumed_eof = true;
+                } else {
+                    advanced.position += 1;
+                }
+                next.push(advanced);
+            }
+        }
+
+        let closure = epsilon_closure(atn, next, &mut |predicate| {
+            semantic_predicate(lexer, predicate)
+        });
+        active = prune_after_accepts(atn, closure.configs);
+        update_best_accept(atn, &active, &mut best);
+    }
+
+    best.map_or(
+        MatchResult::NoViableAlt { stop: error_stop },
+        MatchResult::Accept,
+    )
+}
+
+fn update_best_accept(atn: &LexerAtn, active: &[LexerConfig], best: &mut Option<AcceptState>) {
+    let Some(accept) = best_accept(atn, active) else {
+        return;
+    };
+    if best.as_ref().is_none_or(|current| {
+        accept.position > current.position
+            || (accept.position == current.position && accept.rule_index < current.rule_index)
+    }) {
+        *best = Some(accept);
+    }
 }
 
 /// Applies the interpreter's longest-match / lowest-rule preference to one

--- a/src/atn/lexer_dfa.rs
+++ b/src/atn/lexer_dfa.rs
@@ -11,11 +11,11 @@
 //! closure crosses a semantic predicate (whose outcome exists only at parse
 //! time), grows an unbounded rule-call stack (recursive lexer rules such as
 //! nested comments), or exceeds the state budget is compiled as an *escape*
-//! edge. A token walk that reaches an escape edge is re-matched from the
-//! token start by the ATN interpreter, so rare dynamic constructs never
-//! poison the rest of the mode. Because the construction reuses the
-//! interpreter's own closure, pruning, and accept-selection code, a compiled
-//! walk that does not escape reproduces interpreter behavior exactly.
+//! edge. Dynamic closures carry their pre-closure configs so the interpreter
+//! resumes from the narrowed edge instead of re-matching from the token start.
+//! Because the construction reuses the interpreter's own closure, pruning, and
+//! accept-selection code, a compiled walk that does not escape reproduces
+//! interpreter behavior exactly.
 
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
@@ -38,7 +38,7 @@ const MAX_CHAR_VALUE: i32 = 0x0010_FFFF;
 /// Sentinel state id meaning "no transition".
 pub(super) const DEAD_STATE: u16 = u16::MAX;
 
-/// Sentinel state id meaning "re-match this token with the ATN interpreter".
+/// Sentinel state id meaning "hand this edge to the ATN interpreter".
 pub(super) const ESCAPE_STATE: u16 = u16::MAX - 1;
 
 /// Per-mode state budget; targets past it compile as escape edges. The cap
@@ -72,6 +72,8 @@ pub struct CompiledLexerDfa {
     ascii_rows: Vec<[u16; ASCII_EDGE_SYMBOLS]>,
     wide_rows: Vec<Box<[WideRange]>>,
     accepts: Vec<CompiledLexerAccept>,
+    escape_rows: Vec<CompiledLexerEscapeRow>,
+    continuations: Vec<CompiledLexerContinuation>,
 }
 
 /// One compiled DFA state; rows are pooled indices because many states share
@@ -91,6 +93,39 @@ struct WideRange {
     low: u32,
     high: u32,
     target: u16,
+}
+
+/// Dynamic outgoing edges for one compiled state.
+#[derive(Clone, Debug)]
+struct CompiledLexerEscapeRow {
+    ranges: Box<[CompiledLexerEscapeRange]>,
+    eof: u32,
+}
+
+/// Inclusive character range that resumes one interpreter continuation.
+#[derive(Clone, Copy, Debug)]
+struct CompiledLexerEscapeRange {
+    low: u32,
+    high: u32,
+    continuation: u32,
+}
+
+/// ATN configs immediately after an escaped consuming transition and before
+/// its dynamic epsilon closure.
+#[derive(Clone, Debug)]
+pub(super) struct CompiledLexerContinuation {
+    pub(super) configs: Vec<CompiledLexerConfig>,
+}
+
+/// Position-independent ATN config stored in an escape continuation.
+#[derive(Clone, Debug)]
+pub(super) struct CompiledLexerConfig {
+    pub(super) state: usize,
+    pub(super) consumed_eof: bool,
+    pub(super) alt_rule_index: Option<usize>,
+    pub(super) passed_non_greedy: bool,
+    pub(super) stack: Vec<usize>,
+    pub(super) actions: Vec<CompiledLexerActionTrace>,
 }
 
 /// Accept metadata for one DFA state: the winning lexer rule plus the action
@@ -113,8 +148,8 @@ pub(super) struct CompiledLexerActionTrace {
 }
 
 impl CompiledLexerDfa {
-    /// Compiles every lexer mode of `atn` that has no semantic predicates and
-    /// fits the state budget; the rest stay interpreter-matched.
+    /// Compiles every lexer mode whose initial closure is static and fits the
+    /// state budget; dynamic interior edges carry interpreter continuations.
     pub fn compile(atn: &LexerAtn) -> Self {
         let mut dfa = Self {
             mode_starts: Vec::new(),
@@ -122,6 +157,8 @@ impl CompiledLexerDfa {
             ascii_rows: Vec::new(),
             wide_rows: Vec::new(),
             accepts: Vec::new(),
+            escape_rows: Vec::new(),
+            continuations: Vec::new(),
         };
         let mut pools = RowPools::default();
         for mode in 0..atn.mode_to_start_state().len() {
@@ -204,6 +241,28 @@ impl CompiledLexerDfa {
         self.states[usize::from(state)].eof_target
     }
 
+    /// Interpreter continuation for an escaped character edge.
+    pub(super) fn char_continuation(
+        &self,
+        state: u16,
+        symbol: i32,
+    ) -> Option<&CompiledLexerContinuation> {
+        let code_point = symbol.cast_unsigned();
+        let ranges = &self.escape_rows[usize::from(state)].ranges;
+        let found = match ranges.binary_search_by(|range| range.low.cmp(&code_point)) {
+            Ok(found) => Some(found),
+            Err(insert) if insert > 0 && ranges[insert - 1].high >= code_point => Some(insert - 1),
+            Err(_) => None,
+        }?;
+        self.continuations.get(ranges[found].continuation as usize)
+    }
+
+    /// Interpreter continuation for an escaped EOF edge.
+    pub(super) fn eof_continuation(&self, state: u16) -> Option<&CompiledLexerContinuation> {
+        self.continuations
+            .get(self.escape_rows[usize::from(state)].eof as usize)
+    }
+
     /// Flattens the compiled DFA into a `u32` stream for embedding in
     /// generated code.
     ///
@@ -211,7 +270,7 @@ impl CompiledLexerDfa {
     /// rejects streams from other versions so generated lexers can fall back
     /// to [`Self::compile`].
     pub fn serialize(&self) -> Vec<u32> {
-        // Exact word count: the tag, five section-length words, and each
+        // Exact word count: the tag, seven section-length words, and each
         // section's payload (states are 4 words; ASCII rows pack 2 targets
         // per word; wide ranges and action traces are 3 words each behind
         // their per-row/per-accept length words).
@@ -221,12 +280,30 @@ impl CompiledLexerDfa {
             .iter()
             .map(|accept| 3 + accept.actions.len() * 3)
             .sum();
-        let capacity = 6
+        let escape_row_words: usize = self
+            .escape_rows
+            .iter()
+            .map(|row| 2 + row.ranges.len() * 3)
+            .sum();
+        let continuation_words: usize = self
+            .continuations
+            .iter()
+            .map(|continuation| {
+                1 + continuation
+                    .configs
+                    .iter()
+                    .map(|config| 6 + config.stack.len() + config.actions.len() * 3)
+                    .sum::<usize>()
+            })
+            .sum();
+        let capacity = 8
             + self.mode_starts.len()
             + self.states.len() * 4
             + self.ascii_rows.len() * (ASCII_EDGE_SYMBOLS / 2)
             + wide_words
-            + accept_words;
+            + accept_words
+            + escape_row_words
+            + continuation_words;
         let mut out = Vec::with_capacity(capacity);
         out.push(SERIALIZED_TAG);
         out.push(self.mode_starts.len() as u32);
@@ -266,6 +343,36 @@ impl CompiledLexerDfa {
                 out.push(action.behind as u32);
             }
         }
+        out.push(self.escape_rows.len() as u32);
+        for row in &self.escape_rows {
+            out.push(row.eof);
+            out.push(row.ranges.len() as u32);
+            for range in &*row.ranges {
+                out.push(range.low);
+                out.push(range.high);
+                out.push(range.continuation);
+            }
+        }
+        out.push(self.continuations.len() as u32);
+        for continuation in &self.continuations {
+            out.push(continuation.configs.len() as u32);
+            for config in &continuation.configs {
+                out.push(config.state as u32);
+                out.push(config.alt_rule_index.map_or(u32::MAX, |rule| rule as u32));
+                out.push(u32::from(config.consumed_eof));
+                out.push(u32::from(config.passed_non_greedy));
+                out.push(config.stack.len() as u32);
+                for &state in &config.stack {
+                    out.push(state as u32);
+                }
+                out.push(config.actions.len() as u32);
+                for action in &config.actions {
+                    out.push(action.action_index as u32);
+                    out.push(action.rule_index as u32);
+                    out.push(action.behind as u32);
+                }
+            }
+        }
         debug_assert_eq!(
             out.len(),
             capacity,
@@ -296,6 +403,8 @@ impl CompiledLexerDfa {
         let ascii_rows = reader.read_ascii_rows()?;
         let wide_rows = reader.read_wide_rows()?;
         let accepts = reader.read_accepts()?;
+        let escape_rows = reader.read_escape_rows()?;
+        let continuations = reader.read_continuations()?;
         if reader.position != data.len() {
             return None;
         }
@@ -305,6 +414,8 @@ impl CompiledLexerDfa {
             ascii_rows,
             wide_rows,
             accepts,
+            escape_rows,
+            continuations,
         };
         dfa.table_indexes_are_valid().then_some(dfa)
     }
@@ -331,6 +442,15 @@ impl CompiledLexerDfa {
             && self.wide_rows.iter().all(|row| {
                 wide_row_is_searchable(row) && row.iter().all(|range| state_ok(range.target))
             })
+            && self.escape_rows.len() == self.states.len()
+            && self.escape_rows.iter().all(|row| {
+                (row.eof == u32::MAX || (row.eof as usize) < self.continuations.len())
+                    && escape_row_is_searchable(&row.ranges)
+                    && row
+                        .ranges
+                        .iter()
+                        .all(|range| (range.continuation as usize) < self.continuations.len())
+            })
     }
 }
 
@@ -342,9 +462,14 @@ fn wide_row_is_searchable(row: &[WideRange]) -> bool {
         && row.windows(2).all(|pair| pair[0].high < pair[1].low)
 }
 
+fn escape_row_is_searchable(row: &[CompiledLexerEscapeRange]) -> bool {
+    row.iter().all(|range| range.low <= range.high)
+        && row.windows(2).all(|pair| pair[0].high < pair[1].low)
+}
+
 /// Version tag guarding embedded tables against format or construction-semantic
 /// drift.
-const SERIALIZED_TAG: u32 = 0x4C58_4402;
+const SERIALIZED_TAG: u32 = 0x4C58_4403;
 
 /// Cursor over a serialized DFA stream.
 struct SerializedReader<'a> {
@@ -437,6 +562,72 @@ impl SerializedReader<'_> {
         }
         Some(accepts)
     }
+
+    fn read_escape_rows(&mut self) -> Option<Vec<CompiledLexerEscapeRow>> {
+        let count = self.next_len()?;
+        let mut rows = Vec::with_capacity(count.min(self.data.len()));
+        for _ in 0..count {
+            let eof = self.next()?;
+            let len = self.next_len()?;
+            let mut ranges = Vec::with_capacity(len.min(self.data.len()));
+            for _ in 0..len {
+                ranges.push(CompiledLexerEscapeRange {
+                    low: self.next()?,
+                    high: self.next()?,
+                    continuation: self.next()?,
+                });
+            }
+            rows.push(CompiledLexerEscapeRow {
+                ranges: ranges.into(),
+                eof,
+            });
+        }
+        Some(rows)
+    }
+
+    fn read_continuations(&mut self) -> Option<Vec<CompiledLexerContinuation>> {
+        let count = self.next_len()?;
+        let mut continuations = Vec::with_capacity(count.min(self.data.len()));
+        for _ in 0..count {
+            let config_count = self.next_len()?;
+            let mut configs = Vec::with_capacity(config_count.min(self.data.len()));
+            for _ in 0..config_count {
+                let state = self.next_len()?;
+                let alt_rule = self.next()?;
+                let alt_rule_index = if alt_rule == u32::MAX {
+                    None
+                } else {
+                    Some(usize::try_from(alt_rule).ok()?)
+                };
+                let consumed_eof = self.next()? != 0;
+                let passed_non_greedy = self.next()? != 0;
+                let stack_count = self.next_len()?;
+                let mut stack = Vec::with_capacity(stack_count.min(self.data.len()));
+                for _ in 0..stack_count {
+                    stack.push(self.next_len()?);
+                }
+                let action_count = self.next_len()?;
+                let mut actions = Vec::with_capacity(action_count.min(self.data.len()));
+                for _ in 0..action_count {
+                    actions.push(CompiledLexerActionTrace {
+                        action_index: self.next_len()?,
+                        rule_index: self.next_len()?,
+                        behind: self.next_len()?,
+                    });
+                }
+                configs.push(CompiledLexerConfig {
+                    state,
+                    consumed_eof,
+                    alt_rule_index,
+                    passed_non_greedy,
+                    stack,
+                    actions,
+                });
+            }
+            continuations.push(CompiledLexerContinuation { configs });
+        }
+        Some(continuations)
+    }
 }
 
 /// Deduplicating pools for edge rows shared by many DFA states.
@@ -477,10 +668,12 @@ impl RowPools {
 /// shared [`CompiledLexerDfa`] until the whole mode succeeds.
 struct ModeBuild {
     base: usize,
+    continuation_base: usize,
     ids: FxHashMap<LexerDfaKey, u16>,
     configs: Vec<Vec<LexerConfig>>,
     steps: Vec<usize>,
     accepts: Vec<Option<CompiledLexerAccept>>,
+    continuations: Vec<CompiledLexerContinuation>,
 }
 
 /// Edge rows produced by expanding one DFA state.
@@ -488,16 +681,33 @@ struct StateRows {
     /// Sorted, disjoint code-point segments with live targets.
     segments: Vec<(i32, i32, u16)>,
     eof_target: u16,
+    escapes: Vec<(i32, i32, u32)>,
+    eof_escape: u32,
+}
+
+#[derive(Clone, Copy)]
+struct EdgeTarget {
+    state: u16,
+    continuation: u32,
+}
+
+impl EdgeTarget {
+    const DEAD: Self = Self {
+        state: DEAD_STATE,
+        continuation: u32::MAX,
+    };
 }
 
 impl ModeBuild {
-    fn new(base: usize) -> Self {
+    fn new(base: usize, continuation_base: usize) -> Self {
         Self {
             base,
+            continuation_base,
             ids: FxHashMap::default(),
             configs: Vec::new(),
             steps: Vec::new(),
             accepts: Vec::new(),
+            continuations: Vec::new(),
         }
     }
 
@@ -531,6 +741,35 @@ impl ModeBuild {
         self.accepts.push(compiled_accept(atn, &configs, step));
         self.configs.push(configs);
         self.steps.push(step);
+        id
+    }
+
+    fn add_continuation(&mut self, configs: &[LexerConfig], step: usize) -> u32 {
+        let id = self.continuation_base + self.continuations.len();
+        let Ok(id) = u32::try_from(id) else {
+            return u32::MAX;
+        };
+        self.continuations.push(CompiledLexerContinuation {
+            configs: configs
+                .iter()
+                .map(|config| CompiledLexerConfig {
+                    state: config.state,
+                    consumed_eof: config.consumed_eof,
+                    alt_rule_index: config.alt_rule_index,
+                    passed_non_greedy: config.passed_non_greedy,
+                    stack: config.stack.clone(),
+                    actions: config
+                        .actions
+                        .iter()
+                        .map(|action| CompiledLexerActionTrace {
+                            action_index: action.action_index,
+                            rule_index: action.rule_index,
+                            behind: step.saturating_sub(action.position),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        });
         id
     }
 }
@@ -597,7 +836,7 @@ fn build_mode(
     pools: &mut RowPools,
 ) -> Option<u16> {
     let start_state = atn.mode_to_start_state().get(mode).copied()?;
-    let mut build = ModeBuild::new(dfa.states.len());
+    let mut build = ModeBuild::new(dfa.states.len(), dfa.continuations.len());
     let start_configs = closed_configs(
         atn,
         vec![LexerConfig {
@@ -696,12 +935,14 @@ fn expand_state(atn: &LexerAtn, build: &mut ModeBuild, local: usize) -> StateRow
 
     let mut rows = StateRows {
         segments: Vec::new(),
-        eof_target,
+        eof_target: eof_target.state,
+        escapes: Vec::new(),
+        eof_escape: eof_target.continuation,
     };
     // Distinct transition sets are few even when segments are many (large
     // Unicode classes fragment the alphabet), so closures run once per
     // matching-transition mask, not once per segment.
-    let mut mask_targets: FxHashMap<Vec<u64>, u16> = FxHashMap::default();
+    let mut mask_targets: FxHashMap<Vec<u64>, EdgeTarget> = FxHashMap::default();
     for (index, &(low, high)) in segments.iter().enumerate() {
         let mask = &matrix[index * words..(index + 1) * words];
         if mask.iter().all(|&word| word == 0) {
@@ -715,8 +956,11 @@ fn expand_state(atn: &LexerAtn, build: &mut ModeBuild, local: usize) -> StateRow
                 target
             }
         };
-        if target != DEAD_STATE {
-            rows.segments.push((low, high, target));
+        if target.state != DEAD_STATE {
+            rows.segments.push((low, high, target.state));
+            if target.continuation != u32::MAX {
+                rows.escapes.push((low, high, target.continuation));
+            }
         }
     }
     rows
@@ -826,7 +1070,7 @@ fn move_target(
     step: usize,
     entries: &[(usize, &LexerTransition)],
     mask: &[u64],
-) -> u16 {
+) -> EdgeTarget {
     let mut moved = Vec::new();
     for (bit, (config_index, transition)) in entries.iter().enumerate() {
         if mask[bit / 64] & (1 << (bit % 64)) == 0 {
@@ -837,13 +1081,20 @@ fn move_target(
         advanced.position += 1;
         moved.push(advanced);
     }
+    let continuation_configs = moved.clone();
     let Some(active) = closed_configs(atn, moved) else {
-        return ESCAPE_STATE;
+        return EdgeTarget {
+            state: ESCAPE_STATE,
+            continuation: build.add_continuation(&continuation_configs, step + 1),
+        };
     };
     if active.is_empty() {
-        return DEAD_STATE;
+        return EdgeTarget::DEAD;
     }
-    build.intern(atn, active, step + 1)
+    EdgeTarget {
+        state: build.intern(atn, active, step + 1),
+        continuation: u32::MAX,
+    }
 }
 
 /// Advances the EOF-matching entries; EOF consumes no character, so the input
@@ -854,7 +1105,7 @@ fn eof_move(
     configs: &[LexerConfig],
     step: usize,
     entries: &[(usize, &LexerTransition)],
-) -> u16 {
+) -> EdgeTarget {
     let mut moved = Vec::new();
     for (config_index, transition) in entries {
         if !transition.matches(EOF, MIN_CHAR_VALUE, MAX_CHAR_VALUE) {
@@ -866,15 +1117,22 @@ fn eof_move(
         moved.push(advanced);
     }
     if moved.is_empty() {
-        return DEAD_STATE;
+        return EdgeTarget::DEAD;
     }
+    let continuation_configs = moved.clone();
     let Some(active) = closed_configs(atn, moved) else {
-        return ESCAPE_STATE;
+        return EdgeTarget {
+            state: ESCAPE_STATE,
+            continuation: build.add_continuation(&continuation_configs, step),
+        };
     };
     if active.is_empty() {
-        return DEAD_STATE;
+        return EdgeTarget::DEAD;
     }
-    build.intern(atn, active, step)
+    EdgeTarget {
+        state: build.intern(atn, active, step),
+        continuation: u32::MAX,
+    }
 }
 
 /// Converts a finished mode's edge rows into pooled table entries.
@@ -884,7 +1142,12 @@ fn commit_mode(
     build: ModeBuild,
     rows: Vec<StateRows>,
 ) {
-    for (accept, state_rows) in build.accepts.into_iter().zip(rows) {
+    let ModeBuild {
+        accepts,
+        continuations,
+        ..
+    } = build;
+    for (accept, state_rows) in accepts.into_iter().zip(rows) {
         let accept_id = accept.map_or(u32::MAX, |accept| {
             dfa.accepts.push(accept);
             (dfa.accepts.len() - 1) as u32
@@ -896,7 +1159,33 @@ fn commit_mode(
             eof_target: state_rows.eof_target,
             accept: accept_id,
         });
+        dfa.escape_rows.push(CompiledLexerEscapeRow {
+            ranges: merge_escape_ranges(&state_rows.escapes).into(),
+            eof: state_rows.eof_escape,
+        });
     }
+    dfa.continuations.extend(continuations);
+}
+
+fn merge_escape_ranges(segments: &[(i32, i32, u32)]) -> Vec<CompiledLexerEscapeRange> {
+    let mut ranges: Vec<CompiledLexerEscapeRange> = Vec::new();
+    for &(low, high, continuation) in segments {
+        let low = low.cast_unsigned();
+        let high = high.cast_unsigned();
+        if let Some(last) = ranges.last_mut()
+            && last.continuation == continuation
+            && last.high + 1 == low
+        {
+            last.high = high;
+            continue;
+        }
+        ranges.push(CompiledLexerEscapeRange {
+            low,
+            high,
+            continuation,
+        });
+    }
+    ranges
 }
 
 /// Splits sorted segments into the dense ASCII row and merged wide ranges.
@@ -927,7 +1216,9 @@ fn split_rows(segments: &[(i32, i32, u16)]) -> ([u16; ASCII_EDGE_SYMBOLS], Vec<W
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::atn::lexer::{next_token, next_token_compiled, next_token_compiled_with_hooks};
+    use crate::atn::lexer::{
+        next_token, next_token_compiled, next_token_compiled_with_hooks, next_token_with_hooks,
+    };
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
     use crate::char_stream::{CharStream, InputStream, TextInterval};
     use crate::int_stream::IntStream;
@@ -1119,12 +1410,16 @@ mod tests {
     }
 
     #[test]
-    fn predicate_edge_escapes_to_the_interpreter() {
+    fn predicate_edge_resumes_the_interpreter_for_true_and_false_outcomes() {
         let atn = two_rule_atn(true);
         let dfa = CompiledLexerDfa::compile(&atn);
         // The predicate sits mid-rule, so the mode still compiles; only the
-        // edge that would cross it escapes to the interpreter.
+        // edge that would cross it resumes the interpreter.
         assert!(dfa.mode_start(0).is_some());
+        assert!(
+            !dfa.continuations.is_empty(),
+            "predicate edge should preserve a narrowed continuation"
+        );
 
         let mut lexer = BaseLexer::new(InputStream::new(" ab"), recognizer_data());
         let mut store = TokenStore::new(lexer.source_text(), lexer.source_name());
@@ -1142,6 +1437,55 @@ mod tests {
         let token = sink.view(id).expect("emitted token should exist");
         assert_eq!(token.token_type(), 1);
         assert_eq!(token.text(), "ab");
+
+        let mut compiled = BaseLexer::new(InputStream::new("ab"), recognizer_data());
+        let mut interpreted = BaseLexer::new(InputStream::new("ab"), recognizer_data());
+        let mut compiled_store = TokenStore::new(compiled.source_text(), compiled.source_name());
+        let mut interpreted_store =
+            TokenStore::new(interpreted.source_text(), interpreted.source_name());
+        let mut compiled_sink = TokenSink::new(&mut compiled_store);
+        let mut interpreted_sink = TokenSink::new(&mut interpreted_store);
+        let compiled_id = next_token_compiled_with_hooks(
+            &mut compiled,
+            &mut compiled_sink,
+            &atn,
+            &dfa,
+            |_, _| {},
+            |_, _| false,
+            |_, _, _| {},
+        )
+        .expect("false predicate should recover to EOF");
+        let interpreted_id = next_token_with_hooks(
+            &mut interpreted,
+            &mut interpreted_sink,
+            &atn,
+            |_, _| {},
+            |_, _| false,
+            |_, _, _| {},
+        )
+        .expect("interpreted false predicate should recover to EOF");
+        assert_eq!(
+            compiled_sink
+                .view(compiled_id)
+                .expect("compiled token should exist")
+                .token_type(),
+            interpreted_sink
+                .view(interpreted_id)
+                .expect("interpreted token should exist")
+                .token_type()
+        );
+        assert_eq!(
+            compiled
+                .drain_errors()
+                .into_iter()
+                .map(|error| error.message)
+                .collect::<Vec<_>>(),
+            interpreted
+                .drain_errors()
+                .into_iter()
+                .map(|error| error.message)
+                .collect::<Vec<_>>()
+        );
     }
 
     #[test]
@@ -1240,13 +1584,14 @@ mod tests {
 
     #[test]
     fn serialization_round_trips() {
-        let atn = two_rule_atn(false);
+        let atn = two_rule_atn(true);
         let dfa = CompiledLexerDfa::compile(&atn);
         let stream = dfa.serialize();
 
         let restored =
             CompiledLexerDfa::from_serialized(&stream).expect("stream should deserialize");
         assert_eq!(restored.serialize(), stream);
+        assert_eq!(restored.continuations.len(), dfa.continuations.len());
 
         let mut lexer = BaseLexer::new(InputStream::new(" ab"), recognizer_data());
         let token = compiled_token(&mut lexer, &atn, &restored);
@@ -1273,6 +1618,21 @@ mod tests {
         let mut inverted = stream;
         inverted.swap(position, position + 1);
         assert!(CompiledLexerDfa::from_serialized(&inverted).is_none());
+    }
+
+    #[test]
+    fn malformed_escape_continuations_are_rejected() {
+        let atn = two_rule_atn(true);
+        let mut dfa = CompiledLexerDfa::compile(&atn);
+        let range = dfa
+            .escape_rows
+            .iter_mut()
+            .flat_map(|row| row.ranges.iter_mut())
+            .next()
+            .expect("predicate grammar should contain an escape range");
+        range.continuation = u32::MAX - 1;
+
+        assert!(CompiledLexerDfa::from_serialized(&dfa.serialize()).is_none());
     }
 
     #[test]

--- a/src/atn/lexer_dfa.rs
+++ b/src/atn/lexer_dfa.rs
@@ -254,13 +254,14 @@ impl CompiledLexerDfa {
             Err(insert) if insert > 0 && ranges[insert - 1].high >= code_point => Some(insert - 1),
             Err(_) => None,
         }?;
-        self.continuations.get(ranges[found].continuation as usize)
+        let continuation = usize::try_from(ranges[found].continuation).ok()?;
+        self.continuations.get(continuation)
     }
 
     /// Interpreter continuation for an escaped EOF edge.
     pub(super) fn eof_continuation(&self, state: u16) -> Option<&CompiledLexerContinuation> {
-        self.continuations
-            .get(self.escape_rows[usize::from(state)].eof as usize)
+        let continuation = usize::try_from(self.escape_rows[usize::from(state)].eof).ok()?;
+        self.continuations.get(continuation)
     }
 
     /// Flattens the compiled DFA into a `u32` stream for embedding in
@@ -425,6 +426,10 @@ impl CompiledLexerDfa {
     fn table_indexes_are_valid(&self) -> bool {
         let state_ok =
             |target: u16| usize::from(target) < self.states.len() || target >= ESCAPE_STATE;
+        let continuation_ok = |continuation: u32| {
+            usize::try_from(continuation)
+                .is_ok_and(|continuation| continuation < self.continuations.len())
+        };
         self.mode_starts
             .iter()
             .flatten()
@@ -444,12 +449,12 @@ impl CompiledLexerDfa {
             })
             && self.escape_rows.len() == self.states.len()
             && self.escape_rows.iter().all(|row| {
-                (row.eof == u32::MAX || (row.eof as usize) < self.continuations.len())
+                (row.eof == u32::MAX || continuation_ok(row.eof))
                     && escape_row_is_searchable(&row.ranges)
                     && row
                         .ranges
                         .iter()
-                        .all(|range| (range.continuation as usize) < self.continuations.len())
+                        .all(|range| continuation_ok(range.continuation))
             })
     }
 }
@@ -1174,7 +1179,7 @@ fn merge_escape_ranges(segments: &[(i32, i32, u32)]) -> Vec<CompiledLexerEscapeR
         let high = high.cast_unsigned();
         if let Some(last) = ranges.last_mut()
             && last.continuation == continuation
-            && last.high + 1 == low
+            && last.high.checked_add(1) == Some(low)
         {
             last.high = high;
             continue;
@@ -1633,6 +1638,15 @@ mod tests {
         range.continuation = u32::MAX - 1;
 
         assert!(CompiledLexerDfa::from_serialized(&dfa.serialize()).is_none());
+    }
+
+    #[test]
+    fn escape_range_merging_does_not_wrap_maximum_bound() {
+        let ranges = merge_escape_ranges(&[(-1, -1, 0), (0, 0, 0)]);
+
+        assert_eq!(ranges.len(), 2);
+        assert_eq!((ranges[0].low, ranges[0].high), (u32::MAX, u32::MAX));
+        assert_eq!((ranges[1].low, ranges[1].high), (0, 0));
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -155,6 +155,12 @@ mod perf_counters {
         pub(super) static MEMO_INSERTED: Cell<u64> = const { Cell::new(0) };
         pub(super) static OUTCOMES_PUSHED: Cell<u64> = const { Cell::new(0) };
         pub(super) static OUTCOMES_CLONED: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOME_DEDUPE_INPUTS: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOME_DEDUPE_REMOVED: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOME_DEDUPE_INLINE: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOME_DEDUPE_DENSE: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOME_DEDUPE_SPARSE: Cell<u64> = const { Cell::new(0) };
+        pub(super) static OUTCOME_DEDUPE_DENSE_WORDS: Cell<u64> = const { Cell::new(0) };
     }
     pub(super) fn inc(c: &'static std::thread::LocalKey<Cell<u64>>, n: u64) {
         c.with(|v| v.set(v.get() + n));
@@ -172,7 +178,7 @@ mod perf_counters {
         pub(super) static OUTCOMES_RETURN_1: Cell<u64> = const { Cell::new(0) };
         pub(super) static OUTCOMES_RETURN_N: Cell<u64> = const { Cell::new(0) };
     }
-    pub(super) fn snapshot() -> [(&'static str, u64); 18] {
+    pub(super) fn snapshot() -> [(&'static str, u64); 24] {
         [
             ("rfs_calls", RFS_CALLS.with(Cell::get)),
             ("rfs_memo_hits", RFS_MEMO_HITS.with(Cell::get)),
@@ -181,6 +187,27 @@ mod perf_counters {
             ("memo_inserted", MEMO_INSERTED.with(Cell::get)),
             ("outcomes_pushed", OUTCOMES_PUSHED.with(Cell::get)),
             ("outcomes_cloned", OUTCOMES_CLONED.with(Cell::get)),
+            (
+                "outcome_dedupe_inputs",
+                OUTCOME_DEDUPE_INPUTS.with(Cell::get),
+            ),
+            (
+                "outcome_dedupe_removed",
+                OUTCOME_DEDUPE_REMOVED.with(Cell::get),
+            ),
+            (
+                "outcome_dedupe_inline",
+                OUTCOME_DEDUPE_INLINE.with(Cell::get),
+            ),
+            ("outcome_dedupe_dense", OUTCOME_DEDUPE_DENSE.with(Cell::get)),
+            (
+                "outcome_dedupe_sparse",
+                OUTCOME_DEDUPE_SPARSE.with(Cell::get),
+            ),
+            (
+                "outcome_dedupe_dense_words",
+                OUTCOME_DEDUPE_DENSE_WORDS.with(Cell::get),
+            ),
             ("epsilon_transitions", EPSILON_TRANSITIONS.with(Cell::get)),
             ("rule_transitions", RULE_TRANSITIONS.with(Cell::get)),
             (
@@ -205,6 +232,12 @@ mod perf_counters {
         MEMO_INSERTED.with(|c| c.set(0));
         OUTCOMES_PUSHED.with(|c| c.set(0));
         OUTCOMES_CLONED.with(|c| c.set(0));
+        OUTCOME_DEDUPE_INPUTS.with(|c| c.set(0));
+        OUTCOME_DEDUPE_REMOVED.with(|c| c.set(0));
+        OUTCOME_DEDUPE_INLINE.with(|c| c.set(0));
+        OUTCOME_DEDUPE_DENSE.with(|c| c.set(0));
+        OUTCOME_DEDUPE_SPARSE.with(|c| c.set(0));
+        OUTCOME_DEDUPE_DENSE_WORDS.with(|c| c.set(0));
         EPSILON_TRANSITIONS.with(|c| c.set(0));
         RULE_TRANSITIONS.with(|c| c.set(0));
         ATOM_RANGE_TRANSITIONS.with(|c| c.set(0));
@@ -1150,6 +1183,8 @@ pub struct BaseParser<S, H = NoSemanticHooks> {
     single_outcome_probe_seen: FxHashSet<FastRecognizeKey>,
     single_outcome_probe_samples: usize,
     single_outcome_probe_repeats: usize,
+    /// Reusable direct-index/hash storage for clean speculative endpoints.
+    fast_outcome_dedup: FastOutcomeDedupScratch,
     /// Empty recovery-symbols singleton used as the default at rule entry and
     /// after token consumption.
     empty_recovery_symbols: Rc<BTreeSet<i32>>,
@@ -1233,6 +1268,13 @@ struct FastRecognizeOutcome {
     /// Copying an outcome copies this compact ID; prepending appends one
     /// `SeqLink` without allocating an individual node or list tail.
     nodes: NodeSeqId,
+}
+
+#[derive(Debug, Default)]
+struct FastOutcomeDedupScratch {
+    dense_words: Vec<u64>,
+    touched_dense_words: Vec<u32>,
+    sparse_keys: FxHashSet<(usize, bool)>,
 }
 
 /// Handle into the parser-owned deferred tree rope.
@@ -4548,6 +4590,7 @@ where
             single_outcome_probe_seen: FxHashSet::default(),
             single_outcome_probe_samples: 0,
             single_outcome_probe_repeats: 0,
+            fast_outcome_dedup: FastOutcomeDedupScratch::default(),
             empty_recovery_symbols: Rc::new(BTreeSet::new()),
             fast_first_set_prefilter: true,
             fast_recovery_enabled: true,
@@ -7675,7 +7718,7 @@ where
                 }
             }
         }
-        dedupe_clean_fast_outcomes(&mut outcomes);
+        dedupe_clean_fast_outcomes(&mut outcomes, &mut self.fast_outcome_dedup);
         outcomes
     }
 
@@ -8503,7 +8546,7 @@ where
         if self.fast_recovery_enabled {
             dedupe_fast_outcomes(&mut outcomes, &self.recognition_arena);
         } else {
-            dedupe_clean_fast_outcomes(&mut outcomes);
+            dedupe_clean_fast_outcomes(&mut outcomes, &mut self.fast_outcome_dedup);
         }
         // Skip memoization for single-transition states whose outcome is
         // unambiguous: they only get re-entered if the caller revisits the
@@ -11527,44 +11570,147 @@ fn dedupe_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>, arena: &Recogn
     });
 }
 
-fn dedupe_clean_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>) {
-    if outcomes.len() < 2 {
-        return;
+const FAST_OUTCOME_INLINE_KEYS: usize = 8;
+const FAST_OUTCOME_BITS_PER_WORD: usize = 64;
+const MAX_FAST_OUTCOME_DENSE_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum FastOutcomeDedupStrategy {
+    Inline,
+    Dense,
+    Sparse,
+}
+
+impl FastOutcomeDedupScratch {
+    fn prepare_dense(&mut self, word_count: usize) {
+        while let Some(word_index) = self.touched_dense_words.pop() {
+            self.dense_words[usize::try_from(word_index).expect("u32 fits in usize")] = 0;
+        }
+        if self.dense_words.len() < word_count {
+            self.dense_words.resize(word_count, 0);
+        }
     }
-    // Most outcomes lists are 2-4 entries; an inline scan beats BTreeSet
-    // here because BTreeSet's allocation + per-insert balancing dominates
-    // O(log n) wins on tiny n. Retains the original order so callers that
-    // depend on alt ordering (e.g. fast outcome selection) stay correct.
-    //
-    // Beyond the inline buffer we promote to a heap Vec so all kept entries
-    // continue to participate in dedup — leaking duplicates here on
-    // pathological grammars (e.g. ktor's deeply ambiguous Kotlin parse)
-    // explodes the speculative cache one step up the recursion.
-    let mut inline_keys: [(usize, bool); 8] = [(0, false); 8];
-    let mut inline_len = 0_usize;
-    let mut overflow: Vec<(usize, bool)> = Vec::new();
-    outcomes.retain(|outcome| {
-        let key = (outcome.index, outcome.consumed_eof);
-        for &existing in &inline_keys[..inline_len] {
-            if existing == key {
+}
+
+fn clean_fast_outcome_dense_layout(outcomes: &[FastRecognizeOutcome]) -> Option<(usize, usize)> {
+    let first_index = outcomes.first()?.index;
+    let (min_index, max_index) = outcomes[1..].iter().fold(
+        (first_index, first_index),
+        |(min_index, max_index), outcome| {
+            (min_index.min(outcome.index), max_index.max(outcome.index))
+        },
+    );
+    let index_span = max_index.checked_sub(min_index)?.checked_add(1)?;
+    let bit_count = index_span.checked_mul(2)?;
+    let word_count =
+        bit_count.checked_add(FAST_OUTCOME_BITS_PER_WORD - 1)? / FAST_OUTCOME_BITS_PER_WORD;
+    let dense_bytes = word_count.checked_mul(size_of::<u64>())?;
+    let sparse_key_bytes = outcomes.len().checked_mul(size_of::<(usize, bool)>())?;
+    (dense_bytes <= MAX_FAST_OUTCOME_DENSE_BYTES && dense_bytes <= sparse_key_bytes)
+        .then_some((min_index, word_count))
+}
+
+#[cfg(feature = "perf-counters")]
+fn record_clean_fast_outcome_dedup(
+    strategy: FastOutcomeDedupStrategy,
+    input_len: usize,
+    output_len: usize,
+    dense_words: usize,
+) {
+    let counter = match strategy {
+        FastOutcomeDedupStrategy::Inline => &perf_counters::OUTCOME_DEDUPE_INLINE,
+        FastOutcomeDedupStrategy::Dense => &perf_counters::OUTCOME_DEDUPE_DENSE,
+        FastOutcomeDedupStrategy::Sparse => &perf_counters::OUTCOME_DEDUPE_SPARSE,
+    };
+    perf_counters::inc(
+        &perf_counters::OUTCOME_DEDUPE_INPUTS,
+        u64::try_from(input_len).unwrap_or(u64::MAX),
+    );
+    perf_counters::inc(
+        &perf_counters::OUTCOME_DEDUPE_REMOVED,
+        u64::try_from(input_len - output_len).unwrap_or(u64::MAX),
+    );
+    perf_counters::inc(counter, 1);
+    perf_counters::inc(
+        &perf_counters::OUTCOME_DEDUPE_DENSE_WORDS,
+        u64::try_from(dense_words).unwrap_or(u64::MAX),
+    );
+}
+
+/// Removes duplicate clean endpoints while preserving transition-discovery
+/// order. Tiny lists stay on the stack; larger compact ranges use a direct
+/// bitmap, and only wide sparse ranges pay for hashing.
+fn dedupe_clean_fast_outcomes(
+    outcomes: &mut Vec<FastRecognizeOutcome>,
+    scratch: &mut FastOutcomeDedupScratch,
+) -> FastOutcomeDedupStrategy {
+    #[cfg(feature = "perf-counters")]
+    let input_len = outcomes.len();
+    if outcomes.len() <= FAST_OUTCOME_INLINE_KEYS {
+        let mut inline_keys = [(0, false); FAST_OUTCOME_INLINE_KEYS];
+        let mut inline_len = 0_usize;
+        outcomes.retain(|outcome| {
+            let key = (outcome.index, outcome.consumed_eof);
+            if inline_keys[..inline_len].contains(&key) {
                 return false;
             }
-        }
-        if !overflow.is_empty() {
-            for &existing in &overflow {
-                if existing == key {
-                    return false;
-                }
-            }
-        }
-        if inline_len < inline_keys.len() {
             inline_keys[inline_len] = key;
             inline_len += 1;
-        } else {
-            overflow.push(key);
-        }
-        true
+            true
+        });
+        #[cfg(feature = "perf-counters")]
+        record_clean_fast_outcome_dedup(
+            FastOutcomeDedupStrategy::Inline,
+            input_len,
+            outcomes.len(),
+            0,
+        );
+        return FastOutcomeDedupStrategy::Inline;
+    }
+
+    if let Some((base_index, word_count)) = clean_fast_outcome_dense_layout(outcomes) {
+        scratch.prepare_dense(word_count);
+        outcomes.retain(|outcome| {
+            let bit_index = (outcome.index - base_index) * 2 + usize::from(outcome.consumed_eof);
+            let word_index = bit_index / FAST_OUTCOME_BITS_PER_WORD;
+            let bit = 1_u64 << (bit_index % FAST_OUTCOME_BITS_PER_WORD);
+            let word = &mut scratch.dense_words[word_index];
+            if *word & bit != 0 {
+                return false;
+            }
+            if *word == 0 {
+                scratch
+                    .touched_dense_words
+                    .push(u32::try_from(word_index).expect("dense outcome bitmap is capped"));
+            }
+            *word |= bit;
+            true
+        });
+        #[cfg(feature = "perf-counters")]
+        record_clean_fast_outcome_dedup(
+            FastOutcomeDedupStrategy::Dense,
+            input_len,
+            outcomes.len(),
+            word_count,
+        );
+        return FastOutcomeDedupStrategy::Dense;
+    }
+
+    scratch.sparse_keys.clear();
+    scratch.sparse_keys.reserve(outcomes.len());
+    outcomes.retain(|outcome| {
+        scratch
+            .sparse_keys
+            .insert((outcome.index, outcome.consumed_eof))
     });
+    #[cfg(feature = "perf-counters")]
+    record_clean_fast_outcome_dedup(
+        FastOutcomeDedupStrategy::Sparse,
+        input_len,
+        outcomes.len(),
+        0,
+    );
+    FastOutcomeDedupStrategy::Sparse
 }
 
 /// Sorts and removes equivalent endpoints, including action traces and the
@@ -15770,6 +15916,123 @@ mod tests {
         // With no rule start recorded, it falls back to the provided index.
         let empty = parser.rule_node(ParserRuleContext::new(0, 0));
         assert_eq!(parser.after_action_start_index_for_tree(empty, 7), 7);
+    }
+
+    fn clean_fast_outcome(index: usize, consumed_eof: bool, marker: u32) -> FastRecognizeOutcome {
+        FastRecognizeOutcome {
+            index,
+            consumed_eof,
+            diagnostics: DiagnosticSeqId::EMPTY,
+            deferred_nodes: FastDeferredNodeId::EMPTY,
+            nodes: NodeSeqId(marker),
+        }
+    }
+
+    #[test]
+    fn clean_fast_outcome_dedupe_scans_small_lists_inline() {
+        let mut outcomes = vec![
+            clean_fast_outcome(4, false, 0),
+            clean_fast_outcome(2, false, 1),
+            clean_fast_outcome(4, false, 2),
+            clean_fast_outcome(4, true, 3),
+            clean_fast_outcome(2, false, 4),
+        ];
+        let mut scratch = FastOutcomeDedupScratch::default();
+
+        let strategy = dedupe_clean_fast_outcomes(&mut outcomes, &mut scratch);
+
+        assert_eq!(strategy, FastOutcomeDedupStrategy::Inline);
+        assert_eq!(
+            outcomes
+                .iter()
+                .map(|outcome| (outcome.index, outcome.consumed_eof, outcome.nodes.0))
+                .collect::<Vec<_>>(),
+            vec![(4, false, 0), (2, false, 1), (4, true, 3)]
+        );
+        assert!(scratch.dense_words.is_empty());
+        assert!(scratch.sparse_keys.is_empty());
+    }
+
+    #[test]
+    fn clean_fast_outcome_dedupe_uses_and_reuses_dense_bitmap() {
+        let mut scratch = FastOutcomeDedupScratch::default();
+        let mut outcomes = (100..109)
+            .flat_map(|index| {
+                [
+                    clean_fast_outcome(
+                        index,
+                        false,
+                        u32::try_from(index).expect("test index fits in u32"),
+                    ),
+                    clean_fast_outcome(index, false, u32::MAX),
+                ]
+            })
+            .collect();
+
+        let strategy = dedupe_clean_fast_outcomes(&mut outcomes, &mut scratch);
+
+        assert_eq!(strategy, FastOutcomeDedupStrategy::Dense);
+        assert_eq!(outcomes.len(), 9);
+        assert_eq!(outcomes[0].nodes, NodeSeqId(100));
+        let dense_capacity = scratch.dense_words.capacity();
+
+        let mut reused = (1_000..1_009)
+            .map(|index| {
+                clean_fast_outcome(
+                    index,
+                    false,
+                    u32::try_from(index).expect("test index fits in u32"),
+                )
+            })
+            .collect();
+        let strategy = dedupe_clean_fast_outcomes(&mut reused, &mut scratch);
+
+        assert_eq!(strategy, FastOutcomeDedupStrategy::Dense);
+        assert_eq!(reused.len(), 9);
+        assert_eq!(scratch.dense_words.capacity(), dense_capacity);
+    }
+
+    #[test]
+    fn clean_fast_outcome_dedupe_uses_and_reuses_sparse_hash() {
+        let mut scratch = FastOutcomeDedupScratch::default();
+        let sparse_indexes = [
+            0, 100_000, 200_000, 300_000, 400_000, 500_000, 600_000, 700_000, 800_000,
+        ];
+        let mut outcomes = sparse_indexes
+            .into_iter()
+            .chain([400_000])
+            .enumerate()
+            .map(|(marker, index)| {
+                clean_fast_outcome(
+                    index,
+                    false,
+                    u32::try_from(marker).expect("test marker fits in u32"),
+                )
+            })
+            .collect();
+
+        let strategy = dedupe_clean_fast_outcomes(&mut outcomes, &mut scratch);
+
+        assert_eq!(strategy, FastOutcomeDedupStrategy::Sparse);
+        assert_eq!(outcomes.len(), sparse_indexes.len());
+        assert_eq!(outcomes[4].nodes, NodeSeqId(4));
+        let sparse_capacity = scratch.sparse_keys.capacity();
+
+        let mut reused = sparse_indexes
+            .into_iter()
+            .map(|index| {
+                clean_fast_outcome(
+                    index,
+                    false,
+                    u32::try_from(index).expect("test index fits in u32"),
+                )
+            })
+            .collect();
+        let strategy = dedupe_clean_fast_outcomes(&mut reused, &mut scratch);
+
+        assert_eq!(strategy, FastOutcomeDedupStrategy::Sparse);
+        assert_eq!(reused.len(), sparse_indexes.len());
+        assert_eq!(scratch.sparse_keys.capacity(), sparse_capacity);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11573,6 +11573,7 @@ fn dedupe_fast_outcomes(outcomes: &mut Vec<FastRecognizeOutcome>, arena: &Recogn
 const FAST_OUTCOME_INLINE_KEYS: usize = 8;
 const FAST_OUTCOME_BITS_PER_WORD: usize = 64;
 const MAX_FAST_OUTCOME_DENSE_BYTES: usize = 64 * 1024;
+const MAX_RETAINED_FAST_OUTCOME_SPARSE_KEYS: usize = 65_536;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum FastOutcomeDedupStrategy {
@@ -11710,6 +11711,9 @@ fn dedupe_clean_fast_outcomes(
         outcomes.len(),
         0,
     );
+    if scratch.sparse_keys.capacity() > MAX_RETAINED_FAST_OUTCOME_SPARSE_KEYS {
+        scratch.sparse_keys = FxHashSet::default();
+    }
     FastOutcomeDedupStrategy::Sparse
 }
 
@@ -16033,6 +16037,24 @@ mod tests {
         assert_eq!(strategy, FastOutcomeDedupStrategy::Sparse);
         assert_eq!(reused.len(), sparse_indexes.len());
         assert_eq!(scratch.sparse_keys.capacity(), sparse_capacity);
+    }
+
+    #[test]
+    fn clean_fast_outcome_dedupe_releases_oversized_sparse_hash() {
+        let mut scratch = FastOutcomeDedupScratch::default();
+        scratch
+            .sparse_keys
+            .reserve(MAX_RETAINED_FAST_OUTCOME_SPARSE_KEYS * 2);
+        assert!(scratch.sparse_keys.capacity() > MAX_RETAINED_FAST_OUTCOME_SPARSE_KEYS);
+        let mut outcomes = (0..9)
+            .map(|index| clean_fast_outcome(index * 100_000, false, index as u32))
+            .collect();
+
+        let strategy = dedupe_clean_fast_outcomes(&mut outcomes, &mut scratch);
+
+        assert_eq!(strategy, FastOutcomeDedupStrategy::Sparse);
+        assert!(scratch.sparse_keys.is_empty());
+        assert!(scratch.sparse_keys.capacity() <= MAX_RETAINED_FAST_OUTCOME_SPARSE_KEYS);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- preserve narrowed ATN configs when compiled lexer DFA construction encounters a dynamic escape edge
- resume interpretation at that edge instead of restarting from the lexer mode's full start closure
- replace quadratic clean parser-outcome scans with an adaptive inline/dense/sparse deduplicator
- retain parser-owned bitmap and hash scratch across recursive recognizer calls
- expose perf counters for deduplication inputs, removals, representation choices, and dense words

Closes #108.

## Root causes

### Compiled lexer fallback

The compiled lexer escaped at predicate-sensitive edges, then rematched the token from the mode start. For the MySQL lexer, that rebuilt a closure spanning roughly 900 rules for each dynamic edge.

The lexer now captures configs immediately after the escaped consuming transition and before its dynamic epsilon closure. The interpreter resumes from those narrowed configs while preserving semantic predicates, actions, recursive rule stacks, longest-match accepts, and recognition-error spans.

### Clean parser outcome deduplication

Large `VALUES` lists produced compact, ordered endpoint ranges. The clean fast recognizer stored the first eight endpoints inline, then linearly scanned an overflow `Vec` for every subsequent endpoint. Statement 44 spent 27.7% of total sampled time in that quadratic scan even though almost every endpoint was unique.

The replacement chooses from the observed data shape:

- up to 8 outcomes: stack-inline scan
- compact endpoint span: direct bitmap with two bits per token index, capped at 64 KiB
- wide sparse span: reusable `FxHashSet<(usize, bool)>`

`Vec::retain` preserves first-discovered greedy ordering, and the key keeps ordinary and EOF-consuming outcomes distinct. Bitmap words are cleared through a touched-word list, so scratch reuse does not scan the full retained capacity.

Both runtime and codegen changes remain grammar-agnostic.

## Performance

Exact same-host parser A/B, `d57174505` versus `bc9ee21ad`:

| Fixture | Before | After | Change |
|---|---:|---:|---:|
| Sakila statement 44 parse | 617.5 ms | 280.0 ms | 2.21x faster |
| Full workload warm total | 4.19 s | 3.19-3.29 s | about 23% faster |
| Sakila warm total | 3.40 s | 2.41 s | about 29% faster |

Synthetic bulk-`VALUES` parse scaling:

| Rows | int7 before | int7 after | payment before | payment after |
|---:|---:|---:|---:|---:|
| 1,000 | 28.3 ms | 26.4 ms | 25.5 ms | 24.3 ms |
| 2,000 | 55.9 ms | 49.2 ms | 57.4 ms | 49.3 ms |
| 4,000 | 125.4 ms | 98.2 ms | 131.0 ms | 98.4 ms |
| 8,000 | 312.8 ms | 186.8 ms | 324.6 ms | 191.5 ms |
| 12,000 | 591.2 ms | 264.5 ms | 587.3 ms | 272.1 ms |

The 12k payment fixture recorded 2.33 million clean endpoint inputs: 2.35 million calls stayed inline, 15 large lists used the dense bitmap, and none required sparse hashing. A three-run statement-44 profile reduced clean deduplication from 27.7% to 1.36% of total self samples.

The previously recorded C++ workload total on this host is 2.96 s; current Rust is 3.19-3.29 s.

## Validation

- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` (357 passed, 0 failed, 0 skipped)
- protected parse benchmark against the exact pre-change head (12/12 under 1.15x, 0.9984x geomean, 1.0305x worst fixture)
- full MySQL benchmark corpus (1,509 statements, zero errors)
- focused inline, dense, sparse, ordering, EOF distinction, and scratch-reuse tests
- `git diff --check`
