### PR TITLE
Add recognizer reuse APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Added
+
+- Generated lexers and parsers now expose ANTLR-style recognizer reuse APIs:
+  `set_input_stream`, `set_token_source`, `set_token_stream`, full `reset`,
+  and `clear_dfa`. `CommonTokenStream::refill` supports re-feeding the lexer
+  owned inside an existing parser without reconstructing either recognizer.
+
 ### Performance
 
 - Compiled lexers read in-memory ASCII directly from their static DFA tables
@@ -10,6 +17,8 @@
 
 ### Breaking
 
+- Generated parser rules named `reset`, `setTokenStream`, `tokenStreamMut`, or
+  `clearDfa` now gain a `_rule` suffix to avoid the recognizer reuse methods.
 - Buffered tokens now live once in a compact `TokenStore` and are addressed by
   `TokenId`; public access uses borrowing `TokenView` values.
 - `CommonTokenStream` owns its `TokenStore` directly. `BaseParser` owns one flat

--- a/README.md
+++ b/README.md
@@ -183,6 +183,36 @@ fn main() -> Result<(), antlr4_runtime::AntlrError> {
 }
 ```
 
+### Reusing Recognizers
+
+Generated recognizers can be re-fed without reconstructing the lexer or parser.
+The token stream owns its lexer, so use the mutable accessors to update that
+nested source and rebuild the token buffer:
+
+```rust
+let lexer = JsonLexer::new(InputStream::new(""));
+let tokens = CommonTokenStream::new(lexer);
+let mut parser = Json::new(tokens);
+
+for input in [r#"{"a":1}"#, r#"{"b":2}"#] {
+    let tokens = parser.token_stream_mut();
+    tokens
+        .token_source_mut()
+        .set_input_stream(InputStream::new(input));
+    tokens.refill();
+    parser.reset();
+
+    let tree = parser.json()?;
+    println!("{}", parser.node(tree).text());
+}
+```
+
+`CommonTokenStream::set_token_source` and generated
+`Parser::set_token_stream` replace whole layers when ownership is already
+available. `clear_dfa()` on generated lexers and parsers drops learned fallback
+and decision DFA state for cold measurements or memory control; immutable
+ahead-of-time lexer DFA tables remain embedded generated data.
+
 ### Choosing Parser Entry Rules
 
 Generated parsers expose one public method per grammar rule. Call the method

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -4,6 +4,13 @@
 generator changes. Generated lexers and parsers must use the same release of
 `antlr4-rust-gen` as the runtime.
 
+## Recognizer Reuse Method Names
+
+Generated parsers now reserve `reset`, `set_token_stream`,
+`token_stream_mut`, and `clear_dfa` for recognizer reuse. Grammar rules that
+normalize to one of those Rust names gain the usual `_rule` suffix after
+regeneration, such as `reset_rule()`.
+
 ## Compact Token, Tree, and Prediction Stores
 
 The compact token, flat CST, and prediction-context stores replace the previous

--- a/src/atn/lexer.rs
+++ b/src/atn/lexer.rs
@@ -307,6 +307,17 @@ where
     hooks.lexer_reset(&mut ctx);
 }
 
+/// Replaces a base lexer's input and resets caller-owned lifecycle state.
+pub fn set_input_stream_with_semantic_hooks<I, H>(lexer: &mut BaseLexer<I>, hooks: &mut H, input: I)
+where
+    I: CharStream,
+    H: SemanticHooks,
+{
+    lexer.set_input_stream(input);
+    let mut ctx = LexerLifecycleCtx::new(lexer, None);
+    hooks.lexer_reset(&mut ctx);
+}
+
 /// Runs one lexer-token match with a shared [`SemanticHooks`] object.
 ///
 /// This is the trait-based facade over the historical lexer closure hooks.
@@ -2777,6 +2788,14 @@ mod tests {
         reset_with_semantic_hooks(&mut lexer, &mut hooks);
         assert!(!hooks.transient);
         assert_eq!(hooks.reset_count, 1);
+
+        set_input_stream_with_semantic_hooks(
+            &mut lexer,
+            &mut hooks,
+            InputStream::with_source_name(".x", "replacement"),
+        );
+        assert_eq!(hooks.reset_count, 2);
+        assert_eq!(lexer.source_name(), "replacement");
 
         let after_reset =
             next_token_compiled_with_semantic_hooks(&mut lexer, &mut sink, &atn, &dfa, &mut hooks)

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -30,6 +30,7 @@ pub struct ParserAtnSimulator<'a> {
     outer_context_cache_hits: usize,
     outer_context_cache_misses: usize,
     shared_cache_key: Option<usize>,
+    shared_cache_generation: u64,
     /// Java's `LL_EXACT_AMBIG_DETECTION`: the full-context loop keeps
     /// consuming past "resolves to one viable alt" conflicts until every
     /// `(state, context)` subset conflicts over the same alt set.
@@ -57,9 +58,25 @@ impl PredictionStore {
     }
 }
 
+#[derive(Debug, Default)]
+struct SharedPredictionStore {
+    generation: u64,
+    store: Option<PredictionStore>,
+}
+
 thread_local! {
-    static SHARED_PREDICTION_STORES: RefCell<HashMap<usize, PredictionStore>> =
+    static SHARED_PREDICTION_STORES: RefCell<HashMap<usize, SharedPredictionStore>> =
         RefCell::new(HashMap::new());
+}
+
+fn clear_shared_prediction_store(key: usize) -> u64 {
+    SHARED_PREDICTION_STORES.with(|cache| {
+        let mut cache = cache.borrow_mut();
+        let shared = cache.entry(key).or_default();
+        shared.generation = shared.generation.wrapping_add(1);
+        shared.store = None;
+        shared.generation
+    })
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -378,19 +395,28 @@ impl Drop for ParserAtnSimulator<'_> {
         // (that one started cold and checked its copy in first) — then union
         // the two by config-set identity so neither side's learning is lost.
         let store = std::mem::take(&mut self.store);
-        SHARED_PREDICTION_STORES.with(|cache| {
+        let published = SHARED_PREDICTION_STORES.with(|cache| {
             let mut cache = cache.borrow_mut();
-            if let Some(shared) = cache.get_mut(&key) {
-                union_prediction_stores(shared, store, &mut self.workspace);
-            } else {
-                cache.insert(key, store);
+            let shared = cache.entry(key).or_default();
+            if shared.generation != self.shared_cache_generation {
+                return false;
             }
+            if let Some(shared_store) = shared.store.as_mut() {
+                union_prediction_stores(shared_store, store, &mut self.workspace);
+            } else {
+                shared.store = Some(store);
+            }
+            true
         });
         #[cfg(feature = "perf-counters")]
-        crate::perf::record_dfa_cache_publication(
-            publication_started.elapsed().as_nanos(),
-            published_states,
-        );
+        if published {
+            crate::perf::record_dfa_cache_publication(
+                publication_started.elapsed().as_nanos(),
+                published_states,
+            );
+        }
+        #[cfg(not(feature = "perf-counters"))]
+        let _ = published;
     }
 }
 
@@ -404,8 +430,33 @@ impl<'a> ParserAtnSimulator<'a> {
             outer_context_cache_hits: 0,
             outer_context_cache_misses: 0,
             shared_cache_key: None,
+            shared_cache_generation: 0,
             exact_ambig_detection: false,
         }
+    }
+
+    /// Resets transient simulator state while retaining learned decision DFAs.
+    pub fn reset(&mut self) {
+        self.outer_context_cache = None;
+        self.workspace.reset();
+    }
+
+    /// Clears this simulator's learned decision DFAs.
+    ///
+    /// Shared simulators also invalidate the thread-local cache generation so
+    /// an overlapping stale simulator cannot republish pre-clear states later.
+    pub fn clear_dfa(&mut self) {
+        self.store = PredictionStore::new(self.atn);
+        self.reset();
+        if let Some(key) = self.shared_cache_key {
+            self.shared_cache_generation = clear_shared_prediction_store(key);
+        }
+    }
+
+    /// Clears the thread-local learned DFA store for a generated parser ATN.
+    pub fn clear_shared_dfa(atn: &'static Atn) {
+        let ptr: *const Atn = atn;
+        clear_shared_prediction_store(ptr as usize);
     }
 
     /// Switches the full-context resolution strategy (Java's
@@ -463,9 +514,17 @@ impl<'a> ParserAtnSimulator<'a> {
         let key = ptr as usize;
         #[cfg(feature = "perf-counters")]
         let import_started = std::time::Instant::now();
-        let store = SHARED_PREDICTION_STORES
-            .with(|cache| cache.borrow_mut().remove(&key))
-            .unwrap_or_else(|| PredictionStore::new(atn));
+        let (store, generation) = SHARED_PREDICTION_STORES.with(|cache| {
+            let mut cache = cache.borrow_mut();
+            let shared = cache.entry(key).or_default();
+            (
+                shared
+                    .store
+                    .take()
+                    .unwrap_or_else(|| PredictionStore::new(atn)),
+                shared.generation,
+            )
+        });
         #[cfg(feature = "perf-counters")]
         crate::perf::record_dfa_cache_import(
             import_started.elapsed().as_nanos(),
@@ -483,6 +542,7 @@ impl<'a> ParserAtnSimulator<'a> {
             outer_context_cache_hits: 0,
             outer_context_cache_misses: 0,
             shared_cache_key: Some(key),
+            shared_cache_generation: generation,
             exact_ambig_detection: false,
         }
     }
@@ -1819,6 +1879,37 @@ mod tests {
 
         let simulator = ParserAtnSimulator::new_shared(atn);
         assert_eq!(simulator.decision_dfas()[0].states().len(), learned_states);
+    }
+
+    #[test]
+    fn clear_shared_dfa_drops_learned_states() {
+        let atn = Box::leak(Box::new(two_token_decision_atn()));
+        {
+            let mut simulator = ParserAtnSimulator::new_shared(atn);
+            assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
+            assert!(!simulator.decision_dfas()[0].is_empty());
+        }
+
+        ParserAtnSimulator::clear_shared_dfa(atn);
+
+        let simulator = ParserAtnSimulator::new_shared(atn);
+        assert!(simulator.decision_dfas()[0].is_empty());
+    }
+
+    #[test]
+    fn clear_dfa_rejects_stale_overlapping_simulator_publication() {
+        let atn = Box::leak(Box::new(two_token_decision_atn()));
+        let mut current = ParserAtnSimulator::new_shared(atn);
+        let mut stale = ParserAtnSimulator::new_shared(atn);
+        assert_eq!(stale.adaptive_predict(0, [1, 2]), Ok(1));
+        assert!(!stale.decision_dfas()[0].is_empty());
+
+        current.clear_dfa();
+        drop(stale);
+        drop(current);
+
+        let simulator = ParserAtnSimulator::new_shared(atn);
+        assert!(simulator.decision_dfas()[0].is_empty());
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2425,6 +2425,24 @@ where
         }}
     }}
 
+    /// Replaces the input stream and resets runtime and lifecycle state.
+    pub fn set_input_stream(&mut self, input: I) {{
+        if H::ENABLES_LEXER_LIFECYCLE {{
+            antlr4_runtime::atn::lexer::set_input_stream_with_semantic_hooks(
+                &mut self.base,
+                &mut self.hooks,
+                input,
+            );
+        }} else {{
+            self.base.set_input_stream(input);
+        }}
+    }}
+
+    /// Clears the learned lexer DFA shared by this grammar.
+    pub fn clear_dfa(&self) {{
+        self.base.clear_dfa();
+    }}
+
 {action_method}
 {predicate_method}
 }}
@@ -6140,9 +6158,13 @@ fn render_parser(
 }
 
 const GENERATED_PARSER_RESERVED_RULE_METHODS: &[&str] = &[
+    "reset",
+    "set_token_stream",
     "token_stream",
+    "token_stream_mut",
     "token_store",
     "parse_tree_storage",
+    "clear_dfa",
     "node",
     "into_token_stream",
     "into_token_store",
@@ -7745,9 +7767,30 @@ where
         metadata()
     }}
 
+    /// Fully resets parser-owned state and rewinds the current token stream.
+    pub fn reset(&mut self) {{
+        self.base.reset();
+        if let Some(simulator) = self.simulator.as_mut() {{
+            simulator.reset();
+        }}
+    }}
+
+    /// Replaces the token stream and fully resets parser-owned state.
+    pub fn set_token_stream(&mut self, input: CommonTokenStream<L>) {{
+        self.base.set_token_stream(input);
+        if let Some(simulator) = self.simulator.as_mut() {{
+            simulator.reset();
+        }}
+    }}
+
     #[must_use]
     pub const fn token_stream(&self) -> &CommonTokenStream<L> {{
         self.base.token_stream()
+    }}
+
+    #[must_use]
+    pub const fn token_stream_mut(&mut self) -> &mut CommonTokenStream<L> {{
+        self.base.token_stream_mut()
     }}
 
     #[must_use]
@@ -7774,6 +7817,15 @@ where
             antlr4_runtime::ParserDfaStats::default,
             antlr4_runtime::ParserAtnSimulator::parser_dfa_stats,
         )
+    }}
+
+    /// Clears this grammar's learned parser decision DFAs.
+    pub fn clear_dfa(&mut self) {{
+        if let Some(simulator) = self.simulator.as_mut() {{
+            simulator.clear_dfa();
+        }} else {{
+            antlr4_runtime::ParserAtnSimulator::clear_shared_dfa(atn());
+        }}
     }}
 
     #[must_use]
@@ -10948,11 +11000,14 @@ atn:
     }
 
     #[test]
-    fn parser_rule_method_names_reserve_token_stream_accessors() {
+    fn parser_rule_method_names_reserve_recognizer_reuse_accessors() {
         let rule_names = vec![
             "tokenStream".to_owned(),
             "into_token_stream".to_owned(),
             "token_stream_rule".to_owned(),
+            "reset".to_owned(),
+            "setTokenStream".to_owned(),
+            "clearDfa".to_owned(),
             "regularRule".to_owned(),
         ];
 
@@ -10962,6 +11017,9 @@ atn:
                 "token_stream_rule",
                 "into_token_stream_rule",
                 "token_stream_rule_2",
+                "reset_rule",
+                "set_token_stream_rule",
+                "clear_dfa_rule",
                 "regular_rule"
             ]
         );
@@ -12452,6 +12510,20 @@ s : ;
 
         assert!(rendered.contains("pub const fn token_stream(&self) -> &CommonTokenStream<L>"));
         assert!(rendered.contains("self.base.token_stream()"));
+        assert!(
+            rendered
+                .contains("pub const fn token_stream_mut(&mut self) -> &mut CommonTokenStream<L>")
+        );
+        assert!(rendered.contains("self.base.token_stream_mut()"));
+        assert!(
+            rendered.contains("pub fn set_token_stream(&mut self, input: CommonTokenStream<L>)")
+        );
+        assert!(rendered.contains("self.base.set_token_stream(input)"));
+        assert!(rendered.contains("pub fn reset(&mut self)"));
+        assert!(rendered.contains("self.base.reset()"));
+        assert!(rendered.contains("pub fn clear_dfa(&mut self)"));
+        assert!(rendered.contains("simulator.clear_dfa()"));
+        assert!(rendered.contains("ParserAtnSimulator::clear_shared_dfa(atn())"));
         assert!(rendered.contains("pub fn into_token_stream(self) -> CommonTokenStream<L>"));
         assert!(rendered.contains("self.base.into_token_stream()"));
         assert!(
@@ -15895,6 +15967,11 @@ ID : [a-z]+ ;\n";
         assert!(module.contains("next_token_compiled_with_semantic_dispatch"));
         assert!(module.contains("pub fn reset(&mut self)"));
         assert!(module.contains("reset_with_semantic_hooks"));
+        assert!(module.contains("pub fn set_input_stream(&mut self, input: I)"));
+        assert!(module.contains("set_input_stream_with_semantic_hooks"));
+        assert!(module.contains("self.base.set_input_stream(input)"));
+        assert!(module.contains("pub fn clear_dfa(&self)"));
+        assert!(module.contains("self.base.clear_dfa()"));
         assert!(module.contains(
             "fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError>"
         ));

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -766,6 +766,16 @@ where
         self.pending_tokens.clear();
     }
 
+    /// Replaces the character stream and fully resets lexer state for reuse.
+    ///
+    /// Learned DFA tables and configuration such as forced interpretation are
+    /// retained. The new stream is always rewound to its beginning.
+    pub fn set_input_stream(&mut self, input: I) {
+        self.input = input;
+        self.has_source_text = self.input.source_text().is_some();
+        self.reset();
+    }
+
     /// Switches this lexer to the thread-shared learned DFA for `atn`.
     ///
     /// Generated lexers create a fresh instance per parse; without sharing,
@@ -782,6 +792,15 @@ where
         self.dfa_cache = SHARED_LEXER_DFA_CACHES
             .with(|caches| Rc::clone(caches.borrow_mut().entry(key).or_insert_with(Rc::default)));
         self
+    }
+
+    /// Clears the learned lexer DFA shared by recognizers for this grammar.
+    ///
+    /// Ahead-of-time compiled DFA tables are immutable generated data and are
+    /// unaffected. Any path that falls back to ATN interpretation relearns its
+    /// dynamic DFA from an empty cache after this call.
+    pub fn clear_dfa(&self) {
+        *self.dfa_cache.borrow_mut() = LexerDfaCache::default();
     }
 
     pub const fn input(&self) -> &I {
@@ -1648,5 +1667,60 @@ mod tests {
             1,
             "deduplication resets at every token boundary, even after rewinding"
         );
+    }
+
+    #[test]
+    fn set_input_stream_replaces_input_and_resets_transient_state() {
+        let data = RecognizerData::new(
+            "T",
+            Vocabulary::new(
+                std::iter::empty::<Option<&str>>(),
+                std::iter::empty::<Option<&str>>(),
+                std::iter::empty::<Option<&str>>(),
+            ),
+        );
+        let mut lexer = BaseLexer::new(InputStream::new("old"), data);
+        lexer.consume_char();
+        lexer.set_mode(7);
+        lexer.push_mode(9);
+        lexer.set_type(3);
+        lexer.record_error(1, 0, "stale");
+
+        lexer.set_input_stream(InputStream::with_source_name("new", "replacement"));
+
+        assert_eq!(lexer.input().index(), 0);
+        assert_eq!(lexer.input().size(), 3);
+        assert_eq!(lexer.source_name(), "replacement");
+        assert_eq!(lexer.source_text().as_deref(), Some("new"));
+        assert_eq!(lexer.mode(), DEFAULT_MODE);
+        assert_eq!(lexer.token_type(), INVALID_TOKEN_TYPE);
+        assert_eq!((lexer.line(), lexer.column()), (1, 0));
+        assert!(!lexer.hit_eof());
+        assert!(lexer.drain_errors().is_empty());
+        assert!(lexer.pop_mode().is_none());
+    }
+
+    #[test]
+    fn clear_dfa_invalidates_all_lexers_sharing_the_cache() {
+        let atn = Box::leak(Box::new(LexerAtn::new(1)));
+        let data = || {
+            RecognizerData::new(
+                "T",
+                Vocabulary::new(
+                    std::iter::empty::<Option<&str>>(),
+                    std::iter::empty::<Option<&str>>(),
+                    std::iter::empty::<Option<&str>>(),
+                ),
+            )
+        };
+        let first = BaseLexer::new(InputStream::new("a"), data()).with_shared_dfa(atn);
+        let second = BaseLexer::new(InputStream::new("a"), data()).with_shared_dfa(atn);
+        let state = first.lexer_dfa_state(LexerDfaKey::new(Vec::new()), Some(1));
+        first.record_lexer_dfa_edge(state, i32::from(b'a'), state);
+
+        assert!(!second.lexer_dfa_string().is_empty());
+        first.clear_dfa();
+        assert!(first.lexer_dfa_string().is_empty());
+        assert!(second.lexer_dfa_string().is_empty());
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4605,6 +4605,41 @@ where
         &mut self.input
     }
 
+    /// Fully resets parser-owned state and rewinds the current token stream.
+    ///
+    /// Parser configuration, semantic hooks, learned DFA tables, and
+    /// grammar-owned member values are retained.
+    pub fn reset(&mut self) {
+        self.input.seek(0);
+        self.tree.reset();
+        self.data.set_state(-1);
+        self.syntax_errors = 0;
+        self.prediction_diagnostics.clear();
+        self.reported_prediction_diagnostics.clear();
+        self.generated_parser_diagnostics.clear();
+        self.generated_sync_expected = None;
+        self.rule_context_stack.clear();
+        self.advance_rule_context_version();
+        self.left_recursive_caller_overlap_cache = std::array::from_fn(|_| None);
+        self.pending_invoking_states.clear();
+        self.precedence_stack.clear();
+        self.precedence_stack.push(0);
+        self.invoked_predicates.clear();
+        self.unknown_predicate_hits.clear();
+        self.unhandled_action_hits.clear();
+        self.reset_per_parse_caches();
+        self.fast_first_set_prefilter = true;
+        self.fast_recovery_enabled = true;
+        self.fast_token_nodes_enabled = true;
+        self.reset_recognition_arena();
+    }
+
+    /// Replaces the buffered token stream and fully resets this parser.
+    pub fn set_token_stream(&mut self, input: CommonTokenStream<S>) {
+        self.input = input;
+        self.reset();
+    }
+
     /// Installs the policy for predicate coordinates that no translated table
     /// entry or user hook resolves.
     ///
@@ -4647,6 +4682,12 @@ where
     #[must_use]
     pub const fn token_stream(&self) -> &CommonTokenStream<S> {
         &self.input
+    }
+
+    /// Returns the token stream for source replacement or in-place re-feeding.
+    #[must_use]
+    pub const fn token_stream_mut(&mut self) -> &mut CommonTokenStream<S> {
+        &mut self.input
     }
 
     /// Returns the canonical token store referenced by parse trees.
@@ -14160,6 +14201,68 @@ mod tests {
 
         parser.exit_rule();
         assert!(parser.rule_context_stack.is_empty());
+    }
+
+    #[test]
+    fn reset_rewinds_input_and_clears_parser_owned_parse_state() {
+        let mut parser = mini_parser(vec![
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 1, 1, 1),
+        ]);
+        let matched = parser.match_token(1).expect("token should match");
+        assert_eq!(parser.node(matched).text(), "x");
+        parser.record_generated_syntax_error();
+        parser.set_int_member(7, 11);
+        parser.set_build_parse_trees(false);
+        parser.set_report_diagnostic_errors(true);
+        parser.set_prediction_mode(PredictionMode::Sll);
+        parser.set_bail_on_error(true);
+        let _context = parser.enter_recursion_rule(9, 0, 4);
+        parser.pending_invoking_states.push(5);
+        parser.unknown_predicate_hits.push((0, 1));
+        parser.unhandled_action_hits.push((0, 2));
+
+        parser.reset();
+
+        assert_eq!(parser.input.index(), 0);
+        assert_eq!(parser.la(1), 1);
+        assert_eq!(parser.state(), -1);
+        assert_eq!(parser.number_of_syntax_errors(), 0);
+        assert_eq!(parser.parse_tree_storage().node_count(), 0);
+        assert!(parser.rule_context_stack.is_empty());
+        assert!(parser.pending_invoking_states.is_empty());
+        assert_eq!(parser.precedence_stack, [0]);
+        assert!(parser.unknown_predicate_hits.is_empty());
+        assert!(parser.unhandled_action_hits.is_empty());
+        assert_eq!(parser.int_member(7), Some(11));
+        assert!(!parser.build_parse_trees());
+        assert!(parser.report_diagnostic_errors());
+        assert_eq!(parser.prediction_mode(), PredictionMode::Sll);
+        assert!(parser.bail_on_error());
+    }
+
+    #[test]
+    fn set_token_stream_replaces_input_and_resets_parser() {
+        let mut parser = mini_parser(vec![
+            TestToken::new(1).with_text("old"),
+            TestToken::eof("parser-test", 1, 1, 1),
+        ]);
+        parser.consume();
+        parser.record_generated_syntax_error();
+        let replacement = CommonTokenStream::new(Source {
+            tokens: vec![
+                TestToken::new(2).with_text("new"),
+                TestToken::eof("parser-test", 1, 1, 1),
+            ],
+            index: 0,
+        });
+
+        parser.set_token_stream(replacement);
+
+        assert_eq!(parser.input.index(), 0);
+        assert_eq!(parser.la(1), 2);
+        assert_eq!(parser.input.text_all(), "new");
+        assert_eq!(parser.number_of_syntax_errors(), 0);
     }
 
     #[test]

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -26,6 +26,46 @@ pub struct CommonTokenStream<S> {
 
 const UNKNOWN_NEXT_VISIBLE: usize = usize::MAX;
 
+fn buffer_token_source<S>(
+    source: &mut S,
+) -> Result<(TokenStore, Vec<BufferedSourceError>), TokenStoreError>
+where
+    S: TokenSource,
+{
+    let source_name = source.source_name().to_owned();
+    let mut store = TokenStore::new(source.source_text(), source_name);
+    let mut source_errors = Vec::new();
+    loop {
+        let expected_id = store.len();
+        let mut sink = TokenSink::new(&mut store);
+        let id = source.next_token(&mut sink)?;
+        let appended = sink.token_count().saturating_sub(expected_id);
+        if appended != 1 || id.index() != expected_id {
+            return Err(TokenStoreError::invalid_source_output(
+                expected_id,
+                id.index(),
+                appended,
+            ));
+        }
+        source_errors.extend(
+            source
+                .drain_errors()
+                .into_iter()
+                .map(|error| BufferedSourceError {
+                    token_index: id.index(),
+                    error,
+                }),
+        );
+        let token = sink
+            .view(id)
+            .expect("token source returned an ID it did not emit");
+        if token.token_type() == TOKEN_EOF {
+            break;
+        }
+    }
+    Ok((store, source_errors))
+}
+
 impl<S> CommonTokenStream<S>
 where
     S: TokenSource,
@@ -51,34 +91,7 @@ where
     }
 
     pub fn try_with_channel(mut source: S, channel: i32) -> Result<Self, TokenStoreError> {
-        let source_name = source.source_name().to_owned();
-        let mut store = TokenStore::new(source.source_text(), source_name);
-        let mut source_errors = Vec::new();
-        loop {
-            let expected_id = store.len();
-            let mut sink = TokenSink::new(&mut store);
-            let id = source.next_token(&mut sink)?;
-            let appended = sink.token_count().saturating_sub(expected_id);
-            if appended != 1 || id.index() != expected_id {
-                return Err(TokenStoreError::invalid_source_output(
-                    expected_id,
-                    id.index(),
-                    appended,
-                ));
-            }
-            source_errors.extend(source.drain_errors().into_iter().map(|error| {
-                BufferedSourceError {
-                    token_index: id.index(),
-                    error,
-                }
-            }));
-            let token = sink
-                .view(id)
-                .expect("token source returned an ID it did not emit");
-            if token.token_type() == TOKEN_EOF {
-                break;
-            }
-        }
+        let (store, source_errors) = buffer_token_source(&mut source)?;
         let source_token_count = store.len();
         let mut stream = Self {
             source,
@@ -93,6 +106,44 @@ where
         stream.cursor = stream.adjust_seek_index(0);
         stream.requested_token_count.set(0);
         Ok(stream)
+    }
+
+    /// Replaces the token source and eagerly buffers it through EOF.
+    ///
+    /// The configured channel is retained; cursor, token storage, requested
+    /// lookahead, and buffered source errors are reset.
+    pub fn set_token_source(&mut self, source: S) {
+        self.try_set_token_source(source)
+            .unwrap_or_else(|error| panic!("failed to buffer tokens: {error}"));
+    }
+
+    /// Fallible form of [`Self::set_token_source`].
+    pub fn try_set_token_source(&mut self, source: S) -> Result<(), TokenStoreError> {
+        let replacement = Self::try_with_channel(source, self.channel)?;
+        *self = replacement;
+        Ok(())
+    }
+
+    /// Rebuffers the current token source after it has been reset or re-fed.
+    ///
+    /// This supports fully owned recognizer stacks: mutate the nested source
+    /// through [`Self::token_source_mut`], then call `refill` without moving the
+    /// lexer out of the stream.
+    pub fn refill(&mut self) {
+        self.try_refill()
+            .unwrap_or_else(|error| panic!("failed to buffer tokens: {error}"));
+    }
+
+    /// Fallible form of [`Self::refill`].
+    pub fn try_refill(&mut self) -> Result<(), TokenStoreError> {
+        let (store, source_errors) = buffer_token_source(&mut self.source)?;
+        self.store = store;
+        self.source_token_count = self.store.len();
+        self.next_visible_after = vec![UNKNOWN_NEXT_VISIBLE; self.source_token_count];
+        self.cursor = self.adjust_seek_index(0);
+        self.requested_token_count.set(0);
+        self.source_errors = source_errors;
+        Ok(())
     }
 
     /// Idempotent eager-buffering operation. Construction already buffers
@@ -161,6 +212,11 @@ where
 
     pub const fn token_source(&self) -> &S {
         &self.source
+    }
+
+    /// Returns the current source for in-place lexer re-feeding.
+    pub const fn token_source_mut(&mut self) -> &mut S {
+        &mut self.source
     }
 
     /// Iterates borrowing views of the original buffered token sequence.
@@ -601,5 +657,43 @@ mod tests {
             stream.tokens().next_back().map(|token| token.token_type()),
             Some(TOKEN_EOF)
         );
+    }
+
+    #[test]
+    fn set_token_source_replaces_buffer_and_preserves_channel() {
+        let mut stream = CommonTokenStream::with_channel(
+            source(vec![
+                TokenSpec::explicit(1, "old").with_channel(2),
+                TokenSpec::eof(3, 3, 1, 3),
+            ]),
+            2,
+        );
+
+        stream.set_token_source(source(vec![
+            TokenSpec::explicit(2, "new").with_channel(2),
+            TokenSpec::eof(3, 3, 1, 3),
+        ]));
+
+        assert_eq!(stream.channel(), 2);
+        assert_eq!(stream.index(), 0);
+        assert_eq!(stream.la_token(1), 2);
+        assert_eq!(stream.text_all(), "new");
+    }
+
+    #[test]
+    fn refill_reuses_mutated_token_source_in_place() {
+        let mut stream = CommonTokenStream::new(source(vec![
+            TokenSpec::explicit(1, "old"),
+            TokenSpec::eof(3, 3, 1, 3),
+        ]));
+        let source = stream.token_source_mut();
+        source.tokens = vec![TokenSpec::explicit(2, "new"), TokenSpec::eof(3, 3, 1, 3)].into();
+        source.index = 0;
+
+        stream.refill();
+
+        assert_eq!(stream.index(), 0);
+        assert_eq!(stream.la_token(1), 2);
+        assert_eq!(stream.text_all(), "new");
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -155,6 +155,23 @@ impl ParseTreeStorage {
         }
     }
 
+    pub(crate) fn reset(&mut self) {
+        self.kinds.clear();
+        self.child_starts.clear();
+        self.child_lens.clear();
+        self.payload_a.clear();
+        self.payload_b.clear();
+        self.starts.clear();
+        self.stops.clear();
+        self.alt_numbers.clear();
+        self.extra_ids.clear();
+        self.parents.clear();
+        self.flags.clear();
+        self.children.clear();
+        self.extras.clear();
+        self.child_links.clear();
+    }
+
     pub(crate) fn release_scratch(&mut self) {
         self.child_links.clear();
     }


### PR DESCRIPTION
## Summary

- add generated lexer `set_input_stream`, lifecycle-aware reset, and learned `clear_dfa`
- add `CommonTokenStream` source replacement, mutable source access, and in-place refill
- add full parser reset, token-stream replacement, mutable stream access, and parser DFA clearing
- invalidate shared parser DFA generations so overlapping stale simulators cannot republish cleared states
- document the owned-stack reuse pattern and generated rule-name migration

## Root cause

The Rust runtime owned each input layer but exposed no way to replace or rebuild those layers in place. Parser DFA state also lived in a checked-out thread-local store, so clearing only one simulator would allow another active simulator to publish stale learned states later.

## Impact

Long-lived services can now reuse one generated lexer, token stream, and parser across inputs. Callers can explicitly clear learned DFA state for cold measurements or memory control while retaining parser configuration, semantic hooks, and grammar-owned member state across reset.

Closes #112.

## Validation

- `cargo fmt --check`
- `cargo test --locked --all-targets --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite`
  - `357 passed, 0 failed, 0 skipped, 357 run`