### PR TITLE
fix: Make recovery diagnostics configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,15 +177,21 @@ use generated::json::Json;
 use generated::json_lexer::JsonLexer;
 
 fn main() -> Result<(), antlr4_runtime::AntlrError> {
-    let lexer = JsonLexer::new(InputStream::new(r#"{"a":1}"#));
+    let mut lexer = JsonLexer::new(InputStream::new(r#"{"a":1}"#));
+    lexer.remove_error_listeners();
     let tokens = CommonTokenStream::new(lexer);
     let mut parser = Json::new(tokens);
+    parser.remove_error_listeners();
     let tree = parser.json()?;
 
     println!("{}", parser.node(tree).text());
     Ok(())
 }
 ```
+
+Generated recognizers install a `ConsoleErrorListener` by default. Remove it
+from both the lexer and parser to suppress recovery output, as above, or call
+`add_error_listener` after removal to redirect diagnostics to a replacement.
 
 ### Reusing Recognizers
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2406,6 +2406,19 @@ where
         metadata()
     }}
 
+    /// Adds a listener for lexer diagnostics.
+    pub fn add_error_listener<T>(&mut self, listener: T)
+    where
+        T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + 'static,
+    {{
+        self.base.add_error_listener(listener);
+    }}
+
+    /// Removes every lexer error listener, including the default console listener.
+    pub fn remove_error_listeners(&mut self) {{
+        self.base.remove_error_listeners();
+    }}
+
     /// Routes every token through ATN interpretation instead of the compiled
     /// lexer DFA, so the learned-DFA trace (`lexer_dfa_string`) observes each
     /// match.
@@ -2499,6 +2512,16 @@ where
     fn source_text(&self) -> Option<std::rc::Rc<str>> {{ self.base.source_text() }}
     fn drain_errors(&mut self) -> Vec<antlr4_runtime::token::TokenSourceError> {{
         self.base.drain_errors()
+    }}
+    fn report_error(&self, source_error: &antlr4_runtime::token::TokenSourceError) -> bool {{
+        antlr4_runtime::Recognizer::notify_error_listeners(
+            self,
+            source_error.line,
+            source_error.column,
+            &source_error.message,
+            None,
+        );
+        true
     }}
     fn lexer_dfa_string(&self) -> String {{
         self.base.lexer_dfa_string()
@@ -6207,6 +6230,8 @@ const GENERATED_PARSER_RESERVED_RULE_METHODS: &[&str] = &[
     "token_store",
     "parse_tree_storage",
     "clear_dfa",
+    "add_error_listener",
+    "remove_error_listeners",
     "node",
     "into_token_stream",
     "into_token_store",
@@ -7807,6 +7832,19 @@ where
 
     pub fn metadata() -> &'static GrammarMetadata {{
         metadata()
+    }}
+
+    /// Adds a listener for parser diagnostics.
+    pub fn add_error_listener<T>(&mut self, listener: T)
+    where
+        T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + 'static,
+    {{
+        self.base.add_error_listener(listener);
+    }}
+
+    /// Removes every parser error listener, including the default console listener.
+    pub fn remove_error_listeners(&mut self) {{
+        self.base.remove_error_listeners();
     }}
 
     /// Fully resets parser-owned state and rewinds the current token stream.
@@ -11050,6 +11088,8 @@ atn:
             "reset".to_owned(),
             "setTokenStream".to_owned(),
             "clearDfa".to_owned(),
+            "addErrorListener".to_owned(),
+            "removeErrorListeners".to_owned(),
             "regularRule".to_owned(),
         ];
 
@@ -11062,6 +11102,8 @@ atn:
                 "reset_rule",
                 "set_token_stream_rule",
                 "clear_dfa_rule",
+                "add_error_listener_rule",
+                "remove_error_listeners_rule",
                 "regular_rule"
             ]
         );
@@ -12621,6 +12663,10 @@ s : ;
         assert!(rendered.contains("pub fn clear_dfa(&mut self)"));
         assert!(rendered.contains("simulator.clear_dfa()"));
         assert!(rendered.contains("ParserAtnSimulator::clear_shared_dfa(atn())"));
+        assert!(rendered.contains("pub fn add_error_listener<T>(&mut self, listener: T)"));
+        assert!(rendered.contains("self.base.add_error_listener(listener)"));
+        assert!(rendered.contains("pub fn remove_error_listeners(&mut self)"));
+        assert!(rendered.contains("self.base.remove_error_listeners()"));
         assert!(rendered.contains("pub fn into_token_stream(self) -> CommonTokenStream<L>"));
         assert!(rendered.contains("self.base.into_token_stream()"));
         assert!(
@@ -16114,12 +16160,20 @@ ID : [a-z]+ ;\n";
         assert!(module.contains("self.base.set_input_stream(input)"));
         assert!(module.contains("pub fn clear_dfa(&self)"));
         assert!(module.contains("self.base.clear_dfa()"));
+        assert!(module.contains("pub fn add_error_listener<T>(&mut self, listener: T)"));
+        assert!(module.contains("self.base.add_error_listener(listener)"));
+        assert!(module.contains("pub fn remove_error_listeners(&mut self)"));
+        assert!(module.contains("self.base.remove_error_listeners()"));
         assert!(module.contains(
             "fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError>"
         ));
         assert!(module.contains(
             "fn source_text(&self) -> Option<std::rc::Rc<str>> { self.base.source_text() }"
         ));
+        assert!(module.contains(
+            "fn report_error(&self, source_error: &antlr4_runtime::token::TokenSourceError) -> bool"
+        ));
+        assert!(module.contains("Recognizer::notify_error_listeners("));
         assert!(!module.contains("CommonToken"));
         assert!(!module.contains("TokenFactory"));
     }

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2409,7 +2409,7 @@ where
     /// Adds a listener for lexer diagnostics.
     pub fn add_error_listener<T>(&mut self, listener: T)
     where
-        T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + 'static,
+        T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + Send + 'static,
     {{
         self.base.add_error_listener(listener);
     }}
@@ -7837,7 +7837,7 @@ where
     /// Adds a listener for parser diagnostics.
     pub fn add_error_listener<T>(&mut self, listener: T)
     where
-        T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + 'static,
+        T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + Send + 'static,
     {{
         self.base.add_error_listener(listener);
     }}
@@ -12664,6 +12664,9 @@ s : ;
         assert!(rendered.contains("simulator.clear_dfa()"));
         assert!(rendered.contains("ParserAtnSimulator::clear_shared_dfa(atn())"));
         assert!(rendered.contains("pub fn add_error_listener<T>(&mut self, listener: T)"));
+        assert!(rendered.contains(
+            "T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + Send + 'static,"
+        ));
         assert!(rendered.contains("self.base.add_error_listener(listener)"));
         assert!(rendered.contains("pub fn remove_error_listeners(&mut self)"));
         assert!(rendered.contains("self.base.remove_error_listeners()"));
@@ -16161,6 +16164,9 @@ ID : [a-z]+ ;\n";
         assert!(module.contains("pub fn clear_dfa(&self)"));
         assert!(module.contains("self.base.clear_dfa()"));
         assert!(module.contains("pub fn add_error_listener<T>(&mut self, listener: T)"));
+        assert!(module.contains(
+            "T: for<'a> antlr4_runtime::ErrorListener<dyn antlr4_runtime::Recognizer + 'a> + Send + 'static,"
+        ));
         assert!(module.contains("self.base.add_error_listener(listener)"));
         assert!(module.contains("pub fn remove_error_listeners(&mut self)"));
         assert!(module.contains("self.base.remove_error_listeners()"));

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -23,7 +23,12 @@ pub enum AntlrError {
     Unsupported(String),
 }
 
-pub trait ErrorListener<R: Recognizer> {
+/// Receives recognizer diagnostics.
+///
+/// Listeners registered through [`Recognizer::add_error_listener`] must work
+/// with every recognizer type. Implement the trait generically, as
+/// [`ConsoleErrorListener`] does, when a listener will be registered.
+pub trait ErrorListener<R: Recognizer + ?Sized> {
     fn syntax_error(
         &mut self,
         recognizer: &R,
@@ -37,7 +42,7 @@ pub trait ErrorListener<R: Recognizer> {
 #[derive(Debug, Default)]
 pub struct ConsoleErrorListener;
 
-impl<R: Recognizer> ErrorListener<R> for ConsoleErrorListener {
+impl<R: Recognizer + ?Sized> ErrorListener<R> for ConsoleErrorListener {
     #[allow(clippy::print_stderr)]
     fn syntax_error(
         &mut self,

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -25,9 +25,10 @@ pub enum AntlrError {
 
 /// Receives recognizer diagnostics.
 ///
-/// Listeners registered through [`Recognizer::add_error_listener`] must work
-/// with every recognizer type. Implement the trait generically, as
-/// [`ConsoleErrorListener`] does, when a listener will be registered.
+/// Listeners registered through [`Recognizer::add_error_listener`] must be
+/// [`Send`] and work with every recognizer type. Implement the trait
+/// generically, as [`ConsoleErrorListener`] does, when a listener will be
+/// registered.
 pub trait ErrorListener<R: Recognizer + ?Sized> {
     fn syntax_error(
         &mut self,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4872,7 +4872,8 @@ where
     /// Emits diagnostics buffered by the token stream while generated parser
     /// code was fetching lexer tokens directly.
     pub fn report_token_source_errors(&mut self) {
-        report_token_source_errors(&self.input.drain_source_errors());
+        let errors = self.input.drain_source_errors();
+        self.dispatch_token_source_errors(&errors);
     }
 
     /// Captures generated-parser diagnostics and syntax-error count before a
@@ -4898,7 +4899,72 @@ where
     pub fn report_generated_parser_diagnostics(&mut self) {
         let parser_diagnostics = std::mem::take(&mut self.generated_parser_diagnostics);
         let token_errors = self.input.drain_source_errors();
-        report_generated_diagnostics(&parser_diagnostics, &token_errors);
+        self.dispatch_generated_diagnostics(&parser_diagnostics, &token_errors);
+    }
+
+    fn dispatch_parser_diagnostic(&self, diagnostic: &ParserDiagnostic) {
+        self.notify_error_listeners(
+            diagnostic.line,
+            diagnostic.column,
+            &diagnostic.message,
+            None,
+        );
+    }
+
+    fn dispatch_parser_diagnostics<'a>(
+        &self,
+        diagnostics: impl IntoIterator<Item = &'a ParserDiagnostic>,
+    ) {
+        for diagnostic in diagnostics {
+            self.dispatch_parser_diagnostic(diagnostic);
+        }
+    }
+
+    fn dispatch_token_source_error(&self, source_error: &TokenSourceError) {
+        if self.input.token_source().report_error(source_error) {
+            return;
+        }
+        self.notify_error_listeners(
+            source_error.line,
+            source_error.column,
+            &source_error.message,
+            None,
+        );
+    }
+
+    fn dispatch_token_source_errors(&self, errors: &[TokenSourceError]) {
+        for error in errors {
+            self.dispatch_token_source_error(error);
+        }
+    }
+
+    /// Dispatches generated parser and lexer diagnostics in the same
+    /// source-position order as ANTLR's lazy token stream reports them.
+    fn dispatch_generated_diagnostics(
+        &self,
+        parser_diagnostics: &[ParserDiagnostic],
+        token_errors: &[TokenSourceError],
+    ) {
+        // Parser diagnostics keep their event order: Java's console and
+        // DiagnosticErrorListener print reports as prediction produces them,
+        // so reportAttemptingFullContext precedes reportContextSensitivity
+        // even though the latter's position is earlier. Buffered token-source
+        // errors interleave by source position and win ties.
+        let mut token_iter = token_errors.iter().peekable();
+        for diagnostic in parser_diagnostics {
+            while let Some(error) = token_iter.peek() {
+                if (error.line, error.column) <= (diagnostic.line, diagnostic.column) {
+                    self.dispatch_token_source_error(error);
+                    token_iter.next();
+                } else {
+                    break;
+                }
+            }
+            self.dispatch_parser_diagnostic(diagnostic);
+        }
+        for error in token_iter {
+            self.dispatch_token_source_error(error);
+        }
     }
 
     /// Buffers ANTLR-style ambiguity diagnostics discovered by generated
@@ -6424,7 +6490,7 @@ where
 
         match result {
             Ok(tree) => {
-                report_token_source_errors(&self.input.drain_source_errors());
+                self.report_token_source_errors();
                 self.release_tree_scratch_if_idle();
                 Ok(tree)
             }
@@ -6550,12 +6616,12 @@ where
                 if predicate_context.is_some()
                     && let Some(error) = self.unknown_semantic_error()
                 {
-                    report_token_source_errors(&self.input.drain_source_errors());
+                    self.report_token_source_errors();
                     return error;
                 }
                 let error = self.recognition_error(rule_index, start_index, &expected);
                 self.record_syntax_errors(1);
-                report_token_source_errors(&self.input.drain_source_errors());
+                self.report_token_source_errors();
                 error
             })?
         } else {
@@ -6564,13 +6630,13 @@ where
         if predicate_context.is_some()
             && let Some(error) = self.unknown_semantic_error()
         {
-            report_token_source_errors(&self.input.drain_source_errors());
+            self.report_token_source_errors();
             return Err(error);
         }
         self.record_syntax_errors(self.recognition_arena.diagnostics_len(outcome.diagnostics));
-        report_parser_diagnostics(&self.prediction_diagnostics);
-        report_parser_diagnostics(self.recognition_arena.diagnostics(outcome.diagnostics));
-        report_token_source_errors(&self.input.drain_source_errors());
+        self.dispatch_parser_diagnostics(&self.prediction_diagnostics);
+        self.dispatch_parser_diagnostics(self.recognition_arena.diagnostics(outcome.diagnostics));
+        self.report_token_source_errors();
         let mut context = ParserRuleContext::with_child_capacity(
             rule_index,
             self.state(),
@@ -7097,7 +7163,7 @@ where
             &mut expected,
         );
         if let Some(error) = self.unknown_semantic_error() {
-            report_token_source_errors(&self.input.drain_source_errors());
+            self.report_token_source_errors();
             // Keep the recorded coordinates: when this interpreted rule is a
             // child of a generated parent, the parent's catch block recovers an
             // ordinary `AntlrError` into a partial subtree, so the fail-loud
@@ -7116,14 +7182,14 @@ where
         ) else {
             let error = self.recognition_error(rule_index, start_index, &expected);
             self.record_syntax_errors(1);
-            report_token_source_errors(&self.input.drain_source_errors());
+            self.report_token_source_errors();
             return Err(error);
         };
 
         self.record_syntax_errors(self.recognition_arena.diagnostics_len(outcome.diagnostics));
-        report_parser_diagnostics(&self.prediction_diagnostics);
-        report_parser_diagnostics(self.recognition_arena.diagnostics(outcome.diagnostics));
-        report_token_source_errors(&self.input.drain_source_errors());
+        self.dispatch_parser_diagnostics(&self.prediction_diagnostics);
+        self.dispatch_parser_diagnostics(self.recognition_arena.diagnostics(outcome.diagnostics));
+        self.report_token_source_errors();
         let mut actions = outcome.actions;
         if init_action_rules.contains(&rule_index) {
             actions.insert(
@@ -11329,59 +11395,6 @@ fn diagnostic_for_token<T: Token>(token: Option<T>, message: String) -> ParserDi
     }
 }
 
-/// Emits parser diagnostics for the selected recovered parse path.
-#[allow(clippy::print_stderr)]
-fn report_parser_diagnostics<'a>(diagnostics: impl IntoIterator<Item = &'a ParserDiagnostic>) {
-    for diagnostic in diagnostics {
-        eprintln!(
-            "line {}:{} {}",
-            diagnostic.line, diagnostic.column, diagnostic.message
-        );
-    }
-}
-
-/// Emits generated parser diagnostics and lexer diagnostics in the same
-/// source-position order as ANTLR's lazy token stream reports them.
-#[allow(clippy::print_stderr)]
-fn report_generated_diagnostics(
-    parser_diagnostics: &[ParserDiagnostic],
-    token_errors: &[TokenSourceError],
-) {
-    // Parser diagnostics keep their event order: Java's console and
-    // DiagnosticErrorListener print reports as prediction produces them, so
-    // `reportAttemptingFullContext` precedes `reportContextSensitivity` even
-    // though the latter's position is earlier. Buffered token-source errors
-    // interleave by source position — ANTLR's lazy token stream surfaces a
-    // lexer error when the parser first fetches that token — and win ties.
-    let mut token_iter = token_errors.iter().peekable();
-    for diagnostic in parser_diagnostics {
-        while let Some(error) = token_iter.peek() {
-            if (error.line, error.column) <= (diagnostic.line, diagnostic.column) {
-                eprintln!("line {}:{} {}", error.line, error.column, error.message);
-                token_iter.next();
-            } else {
-                break;
-            }
-        }
-        eprintln!(
-            "line {}:{} {}",
-            diagnostic.line, diagnostic.column, diagnostic.message
-        );
-    }
-    for error in token_iter {
-        eprintln!("line {}:{} {}", error.line, error.column, error.message);
-    }
-}
-
-/// Emits buffered token-source diagnostics after parser diagnostics that were
-/// discovered while speculatively reading the same token stream.
-#[allow(clippy::print_stderr)]
-fn report_token_source_errors(errors: &[TokenSourceError]) {
-    for error in errors {
-        eprintln!("line {}:{} {}", error.line, error.column, error.message);
-    }
-}
-
 fn expected_symbols_display(symbols: &BTreeSet<i32>, vocabulary: &Vocabulary) -> String {
     expected_symbols_display_iter(symbols.iter().copied(), vocabulary)
 }
@@ -12071,7 +12084,9 @@ mod tests {
     use crate::token_stream::CommonTokenStream;
     use crate::tree::{NodeKind, ParseTreeStats};
     use crate::vocabulary::Vocabulary;
+    use std::cell::RefCell;
     use std::mem::size_of;
+    use std::rc::Rc;
 
     #[test]
     fn fx_hasher_write_matches_typed_methods_for_full_words() {
@@ -12221,6 +12236,71 @@ mod tests {
         }
     }
 
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct RecordedDiagnostic {
+        grammar_file_name: String,
+        line: usize,
+        column: usize,
+        message: String,
+        error: Option<AntlrError>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecordingErrorListener {
+        diagnostics: Rc<RefCell<Vec<RecordedDiagnostic>>>,
+    }
+
+    impl<R> crate::ErrorListener<R> for RecordingErrorListener
+    where
+        R: Recognizer + ?Sized,
+    {
+        fn syntax_error(
+            &mut self,
+            recognizer: &R,
+            line: usize,
+            column: usize,
+            message: &str,
+            error: Option<&AntlrError>,
+        ) {
+            self.diagnostics.borrow_mut().push(RecordedDiagnostic {
+                grammar_file_name: recognizer.grammar_file_name().to_owned(),
+                line,
+                column,
+                message: message.to_owned(),
+                error: error.cloned(),
+            });
+        }
+    }
+
+    #[derive(Debug)]
+    struct ReportingSource {
+        source: Source,
+        diagnostics: Rc<RefCell<Vec<TokenSourceError>>>,
+    }
+
+    impl TokenSource for ReportingSource {
+        fn next_token(&mut self, sink: &mut TokenSink<'_>) -> Result<TokenId, TokenStoreError> {
+            self.source.next_token(sink)
+        }
+
+        fn line(&self) -> usize {
+            self.source.line()
+        }
+
+        fn column(&self) -> usize {
+            self.source.column()
+        }
+
+        fn source_name(&self) -> &str {
+            self.source.source_name()
+        }
+
+        fn report_error(&self, error: &TokenSourceError) -> bool {
+            self.diagnostics.borrow_mut().push(error.clone());
+            true
+        }
+    }
+
     fn mini_parser_data() -> RecognizerData {
         RecognizerData::new(
             "Mini.g4",
@@ -12243,6 +12323,82 @@ mod tests {
             mini_parser_data(),
             hooks,
         )
+    }
+
+    #[test]
+    fn parser_dispatches_recovery_diagnostics_through_registered_listeners() {
+        let mut parser = mini_parser(vec![TestToken::eof("parser-test", 0, 1, 0)]);
+        parser.remove_error_listeners();
+        let diagnostics = Rc::new(RefCell::new(Vec::new()));
+        parser.add_error_listener(RecordingErrorListener {
+            diagnostics: Rc::clone(&diagnostics),
+        });
+        let parser_diagnostics = [ParserDiagnostic {
+            line: 1,
+            column: 2,
+            message: "missing 'x' at 'y'".to_owned(),
+        }];
+        let token_errors = [
+            TokenSourceError::new(1, 1, "token recognition error at: '@'"),
+            TokenSourceError::new(1, 3, "token recognition error at: '#'"),
+        ];
+
+        parser.dispatch_generated_diagnostics(&parser_diagnostics, &token_errors);
+
+        assert_eq!(
+            *diagnostics.borrow(),
+            [
+                RecordedDiagnostic {
+                    grammar_file_name: "Mini.g4".to_owned(),
+                    line: 1,
+                    column: 1,
+                    message: "token recognition error at: '@'".to_owned(),
+                    error: None,
+                },
+                RecordedDiagnostic {
+                    grammar_file_name: "Mini.g4".to_owned(),
+                    line: 1,
+                    column: 2,
+                    message: "missing 'x' at 'y'".to_owned(),
+                    error: None,
+                },
+                RecordedDiagnostic {
+                    grammar_file_name: "Mini.g4".to_owned(),
+                    line: 1,
+                    column: 3,
+                    message: "token recognition error at: '#'".to_owned(),
+                    error: None,
+                },
+            ]
+        );
+
+        parser.remove_error_listeners();
+        parser.dispatch_generated_diagnostics(&parser_diagnostics, &token_errors);
+        assert_eq!(diagnostics.borrow().len(), 3);
+    }
+
+    #[test]
+    fn parser_leaves_token_errors_to_source_owned_listeners() {
+        let source_diagnostics = Rc::new(RefCell::new(Vec::new()));
+        let source = ReportingSource {
+            source: Source {
+                tokens: vec![TestToken::eof("parser-test", 0, 1, 0)],
+                index: 0,
+            },
+            diagnostics: Rc::clone(&source_diagnostics),
+        };
+        let mut parser = BaseParser::new(CommonTokenStream::new(source), mini_parser_data());
+        parser.remove_error_listeners();
+        let parser_diagnostics = Rc::new(RefCell::new(Vec::new()));
+        parser.add_error_listener(RecordingErrorListener {
+            diagnostics: Rc::clone(&parser_diagnostics),
+        });
+        let source_error = TokenSourceError::new(2, 4, "token recognition error at: '$'");
+
+        parser.dispatch_token_source_errors(std::slice::from_ref(&source_error));
+
+        assert_eq!(*source_diagnostics.borrow(), [source_error]);
+        assert!(parser_diagnostics.borrow().is_empty());
     }
 
     fn finish_atn(builder: ParserAtnBuilder) -> Atn {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12087,6 +12087,7 @@ mod tests {
     use std::cell::RefCell;
     use std::mem::size_of;
     use std::rc::Rc;
+    use std::sync::{Arc, Mutex};
 
     #[test]
     fn fx_hasher_write_matches_typed_methods_for_full_words() {
@@ -12247,7 +12248,7 @@ mod tests {
 
     #[derive(Clone, Debug)]
     struct RecordingErrorListener {
-        diagnostics: Rc<RefCell<Vec<RecordedDiagnostic>>>,
+        diagnostics: Arc<Mutex<Vec<RecordedDiagnostic>>>,
     }
 
     impl<R> crate::ErrorListener<R> for RecordingErrorListener
@@ -12262,13 +12263,16 @@ mod tests {
             message: &str,
             error: Option<&AntlrError>,
         ) {
-            self.diagnostics.borrow_mut().push(RecordedDiagnostic {
-                grammar_file_name: recognizer.grammar_file_name().to_owned(),
-                line,
-                column,
-                message: message.to_owned(),
-                error: error.cloned(),
-            });
+            self.diagnostics
+                .lock()
+                .expect("recorded diagnostics lock")
+                .push(RecordedDiagnostic {
+                    grammar_file_name: recognizer.grammar_file_name().to_owned(),
+                    line,
+                    column,
+                    message: message.to_owned(),
+                    error: error.cloned(),
+                });
         }
     }
 
@@ -12329,9 +12333,9 @@ mod tests {
     fn parser_dispatches_recovery_diagnostics_through_registered_listeners() {
         let mut parser = mini_parser(vec![TestToken::eof("parser-test", 0, 1, 0)]);
         parser.remove_error_listeners();
-        let diagnostics = Rc::new(RefCell::new(Vec::new()));
+        let diagnostics = Arc::new(Mutex::new(Vec::new()));
         parser.add_error_listener(RecordingErrorListener {
-            diagnostics: Rc::clone(&diagnostics),
+            diagnostics: Arc::clone(&diagnostics),
         });
         let parser_diagnostics = [ParserDiagnostic {
             line: 1,
@@ -12346,7 +12350,7 @@ mod tests {
         parser.dispatch_generated_diagnostics(&parser_diagnostics, &token_errors);
 
         assert_eq!(
-            *diagnostics.borrow(),
+            *diagnostics.lock().expect("recorded diagnostics lock"),
             [
                 RecordedDiagnostic {
                     grammar_file_name: "Mini.g4".to_owned(),
@@ -12374,7 +12378,10 @@ mod tests {
 
         parser.remove_error_listeners();
         parser.dispatch_generated_diagnostics(&parser_diagnostics, &token_errors);
-        assert_eq!(diagnostics.borrow().len(), 3);
+        assert_eq!(
+            diagnostics.lock().expect("recorded diagnostics lock").len(),
+            3
+        );
     }
 
     #[test]
@@ -12389,16 +12396,21 @@ mod tests {
         };
         let mut parser = BaseParser::new(CommonTokenStream::new(source), mini_parser_data());
         parser.remove_error_listeners();
-        let parser_diagnostics = Rc::new(RefCell::new(Vec::new()));
+        let parser_diagnostics = Arc::new(Mutex::new(Vec::new()));
         parser.add_error_listener(RecordingErrorListener {
-            diagnostics: Rc::clone(&parser_diagnostics),
+            diagnostics: Arc::clone(&parser_diagnostics),
         });
         let source_error = TokenSourceError::new(2, 4, "token recognition error at: '$'");
 
         parser.dispatch_token_source_errors(std::slice::from_ref(&source_error));
 
         assert_eq!(*source_diagnostics.borrow(), [source_error]);
-        assert!(parser_diagnostics.borrow().is_empty());
+        assert!(
+            parser_diagnostics
+                .lock()
+                .expect("recorded diagnostics lock")
+                .is_empty()
+        );
     }
 
     fn finish_atn(builder: ParserAtnBuilder) -> Atn {

--- a/src/recognizer.rs
+++ b/src/recognizer.rs
@@ -1,4 +1,40 @@
+use std::cell::RefCell;
+use std::fmt;
+use std::rc::Rc;
+
+use crate::errors::{AntlrError, ConsoleErrorListener, ErrorListener};
 use crate::vocabulary::Vocabulary;
+
+#[derive(Clone)]
+struct ErrorListenerSlot(Rc<RefCell<dyn for<'a> ErrorListener<dyn Recognizer + 'a>>>);
+
+impl ErrorListenerSlot {
+    fn new<L>(listener: L) -> Self
+    where
+        L: for<'a> ErrorListener<dyn Recognizer + 'a> + 'static,
+    {
+        Self(Rc::new(RefCell::new(listener)))
+    }
+
+    fn syntax_error(
+        &self,
+        recognizer: &(dyn Recognizer + '_),
+        line: usize,
+        column: usize,
+        message: &str,
+        error: Option<&AntlrError>,
+    ) {
+        self.0
+            .borrow_mut()
+            .syntax_error(recognizer, line, column, message, error);
+    }
+}
+
+impl fmt::Debug for ErrorListenerSlot {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ErrorListener")
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct RecognizerData {
@@ -8,6 +44,7 @@ pub struct RecognizerData {
     mode_names: Vec<String>,
     vocabulary: Vocabulary,
     state: isize,
+    error_listeners: Vec<ErrorListenerSlot>,
 }
 
 impl RecognizerData {
@@ -19,6 +56,7 @@ impl RecognizerData {
             mode_names: Vec::new(),
             vocabulary,
             state: -1,
+            error_listeners: vec![ErrorListenerSlot::new(ConsoleErrorListener)],
         }
     }
 
@@ -66,6 +104,30 @@ impl RecognizerData {
     pub const fn set_state(&mut self, state: isize) {
         self.state = state;
     }
+
+    fn add_error_listener<L>(&mut self, listener: L)
+    where
+        L: for<'a> ErrorListener<dyn Recognizer + 'a> + 'static,
+    {
+        self.error_listeners.push(ErrorListenerSlot::new(listener));
+    }
+
+    fn remove_error_listeners(&mut self) {
+        self.error_listeners.clear();
+    }
+
+    fn notify_error_listeners(
+        &self,
+        recognizer: &dyn Recognizer,
+        line: usize,
+        column: usize,
+        message: &str,
+        error: Option<&AntlrError>,
+    ) {
+        for listener in &self.error_listeners {
+            listener.syntax_error(recognizer, line, column, message, error);
+        }
+    }
 }
 
 pub trait Recognizer {
@@ -100,9 +162,152 @@ pub trait Recognizer {
         self.data_mut().set_state(state);
     }
 
+    /// Adds a listener for syntax and prediction diagnostics.
+    ///
+    /// Recognizers start with one [`ConsoleErrorListener`]. Call
+    /// [`Self::remove_error_listeners`] before adding a replacement when
+    /// diagnostics should not also be written to stderr.
+    fn add_error_listener<L>(&mut self, listener: L)
+    where
+        Self: Sized,
+        L: for<'a> ErrorListener<dyn Recognizer + 'a> + 'static,
+    {
+        self.data_mut().add_error_listener(listener);
+    }
+
+    /// Removes every error listener, including the default console listener.
+    fn remove_error_listeners(&mut self) {
+        self.data_mut().remove_error_listeners();
+    }
+
+    /// Sends one diagnostic to every registered error listener.
+    fn notify_error_listeners(
+        &self,
+        line: usize,
+        column: usize,
+        message: &str,
+        error: Option<&AntlrError>,
+    ) where
+        Self: Sized,
+    {
+        self.data()
+            .notify_error_listeners(self, line, column, message, error);
+    }
+
     fn sempred(&mut self, _rule_index: usize, _pred_index: usize) -> bool {
         true
     }
 
     fn action(&mut self, _rule_index: usize, _action_index: usize) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    struct RecordedError {
+        grammar_file_name: String,
+        line: usize,
+        column: usize,
+        message: String,
+        error: Option<AntlrError>,
+    }
+
+    #[derive(Clone, Debug)]
+    struct RecordingErrorListener {
+        errors: Rc<RefCell<Vec<RecordedError>>>,
+    }
+
+    impl<R> ErrorListener<R> for RecordingErrorListener
+    where
+        R: Recognizer + ?Sized,
+    {
+        fn syntax_error(
+            &mut self,
+            recognizer: &R,
+            line: usize,
+            column: usize,
+            message: &str,
+            error: Option<&AntlrError>,
+        ) {
+            self.errors.borrow_mut().push(RecordedError {
+                grammar_file_name: recognizer.grammar_file_name().to_owned(),
+                line,
+                column,
+                message: message.to_owned(),
+                error: error.cloned(),
+            });
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct TestRecognizer {
+        data: RecognizerData,
+    }
+
+    impl Recognizer for TestRecognizer {
+        fn data(&self) -> &RecognizerData {
+            &self.data
+        }
+
+        fn data_mut(&mut self) -> &mut RecognizerData {
+            &mut self.data
+        }
+    }
+
+    fn test_recognizer() -> TestRecognizer {
+        TestRecognizer {
+            data: RecognizerData::new(
+                "Test.g4",
+                Vocabulary::new(
+                    std::iter::empty::<Option<&str>>(),
+                    std::iter::empty::<Option<&str>>(),
+                    std::iter::empty::<Option<&str>>(),
+                ),
+            ),
+        }
+    }
+
+    #[test]
+    fn recognizers_replace_the_default_console_error_listener() {
+        let mut recognizer = test_recognizer();
+        assert_eq!(recognizer.data.error_listeners.len(), 1);
+
+        recognizer.remove_error_listeners();
+        assert!(recognizer.data.error_listeners.is_empty());
+
+        let errors = Rc::new(RefCell::new(Vec::new()));
+        recognizer.add_error_listener(RecordingErrorListener {
+            errors: Rc::clone(&errors),
+        });
+        let error = AntlrError::ParserError {
+            line: 3,
+            column: 5,
+            message: "unexpected token".to_owned(),
+        };
+        recognizer.notify_error_listeners(3, 5, "unexpected token", Some(&error));
+
+        assert_eq!(
+            *errors.borrow(),
+            [RecordedError {
+                grammar_file_name: "Test.g4".to_owned(),
+                line: 3,
+                column: 5,
+                message: "unexpected token".to_owned(),
+                error: Some(error),
+            }]
+        );
+    }
+
+    #[test]
+    fn cloned_recognizers_can_reconfigure_their_listener_lists_independently() {
+        let mut original = test_recognizer();
+        let clone = original.clone();
+
+        original.remove_error_listeners();
+
+        assert!(original.data.error_listeners.is_empty());
+        assert_eq!(clone.data.error_listeners.len(), 1);
+    }
 }

--- a/src/recognizer.rs
+++ b/src/recognizer.rs
@@ -1,19 +1,18 @@
-use std::cell::RefCell;
 use std::fmt;
-use std::rc::Rc;
+use std::sync::{Arc, Mutex};
 
 use crate::errors::{AntlrError, ConsoleErrorListener, ErrorListener};
 use crate::vocabulary::Vocabulary;
 
 #[derive(Clone)]
-struct ErrorListenerSlot(Rc<RefCell<dyn for<'a> ErrorListener<dyn Recognizer + 'a>>>);
+struct ErrorListenerSlot(Arc<Mutex<dyn for<'a> ErrorListener<dyn Recognizer + 'a> + Send>>);
 
 impl ErrorListenerSlot {
     fn new<L>(listener: L) -> Self
     where
-        L: for<'a> ErrorListener<dyn Recognizer + 'a> + 'static,
+        L: for<'a> ErrorListener<dyn Recognizer + 'a> + Send + 'static,
     {
-        Self(Rc::new(RefCell::new(listener)))
+        Self(Arc::new(Mutex::new(listener)))
     }
 
     fn syntax_error(
@@ -25,7 +24,8 @@ impl ErrorListenerSlot {
         error: Option<&AntlrError>,
     ) {
         self.0
-            .borrow_mut()
+            .lock()
+            .expect("error listener lock poisoned")
             .syntax_error(recognizer, line, column, message, error);
     }
 }
@@ -107,7 +107,7 @@ impl RecognizerData {
 
     fn add_error_listener<L>(&mut self, listener: L)
     where
-        L: for<'a> ErrorListener<dyn Recognizer + 'a> + 'static,
+        L: for<'a> ErrorListener<dyn Recognizer + 'a> + Send + 'static,
     {
         self.error_listeners.push(ErrorListenerSlot::new(listener));
     }
@@ -170,7 +170,7 @@ pub trait Recognizer {
     fn add_error_listener<L>(&mut self, listener: L)
     where
         Self: Sized,
-        L: for<'a> ErrorListener<dyn Recognizer + 'a> + 'static,
+        L: for<'a> ErrorListener<dyn Recognizer + 'a> + Send + 'static,
     {
         self.data_mut().add_error_listener(listener);
     }
@@ -216,7 +216,7 @@ mod tests {
 
     #[derive(Clone, Debug)]
     struct RecordingErrorListener {
-        errors: Rc<RefCell<Vec<RecordedError>>>,
+        errors: Arc<Mutex<Vec<RecordedError>>>,
     }
 
     impl<R> ErrorListener<R> for RecordingErrorListener
@@ -231,13 +231,16 @@ mod tests {
             message: &str,
             error: Option<&AntlrError>,
         ) {
-            self.errors.borrow_mut().push(RecordedError {
-                grammar_file_name: recognizer.grammar_file_name().to_owned(),
-                line,
-                column,
-                message: message.to_owned(),
-                error: error.cloned(),
-            });
+            self.errors
+                .lock()
+                .expect("recorded errors lock")
+                .push(RecordedError {
+                    grammar_file_name: recognizer.grammar_file_name().to_owned(),
+                    line,
+                    column,
+                    message: message.to_owned(),
+                    error: error.cloned(),
+                });
         }
     }
 
@@ -277,9 +280,9 @@ mod tests {
         recognizer.remove_error_listeners();
         assert!(recognizer.data.error_listeners.is_empty());
 
-        let errors = Rc::new(RefCell::new(Vec::new()));
+        let errors = Arc::new(Mutex::new(Vec::new()));
         recognizer.add_error_listener(RecordingErrorListener {
-            errors: Rc::clone(&errors),
+            errors: Arc::clone(&errors),
         });
         let error = AntlrError::ParserError {
             line: 3,
@@ -289,7 +292,7 @@ mod tests {
         recognizer.notify_error_listeners(3, 5, "unexpected token", Some(&error));
 
         assert_eq!(
-            *errors.borrow(),
+            *errors.lock().expect("recorded errors lock"),
             [RecordedError {
                 grammar_file_name: "Test.g4".to_owned(),
                 line: 3,
@@ -298,6 +301,13 @@ mod tests {
                 error: Some(error),
             }]
         );
+    }
+
+    #[test]
+    fn recognizer_data_remains_send_and_sync() {
+        fn assert_send_and_sync<T: Send + Sync>() {}
+
+        assert_send_and_sync::<RecognizerData>();
     }
 
     #[test]

--- a/src/token.rs
+++ b/src/token.rs
@@ -694,6 +694,15 @@ pub trait TokenSource {
         Vec::new()
     }
 
+    /// Reports a buffered diagnostic through source-owned listeners.
+    ///
+    /// Returns `true` when the source owns diagnostic reporting. The parser
+    /// uses its own listeners as a fallback for token sources that return
+    /// `false`.
+    fn report_error(&self, _error: &TokenSourceError) -> bool {
+        false
+    }
+
     /// Serializes lexer DFA cache state when the token source exposes one.
     fn lexer_dfa_string(&self) -> String {
         String::new()


### PR DESCRIPTION
Closes #139

## Summary

- add a default `ConsoleErrorListener` registry to recognizers with public `add_error_listener` and `remove_error_listeners` APIs
- route interpreted parser, generated parser, and buffered token-source diagnostics through parser or lexer listeners while preserving ANTLR output ordering
- expose listener controls on generated lexer/parser wrappers and document suppressing the default console listeners
- add focused coverage for listener replacement, cloning, source-owned routing, diagnostic ordering, and generated method emission

## Root cause

Recovery helpers in `parser.rs` wrote directly to stderr, bypassing the existing `ErrorListener` abstraction. Recognizers carried no listener registry, and buffered lexer errors had no way to return to source-owned listeners after the token stream interleaved them with parser diagnostics.

## Impact

Consumers can now remove the default listeners on both generated recognizers to suppress recovery output, or replace them with custom listeners. Prediction diagnostics remain controlled separately by `set_report_diagnostic_errors` but are delivered through the same parser listener registry when enabled.

## Validation

- `cargo test --locked --all-targets --all-features` (419 passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --all-features`
- `cargo fmt --all -- --check`
- `git diff --check`
- full ANTLR runtime testsuite: 357 passed, 0 failed, 0 skipped
- Kotlin parser parity: all 9 Kotlin/script snippets matched Python byte-for-byte
- generated `ParserErrors/SingleSetInsertion` black-box check after removing lexer and parser listeners: 0 stdout bytes, 0 stderr bytes