### PR TITLE
feat: make TokenStore iterable

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Install stable Rust
         run: |
-          rustup toolchain install stable --profile minimal --component clippy --no-self-update
+          rustup toolchain install --profile minimal --no-self-update
           rustup default stable
 
       - name: install cargo binstall
@@ -69,6 +69,8 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@v1
+        env:
+          CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR: "1"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
@@ -86,9 +88,7 @@ jobs:
             --model "claude-opus-4-8[1m]"
             --no-chrome
             --dangerously-skip-permissions
-          plugins: |
-            code-review
-            rust-analyzer-lsp
+          plugins: "code-review@claude-code-plugins"
 
           # The trailing directive fixes a CI-only stall: the review skill fans out to
           # parallel sub-agents, and on its final turn the model would emit "I'll wait

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,7 +35,9 @@ Generated `parse()` returns `ParsedFile`, which owns the token store, flat CST,
 and root ID. Access the root through `tree()`, inspect storage metrics through
 `storage().stats()`, or resolve another ID through `node()`. Direct rule calls
 return `NodeId`; use `parser.node(id)` while the parser is alive, or consume the
-parser with `into_parsed_file(id)`.
+parser with `into_parsed_file(id)`. Iterate every retained token, including
+hidden-channel tokens and EOF, with `parsed.tokens().iter()` or
+`for token in parsed.tokens()`.
 
 Parser prediction contexts are compact and store-local. `ContextId` replaces
 the exported recursive `PredictionContext` graph; singleton records live

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy", "llvm-tools", "rust-analyzer"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,8 +39,8 @@ pub use prediction::{ContextId, PredictionContextStats, SemanticContext};
 pub use recognizer::{Recognizer, RecognizerData};
 pub use token::{
     DEFAULT_CHANNEL, HIDDEN_CHANNEL, INVALID_TOKEN_TYPE, MAX_TOKEN_OFFSET, TOKEN_EOF, Token,
-    TokenChannel, TokenId, TokenSink, TokenSource, TokenSpec, TokenStore, TokenStoreError,
-    TokenView,
+    TokenChannel, TokenId, TokenIter, TokenSink, TokenSource, TokenSpec, TokenStore,
+    TokenStoreError, TokenView,
 };
 pub use token_stream::CommonTokenStream;
 pub use tree::{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -12324,7 +12324,9 @@ mod tests {
         ParserAtnPredictionDiagnostic, ParserAtnPredictionDiagnosticKind, ParserAtnSimulator,
     };
     use crate::atn::serialized::{AtnDeserializer, SerializedAtn};
-    use crate::token::{HIDDEN_CHANNEL, Token, TokenId, TokenSink, TokenSpec, TokenStoreError};
+    use crate::token::{
+        DEFAULT_CHANNEL, HIDDEN_CHANNEL, Token, TokenId, TokenSink, TokenSpec, TokenStoreError,
+    };
     use crate::token_stream::CommonTokenStream;
     use crate::tree::{NodeKind, ParseTreeStats};
     use crate::vocabulary::Vocabulary;
@@ -16301,6 +16303,37 @@ mod tests {
             stream.tokens().nth(1).expect("EOF token").token_type(),
             TOKEN_EOF
         );
+    }
+
+    #[test]
+    fn parsed_file_exposes_all_buffered_tokens() {
+        let atn = token_then_eof_atn();
+        let mut parser = mini_parser(vec![
+            TestToken::new(99)
+                .with_text(" comment")
+                .with_channel(HIDDEN_CHANNEL),
+            TestToken::new(1).with_text("x"),
+            TestToken::eof("parser-test", 9, 1, 9),
+        ]);
+
+        let tree = parser
+            .parse_atn_rule(&atn, 0)
+            .expect("artificial parser rule should parse");
+        let parsed = parser.into_parsed_file(tree);
+
+        assert_eq!(
+            parsed
+                .tokens()
+                .iter()
+                .map(|token| (token.token_type(), token.channel(), token.text()))
+                .collect::<Vec<_>>(),
+            [
+                (99, HIDDEN_CHANNEL, " comment"),
+                (1, DEFAULT_CHANNEL, "x"),
+                (TOKEN_EOF, DEFAULT_CHANNEL, "<EOF>"),
+            ]
+        );
+        assert_eq!(parsed.tokens().into_iter().count(), 3);
     }
 
     #[test]

--- a/src/token.rs
+++ b/src/token.rs
@@ -344,6 +344,23 @@ impl TokenStore {
         self.token_types.is_empty()
     }
 
+    /// Iterates borrowing views of every stored token in [`TokenId`] order.
+    pub fn iter(&self) -> TokenIter<'_> {
+        self.iter_prefix(self.len())
+    }
+
+    pub(crate) fn iter_prefix(&self, stop: usize) -> TokenIter<'_> {
+        assert!(
+            stop <= self.len(),
+            "token iterator prefix exceeds store length"
+        );
+        TokenIter {
+            store: self,
+            next: 0,
+            stop,
+        }
+    }
+
     pub(crate) fn push(&mut self, spec: TokenSpec) -> Result<TokenId, TokenStoreError> {
         let raw_id = u32::try_from(self.len())
             .map_err(|_| TokenStoreError::overflow("count", self.len(), u32::MAX as usize))?;
@@ -485,6 +502,54 @@ impl TokenStore {
         source.get(start..stop)
     }
 }
+
+impl<'a> IntoIterator for &'a TokenStore {
+    type Item = TokenView<'a>;
+    type IntoIter = TokenIter<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// Iterator over borrowing views of a token store.
+#[derive(Debug)]
+pub struct TokenIter<'a> {
+    store: &'a TokenStore,
+    next: usize,
+    stop: usize,
+}
+
+impl<'a> Iterator for TokenIter<'a> {
+    type Item = TokenView<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.next >= self.stop {
+            return None;
+        }
+        let id = TokenId::try_from(self.next).ok()?;
+        self.next += 1;
+        self.store.view(id)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.stop - self.next;
+        (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for TokenIter<'_> {
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.next >= self.stop {
+            return None;
+        }
+        self.stop -= 1;
+        let id = TokenId::try_from(self.stop).ok()?;
+        self.store.view(id)
+    }
+}
+
+impl ExactSizeIterator for TokenIter<'_> {}
 
 const fn default_stop_byte(start: usize, stop: usize) -> usize {
     match stop.checked_add(1) {
@@ -833,5 +898,38 @@ mod tests {
             .push(TokenSpec::explicit(1, "x").with_span(MAX_TOKEN_OFFSET + 1, 0))
             .expect_err("overlarge offsets must fail");
         assert!(error.to_string().contains("supported limit"));
+    }
+
+    #[test]
+    fn token_store_iterates_all_records_in_id_order() {
+        let mut store = TokenStore::new(None, "iterator-test");
+        for spec in [
+            TokenSpec::explicit(1, "a"),
+            TokenSpec::explicit(2, " comment").with_channel(HIDDEN_CHANNEL),
+            TokenSpec::eof(9, 9, 1, 9),
+        ] {
+            store.push(spec).expect("test token should fit");
+        }
+
+        let mut iter = store.iter();
+        assert_eq!(iter.len(), 3);
+        assert_eq!(iter.next().map(|token| token.text()), Some("a"));
+        assert_eq!(
+            iter.next_back().map(|token| token.token_type()),
+            Some(TOKEN_EOF)
+        );
+        assert_eq!(iter.len(), 1);
+
+        assert_eq!(
+            (&store)
+                .into_iter()
+                .map(|token| (token.token_id().index(), token.channel()))
+                .collect::<Vec<_>>(),
+            [
+                (0, DEFAULT_CHANNEL),
+                (1, HIDDEN_CHANNEL),
+                (2, DEFAULT_CHANNEL)
+            ]
+        );
     }
 }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -1,6 +1,7 @@
 use crate::int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
 use std::cell::Cell;
 
+pub use crate::token::TokenIter;
 use crate::token::{
     DEFAULT_CHANNEL, TOKEN_EOF, Token, TokenId, TokenSink, TokenSource, TokenSourceError,
     TokenSpec, TokenStore, TokenStoreError, TokenView,
@@ -222,11 +223,7 @@ where
     /// Iterates borrowing views of the original buffered token sequence.
     pub fn tokens(&self) -> TokenIter<'_> {
         self.note_requested_count(self.source_token_count);
-        TokenIter {
-            store: &self.store,
-            next: 0,
-            stop: self.source_token_count,
-        }
+        self.store.iter_prefix(self.source_token_count)
     }
 
     pub const fn token_count(&self) -> usize {
@@ -429,44 +426,6 @@ where
     }
 }
 
-#[derive(Debug)]
-pub struct TokenIter<'a> {
-    store: &'a TokenStore,
-    next: usize,
-    stop: usize,
-}
-
-impl<'a> Iterator for TokenIter<'a> {
-    type Item = TokenView<'a>;
-
-    fn next(&mut self) -> Option<Self::Item> {
-        if self.next >= self.stop {
-            return None;
-        }
-        let id = TokenId::try_from(self.next).ok()?;
-        self.next += 1;
-        self.store.view(id)
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let remaining = self.stop - self.next;
-        (remaining, Some(remaining))
-    }
-}
-
-impl DoubleEndedIterator for TokenIter<'_> {
-    fn next_back(&mut self) -> Option<Self::Item> {
-        if self.next >= self.stop {
-            return None;
-        }
-        self.stop -= 1;
-        let id = TokenId::try_from(self.stop).ok()?;
-        self.store.view(id)
-    }
-}
-
-impl ExactSizeIterator for TokenIter<'_> {}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -656,6 +615,28 @@ mod tests {
         assert_eq!(
             stream.tokens().next_back().map(|token| token.token_type()),
             Some(TOKEN_EOF)
+        );
+    }
+
+    #[test]
+    fn stream_tokens_exclude_parser_insertions_but_store_iterates_them() {
+        let mut stream = CommonTokenStream::new(source(vec![
+            TokenSpec::explicit(1, "a"),
+            TokenSpec::eof(1, 1, 1, 1),
+        ]));
+        stream
+            .insert(TokenSpec::explicit(2, "<missing token>"))
+            .expect("synthetic token should fit");
+
+        assert_eq!(stream.tokens().len(), 2);
+        assert_eq!(stream.token_store().iter().len(), 3);
+        assert_eq!(
+            stream
+                .token_store()
+                .iter()
+                .next_back()
+                .map(|token| token.text()),
+            Some("<missing token>")
         );
     }
 


### PR DESCRIPTION
## Summary

- add `TokenStore::iter()` and `IntoIterator for &TokenStore`
- move the borrowing `TokenIter` to the storage layer while preserving its existing `token_stream::TokenIter` path
- keep `CommonTokenStream::tokens()` limited to the original source sequence and document iteration from an owned `ParsedFile`

## Why

`ParsedFile::tokens()` returns the retained `TokenStore`, but the store exposed only `len()` and `view(TokenId)`. Consumers that needed a complete pass, including hidden-channel comments, had to reconstruct token IDs manually even though the existing stream iterator already borrowed the store directly.

Consumers can now use either `parsed.tokens().iter()` or `for token in parsed.tokens()`. Store iteration follows `TokenId` order and includes every retained record; stream iteration keeps its previous source-token semantics.

## Validation

- `cargo test --locked`
- `cargo test --locked --all-features`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`

Closes #123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added token iteration support, including forward and reverse traversal.
  - Token stores can now be used directly in iteration workflows.
  - Parsed files expose all buffered tokens, including hidden-channel content and the end-of-file marker.
  - Common token stream iteration continues to return source tokens while excluding synthetic parser insertions.

- **Tests**
  - Added coverage validating token ordering, channels, text, EOF handling, and filtering of inserted tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->