### PR TITLE
[codex] Add antlr4-rust-gen version flags

### DIFF
--- a/docs/migration.md
+++ b/docs/migration.md
@@ -2,7 +2,9 @@
 
 `antlr-rust-runtime` is pre-1.0. Minor releases may include breaking runtime and
 generator changes. Generated lexers and parsers must use the same release of
-`antlr4-rust-gen` as the runtime.
+`antlr4-rust-gen` as the runtime. Before regenerating, run
+`antlr4-rust-gen --version` and compare the reported release with the
+`antlr-rust-runtime` dependency version.
 
 ## Recognizer Reuse Method Names
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -69,10 +69,18 @@ pub use self::__antlr4_rust_generated::*;
 ";
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let Some(args) = Args::parse()? else {
-        let mut stdout = io::stdout().lock();
-        writeln!(stdout, "{}", usage())?;
-        return Ok(());
+    let args = match Args::parse()? {
+        CliCommand::Generate(args) => args,
+        CliCommand::Help => {
+            let mut stdout = io::stdout().lock();
+            writeln!(stdout, "{}", usage())?;
+            return Ok(());
+        }
+        CliCommand::Version => {
+            let mut stdout = io::stdout().lock();
+            writeln!(stdout, "antlr4-rust-gen {}", env!("CARGO_PKG_VERSION"))?;
+            return Ok(());
+        }
     };
     let compilation = grammar::compiler::compile(LoadOptions {
         roots: args.roots.clone(),
@@ -1828,8 +1836,14 @@ struct Args {
     embedded_actions: bool,
 }
 
+enum CliCommand {
+    Generate(Args),
+    Help,
+    Version,
+}
+
 impl Args {
-    fn parse() -> Result<Option<Self>, String> {
+    fn parse() -> Result<CliCommand, String> {
         let mut roots = Vec::new();
         let mut library_directories = Vec::new();
         let mut out_dir = None;
@@ -1888,7 +1902,8 @@ impl Args {
                     sem_unknown =
                         SemUnknownPolicy::parse_flag(&next_arg(&mut iter, "--sem-unknown")?)?;
                 }
-                "--help" | "-h" => return Ok(None),
+                "--help" | "-h" => return Ok(CliCommand::Help),
+                "--version" | "-V" => return Ok(CliCommand::Version),
                 other if other.starts_with("-I") && other.len() > 2 => {
                     library_directories.push(PathBuf::from(&other[2..]));
                 }
@@ -1906,7 +1921,7 @@ impl Args {
             ));
         }
 
-        Ok(Some(Self {
+        Ok(CliCommand::Generate(Self {
             roots,
             library_directories,
             out_dir: out_dir.unwrap_or_else(|| PathBuf::from(".")),
@@ -1948,6 +1963,7 @@ Options:
   --sem-patterns FILE              Load semantic helper patterns
   --option-hook KEY=VALUE          Acknowledge an option implemented by caller hooks
   --require-full-semantics         Fail if any semantic coordinate or option is unsupported
+  -V, --version                    Print version
   -h, --help                       Print this help"
         .to_owned()
 }

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -179,15 +179,17 @@ fn help_flag_as_option_value_is_not_intercepted() {
 }
 
 #[test]
-fn version_flag_as_option_value_is_not_intercepted() {
-    let output = run_antlr4_rust_gen(&["--option-hook", "--version"]);
+fn version_flags_as_option_values_are_not_intercepted() {
+    for flag in ["--version", "-V"] {
+        let output = run_antlr4_rust_gen(&["--option-hook", flag]);
 
-    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
-    assert_eq!(utf8(&output.stdout), "");
+        assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+        assert_eq!(utf8(&output.stdout), "");
 
-    let stderr = utf8(&output.stderr);
-    assert!(stderr.contains("--option-hook requires KEY=VALUE"));
-    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+        let stderr = utf8(&output.stderr);
+        assert!(stderr.contains("--option-hook requires KEY=VALUE"));
+        assert!(stderr.contains("Usage: antlr4-rust-gen"));
+    }
 }
 
 #[test]

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -134,6 +134,7 @@ fn long_help_describes_source_only_cli() {
     assert!(!stdout.contains("--lexer "), "{stdout}");
     assert!(!stdout.contains("--parser "), "{stdout}");
     assert!(!stdout.contains("--grammar "), "{stdout}");
+    assert!(stdout.contains("  -V, --version"), "{stdout}");
     assert!(stdout.contains("  -h, --help"), "{stdout}");
 }
 
@@ -147,8 +148,39 @@ fn short_help_exits_successfully_on_stdout() {
 }
 
 #[test]
+fn long_and_short_version_exit_successfully_on_stdout() {
+    for flag in ["--version", "-V"] {
+        let output = run_antlr4_rust_gen(&[flag]);
+
+        assert!(
+            output.status.success(),
+            "{flag} status: {:?}\nstderr: {}",
+            output.status.code(),
+            utf8(&output.stderr)
+        );
+        assert_eq!(utf8(&output.stderr), "");
+        assert_eq!(
+            utf8(&output.stdout),
+            concat!("antlr4-rust-gen ", env!("CARGO_PKG_VERSION"), "\n")
+        );
+    }
+}
+
+#[test]
 fn help_flag_as_option_value_is_not_intercepted() {
     let output = run_antlr4_rust_gen(&["--option-hook", "--help"]);
+
+    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stdout), "");
+
+    let stderr = utf8(&output.stderr);
+    assert!(stderr.contains("--option-hook requires KEY=VALUE"));
+    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+}
+
+#[test]
+fn version_flag_as_option_value_is_not_intercepted() {
+    let output = run_antlr4_rust_gen(&["--option-hook", "--version"]);
 
     assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
     assert_eq!(utf8(&output.stdout), "");


### PR DESCRIPTION
## Summary

- add `antlr4-rust-gen --version` and `-V`
- print `antlr4-rust-gen <crate version>` to stdout and exit successfully
- advertise the flags in `--help` and cover both spellings plus option-value parsing
- document the pre-regeneration version check in the migration guide

## Root cause

The hand-written CLI parser distinguished only generation from help output, so
it had no command outcome that could report the build-time crate version before
code generation.

## Impact

Users can verify that the generator installed on `PATH` matches the runtime
release before regenerating parsers and lexers.

## Validation

- `cargo test --locked --features codegen --test antlr4_rust_gen_cli` (24 passed)
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `rustfmt --edition 2024 --check src/bin/antlr4-rust-gen.rs tests/antlr4_rust_gen_cli.rs`
- `git diff --check`

Closes #124
