### PR TITLE
chore(deps): replace sha2 dev-dep with hmac-sha256 1.x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,6 +6,7 @@ version = 4
 name = "antlr-rust-runtime"
 version = "0.15.0"
 dependencies = [
+ "hmac-sha256",
  "icu_casemap",
  "icu_properties",
  "insta",
@@ -13,7 +14,6 @@ dependencies = [
  "memchr",
  "petgraph",
  "pretty_assertions",
- "sha2",
  "stacker",
  "thiserror",
 ]
@@ -34,15 +34,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,39 +50,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
-]
 
 [[package]]
 name = "displaydoc"
@@ -145,16 +107,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -179,6 +131,12 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
 
 [[package]]
 name = "icu_casemap"
@@ -445,17 +403,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,12 +511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -580,12 +521,6 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
-
-[[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,9 +37,9 @@ stacker = "0.1.24"
 thiserror = "2"
 
 [dev-dependencies]
+hmac-sha256 = "1"
 insta = { version = "1", default-features = false }
 pretty_assertions = "1"
-sha2 = "0.10"
 
 [[bin]]
 name = "antlr4-rust-gen"

--- a/src/bin_support/grammar/unicode_icu_tests.rs
+++ b/src/bin_support/grammar/unicode_icu_tests.rs
@@ -2,7 +2,7 @@ use super::{property_ranges, simple_lowercase, simple_uppercase};
 use std::collections::BTreeMap;
 use std::fmt::Write;
 
-use sha2::{Digest, Sha256};
+use hmac_sha256::Hash;
 
 const JAVA_PROPERTY_ORACLE: &str = include_str!(concat!(
     env!("CARGO_MANIFEST_DIR"),
@@ -139,10 +139,17 @@ fn every_unicode_property_and_alias_matches_java() {
 }
 
 fn interval_digest(ranges: &[i32]) -> String {
-    let mut digest = Sha256::new();
+    let mut digest = Hash::new();
     for range in ranges.chunks_exact(2) {
         digest.update(range[0].to_be_bytes());
         digest.update(range[1].to_be_bytes());
     }
-    format!("{:x}", digest.finalize())
+    // `hmac_sha256::Hash::finalize` returns a plain `[u8; 32]`, so render it as
+    // lowercase, zero-padded, separator-free hex to match the Java oracle
+    // digests in `java-unicode-properties.tsv` (Java's `MessageDigest` output).
+    let mut hex = String::with_capacity(32 * 2);
+    for byte in digest.finalize() {
+        write!(hex, "{byte:02x}").expect("write to string");
+    }
+    hex
 }


### PR DESCRIPTION
## Why

Renovate #160 bumps the `sha2` **dev-dependency** `0.10 → 0.11`. That "minor" bump is a breaking API change and fails CI:

```
error[E0277]: the trait bound `Array<u8, ...>: LowerHex` is not satisfied
   --> src/bin_support/grammar/unicode_icu_tests.rs:147
```

`sha2` 0.11 migrated RustCrypto's stack from `generic-array` to `hybrid-array`. `Digest::finalize()` now returns `hybrid_array::Array<u8, N>`, which — unlike the old `GenericArray` — does **not** implement `std::fmt::LowerHex`. So `format!("{:x}", digest.finalize())` in the Unicode oracle test no longer compiles, breaking the *Clippy and Unit Tests* job (and, downstream, *claude-review*).

## What

Instead of accepting the bump and tracking RustCrypto's perpetual `0.x` churn on a **test-only** hash, this switches to [`hmac-sha256`](https://crates.io/crates/hmac-sha256) `1.x`:

| | `sha2 = "0.11"` (#160) | `hmac-sha256 = "1"` (this PR) |
|---|---|---|
| Version | `0.x` (breaking minor bumps) | **`1.x` (stable)** |
| Transitive deps | 8 | **0** |
| Recurring Renovate breakage | yes | no |

Net `Cargo.lock` change: **−8 crates / +1** (drops `sha2`, `digest`, `crypto-common`, `generic-array`, `typenum`, `block-buffer`, `cpufeatures`, `version_check`).

- The digest stays **SHA-256** — it's compared byte-for-byte against the checked-in Java `MessageDigest` oracle (`java-unicode-properties.tsv`, ANTLR 4.13.2 / Unicode 17.0), which isn't regenerated here.
- `finalize()` now returns a plain `[u8; 32]`, so the lowercase / zero-padded / separator-free hex is encoded explicitly, matching the file's existing `write!`-into-`String` style.

## Verification

- `every_unicode_property_and_alias_matches_java` passes → new hex output is byte-identical to all 1226 Java oracle digests.
- Full suite: **888 tests, 0 failures**.
- `cargo clippy --locked --all-targets --all-features -- -D warnings` — clean.
- `rustfmt --check` on the touched file — clean.

## Note

Supersedes #160. That PR will auto-close once this merges (removes `sha2` from the tree). Scope is limited to the test suite — `sha2` was a dev-dependency with a single `#[cfg(test)]`-gated use site; no public API, generated output, or runtime behavior changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated Unicode property validation to produce digest values in the format expected by the Java comparison data.
  * Improved consistency of generated Unicode interval verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->