### PR TITLE
perf(parser): add adaptive token sets

### DIFF
--- a/docs/issue-81-token-set-benchmark.md
+++ b/docs/issue-81-token-set-benchmark.md
@@ -1,0 +1,102 @@
+# Issue 81 adaptive parser token-set benchmark record
+
+Measurements were taken on 2026-07-19 on an Apple M3 Pro with Rust 1.96.0.
+The baseline was `main` at `2b826537d`; each runner was generated and built
+from its matching generator/runtime. The grammars-v4 checkout was
+`284602b3f23ca54dc30778204ab7ae9e969145e9`.
+
+## Applicable scope
+
+Current `main` already uses a dense `TokenBitSet` for parser FIRST/lookahead
+caches, and parser ATNs are immutable packed word streams. The remaining hot
+set probes were:
+
+- packed `Set` and `NotSet` transition matching;
+- generated dense set/not-set recognition; and
+- generated leading-lookahead guards for those dense sets.
+
+The change attaches an adaptive lookup representation to each packed parser
+interval set. Sets use two inline words through token type 127, a bounded dense
+table when its cost and density justify one, or the existing normalized
+interval search. Lexer Unicode sets are unchanged. Dense payloads have a hard
+64 KiB per-set limit. Generated direct recognition keeps literal interval
+checks for inline and sparse sets; routing every small generated set through
+packed metadata was not supported by the isolated parser measurements below.
+
+## End-to-end parse results
+
+The ordinary release runners used 10 warmups and 50 measured end-to-end parses
+for each of 17 fixtures. Compiler-level options were disabled so these results
+isolate the token-set representation from native CPU tuning, ThinLTO, and PGO.
+The benchmark harness exposes each of those modes independently, including
+separate PGO profile-generation and profile-use builds. Ratios below one are
+faster.
+
+| Fixtures | Count | Geometric ratio vs main | Aggregate ratio vs main |
+|---|---:|---:|---:|
+| Kotlin | 4 | 1.0120x | 0.9915x |
+| C# | 4 | 0.9705x | 0.9716x |
+| Java | 4 | 0.9752x | 0.9940x |
+| Trino SQL | 5 | 0.9506x | 0.9391x |
+| **All** | **17** | **0.9753x** | **0.9875x** |
+
+The single-pass Kotlin coroutines result was noisy at `1.0959x`. Seven
+alternating process pairs, each with 5 warmups and 20 measured parses,
+produced a `0.9475x` median ratio. The other one-pass ratios above one were C#
+codegen (`1.0063x`) and Bazel Java (`1.0257x`); their paired medians were
+`0.9815x` and `0.9884x`. No fixture had a confirmed regression.
+
+## Parser-only Kotlin results
+
+The Kotlin parity dumper eagerly buffers tokens before starting its parser
+stopwatch. Seven alternating process pairs ran 100 in-process parses per
+fixture with ordinary release settings:
+
+| Fixture | Median paired ratio vs main | Pair range |
+|---|---:|---:|
+| Kotlin lazy bodies | 0.9964x | 0.9933x..1.0372x |
+| Coroutines flow limit | 1.0019x | 0.9911x..1.0115x |
+| Ktor describe route | 1.0046x | 0.9979x..1.0117x |
+| Ktor security inference | 1.0128x | 0.9745x..1.0205x |
+| **Geometric ratio** | **1.0039x** | |
+
+Every range crossed `1.0`; the isolated parser result is effectively flat.
+An earlier experiment routed every generated inline set through packed
+metadata and was rejected. The final policy keeps the indexed path for dense
+generated sets, where it replaces longer interval checks, while packed ATN
+prediction uses the selected representation for every set.
+
+## Representation counters
+
+Each row is one instrumented parse. "Bitset probes" is the combined inline and
+dense count; those probes replace interval membership. Interval probes retain
+the normalized binary search.
+
+| Grammar fixture | Inline sets | Dense sets | Interval sets | Bitset bytes | Bitset probes | Interval probes |
+|---|---:|---:|---:|---:|---:|---:|
+| Kotlin coroutines | 21 | 1 | 3 | 360 | 17,846 | 710 |
+| C# codegen | 14 | 0 | 5 | 224 | 1,870 | 1,112 |
+| Java Closure | 13 | 2 | 0 | 256 | 641 | 0 |
+| Trino TPCH q21 | 5 | 3 | 29 | 200 | 13 | 22 |
+
+The Trino distribution demonstrates the sparse fallback: most of its sets stay
+as intervals, while dense or small sets still receive indexed membership.
+
+## Packed table size
+
+The original normalized intervals remain available for deterministic
+diagnostics and iteration. The delta therefore includes three metadata words
+per set plus the selected bitset payload.
+
+| Grammar | Main packed ATN | Adaptive packed ATN | Bitset payload | Total change |
+|---|---:|---:|---:|---:|
+| Kotlin | 155,188 B | 155,860 B | 360 B | +672 B (+0.43%) |
+| C# | 147,804 B | 148,268 B | 224 B | +464 B (+0.31%) |
+| Java | 103,364 B | 103,812 B | 256 B | +448 B (+0.43%) |
+| Trino | 184,088 B | 184,744 B | 200 B | +656 B (+0.36%) |
+| **Total** | **590,444 B** | **592,684 B** | **1,040 B** | **+2,240 B (+0.38%)** |
+
+Focused tests compare adaptive membership with normalized intervals over
+randomized sets and values, exercise EOF and negative values, verify exact
+`NotSet` vocabulary bounds, validate the legacy packed format, reject
+inconsistent packed bit tables, and lock the 64 KiB dense boundary.

--- a/src/atn/parser_atn.rs
+++ b/src/atn/parser_atn.rs
@@ -331,7 +331,8 @@ impl ParserAtn {
     /// representation as ATN prediction instead of embedding a second set.
     #[inline(always)]
     pub fn token_set(&self, index: usize) -> Option<ParserIntervalSet<'_>> {
-        (index < self.set_count()).then(|| self.interval_set(ParserIntervalSetId(index as u32)))
+        let id = ParserIntervalSetId::try_from(index).ok()?;
+        (index < self.set_count()).then(|| self.interval_set(id))
     }
 
     /// Stable backing-storage address used by thread-local grammar caches.
@@ -345,7 +346,9 @@ impl ParserAtn {
         let mut interval_token_sets = 0;
         let mut token_bitset_bytes = 0;
         for index in 0..self.set_count() {
-            let set = self.interval_set(ParserIntervalSetId(index as u32));
+            let set = self
+                .token_set(index)
+                .expect("in-bounds parser token-set index");
             match set.kind() {
                 ParserTokenSetKind::Inline128 => inline_token_sets += 1,
                 ParserTokenSetKind::Dense => dense_token_sets += 1,
@@ -412,7 +415,9 @@ impl ParserAtn {
     #[cfg(feature = "perf-counters")]
     fn record_token_set_inventory(&self) {
         for index in 0..self.set_count() {
-            let set = self.interval_set(ParserIntervalSetId(index as u32));
+            let set = self
+                .token_set(index)
+                .expect("in-bounds parser token-set index");
             crate::perf::record_parser_token_set_selection(
                 set.kind(),
                 set.bit_len * size_of::<u64>(),
@@ -2890,6 +2895,7 @@ mod tests {
         assert!(empty.is_empty());
         assert!(!empty.contains(TOKEN_EOF));
         assert!(!empty.contains(1));
+        assert!(empty_atn.token_set(usize::MAX).is_none());
     }
 
     #[test]

--- a/src/atn/parser_atn.rs
+++ b/src/atn/parser_atn.rs
@@ -13,21 +13,30 @@ use std::borrow::Cow;
 use std::fmt;
 use std::iter::FusedIterator;
 
-#[cfg(test)]
 use crate::token::TOKEN_EOF;
 
 use super::AtnStateKind;
 
 const PARSER_ATN_MAGIC: u32 = 0x5041_544e;
-const PARSER_ATN_FORMAT_VERSION: u32 = 1;
+const PARSER_ATN_FORMAT_VERSION: u32 = 2;
 const PARSER_ATN_MIN_FORMAT_VERSION: u32 = 1;
-const PARSER_ATN_MAX_FORMAT_VERSION: u32 = 1;
+const PARSER_ATN_MAX_FORMAT_VERSION: u32 = 2;
 const PARSER_ATN_BYTE_ORDER: u32 = 0x0102_0304;
 
-const HEADER_WORDS: usize = 26;
+const LEGACY_HEADER_WORDS: usize = 26;
+const HEADER_WORDS: usize = 29;
 const STATE_WORDS: usize = 7;
 const TRANSITION_WORDS: usize = 5;
-const SET_WORDS: usize = 2;
+const LEGACY_SET_WORDS: usize = 2;
+const SET_WORDS: usize = 5;
+const PACKED_U64_WORDS: usize = 2;
+
+const INLINE_TOKEN_SET_WORDS: usize = 2;
+const INLINE_TOKEN_SET_MAX_SLOT: usize = INLINE_TOKEN_SET_WORDS * u64::BITS as usize - 1;
+const MAX_DENSE_TOKEN_SET_BYTES: usize = 64 * 1024;
+const MAX_DENSE_TOKEN_SET_WORDS: usize = MAX_DENSE_TOKEN_SET_BYTES / size_of::<u64>();
+const DENSE_TOKEN_SET_COST_MULTIPLIER: usize = 2;
+const DENSE_TOKEN_SET_MIN_DENSITY_DENOMINATOR: u64 = 8;
 
 const NO_INDEX: u32 = u32::MAX;
 
@@ -65,6 +74,8 @@ const HEADER_DECISIONS_OFFSET: usize = 19;
 const HEADER_RULE_STARTS_OFFSET: usize = 21;
 const HEADER_RULE_STOPS_OFFSET: usize = 23;
 const HEADER_TOTAL_LEN: usize = 25;
+const HEADER_TOKEN_BIT_WORD_COUNT: usize = 26;
+const HEADER_TOKEN_BITS_OFFSET: usize = 27;
 
 /// Checked compact identity for one parser ATN state.
 #[repr(transparent)]
@@ -131,6 +142,18 @@ impl TryFrom<usize> for ParserIntervalSetId {
     }
 }
 
+/// Membership representation selected for one immutable parser token set.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ParserTokenSetKind {
+    /// Sorted, coalesced inclusive ranges searched by interval boundary.
+    Intervals = 0,
+    /// Two packed words covering EOF and token types `1..=127`.
+    Inline128 = 1,
+    /// A bounded packed word slice for a larger, cost-effective token domain.
+    Dense = 2,
+}
+
 /// Failure while reading, validating, or constructing packed parser ATN data.
 #[derive(Clone, Debug, Eq, PartialEq, thiserror::Error)]
 pub enum ParserAtnError {
@@ -156,6 +179,10 @@ pub struct ParserAtnStats {
     pub transitions: usize,
     pub interval_sets: usize,
     pub interval_ranges: usize,
+    pub inline_token_sets: usize,
+    pub dense_token_sets: usize,
+    pub interval_token_sets: usize,
+    pub token_bitset_bytes: usize,
     pub decisions: usize,
     pub rules: usize,
     pub packed_bytes: usize,
@@ -206,11 +233,14 @@ impl ParserAtn {
     /// Validates and borrows generator-emitted packed data without allocating.
     pub fn from_static(words: &'static [u32]) -> Result<Self, ParserAtnError> {
         let layout = validate_packed(words)?;
-        Ok(Self {
+        let atn = Self {
             words: Cow::Borrowed(words),
             words_address: words.as_ptr() as usize,
             layout,
-        })
+        };
+        #[cfg(feature = "perf-counters")]
+        atn.record_token_set_inventory();
+        Ok(atn)
     }
 
     /// Validates one owned packed stream.
@@ -218,11 +248,14 @@ impl ParserAtn {
         let layout = validate_packed(&words)?;
         let words: Cow<'static, [u32]> = Cow::Owned(words);
         let words_address = words.as_ptr() as usize;
-        Ok(Self {
+        let atn = Self {
             words,
             words_address,
             layout,
-        })
+        };
+        #[cfg(feature = "perf-counters")]
+        atn.record_token_set_inventory();
+        Ok(atn)
     }
 
     /// Canonical generator/runtime format version carried by this ATN.
@@ -292,21 +325,51 @@ impl ParserAtn {
         &self.words
     }
 
+    /// Returns one immutable parser token set by its packed metadata index.
+    ///
+    /// Generated rule bodies use this to share the same adaptive membership
+    /// representation as ATN prediction instead of embedding a second set.
+    #[inline(always)]
+    pub fn token_set(&self, index: usize) -> Option<ParserIntervalSet<'_>> {
+        (index < self.set_count()).then(|| self.interval_set(ParserIntervalSetId(index as u32)))
+    }
+
     /// Stable backing-storage address used by thread-local grammar caches.
     pub(crate) fn storage_identity(&self) -> (usize, usize) {
         (self.words.as_ptr() as usize, self.words.len())
     }
 
     pub fn stats(&self) -> ParserAtnStats {
+        let mut inline_token_sets = 0;
+        let mut dense_token_sets = 0;
+        let mut interval_token_sets = 0;
+        let mut token_bitset_bytes = 0;
+        for index in 0..self.set_count() {
+            let set = self.interval_set(ParserIntervalSetId(index as u32));
+            match set.kind() {
+                ParserTokenSetKind::Inline128 => inline_token_sets += 1,
+                ParserTokenSetKind::Dense => dense_token_sets += 1,
+                ParserTokenSetKind::Intervals => interval_token_sets += 1,
+            }
+            token_bitset_bytes += set.bit_len * size_of::<u64>();
+        }
         ParserAtnStats {
             states: self.state_count(),
             transitions: self.transition_count(),
-            interval_sets: self.layout.sets.len / SET_WORDS,
+            interval_sets: self.set_count(),
             interval_ranges: self.layout.intervals.len / 2,
+            inline_token_sets,
+            dense_token_sets,
+            interval_token_sets,
+            token_bitset_bytes,
             decisions: self.decision_count(),
             rules: self.rule_count(),
             packed_bytes: self.words.len() * size_of::<u32>(),
         }
+    }
+
+    const fn set_count(&self) -> usize {
+        self.layout.sets.len / self.layout.set_words
     }
 
     #[inline(always)]
@@ -316,12 +379,44 @@ impl ParserAtn {
 
     #[inline(always)]
     fn interval_set(&self, id: ParserIntervalSetId) -> ParserIntervalSet<'_> {
-        let start = self.word(self.layout.sets, id.index(), 0, SET_WORDS) as usize;
-        let len = self.word(self.layout.sets, id.index(), 1, SET_WORDS) as usize;
+        let width = self.layout.set_words;
+        let start = self.word(self.layout.sets, id.index(), 0, width) as usize;
+        let len = self.word(self.layout.sets, id.index(), 1, width) as usize;
+        let (kind, bit_start, bit_len) = if self.layout.format_version == 1 {
+            (ParserTokenSetKind::Intervals, 0, 0)
+        } else {
+            (
+                decode_token_set_kind(self.word(self.layout.sets, id.index(), 2, width))
+                    .expect("packed parser token-set kind was validated"),
+                self.word(self.layout.sets, id.index(), 3, width) as usize,
+                self.word(self.layout.sets, id.index(), 4, width) as usize,
+            )
+        };
         ParserIntervalSet {
             atn: self,
+            id,
             start,
             len,
+            kind,
+            bit_start,
+            bit_len,
+        }
+    }
+
+    #[inline(always)]
+    fn token_bit_word(&self, index: usize) -> u64 {
+        let offset = self.layout.token_bits.offset + index * PACKED_U64_WORDS;
+        u64::from(self.packed_word(offset)) | (u64::from(self.packed_word(offset + 1)) << u32::BITS)
+    }
+
+    #[cfg(feature = "perf-counters")]
+    fn record_token_set_inventory(&self) {
+        for index in 0..self.set_count() {
+            let set = self.interval_set(ParserIntervalSetId(index as u32));
+            crate::perf::record_parser_token_set_selection(
+                set.kind(),
+                set.bit_len * size_of::<u64>(),
+            );
         }
     }
 
@@ -854,8 +949,12 @@ impl ParserTransitionData<'_> {
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct ParserIntervalSet<'a> {
     atn: &'a ParserAtn,
+    id: ParserIntervalSetId,
     start: usize,
     len: usize,
+    kind: ParserTokenSetKind,
+    bit_start: usize,
+    bit_len: usize,
 }
 
 impl fmt::Debug for ParserIntervalSet<'_> {
@@ -865,12 +964,47 @@ impl fmt::Debug for ParserIntervalSet<'_> {
 }
 
 impl<'a> ParserIntervalSet<'a> {
+    /// Stable index of this set in the packed parser metadata.
+    pub const fn index(self) -> usize {
+        self.id.index()
+    }
+
+    /// Membership representation selected when the packed ATN was built.
+    pub const fn kind(self) -> ParserTokenSetKind {
+        self.kind
+    }
+
     pub const fn is_empty(self) -> bool {
         self.len == 0
     }
 
     #[inline(always)]
     pub fn contains(self, value: i32) -> bool {
+        let hit = match self.kind {
+            ParserTokenSetKind::Inline128 | ParserTokenSetKind::Dense => {
+                self.contains_bitset(value)
+            }
+            ParserTokenSetKind::Intervals => self.contains_intervals(value),
+        };
+        #[cfg(feature = "perf-counters")]
+        crate::perf::record_parser_token_set_probe(self.kind, hit);
+        hit
+    }
+
+    #[inline(always)]
+    fn contains_bitset(self, value: i32) -> bool {
+        let Some(slot) = token_set_slot(value) else {
+            return false;
+        };
+        let word = slot / u64::BITS as usize;
+        word < self.bit_len
+            && self.atn.token_bit_word(self.bit_start + word)
+                & (1_u64 << (slot % u64::BITS as usize))
+                != 0
+    }
+
+    #[inline(always)]
+    fn contains_intervals(self, value: i32) -> bool {
         let mut low = 0;
         let mut high = self.len;
         while low < high {
@@ -1048,8 +1182,9 @@ pub struct ParserAtnBuilder {
     max_token_type: i32,
     states: Vec<StateBuild>,
     transitions: Vec<TransitionBuild>,
-    interval_sets: Vec<(u32, u32)>,
+    interval_sets: Vec<TokenSetBuild>,
     interval_ranges: Vec<(i32, i32)>,
+    token_bit_words: Vec<u64>,
     decisions: Vec<AtnStateId>,
     rule_starts: Vec<AtnStateId>,
     rule_stops: Vec<AtnStateId>,
@@ -1063,6 +1198,7 @@ impl ParserAtnBuilder {
             transitions: Vec::new(),
             interval_sets: Vec::new(),
             interval_ranges: Vec::new(),
+            token_bit_words: Vec::new(),
             decisions: Vec::new(),
             rule_starts: Vec::new(),
             rule_stops: Vec::new(),
@@ -1122,11 +1258,21 @@ impl ParserAtnBuilder {
         ranges: impl IntoIterator<Item = (i32, i32)>,
     ) -> Result<ParserIntervalSetId, ParserAtnError> {
         let id = ParserIntervalSetId::try_from(self.interval_sets.len())?;
-        let start = compact_id("parser ATN interval start", self.interval_ranges.len())?;
         let normalized = normalize_ranges(ranges);
-        let len = compact_id("parser ATN interval count", normalized.len())?;
+        let interval_start = compact_id("parser ATN interval start", self.interval_ranges.len())?;
+        let interval_len = compact_id("parser ATN interval count", normalized.len())?;
+        let prepared = prepare_token_set(&normalized);
+        let bit_start = compact_id("parser token-set bit start", self.token_bit_words.len())?;
+        let bit_len = compact_id("parser token-set bit count", prepared.words.len())?;
         self.interval_ranges.extend(normalized);
-        self.interval_sets.push((start, len));
+        self.token_bit_words.extend(prepared.words);
+        self.interval_sets.push(TokenSetBuild {
+            interval_start,
+            interval_len,
+            kind: prepared.kind,
+            bit_start,
+            bit_len,
+        });
         Ok(id)
     }
 
@@ -1392,6 +1538,7 @@ impl ParserAtnBuilder {
         self.encode_transitions(&mut words, layout.transitions);
         self.encode_sets(&mut words, layout.sets);
         self.encode_intervals(&mut words, layout.intervals);
+        self.encode_token_bits(&mut words, layout.token_bits);
         encode_ids(&mut words, layout.decisions, &self.decisions);
         encode_ids(&mut words, layout.rule_starts, &self.rule_starts);
         encode_ids(&mut words, layout.rule_stops, &self.rule_stops);
@@ -1422,6 +1569,11 @@ impl ParserAtnBuilder {
         write_section(words, HEADER_TRANSITIONS_OFFSET, layout.transitions)?;
         write_section(words, HEADER_SETS_OFFSET, layout.sets)?;
         write_section(words, HEADER_INTERVALS_OFFSET, layout.intervals)?;
+        words[HEADER_TOKEN_BIT_WORD_COUNT] = compact_id(
+            "parser token-set bit word count",
+            self.token_bit_words.len(),
+        )?;
+        write_section(words, HEADER_TOKEN_BITS_OFFSET, layout.token_bits)?;
         write_section(words, HEADER_DECISIONS_OFFSET, layout.decisions)?;
         write_section(words, HEADER_RULE_STARTS_OFFSET, layout.rule_starts)?;
         write_section(words, HEADER_RULE_STOPS_OFFSET, layout.rule_stops)?;
@@ -1455,10 +1607,13 @@ impl ParserAtnBuilder {
     }
 
     fn encode_sets(&self, words: &mut [u32], section: Section) {
-        for (index, &(start, len)) in self.interval_sets.iter().enumerate() {
+        for (index, set) in self.interval_sets.iter().enumerate() {
             let base = section.offset + index * SET_WORDS;
-            words[base] = start;
-            words[base + 1] = len;
+            words[base] = set.interval_start;
+            words[base + 1] = set.interval_len;
+            words[base + 2] = set.kind as u32;
+            words[base + 3] = set.bit_start;
+            words[base + 4] = set.bit_len;
         }
     }
 
@@ -1467,6 +1622,14 @@ impl ParserAtnBuilder {
             let base = section.offset + index * 2;
             words[base] = pack_i32(start);
             words[base + 1] = pack_i32(stop);
+        }
+    }
+
+    fn encode_token_bits(&self, words: &mut [u32], section: Section) {
+        for (index, &bits) in self.token_bit_words.iter().enumerate() {
+            let base = section.offset + index * PACKED_U64_WORDS;
+            words[base] = bits as u32;
+            words[base + 1] = (bits >> u32::BITS) as u32;
         }
     }
 }
@@ -1540,13 +1703,16 @@ impl ParserTransitionSpec {
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 struct ParserAtnLayout {
+    format_version: u32,
     max_token_type: i32,
     state_count: usize,
     transition_count: usize,
+    set_words: usize,
     states: Section,
     transitions: Section,
     sets: Section,
     intervals: Section,
+    token_bits: Section,
     decisions: Section,
     rule_starts: Section,
     rule_stops: Section,
@@ -1564,6 +1730,7 @@ struct EncodedLayout {
     transitions: Section,
     sets: Section,
     intervals: Section,
+    token_bits: Section,
     decisions: Section,
     rule_starts: Section,
     rule_stops: Section,
@@ -1592,6 +1759,12 @@ impl EncodedLayout {
             2,
             "interval ranges",
         )?;
+        let token_bits = next_section(
+            &mut cursor,
+            builder.token_bit_words.len(),
+            PACKED_U64_WORDS,
+            "token-set bits",
+        )?;
         let decisions = next_section(&mut cursor, builder.decisions.len(), 1, "decisions")?;
         let rule_starts = next_section(&mut cursor, builder.rule_starts.len(), 1, "rule starts")?;
         let rule_stops = next_section(&mut cursor, builder.rule_stops.len(), 1, "rule stops")?;
@@ -1601,6 +1774,7 @@ impl EncodedLayout {
             transitions,
             sets,
             intervals,
+            token_bits,
             decisions,
             rule_starts,
             rule_stops,
@@ -1616,6 +1790,21 @@ struct StateBuild {
     flags: u32,
     end_state: u32,
     loop_back_state: u32,
+}
+
+#[derive(Clone, Debug)]
+struct TokenSetBuild {
+    interval_start: u32,
+    interval_len: u32,
+    kind: ParserTokenSetKind,
+    bit_start: u32,
+    bit_len: u32,
+}
+
+#[derive(Debug)]
+struct PreparedTokenSet {
+    kind: ParserTokenSetKind,
+    words: Vec<u64>,
 }
 
 #[derive(Clone, Debug)]
@@ -1710,9 +1899,9 @@ fn validate_packed(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
 }
 
 fn validate_header(words: &[u32]) -> Result<(), ParserAtnError> {
-    if words.len() < HEADER_WORDS {
+    if words.len() < LEGACY_HEADER_WORDS {
         return Err(ParserAtnError::InvalidData(format!(
-            "header has {} words; expected at least {HEADER_WORDS}",
+            "header has {} words; expected at least {LEGACY_HEADER_WORDS}",
             words.len()
         )));
     }
@@ -1730,16 +1919,27 @@ fn validate_header(words: &[u32]) -> Result<(), ParserAtnError> {
             maximum: PARSER_ATN_MAX_FORMAT_VERSION,
         });
     }
+    let header_words = if version == 1 {
+        LEGACY_HEADER_WORDS
+    } else {
+        HEADER_WORDS
+    };
+    if words.len() < header_words {
+        return Err(ParserAtnError::InvalidData(format!(
+            "format {version} header has {} words; expected at least {header_words}",
+            words.len()
+        )));
+    }
     if words[HEADER_BYTE_ORDER] != PARSER_ATN_BYTE_ORDER {
         return Err(ParserAtnError::InvalidData(format!(
             "byte-order marker 0x{:08x}; expected 0x{PARSER_ATN_BYTE_ORDER:08x}",
             words[HEADER_BYTE_ORDER]
         )));
     }
-    if words[HEADER_SIZE] as usize != HEADER_WORDS {
+    if words[HEADER_SIZE] as usize != header_words {
         return Err(ParserAtnError::InvalidData(format!(
-            "header length {}; expected {HEADER_WORDS}",
-            words[HEADER_SIZE]
+            "format {version} header length {}; expected {header_words}",
+            words[HEADER_SIZE],
         )));
     }
     if words[HEADER_TOTAL_LEN] as usize != words.len() {
@@ -1753,10 +1953,24 @@ fn validate_header(words: &[u32]) -> Result<(), ParserAtnError> {
 }
 
 fn read_layout(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
+    let format_version = words[HEADER_VERSION];
+    let set_words = if format_version == 1 {
+        LEGACY_SET_WORDS
+    } else {
+        SET_WORDS
+    };
     let states = read_section(words, HEADER_STATES_OFFSET)?;
     let transitions = read_section(words, HEADER_TRANSITIONS_OFFSET)?;
     let sets = read_section(words, HEADER_SETS_OFFSET)?;
     let intervals = read_section(words, HEADER_INTERVALS_OFFSET)?;
+    let token_bits = if format_version == 1 {
+        Section {
+            offset: intervals.offset + intervals.len,
+            len: 0,
+        }
+    } else {
+        read_section(words, HEADER_TOKEN_BITS_OFFSET)?
+    };
     let decisions = read_section(words, HEADER_DECISIONS_OFFSET)?;
     let rule_starts = read_section(words, HEADER_RULE_STARTS_OFFSET)?;
     let rule_stops = read_section(words, HEADER_RULE_STOPS_OFFSET)?;
@@ -1773,7 +1987,7 @@ fn read_layout(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
         "interval sets",
         sets,
         words[HEADER_SET_COUNT] as usize,
-        SET_WORDS,
+        set_words,
     )?;
     expect_section_len(
         "intervals",
@@ -1781,6 +1995,14 @@ fn read_layout(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
         words[HEADER_INTERVAL_COUNT] as usize,
         2,
     )?;
+    if format_version != 1 {
+        expect_section_len(
+            "token-set bits",
+            token_bits,
+            words[HEADER_TOKEN_BIT_WORD_COUNT] as usize,
+            PACKED_U64_WORDS,
+        )?;
+    }
     expect_section_len(
         "decisions",
         decisions,
@@ -1800,13 +2022,16 @@ fn read_layout(words: &[u32]) -> Result<ParserAtnLayout, ParserAtnError> {
         1,
     )?;
     Ok(ParserAtnLayout {
+        format_version,
         max_token_type: unpack_i32(words[HEADER_MAX_TOKEN_TYPE]),
         state_count,
         transition_count,
+        set_words,
         states,
         transitions,
         sets,
         intervals,
+        token_bits,
         decisions,
         rule_starts,
         rule_stops,
@@ -1819,11 +2044,16 @@ fn validate_sections(words: &[u32], layout: ParserAtnLayout) -> Result<(), Parse
         ("transitions", layout.transitions),
         ("sets", layout.sets),
         ("intervals", layout.intervals),
+        ("token-set bits", layout.token_bits),
         ("decisions", layout.decisions),
         ("rule starts", layout.rule_starts),
         ("rule stops", layout.rule_stops),
     ];
-    let mut expected_offset = HEADER_WORDS;
+    let mut expected_offset = if layout.format_version == 1 {
+        LEGACY_HEADER_WORDS
+    } else {
+        HEADER_WORDS
+    };
     for (name, section) in sections {
         if section.offset != expected_offset {
             return Err(ParserAtnError::InvalidData(format!(
@@ -1896,7 +2126,11 @@ fn validate_transitions(words: &[u32], layout: ParserAtnLayout) -> Result<(), Pa
                 }
             }
             ParserTransitionKind::Set | ParserTransitionKind::NotSet => {
-                validate_index(words[base + 2], layout.sets.len / SET_WORDS, "interval set")?;
+                validate_index(
+                    words[base + 2],
+                    layout.sets.len / layout.set_words,
+                    "interval set",
+                )?;
             }
             ParserTransitionKind::Rule => {
                 validate_index(words[base + 2], layout.rule_starts.len, "rule index")?;
@@ -1952,8 +2186,10 @@ fn validate_state_flags(words: &[u32], layout: ParserAtnLayout) -> Result<(), Pa
 }
 
 fn validate_sets(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtnError> {
-    for set in 0..layout.sets.len / SET_WORDS {
-        let base = layout.sets.offset + set * SET_WORDS;
+    let set_count = layout.sets.len / layout.set_words;
+    let mut bit_cursor = 0;
+    for set in 0..set_count {
+        let base = layout.sets.offset + set * layout.set_words;
         validate_range(
             words[base],
             words[base + 1],
@@ -1979,6 +2215,63 @@ fn validate_sets(words: &[u32], layout: ParserAtnLayout) -> Result<(), ParserAtn
             }
             previous_stop = Some(range_stop);
         }
+        if layout.format_version == 1 {
+            continue;
+        }
+        let kind = decode_token_set_kind(words[base + 2])?;
+        let bit_start = words[base + 3];
+        let bit_len = words[base + 4];
+        if bit_start as usize != bit_cursor {
+            return Err(ParserAtnError::InvalidData(format!(
+                "parser token set {set} bit range starts at {bit_start}, expected {bit_cursor}"
+            )));
+        }
+        validate_range(
+            bit_start,
+            bit_len,
+            layout.token_bits.len / PACKED_U64_WORDS,
+            "parser token-set bits",
+        )?;
+        let (expected_kind, expected_bit_len) =
+            token_set_shape((start..start + len).map(|interval| {
+                let interval_base = layout.intervals.offset + interval * 2;
+                (
+                    unpack_i32(words[interval_base]),
+                    unpack_i32(words[interval_base + 1]),
+                )
+            }));
+        if kind != expected_kind || bit_len as usize != expected_bit_len {
+            return Err(ParserAtnError::InvalidData(format!(
+                "parser token set {set} uses {kind:?} with {bit_len} words; \
+                 expected {expected_kind:?} with {expected_bit_len} words"
+            )));
+        }
+        for bit_word in 0..expected_bit_len {
+            let expected = expected_token_set_word(
+                (start..start + len).map(|interval| {
+                    let interval_base = layout.intervals.offset + interval * 2;
+                    (
+                        unpack_i32(words[interval_base]),
+                        unpack_i32(words[interval_base + 1]),
+                    )
+                }),
+                bit_word,
+            );
+            let actual = packed_u64(words, layout.token_bits, bit_cursor + bit_word);
+            if actual != expected {
+                return Err(ParserAtnError::InvalidData(format!(
+                    "parser token set {set} bit word {bit_word} is 0x{actual:016x}; \
+                     expected 0x{expected:016x}"
+                )));
+            }
+        }
+        bit_cursor += expected_bit_len;
+    }
+    if layout.format_version != 1 && bit_cursor != layout.token_bits.len / PACKED_U64_WORDS {
+        return Err(ParserAtnError::InvalidData(format!(
+            "parser token sets cover {bit_cursor} bit words; expected {}",
+            layout.token_bits.len / PACKED_U64_WORDS
+        )));
     }
     Ok(())
 }
@@ -2041,6 +2334,17 @@ fn decode_transition_kind(value: u32) -> Result<ParserTransitionKind, ParserAtnE
         }
     };
     Ok(kind)
+}
+
+fn decode_token_set_kind(value: u32) -> Result<ParserTokenSetKind, ParserAtnError> {
+    match value {
+        0 => Ok(ParserTokenSetKind::Intervals),
+        1 => Ok(ParserTokenSetKind::Inline128),
+        2 => Ok(ParserTokenSetKind::Dense),
+        other => Err(ParserAtnError::InvalidData(format!(
+            "parser token-set kind {other}"
+        ))),
+    }
 }
 
 const fn state_kind_word(kind: AtnStateKind) -> u32 {
@@ -2117,6 +2421,132 @@ fn normalize_ranges(ranges: impl IntoIterator<Item = (i32, i32)>) -> Vec<(i32, i
         normalized.push((start, stop));
     }
     normalized
+}
+
+/// Selects token-set storage without allocating from an unchecked maximum.
+///
+/// Every compatible set at or below token slot 127 uses two inline words.
+/// Larger sets use dense words only when the payload is at most 64 KiB and
+/// either no larger than interval storage, or at most twice that storage while
+/// covering at least one eighth of the indexed domain. Sparse, malformed, and
+/// very large domains retain normalized interval lookup.
+fn token_set_shape(ranges: impl IntoIterator<Item = (i32, i32)>) -> (ParserTokenSetKind, usize) {
+    let mut compatible = true;
+    let mut max_slot = 0;
+    let mut represented = 0_u64;
+    let mut range_count = 0_usize;
+    for (start, stop) in ranges {
+        range_count += 1;
+        represented = represented.saturating_add(
+            u64::try_from(i64::from(stop) - i64::from(start) + 1).unwrap_or(u64::MAX),
+        );
+        if start == TOKEN_EOF && stop == TOKEN_EOF {
+            continue;
+        }
+        if start < 1 {
+            compatible = false;
+            continue;
+        }
+        let stop = usize::try_from(stop).expect("positive i32 token type fits usize");
+        max_slot = max_slot.max(stop);
+    }
+    if !compatible {
+        return (ParserTokenSetKind::Intervals, 0);
+    }
+    if max_slot <= INLINE_TOKEN_SET_MAX_SLOT {
+        return (ParserTokenSetKind::Inline128, INLINE_TOKEN_SET_WORDS);
+    }
+    let word_len = max_slot / u64::BITS as usize + 1;
+    let Some(dense_bytes) = word_len.checked_mul(size_of::<u64>()) else {
+        return (ParserTokenSetKind::Intervals, 0);
+    };
+    let interval_bytes = range_count.saturating_mul(size_of::<(i32, i32)>());
+    let dense_enough = represented.saturating_mul(DENSE_TOKEN_SET_MIN_DENSITY_DENOMINATOR)
+        >= u64::try_from(max_slot)
+            .unwrap_or(u64::MAX)
+            .saturating_add(1);
+    let cost_effective = dense_bytes <= interval_bytes
+        || (dense_bytes <= interval_bytes.saturating_mul(DENSE_TOKEN_SET_COST_MULTIPLIER)
+            && dense_enough);
+    if word_len <= MAX_DENSE_TOKEN_SET_WORDS && cost_effective {
+        (ParserTokenSetKind::Dense, word_len)
+    } else {
+        (ParserTokenSetKind::Intervals, 0)
+    }
+}
+
+fn prepare_token_set(ranges: &[(i32, i32)]) -> PreparedTokenSet {
+    let (kind, word_len) = token_set_shape(ranges.iter().copied());
+    let mut words = vec![0; word_len];
+    for &(start, stop) in ranges {
+        insert_token_set_range(&mut words, start, stop);
+    }
+    PreparedTokenSet { kind, words }
+}
+
+fn insert_token_set_range(words: &mut [u64], start: i32, stop: i32) {
+    if words.is_empty() {
+        return;
+    }
+    if start == TOKEN_EOF && stop == TOKEN_EOF {
+        words[0] |= 1;
+        return;
+    }
+    debug_assert!(start >= 1 && stop >= start);
+    let start = usize::try_from(start).expect("positive i32 token type fits usize");
+    let stop = usize::try_from(stop).expect("positive i32 token type fits usize");
+    let start_word = start / u64::BITS as usize;
+    let stop_word = stop / u64::BITS as usize;
+    if start_word == stop_word {
+        words[start_word] |= token_word_mask(start % u64::BITS as usize, stop % u64::BITS as usize);
+        return;
+    }
+    words[start_word] |= !0_u64 << (start % u64::BITS as usize);
+    words[(start_word + 1)..stop_word].fill(!0);
+    words[stop_word] |= !0_u64 >> (u64::BITS as usize - 1 - stop % u64::BITS as usize);
+}
+
+fn expected_token_set_word(ranges: impl IntoIterator<Item = (i32, i32)>, word_index: usize) -> u64 {
+    let word_start = word_index * u64::BITS as usize;
+    let word_stop = word_start + u64::BITS as usize - 1;
+    let mut expected = 0;
+    for (start, stop) in ranges {
+        if start == TOKEN_EOF && stop == TOKEN_EOF {
+            if word_index == 0 {
+                expected |= 1;
+            }
+            continue;
+        }
+        let start = usize::try_from(start).expect("positive i32 token type fits usize");
+        let stop = usize::try_from(stop).expect("positive i32 token type fits usize");
+        if stop < word_start || start > word_stop {
+            continue;
+        }
+        expected |= token_word_mask(
+            start.max(word_start) - word_start,
+            stop.min(word_stop) - word_start,
+        );
+    }
+    expected
+}
+
+const fn token_word_mask(start: usize, stop: usize) -> u64 {
+    (!0_u64 << start) & (!0_u64 >> (u64::BITS as usize - 1 - stop))
+}
+
+fn packed_u64(words: &[u32], section: Section, index: usize) -> u64 {
+    let offset = section.offset + index * PACKED_U64_WORDS;
+    u64::from(words[offset]) | (u64::from(words[offset + 1]) << u32::BITS)
+}
+
+fn token_set_slot(value: i32) -> Option<usize> {
+    if value == TOKEN_EOF {
+        Some(0)
+    } else if value > 0 {
+        usize::try_from(value).ok()
+    } else {
+        None
+    }
 }
 
 fn next_section(
@@ -2263,6 +2693,78 @@ mod tests {
         builder.finish().expect("packed parser ATN")
     }
 
+    fn token_set_atn(max_token_type: i32, ranges: &[(i32, i32)]) -> ParserAtn {
+        let mut builder = ParserAtnBuilder::new(max_token_type);
+        builder
+            .add_interval_set(ranges.iter().copied())
+            .expect("token set");
+        builder.finish().expect("packed parser ATN")
+    }
+
+    fn legacy_words(atn: &ParserAtn) -> Vec<u32> {
+        let source = atn.packed_words();
+        let source_layout = atn.layout;
+        let set_count = source_layout.sets.len / source_layout.set_words;
+        let mut cursor = LEGACY_HEADER_WORDS;
+        let states = next_section(
+            &mut cursor,
+            source_layout.state_count,
+            STATE_WORDS,
+            "states",
+        )
+        .expect("legacy states");
+        let transitions = next_section(
+            &mut cursor,
+            source_layout.transition_count,
+            TRANSITION_WORDS,
+            "transitions",
+        )
+        .expect("legacy transitions");
+        let sets =
+            next_section(&mut cursor, set_count, LEGACY_SET_WORDS, "sets").expect("legacy sets");
+        let intervals = next_section(&mut cursor, source_layout.intervals.len / 2, 2, "intervals")
+            .expect("legacy intervals");
+        let decisions = next_section(&mut cursor, source_layout.decisions.len, 1, "decisions")
+            .expect("legacy decisions");
+        let rule_starts =
+            next_section(&mut cursor, source_layout.rule_starts.len, 1, "rule starts")
+                .expect("legacy rule starts");
+        let rule_stops = next_section(&mut cursor, source_layout.rule_stops.len, 1, "rule stops")
+            .expect("legacy rule stops");
+        let mut words = vec![0; cursor];
+        words[..=HEADER_RULE_COUNT].copy_from_slice(&source[..=HEADER_RULE_COUNT]);
+        words[HEADER_VERSION] = 1;
+        words[HEADER_SIZE] = LEGACY_HEADER_WORDS as u32;
+        write_section(&mut words, HEADER_STATES_OFFSET, states).expect("states header");
+        write_section(&mut words, HEADER_TRANSITIONS_OFFSET, transitions)
+            .expect("transitions header");
+        write_section(&mut words, HEADER_SETS_OFFSET, sets).expect("sets header");
+        write_section(&mut words, HEADER_INTERVALS_OFFSET, intervals).expect("intervals header");
+        write_section(&mut words, HEADER_DECISIONS_OFFSET, decisions).expect("decisions header");
+        write_section(&mut words, HEADER_RULE_STARTS_OFFSET, rule_starts)
+            .expect("rule starts header");
+        write_section(&mut words, HEADER_RULE_STOPS_OFFSET, rule_stops).expect("rule stops header");
+        words[HEADER_TOTAL_LEN] = cursor as u32;
+        for (target, section) in [
+            (states, source_layout.states),
+            (transitions, source_layout.transitions),
+            (intervals, source_layout.intervals),
+            (decisions, source_layout.decisions),
+            (rule_starts, source_layout.rule_starts),
+            (rule_stops, source_layout.rule_stops),
+        ] {
+            words[target.offset..target.offset + target.len]
+                .copy_from_slice(&source[section.offset..section.offset + section.len]);
+        }
+        for set in 0..set_count {
+            let source_base = source_layout.sets.offset + set * source_layout.set_words;
+            let target_base = sets.offset + set * LEGACY_SET_WORDS;
+            words[target_base..target_base + LEGACY_SET_WORDS]
+                .copy_from_slice(&source[source_base..source_base + LEGACY_SET_WORDS]);
+        }
+        words
+    }
+
     #[test]
     fn packed_views_preserve_state_and_transition_semantics() {
         let atn = sample_atn();
@@ -2295,11 +2797,147 @@ mod tests {
         assert_eq!(
             ParserAtn::from_owned(wrong_version),
             Err(ParserAtnError::UnsupportedVersion {
-                found: 2,
+                found: 3,
                 minimum: 1,
-                maximum: 1,
+                maximum: 2,
             })
         );
+    }
+
+    #[test]
+    fn legacy_interval_format_remains_readable() {
+        let current = token_set_atn(200, &[(TOKEN_EOF, TOKEN_EOF), (2, 8), (150, 150)]);
+        let legacy = ParserAtn::from_owned(legacy_words(&current)).expect("legacy packed ATN");
+        let set = legacy.token_set(0).expect("legacy token set");
+
+        assert_eq!(legacy.format_version(), 1);
+        assert_eq!(set.kind(), ParserTokenSetKind::Intervals);
+        assert_eq!(
+            set.ranges().collect::<Vec<_>>(),
+            [(TOKEN_EOF, TOKEN_EOF), (2, 8), (150, 150)]
+        );
+        assert!(set.contains(TOKEN_EOF));
+        assert!(set.contains(6));
+        assert!(set.contains(150));
+        assert!(!set.contains(149));
+    }
+
+    #[test]
+    fn adaptive_token_sets_cover_boundaries_and_safe_fallbacks() {
+        let inline = token_set_atn(127, &[(TOKEN_EOF, TOKEN_EOF), (1, 1), (63, 64), (127, 127)]);
+        let inline = inline.token_set(0).expect("inline set");
+        assert_eq!(inline.kind(), ParserTokenSetKind::Inline128);
+        for token in [TOKEN_EOF, 1, 63, 64, 127] {
+            assert!(inline.contains(token), "missing token {token}");
+        }
+        for token in [-2, 0, 2, 62, 65, 126, 128] {
+            assert!(!inline.contains(token), "unexpected token {token}");
+        }
+
+        let singleton_atn = token_set_atn(127, &[(42, 42)]);
+        let singleton = singleton_atn.token_set(0).expect("singleton set");
+        assert_eq!(singleton.kind(), ParserTokenSetKind::Inline128);
+        assert!(singleton.contains(42));
+        assert!(!singleton.contains(41));
+        assert!(!singleton.contains(43));
+
+        let dense_ranges = (1..=512)
+            .step_by(2)
+            .map(|token| (token, token))
+            .collect::<Vec<_>>();
+        let dense_atn = token_set_atn(512, &dense_ranges);
+        let dense = dense_atn.token_set(0).expect("dense set");
+        assert_eq!(dense.kind(), ParserTokenSetKind::Dense);
+        assert!(dense.contains(511));
+        assert!(!dense.contains(512));
+
+        let at_cap_max =
+            i32::try_from(MAX_DENSE_TOKEN_SET_WORDS * u64::BITS as usize - 1).expect("test bound");
+        assert_eq!(
+            token_set_shape((1..=at_cap_max).step_by(2).map(|token| (token, token))),
+            (ParserTokenSetKind::Dense, MAX_DENSE_TOKEN_SET_WORDS)
+        );
+        let over_cap_max = at_cap_max + 1;
+        assert_eq!(
+            token_set_shape(
+                (1..=over_cap_max)
+                    .step_by(2)
+                    .map(|token| (token, token))
+                    .chain([(over_cap_max, over_cap_max)])
+            ),
+            (ParserTokenSetKind::Intervals, 0)
+        );
+
+        for ranges in [
+            vec![(1, 1), (1_000_000, 1_000_000)],
+            vec![(1, 1), (i32::MAX, i32::MAX)],
+            vec![(-2, -2), (1, 4)],
+            vec![(0, 4)],
+        ] {
+            let atn = token_set_atn(i32::MAX, &ranges);
+            let set = atn.token_set(0).expect("interval set");
+            assert_eq!(set.kind(), ParserTokenSetKind::Intervals, "{ranges:?}");
+            assert_eq!(atn.stats().token_bitset_bytes, 0);
+            for &(start, stop) in &ranges {
+                assert!(set.contains(start));
+                assert!(set.contains(stop));
+            }
+        }
+
+        let empty_atn = token_set_atn(0, &[]);
+        let empty = empty_atn.token_set(0).expect("empty set");
+        assert_eq!(empty.kind(), ParserTokenSetKind::Inline128);
+        assert!(empty.is_empty());
+        assert!(!empty.contains(TOKEN_EOF));
+        assert!(!empty.contains(1));
+    }
+
+    #[test]
+    fn adaptive_membership_matches_randomized_normalized_intervals() {
+        let mut random = 0x9e37_79b9_7f4a_7c15_u64;
+        for case in 0..256 {
+            let range_count = (next_random(&mut random) % 24) as usize;
+            let mut ranges = Vec::with_capacity(range_count);
+            for _ in 0..range_count {
+                let start = (next_random(&mut random) % 2_100) as i32 - 4;
+                let width = (next_random(&mut random) % 24) as i32;
+                ranges.push((start, start.saturating_add(width)));
+            }
+            if case % 17 == 0 {
+                ranges.push((TOKEN_EOF, TOKEN_EOF));
+            }
+            if case % 29 == 0 {
+                ranges.push((i32::MAX, i32::MAX));
+            }
+            let normalized = normalize_ranges(ranges);
+            let atn = token_set_atn(i32::MAX, &normalized);
+            let set = atn.token_set(0).expect("randomized set");
+            for token in [TOKEN_EOF, -3, 0, 1, 63, 64, 127, 128, 2_048, i32::MAX] {
+                let expected = normalized
+                    .iter()
+                    .any(|(start, stop)| (*start..=*stop).contains(&token));
+                assert_eq!(
+                    set.contains(token),
+                    expected,
+                    "case {case}, token {token}, kind {:?}, ranges {normalized:?}",
+                    set.kind()
+                );
+            }
+            for _ in 0..64 {
+                let token = (next_random(&mut random) % 2_200) as i32 - 16;
+                let expected = normalized
+                    .iter()
+                    .any(|(start, stop)| (*start..=*stop).contains(&token));
+                assert_eq!(set.contains(token), expected, "case {case}, token {token}");
+            }
+        }
+    }
+
+    fn next_random(state: &mut u64) -> u64 {
+        *state ^= *state << 13;
+        *state ^= *state >> 7;
+        *state ^= *state << 17;
+        *state
     }
 
     #[cfg(target_pointer_width = "64")]
@@ -2315,6 +2953,7 @@ mod tests {
             transitions: section,
             sets: section,
             intervals: section,
+            token_bits: section,
             decisions: section,
             rule_starts: section,
             rule_stops: section,
@@ -2419,6 +3058,97 @@ mod tests {
             Err(ParserAtnError::InvalidData(message))
                 if message.contains("transition target")
         ));
+    }
+
+    #[test]
+    fn not_set_membership_preserves_vocabulary_bounds() {
+        let mut builder = ParserAtnBuilder::new(5);
+        builder
+            .add_state(AtnStateKind::RuleStart, Some(0))
+            .expect("start");
+        builder
+            .add_state(AtnStateKind::RuleStop, Some(0))
+            .expect("stop");
+        builder
+            .set_rule_to_start_state(vec![0])
+            .expect("rule starts");
+        builder.set_rule_to_stop_state(vec![1]).expect("rule stops");
+        let excluded = builder.add_interval_set([(2, 4)]).expect("excluded set");
+        builder
+            .add_transition(
+                0,
+                ParserTransitionSpec::NotSet {
+                    target: 1,
+                    set: excluded,
+                },
+            )
+            .expect("not-set transition");
+        let atn = builder.finish().expect("ATN");
+        let transition = atn
+            .state(0)
+            .expect("start")
+            .transitions()
+            .first()
+            .expect("transition");
+
+        assert!(transition.matches(1, 1, 5));
+        assert!(!transition.matches(2, 1, 5));
+        assert!(!transition.matches(4, 1, 5));
+        assert!(transition.matches(5, 1, 5));
+        assert!(!transition.matches(TOKEN_EOF, 1, 5));
+        assert!(!transition.matches(0, 1, 5));
+        assert!(!transition.matches(6, 1, 5));
+    }
+
+    #[test]
+    fn rejects_inconsistent_adaptive_token_set_bits() {
+        let atn = token_set_atn(127, &[(1, 3), (63, 64), (127, 127)]);
+        let mut words = atn.packed_words().to_vec();
+        words[atn.layout.token_bits.offset] ^= 1 << 1;
+        let error = ParserAtn::from_owned(words).expect_err("corrupted token bits must fail");
+        assert!(error.to_string().contains("bit word"), "{error}");
+
+        let mut words = atn.packed_words().to_vec();
+        words[atn.layout.sets.offset + 2] = 99;
+        let error = ParserAtn::from_owned(words).expect_err("unknown token-set kind must fail");
+        assert!(error.to_string().contains("token-set kind"), "{error}");
+    }
+
+    #[cfg(feature = "perf-counters")]
+    #[test]
+    fn token_set_counters_report_selection_and_probes() {
+        crate::perf::reset();
+        let before = crate::perf::parser_token_set_snapshot();
+        let inline_atn = token_set_atn(10, &[(1, 4)]);
+        let dense_ranges = (1..=256)
+            .step_by(2)
+            .map(|token| (token, token))
+            .collect::<Vec<_>>();
+        let dense_atn = token_set_atn(256, &dense_ranges);
+        let interval_atn = token_set_atn(i32::MAX, &[(1, 1), (i32::MAX, i32::MAX)]);
+        let inline = inline_atn.token_set(0).expect("inline");
+        let dense = dense_atn.token_set(0).expect("dense");
+        let intervals = interval_atn.token_set(0).expect("intervals");
+
+        assert!(inline.contains(2));
+        assert!(!inline.contains(9));
+        assert!(dense.contains(255));
+        assert!(!dense.contains(256));
+        assert!(intervals.contains(i32::MAX));
+        assert!(!intervals.contains(2));
+
+        let after = crate::perf::parser_token_set_snapshot();
+        assert!(after[0] > before[0], "{before:?} -> {after:?}");
+        assert!(after[1] > before[1], "{before:?} -> {after:?}");
+        assert!(after[2] > before[2], "{before:?} -> {after:?}");
+        assert_eq!(after[5] - before[5], 1);
+        assert_eq!(after[6] - before[6], 1);
+        assert_eq!(after[7] - before[7], 1);
+        assert_eq!(after[8] - before[8], 1);
+        assert_eq!(after[9] - before[9], 1);
+        assert_eq!(after[10] - before[10], 1);
+        assert_eq!(after[11] - before[11], 4);
+        assert_eq!(after[12] - before[12], 2);
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 use antlr4_runtime::atn::lexer_dfa::CompiledLexerDfa;
 use antlr4_runtime::atn::parser_atn::{
-    ParserAtn, ParserAtnState, ParserTransition, ParserTransitionData,
+    ParserAtn, ParserAtnState, ParserTokenSetKind, ParserTransition, ParserTransitionData,
 };
 use antlr4_runtime::atn::serialized::{AtnDeserializer, SerializedAtn};
 use antlr4_runtime::atn::{AtnStateKind, LexerAction, LexerTransition};
@@ -2573,10 +2573,12 @@ enum GeneratedParserStep {
         follow_state: usize,
     },
     MatchSet {
+        token_set: Option<usize>,
         intervals: Vec<(i32, i32)>,
         follow_state: usize,
     },
     MatchNotSet {
+        token_set: Option<usize>,
         intervals: Vec<(i32, i32)>,
         follow_state: usize,
     },
@@ -4165,6 +4167,7 @@ fn compile_generated_parser_transition(
             stop,
         } => Some((
             Some(GeneratedParserStep::MatchSet {
+                token_set: None,
                 intervals: vec![(start, stop)],
                 follow_state: target,
             }),
@@ -4172,6 +4175,7 @@ fn compile_generated_parser_transition(
         )),
         ParserTransitionData::Set { target, set } => Some((
             Some(GeneratedParserStep::MatchSet {
+                token_set: (set.kind() == ParserTokenSetKind::Dense).then_some(set.index()),
                 intervals: set.ranges().collect(),
                 follow_state: target,
             }),
@@ -4179,6 +4183,7 @@ fn compile_generated_parser_transition(
         )),
         ParserTransitionData::NotSet { target, set } => Some((
             Some(GeneratedParserStep::MatchNotSet {
+                token_set: (set.kind() == ParserTokenSetKind::Dense).then_some(set.index()),
                 intervals: set.ranges().collect(),
                 follow_state: target,
             }),
@@ -4762,15 +4767,24 @@ fn render_generated_step(
             .expect("writing to a string cannot fail");
         }
         GeneratedParserStep::MatchSet {
+            token_set,
             intervals,
             follow_state,
         } => {
-            let intervals = render_i32_ranges(intervals);
-            writeln!(
-                out,
-                "{pad}let __match = self.base.match_set_recovering(&{intervals}, {follow_state}, atn())?;"
-            )
-            .expect("writing to a string cannot fail");
+            if let Some(token_set) = token_set {
+                writeln!(
+                    out,
+                    "{pad}let __match = self.base.match_token_set_recovering(atn().token_set({token_set}).expect(\"generated parser token-set index\"), {follow_state}, atn())?;"
+                )
+                .expect("writing to a string cannot fail");
+            } else {
+                let intervals = render_i32_ranges(intervals);
+                writeln!(
+                    out,
+                    "{pad}let __match = self.base.match_set_recovering(&{intervals}, {follow_state}, atn())?;"
+                )
+                .expect("writing to a string cannot fail");
+            }
             writeln!(out, "{pad}__consumed_eof |= __match.consumed_eof();")
                 .expect("writing to a string cannot fail");
             writeln!(
@@ -4780,15 +4794,24 @@ fn render_generated_step(
             .expect("writing to a string cannot fail");
         }
         GeneratedParserStep::MatchNotSet {
+            token_set,
             intervals,
             follow_state,
         } => {
-            let intervals = render_i32_ranges(intervals);
-            writeln!(
-                out,
-                "{pad}let __match = self.base.match_not_set_recovering(&{intervals}, 1, atn().max_token_type(), {follow_state}, atn())?;"
-            )
-            .expect("writing to a string cannot fail");
+            if let Some(token_set) = token_set {
+                writeln!(
+                    out,
+                    "{pad}let __match = self.base.match_not_token_set_recovering(atn().token_set({token_set}).expect(\"generated parser token-set index\"), 1, atn().max_token_type(), {follow_state}, atn())?;"
+                )
+                .expect("writing to a string cannot fail");
+            } else {
+                let intervals = render_i32_ranges(intervals);
+                writeln!(
+                    out,
+                    "{pad}let __match = self.base.match_not_set_recovering(&{intervals}, 1, atn().max_token_type(), {follow_state}, atn())?;"
+                )
+                .expect("writing to a string cannot fail");
+            }
             writeln!(out, "{pad}__consumed_eof |= __match.consumed_eof();")
                 .expect("writing to a string cannot fail");
             writeln!(
@@ -5533,13 +5556,21 @@ fn leading_lookahead_condition(steps: &[GeneratedParserStep], la_symbol: &str) -
             GeneratedParserStep::MatchToken { token_type, .. } => {
                 return Some(format!("{la_symbol} == {token_type}"));
             }
-            GeneratedParserStep::MatchSet { intervals, .. } => {
-                return Some(intervals_condition(la_symbol, intervals));
+            GeneratedParserStep::MatchSet {
+                token_set,
+                intervals,
+                ..
+            } => {
+                return Some(token_set_condition(la_symbol, *token_set, intervals));
             }
-            GeneratedParserStep::MatchNotSet { intervals, .. } => {
-                let excluded = intervals_condition(la_symbol, intervals);
+            GeneratedParserStep::MatchNotSet {
+                token_set,
+                intervals,
+                ..
+            } => {
+                let excluded = token_set_condition(la_symbol, *token_set, intervals);
                 return Some(format!(
-                    "{la_symbol} != antlr4_runtime::TOKEN_EOF && !({excluded})"
+                    "(1..=atn().max_token_type()).contains(&{la_symbol}) && !({excluded})"
                 ));
             }
             GeneratedParserStep::MatchWildcard { .. } => {
@@ -5552,6 +5583,17 @@ fn leading_lookahead_condition(steps: &[GeneratedParserStep], la_symbol: &str) -
         }
     }
     None
+}
+
+fn token_set_condition(symbol: &str, token_set: Option<usize>, intervals: &[(i32, i32)]) -> String {
+    token_set.map_or_else(
+        || intervals_condition(symbol, intervals),
+        |token_set| {
+            format!(
+                "atn().token_set({token_set}).expect(\"generated parser token-set index\").contains({symbol})"
+            )
+        },
+    )
 }
 
 fn intervals_condition(symbol: &str, intervals: &[(i32, i32)]) -> String {
@@ -11126,6 +11168,31 @@ atn:
 
     fn ms(intervals: Vec<(i32, i32)>, follow_state: usize) -> GeneratedParserStep {
         GeneratedParserStep::MatchSet {
+            token_set: None,
+            intervals,
+            follow_state,
+        }
+    }
+
+    fn mts(
+        token_set: usize,
+        intervals: Vec<(i32, i32)>,
+        follow_state: usize,
+    ) -> GeneratedParserStep {
+        GeneratedParserStep::MatchSet {
+            token_set: Some(token_set),
+            intervals,
+            follow_state,
+        }
+    }
+
+    fn mnts(
+        token_set: usize,
+        intervals: Vec<(i32, i32)>,
+        follow_state: usize,
+    ) -> GeneratedParserStep {
+        GeneratedParserStep::MatchNotSet {
+            token_set: Some(token_set),
             intervals,
             follow_state,
         }
@@ -11133,6 +11200,7 @@ atn:
 
     fn mns(intervals: Vec<(i32, i32)>, follow_state: usize) -> GeneratedParserStep {
         GeneratedParserStep::MatchNotSet {
+            token_set: None,
             intervals,
             follow_state,
         }
@@ -11775,6 +11843,35 @@ atn:
                 }
             ),
             Some((Some(mns(vec![(1, 1)], 9)), 9))
+        );
+
+        let dense_ranges = (1..=256)
+            .step_by(2)
+            .map(|token| (token, token))
+            .collect::<Vec<_>>();
+        let dense_set_atn = transition_atn(|builder| {
+            let set = builder
+                .add_interval_set(dense_ranges.iter().copied())
+                .expect("dense set");
+            ParserTransitionSpec::Set { target: 8, set }
+        });
+        let dense_set_transition = only_transition(&dense_set_atn);
+        assert_eq!(
+            compile_generated_parser_transition(
+                3,
+                &[],
+                dense_set_transition,
+                ActionStateSets {
+                    all: &BTreeSet::new(),
+                    generated: &BTreeSet::new(),
+                    inline: &BTreeSet::new(),
+                },
+                PredicateCoordinateSets {
+                    all: &BTreeSet::new(),
+                    generated: &BTreeSet::new(),
+                }
+            ),
+            Some((Some(mts(0, dense_ranges, 8)), 8))
         );
     }
 
@@ -12635,6 +12732,51 @@ s : ;
         assert!(rendered.contains("__consumed_eof |= __match.consumed_eof();"));
         // The old non-recovering call must be gone.
         assert!(!rendered.contains("self.base.match_wildcard()"));
+    }
+
+    #[test]
+    fn renders_packed_token_sets_for_generated_matches_and_lookahead() {
+        let step = mts(4, vec![(2, 4), (9, 9)], 7);
+        let rule = GeneratedParserRule {
+            rule_index: 0,
+            entry_state: 0,
+            left_recursive: false,
+            steps: vec![step.clone()],
+        };
+
+        let rendered = render_generated_rule_dispatch(&[Some(rule)], &[], &BTreeMap::new(), false);
+
+        assert!(rendered.contains(
+            "match_token_set_recovering(atn().token_set(4).expect(\"generated parser token-set index\"), 7, atn())"
+        ));
+        assert_eq!(
+            leading_lookahead_condition(&[step], "__la"),
+            Some(
+                "atn().token_set(4).expect(\"generated parser token-set index\").contains(__la)"
+                    .to_owned()
+            )
+        );
+
+        let not_step = mnts(5, vec![(3, 6)], 8);
+        let not_rule = GeneratedParserRule {
+            rule_index: 0,
+            entry_state: 0,
+            left_recursive: false,
+            steps: vec![not_step.clone()],
+        };
+        let rendered =
+            render_generated_rule_dispatch(&[Some(not_rule)], &[], &BTreeMap::new(), false);
+
+        assert!(rendered.contains(
+            "match_not_token_set_recovering(atn().token_set(5).expect(\"generated parser token-set index\"), 1, atn().max_token_type(), 8, atn())"
+        ));
+        assert_eq!(
+            leading_lookahead_condition(&[not_step], "__la"),
+            Some(
+                "(1..=atn().max_token_type()).contains(&__la) && !(atn().token_set(5).expect(\"generated parser token-set index\").contains(__la))"
+                    .to_owned()
+            )
+        );
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2205,12 +2205,16 @@ impl TokenBitSet {
             .enumerate()
             .flat_map(|(word_index, mut bits)| {
                 std::iter::from_fn(move || {
-                    if bits == 0 {
-                        return None;
+                    while bits != 0 {
+                        let bit = bits.trailing_zeros() as usize;
+                        bits &= bits - 1;
+                        if let Some(symbol) =
+                            token_bit_symbol(word_index * u64::BITS as usize + bit)
+                        {
+                            return Some(symbol);
+                        }
                     }
-                    let bit = bits.trailing_zeros() as usize;
-                    bits &= bits - 1;
-                    token_bit_symbol(word_index * u64::BITS as usize + bit)
+                    None
                 })
             })
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -77,7 +77,7 @@ use crate::atn::parser::{
     ParserAtnPrediction, ParserAtnPredictionDiagnosticKind, ParserAtnSimulator,
 };
 use crate::atn::parser_atn::{
-    ParserAtn as Atn, ParserAtnState as AtnState, ParserTransition,
+    ParserAtn as Atn, ParserAtnState as AtnState, ParserIntervalSet, ParserTransition,
     ParserTransitionData as Transition, ParserTransitionKind,
 };
 #[cfg(test)]
@@ -2198,17 +2198,25 @@ impl TokenBitSet {
         self.words.iter().all(|word| *word == 0)
     }
 
+    fn symbols(&self) -> impl Iterator<Item = i32> + '_ {
+        self.words
+            .iter()
+            .copied()
+            .enumerate()
+            .flat_map(|(word_index, mut bits)| {
+                std::iter::from_fn(move || {
+                    if bits == 0 {
+                        return None;
+                    }
+                    let bit = bits.trailing_zeros() as usize;
+                    bits &= bits - 1;
+                    token_bit_symbol(word_index * u64::BITS as usize + bit)
+                })
+            })
+    }
+
     fn extend_btree_set(&self, target: &mut BTreeSet<i32>) {
-        for (word_index, word) in self.words.iter().copied().enumerate() {
-            let mut bits = word;
-            while bits != 0 {
-                let bit = bits.trailing_zeros() as usize;
-                if let Some(symbol) = token_bit_symbol(word_index * u64::BITS as usize + bit) {
-                    target.insert(symbol);
-                }
-                bits &= bits - 1;
-            }
-        }
+        target.extend(self.symbols());
     }
 
     fn to_btree_set(&self) -> BTreeSet<i32> {
@@ -4509,6 +4517,61 @@ pub struct GeneratedMatch {
     consumed_eof: bool,
 }
 
+#[derive(Clone, Copy)]
+enum GeneratedExpectedSymbols<'a> {
+    Tree(&'a BTreeSet<i32>),
+    TokenSet(ParserIntervalSet<'a>),
+    TokenSetComplement {
+        set: ParserIntervalSet<'a>,
+        min_vocabulary: i32,
+        max_vocabulary: i32,
+    },
+}
+
+impl GeneratedExpectedSymbols<'_> {
+    fn is_empty(self) -> bool {
+        match self {
+            Self::Tree(symbols) => symbols.is_empty(),
+            Self::TokenSet(set) => set.is_empty(),
+            Self::TokenSetComplement {
+                set,
+                min_vocabulary,
+                max_vocabulary,
+            } => (min_vocabulary..=max_vocabulary).all(|symbol| set.contains(symbol)),
+        }
+    }
+
+    fn first(self) -> Option<i32> {
+        match self {
+            Self::Tree(symbols) => symbols.iter().next().copied(),
+            Self::TokenSet(set) => set.ranges().next().map(|(start, _)| start),
+            Self::TokenSetComplement {
+                set,
+                min_vocabulary,
+                max_vocabulary,
+            } => (min_vocabulary..=max_vocabulary).find(|symbol| !set.contains(*symbol)),
+        }
+    }
+
+    fn display(self, vocabulary: &Vocabulary) -> String {
+        match self {
+            Self::Tree(symbols) => expected_symbols_display(symbols, vocabulary),
+            Self::TokenSet(set) => expected_symbols_display_iter(
+                set.ranges().flat_map(|(start, stop)| start..=stop),
+                vocabulary,
+            ),
+            Self::TokenSetComplement {
+                set,
+                min_vocabulary,
+                max_vocabulary,
+            } => expected_symbols_display_iter(
+                (min_vocabulary..=max_vocabulary).filter(|symbol| !set.contains(*symbol)),
+                vocabulary,
+            ),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum GeneratedMatchChildren {
     One(ParseTree),
@@ -5102,9 +5165,13 @@ where
         }
         let mut expected_symbols = BTreeSet::new();
         expected_symbols.insert(token_type);
-        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
-            symbol == token_type
-        })
+        self.recover_generated_match(
+            current,
+            GeneratedExpectedSymbols::Tree(&expected_symbols),
+            follow_state,
+            atn,
+            |symbol| symbol == token_type,
+        )
     }
 
     pub fn match_set_recovering(
@@ -5129,9 +5196,43 @@ where
             });
         }
         let expected_symbols = interval_symbols(intervals);
-        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
-            interval_set_contains(intervals, symbol)
-        })
+        self.recover_generated_match(
+            current,
+            GeneratedExpectedSymbols::Tree(&expected_symbols),
+            follow_state,
+            atn,
+            |symbol| interval_set_contains(intervals, symbol),
+        )
+    }
+
+    pub fn match_token_set_recovering(
+        &mut self,
+        set: ParserIntervalSet<'_>,
+        follow_state: usize,
+        atn: &Atn,
+    ) -> Result<GeneratedMatch, AntlrError> {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if set.contains(current_type) {
+            self.generated_sync_expected = None;
+            let consumed_eof = current_type == TOKEN_EOF;
+            self.consume();
+            return Ok(GeneratedMatch {
+                children: GeneratedMatchChildren::One(self.terminal_tree(current)),
+                consumed_eof,
+            });
+        }
+        self.recover_generated_match(
+            current,
+            GeneratedExpectedSymbols::TokenSet(set),
+            follow_state,
+            atn,
+            |symbol| set.contains(symbol),
+        )
     }
 
     pub fn match_not_set_recovering(
@@ -5161,21 +5262,64 @@ where
         }
         let expected_symbols =
             interval_complement_symbols(intervals, min_vocabulary, max_vocabulary);
-        self.recover_generated_match(current, &expected_symbols, follow_state, atn, |symbol| {
-            (min_vocabulary..=max_vocabulary).contains(&symbol)
-                && !interval_set_contains(intervals, symbol)
-        })
+        self.recover_generated_match(
+            current,
+            GeneratedExpectedSymbols::Tree(&expected_symbols),
+            follow_state,
+            atn,
+            |symbol| {
+                (min_vocabulary..=max_vocabulary).contains(&symbol)
+                    && !interval_set_contains(intervals, symbol)
+            },
+        )
+    }
+
+    pub fn match_not_token_set_recovering(
+        &mut self,
+        set: ParserIntervalSet<'_>,
+        min_vocabulary: i32,
+        max_vocabulary: i32,
+        follow_state: usize,
+        atn: &Atn,
+    ) -> Result<GeneratedMatch, AntlrError> {
+        let current = self.input.lt_id(1).ok_or_else(|| AntlrError::ParserError {
+            line: 0,
+            column: 0,
+            message: "missing current token".to_owned(),
+        })?;
+        let current_type = self.token_type_for_id(current);
+        if (min_vocabulary..=max_vocabulary).contains(&current_type) && !set.contains(current_type)
+        {
+            self.generated_sync_expected = None;
+            let consumed_eof = current_type == TOKEN_EOF;
+            self.consume();
+            return Ok(GeneratedMatch {
+                children: GeneratedMatchChildren::One(self.terminal_tree(current)),
+                consumed_eof,
+            });
+        }
+        self.recover_generated_match(
+            current,
+            GeneratedExpectedSymbols::TokenSetComplement {
+                set,
+                min_vocabulary,
+                max_vocabulary,
+            },
+            follow_state,
+            atn,
+            |symbol| (min_vocabulary..=max_vocabulary).contains(&symbol) && !set.contains(symbol),
+        )
     }
 
     fn recover_generated_match(
         &mut self,
         current: TokenId,
-        expected_symbols: &BTreeSet<i32>,
+        expected_symbols: GeneratedExpectedSymbols<'_>,
         follow_state: usize,
         atn: &Atn,
         matches: impl Fn(i32) -> bool,
     ) -> Result<GeneratedMatch, AntlrError> {
-        let expected_display = self.expected_symbols_display(expected_symbols);
+        let expected_display = expected_symbols.display(self.vocabulary());
         let (current_type, current_line, current_column, current_display) = {
             let token = self
                 .input
@@ -5248,10 +5392,8 @@ where
             });
             self.record_syntax_errors(1);
             self.generated_sync_expected = None;
-            let token_type = expected_symbols.iter().next().copied().unwrap_or(TOKEN_EOF);
-            let mut missing_symbol = BTreeSet::new();
-            missing_symbol.insert(token_type);
-            let missing_display = self.expected_symbols_display(&missing_symbol);
+            let token_type = expected_symbols.first().unwrap_or(TOKEN_EOF);
+            let missing_display = expected_symbol_display(token_type, self.vocabulary());
             let token = self.insert_synthetic_token(
                 token_type,
                 format!("<missing {missing_display}>"),
@@ -5267,11 +5409,12 @@ where
                 consumed_eof: false,
             });
         }
-        let mismatch_expected = self.generated_sync_expected.take().map_or_else(
-            || expected_symbols.clone(),
-            |symbols| symbols.to_btree_set(),
-        );
-        let mismatch_expected_display = self.expected_symbols_display(&mismatch_expected);
+        let mismatch_expected_display = self
+            .generated_sync_expected
+            .take()
+            .map_or(expected_display, |symbols| {
+                expected_symbols_display_iter(symbols.symbols(), self.vocabulary())
+            });
         Err(AntlrError::ParserError {
             line: current_line,
             column: current_column,
@@ -11236,9 +11379,16 @@ fn report_token_source_errors(errors: &[TokenSourceError]) {
 }
 
 fn expected_symbols_display(symbols: &BTreeSet<i32>, vocabulary: &Vocabulary) -> String {
+    expected_symbols_display_iter(symbols.iter().copied(), vocabulary)
+}
+
+fn expected_symbols_display_iter(
+    symbols: impl IntoIterator<Item = i32>,
+    vocabulary: &Vocabulary,
+) -> String {
     let items = symbols
-        .iter()
-        .map(|symbol| expected_symbol_display(*symbol, vocabulary))
+        .into_iter()
+        .map(|symbol| expected_symbol_display(symbol, vocabulary))
         .collect::<Vec<_>>();
     if let [single] = items.as_slice() {
         return single.clone();
@@ -14780,7 +14930,13 @@ mod tests {
         }];
 
         let node = parser
-            .match_not_set_recovering(&[(1, 1)], 1, 1, 1, &atn)
+            .match_not_token_set_recovering(
+                atn.token_set(0).expect("excluded token set"),
+                1,
+                1,
+                1,
+                &atn,
+            )
             .expect("empty complement should recover at EOF");
 
         assert_eq!(node.children().len(), 1);

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -68,6 +68,19 @@ struct Counters {
     lexer_range_number_bytes: u64,
     lexer_range_whitespace_bytes: u64,
     lexer_range_other_bytes: u64,
+    parser_token_set_inline_sets: u64,
+    parser_token_set_dense_sets: u64,
+    parser_token_set_interval_sets: u64,
+    parser_token_set_inline_bytes: u64,
+    parser_token_set_dense_bytes: u64,
+    parser_token_set_inline_hits: u64,
+    parser_token_set_inline_misses: u64,
+    parser_token_set_dense_hits: u64,
+    parser_token_set_dense_misses: u64,
+    parser_token_set_interval_hits: u64,
+    parser_token_set_interval_misses: u64,
+    parser_token_set_interval_probes_eliminated: u64,
+    parser_token_set_interval_binary_probes_retained: u64,
     decisions: BTreeMap<usize, DecisionCounters>,
 }
 
@@ -91,6 +104,11 @@ fn add_len(total: &mut u64, max: &mut u64, len: usize) {
     let len = u64::try_from(len).unwrap_or(u64::MAX);
     *total = total.saturating_add(len);
     *max = (*max).max(len);
+}
+
+const fn record_hit(hit: bool, hits: &mut u64, misses: &mut u64) {
+    let counter = if hit { hits } else { misses };
+    *counter = counter.saturating_add(1);
 }
 
 pub(crate) fn record_adaptive_call(decision: usize, forced_full_context: bool) {
@@ -404,6 +422,66 @@ pub(crate) fn record_lexer_range_scan(
     });
 }
 
+pub(crate) fn record_parser_token_set_selection(
+    kind: crate::atn::parser_atn::ParserTokenSetKind,
+    bytes: usize,
+) {
+    use crate::atn::parser_atn::ParserTokenSetKind;
+
+    let bytes = u64::try_from(bytes).unwrap_or(u64::MAX);
+    with_counters(|counters| match kind {
+        ParserTokenSetKind::Inline128 => {
+            counters.parser_token_set_inline_sets =
+                counters.parser_token_set_inline_sets.saturating_add(1);
+            counters.parser_token_set_inline_bytes =
+                counters.parser_token_set_inline_bytes.saturating_add(bytes);
+        }
+        ParserTokenSetKind::Dense => {
+            counters.parser_token_set_dense_sets =
+                counters.parser_token_set_dense_sets.saturating_add(1);
+            counters.parser_token_set_dense_bytes =
+                counters.parser_token_set_dense_bytes.saturating_add(bytes);
+        }
+        ParserTokenSetKind::Intervals => {
+            counters.parser_token_set_interval_sets =
+                counters.parser_token_set_interval_sets.saturating_add(1);
+        }
+    });
+}
+
+pub(crate) fn record_parser_token_set_probe(
+    kind: crate::atn::parser_atn::ParserTokenSetKind,
+    hit: bool,
+) {
+    use crate::atn::parser_atn::ParserTokenSetKind;
+
+    with_counters(|counters| {
+        match kind {
+            ParserTokenSetKind::Inline128 => record_hit(
+                hit,
+                &mut counters.parser_token_set_inline_hits,
+                &mut counters.parser_token_set_inline_misses,
+            ),
+            ParserTokenSetKind::Dense => record_hit(
+                hit,
+                &mut counters.parser_token_set_dense_hits,
+                &mut counters.parser_token_set_dense_misses,
+            ),
+            ParserTokenSetKind::Intervals => record_hit(
+                hit,
+                &mut counters.parser_token_set_interval_hits,
+                &mut counters.parser_token_set_interval_misses,
+            ),
+        }
+        let probe_counter = if kind == ParserTokenSetKind::Intervals {
+            &mut counters.parser_token_set_interval_binary_probes_retained
+        } else {
+            &mut counters.parser_token_set_interval_probes_eliminated
+        };
+        *probe_counter = probe_counter.saturating_add(1);
+    });
+}
+
 pub fn reset() {
     COUNTERS.with(|counters| {
         let mut counters = counters.borrow_mut();
@@ -415,6 +493,11 @@ pub fn reset() {
             counters.lexer_run_descriptors_until,
             counters.lexer_range_descriptors,
             counters.lexer_range_descriptor_classes,
+            counters.parser_token_set_inline_sets,
+            counters.parser_token_set_dense_sets,
+            counters.parser_token_set_interval_sets,
+            counters.parser_token_set_inline_bytes,
+            counters.parser_token_set_dense_bytes,
         );
         *counters = Counters::default();
         counters.lexer_run_descriptors_none = descriptors.0;
@@ -422,6 +505,11 @@ pub fn reset() {
         counters.lexer_run_descriptors_until = descriptors.2;
         counters.lexer_range_descriptors = descriptors.3;
         counters.lexer_range_descriptor_classes = descriptors.4;
+        counters.parser_token_set_inline_sets = descriptors.5;
+        counters.parser_token_set_dense_sets = descriptors.6;
+        counters.parser_token_set_interval_sets = descriptors.7;
+        counters.parser_token_set_inline_bytes = descriptors.8;
+        counters.parser_token_set_dense_bytes = descriptors.9;
     });
 }
 
@@ -456,7 +544,7 @@ fn dump_decisions(counters: &Counters) {
     }
 }
 
-const fn totals(counters: &Counters) -> [(&'static str, u64); 67] {
+const fn totals(counters: &Counters) -> [(&'static str, u64); 80] {
     [
         ("prediction.adaptive_calls", counters.adaptive_calls),
         (
@@ -618,6 +706,58 @@ const fn totals(counters: &Counters) -> [(&'static str, u64); 67] {
             counters.lexer_range_whitespace_bytes,
         ),
         ("lexer.range_other_bytes", counters.lexer_range_other_bytes),
+        (
+            "parser.token_set.selection.inline128",
+            counters.parser_token_set_inline_sets,
+        ),
+        (
+            "parser.token_set.selection.dense",
+            counters.parser_token_set_dense_sets,
+        ),
+        (
+            "parser.token_set.selection.intervals",
+            counters.parser_token_set_interval_sets,
+        ),
+        (
+            "parser.token_set.inline_bytes",
+            counters.parser_token_set_inline_bytes,
+        ),
+        (
+            "parser.token_set.dense_bytes",
+            counters.parser_token_set_dense_bytes,
+        ),
+        (
+            "parser.token_set.inline_hits",
+            counters.parser_token_set_inline_hits,
+        ),
+        (
+            "parser.token_set.inline_misses",
+            counters.parser_token_set_inline_misses,
+        ),
+        (
+            "parser.token_set.dense_hits",
+            counters.parser_token_set_dense_hits,
+        ),
+        (
+            "parser.token_set.dense_misses",
+            counters.parser_token_set_dense_misses,
+        ),
+        (
+            "parser.token_set.interval_hits",
+            counters.parser_token_set_interval_hits,
+        ),
+        (
+            "parser.token_set.interval_misses",
+            counters.parser_token_set_interval_misses,
+        ),
+        (
+            "parser.token_set.interval_probes_eliminated",
+            counters.parser_token_set_interval_probes_eliminated,
+        ),
+        (
+            "parser.token_set.interval_binary_probes_retained",
+            counters.parser_token_set_interval_binary_probes_retained,
+        ),
     ]
 }
 
@@ -680,6 +820,28 @@ pub(crate) fn lexer_range_scan_snapshot() -> [u64; 6] {
             counters.lexer_range_number_bytes,
             counters.lexer_range_whitespace_bytes,
             counters.lexer_range_other_bytes,
+        ]
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn parser_token_set_snapshot() -> [u64; 13] {
+    COUNTERS.with(|counters| {
+        let counters = counters.borrow();
+        [
+            counters.parser_token_set_inline_sets,
+            counters.parser_token_set_dense_sets,
+            counters.parser_token_set_interval_sets,
+            counters.parser_token_set_inline_bytes,
+            counters.parser_token_set_dense_bytes,
+            counters.parser_token_set_inline_hits,
+            counters.parser_token_set_inline_misses,
+            counters.parser_token_set_dense_hits,
+            counters.parser_token_set_dense_misses,
+            counters.parser_token_set_interval_hits,
+            counters.parser_token_set_interval_misses,
+            counters.parser_token_set_interval_probes_eliminated,
+            counters.parser_token_set_interval_binary_probes_retained,
         ]
     })
 }

--- a/tools/parse-bench/README.md
+++ b/tools/parse-bench/README.md
@@ -136,6 +136,43 @@ python3 tools/parse-bench/run.py \
 where Cargo profile settings control the final application and its
 dependencies.
 
+For profile-guided optimization, first build an instrumented runner and train
+it on the selected fixtures:
+
+```bash
+PROFILE_DIR="$(mktemp -d /tmp/antlr-parse-pgo.XXXXXX)"
+PROFILE_DATA=/tmp/antlr-parse-pgo.profdata
+
+python3 tools/parse-bench/run.py \
+  --languages kotlin,csharp,java,trino \
+  --runtimes rust-antlr \
+  --rust-generated-only \
+  --rust-pgo-generate "$PROFILE_DIR" \
+  --work-dir /tmp/antlr-parse-pgo-train
+
+rustup component add llvm-tools-preview
+SYSROOT="$(rustc --print sysroot)"
+HOST="$(rustc -vV | sed -n 's/^host: //p')"
+"$SYSROOT/lib/rustlib/$HOST/bin/llvm-profdata" merge \
+  -o "$PROFILE_DATA" "$PROFILE_DIR"
+```
+
+Then rebuild and measure with the merged profile:
+
+```bash
+python3 tools/parse-bench/run.py \
+  --languages kotlin,csharp,java,trino \
+  --runtimes rust-antlr \
+  --rust-generated-only \
+  --rust-pgo-use "$PROFILE_DATA" \
+  --work-dir /tmp/antlr-parse-pgo-use
+```
+
+The profile-generation timings are instrumented training data, not comparison
+results. When testing PGO together with `--rust-native` or `--rust-thin-lto`,
+pass the same options to both commands. Use separate work directories for the
+ordinary, instrumented, and profile-use runners.
+
 ## Prediction Memory Counters
 
 Set `ANTLR_PERF_DUMP=1` to build the Rust runner with performance counters.
@@ -155,9 +192,11 @@ The dump includes canonical context counts, pooled and retained bytes, arena
 and workspace capacities, merge-cache activity, and outer-context cache
 hits/misses. It also reports learned parser-DFA warm hits/misses, ATN
 fallbacks, state interning activity, dense/sparse row counts, edge-density
-histograms, and hot/cold retained bytes. Store statistics are collected in a
-separate untimed parse after the benchmark loop, so walking the stores does not
-affect reported timings.
+histograms, and hot/cold retained bytes. Parser token-set counters report
+inline, dense, and interval selection; packed bitset bytes; membership
+hits/misses; and interval probes eliminated or retained. Store statistics are
+collected in a separate untimed parse after the benchmark loop, so walking the
+stores does not affect reported timings.
 
 ## PR Watchdog
 

--- a/tools/parse-bench/run.py
+++ b/tools/parse-bench/run.py
@@ -675,6 +675,41 @@ fn dump_parser_dfa_stats(stats: antlr4_runtime::ParserDfaStats) {{
     return runner
 
 
+def rust_codegen_flags(
+    *,
+    native: bool,
+    pgo_generate: Path | None,
+    pgo_use: Path | None,
+) -> list[str]:
+    flags = []
+    if native:
+        flags.append("-Ctarget-cpu=native")
+    if pgo_generate is not None:
+        flags.append(f"-Cprofile-generate={pgo_generate}")
+    if pgo_use is not None:
+        flags.extend(
+            [
+                f"-Cprofile-use={pgo_use}",
+                "-Cllvm-args=-pgo-warn-missing-function",
+            ]
+        )
+    return flags
+
+
+def rust_build_environment(args: argparse.Namespace) -> dict[str, str] | None:
+    flags = rust_codegen_flags(
+        native=args.rust_native,
+        pgo_generate=args.rust_pgo_generate,
+        pgo_use=args.rust_pgo_use,
+    )
+    if not flags:
+        return None
+    env = os.environ.copy()
+    existing = env.get("RUSTFLAGS", "").strip()
+    env["RUSTFLAGS"] = " ".join([existing, *flags]).strip()
+    return env
+
+
 def rust_parse_function(spec: LanguageSpec) -> str:
     return f"""fn lex_{spec.name}(src: &str) -> Result<(), String> {{
     let lexer = generated::{spec.rust_lexer_module}::{spec.rust_lexer_type}::new(InputStream::new(src));
@@ -1177,6 +1212,8 @@ def prepare_work(
     work_dir = args.work_dir
     clear_work_dir(work_dir, args.runtime_root)
     work_dir.mkdir(parents=True, exist_ok=True)
+    if args.rust_pgo_generate is not None:
+        args.rust_pgo_generate.mkdir(parents=True, exist_ok=True)
 
     rust_runner = write_rust_runner(
         work_dir,
@@ -1243,12 +1280,7 @@ def prepare_work(
         ]
         if os.environ.get("ANTLR_PERF_DUMP"):
             rust_build_cmd.extend(["--features", "perf-counters"])
-        rust_build_env = None
-        if args.rust_native:
-            rust_build_env = os.environ.copy()
-            rustflags = rust_build_env.get("RUSTFLAGS", "")
-            rust_build_env["RUSTFLAGS"] = f"{rustflags} -C target-cpu=native".strip()
-        run(rust_build_cmd, env=rust_build_env)
+        run(rust_build_cmd, env=rust_build_environment(args))
         runners["rust-antlr"] = rust_runner / "target" / "release" / "parse-bench-rust-runner"
     if "python-antlr" in runtimes:
         runners["python-antlr"] = write_python_antlr_runner(work_dir, specs, py_gen)
@@ -1509,6 +1541,10 @@ def write_json(results: list[Measurement], args: argparse.Namespace) -> None:
         "repo_commit": git_rev(args.runtime_root),
         "rust_native": args.rust_native,
         "rust_thin_lto": args.rust_thin_lto,
+        "rust_pgo_generate": (
+            str(args.rust_pgo_generate) if args.rust_pgo_generate is not None else None
+        ),
+        "rust_pgo_use": str(args.rust_pgo_use) if args.rust_pgo_use is not None else None,
         "grammars_v4": {
             "path": str(args.grammars_v4),
             "commit": git_rev(args.grammars_v4),
@@ -1536,6 +1572,8 @@ def write_markdown(results: list[Measurement], args: argparse.Namespace) -> None
         f"- Runtime checkout: `{git_rev(args.runtime_root) or args.runtime_root}`",
         f"- Native CPU: `{'yes' if args.rust_native else 'no'}`",
         f"- ThinLTO / one codegen unit: `{'yes' if args.rust_thin_lto else 'no'}`",
+        f"- PGO profile generation: `{args.rust_pgo_generate or 'no'}`",
+        f"- PGO profile use: `{args.rust_pgo_use or 'no'}`",
         f"- Rust generated-only: `{'yes' if args.rust_generated_only else 'no'}`",
         f"- grammars-v4: `{git_rev(args.grammars_v4) or args.grammars_v4}`",
         "",
@@ -1608,6 +1646,19 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Build the Rust runner with ThinLTO and one codegen unit.",
     )
+    rust_pgo = parser.add_mutually_exclusive_group()
+    rust_pgo.add_argument(
+        "--rust-pgo-generate",
+        type=Path,
+        metavar="DIR",
+        help="Build the Rust runner with -Cprofile-generate=DIR for PGO training.",
+    )
+    rust_pgo.add_argument(
+        "--rust-pgo-use",
+        type=Path,
+        metavar="FILE",
+        help="Build the Rust runner with -Cprofile-use=FILE.",
+    )
     parser.add_argument("--iters", type=int, default=10)
     parser.add_argument("--warmups", type=int, default=2)
     parser.add_argument("--quick", action="store_true", help="Use 3 timed iterations and 1 warmup.")
@@ -1644,6 +1695,10 @@ def normalize_paths(args: argparse.Namespace) -> None:
         args.json = args.json.expanduser().resolve()
     if args.markdown is not None:
         args.markdown = args.markdown.expanduser().resolve()
+    if args.rust_pgo_generate is not None:
+        args.rust_pgo_generate = args.rust_pgo_generate.expanduser().resolve()
+    if args.rust_pgo_use is not None:
+        args.rust_pgo_use = args.rust_pgo_use.expanduser().resolve()
 
 
 def main() -> int:
@@ -1666,6 +1721,15 @@ def main() -> int:
     require_path(args.antlr_jar, "ANTLR jar")
     require_path(args.grammars_v4, "grammars-v4 checkout")
     require_path(args.runtime_root / "Cargo.toml", "runtime Cargo manifest")
+    if args.rust_pgo_generate is not None and args.rust_pgo_generate.exists():
+        if not args.rust_pgo_generate.is_dir():
+            raise SystemExit(
+                f"Rust PGO generation path is not a directory: {args.rust_pgo_generate}"
+            )
+    if args.rust_pgo_use is not None:
+        require_path(args.rust_pgo_use, "Rust PGO profile")
+        if not args.rust_pgo_use.is_file():
+            raise SystemExit(f"Rust PGO profile is not a file: {args.rust_pgo_use}")
     ensure_python_dependencies(args.python, runtimes)
 
     runners = prepare_work(args, specs, runtimes)

--- a/tools/parse-bench/test_run.py
+++ b/tools/parse-bench/test_run.py
@@ -126,5 +126,33 @@ class ClearWorkDirTests(unittest.TestCase):
             self.assertTrue(marker.exists())
 
 
+class RustCodegenFlagsTests(unittest.TestCase):
+    def test_combines_native_and_profile_generation(self) -> None:
+        self.assertEqual(
+            RUN.rust_codegen_flags(
+                native=True,
+                pgo_generate=Path("/tmp/parse-profraw"),
+                pgo_use=None,
+            ),
+            [
+                "-Ctarget-cpu=native",
+                "-Cprofile-generate=/tmp/parse-profraw",
+            ],
+        )
+
+    def test_profile_use_warns_about_missing_functions(self) -> None:
+        self.assertEqual(
+            RUN.rust_codegen_flags(
+                native=False,
+                pgo_generate=None,
+                pgo_use=Path("/tmp/parse.profdata"),
+            ),
+            [
+                "-Cprofile-use=/tmp/parse.profdata",
+                "-Cllvm-args=-pgo-warn-missing-function",
+            ],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- add parser-specific adaptive token sets to packed parser ATNs, selecting `Inline128`, bounded `Dense`, or normalized `Intervals` from set shape and storage cost
- use the selected representation for packed `Set`/`NotSet` transitions and recovery, plus dense generated recognition and leading-lookahead guards
- preserve packed format v1 compatibility, cap each dense payload at 64 KiB, and keep lexer Unicode sets unchanged
- add token-set performance counters, PGO generation/use benchmark modes, and a reproducible benchmark record

## Why

Parser prediction repeatedly probes immutable token sets. The remaining applicable hot paths used interval membership for packed parser transitions and emitted longer interval checks for generated dense sets, even though compact parser vocabularies can use indexed bit tests safely.

The final policy deliberately keeps literal checks for small generated sets: parser-only Kotlin measurements showed no benefit from routing every inline set through packed metadata. Interpreted ATN prediction still uses the adaptive representation for every set, while sparse and very large domains retain normalized interval search.

## Results

Ordinary release benchmarks across 17 Kotlin, C#, Java, and Trino fixtures measured a `0.9753x` geometric ratio and `0.9875x` aggregate ratio versus `main` (ratios below 1 are faster). Parser-only Kotlin was effectively flat at `1.0039x`, with every paired range crossing 1.0. No fixture had a confirmed regression.

Packed parser metadata increased by 2,240 bytes across the four grammars (`+0.38%`). The detailed fixture results, representation counters, and table-size deltas are recorded in `docs/issue-81-token-set-benchmark.md`.

## Validation

- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- parse-bench Python tests: 8 passed
- Kotlin parity: 9 fixtures passed byte-for-byte
- ANTLR runtime conformance: 357 passed, 0 failed, 0 skipped
- `cargo fmt --all -- --check`
- `git diff --check`

Closes #81

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved parser token-set matching, including optimized handling for large token sets.
  - Enhanced recovery and expected-token reporting for generated parsers.
  - Added detailed parser token-set performance metrics when performance counters are enabled.

- **Bug Fixes**
  - Preserved compatibility with existing parser data formats.
  - Added stronger validation to detect invalid or corrupted token-set data.

- **Documentation**
  - Added guidance for profile-guided optimization workflows in parsing benchmarks.

- **Chores**
  - Extended benchmark tooling with profile generation and profile-use options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->