### PR TITLE
fix: grouped token accessors in typed contexts

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2669,17 +2669,43 @@ fn structural_terminal_child_target(
         Terminal::Token(name) => Some(name.clone()),
         Terminal::Literal(literal) => {
             let token_type = vocabulary.by_literal.get(literal)?;
-            vocabulary
-                .tokens
-                .iter()
-                .find(|token| token.number == *token_type)
-                .and_then(|token| token.name.as_ref())
-                .filter(|name| !name.starts_with("T__"))
-                .cloned()
+            structural_token_child_target(*token_type, vocabulary)
         }
         Terminal::Eof => Some("EOF".to_owned()),
         Terminal::LexerCharSet(_) | Terminal::Wildcard => None,
     }
+}
+
+fn structural_token_child_target(token_type: i32, vocabulary: &Vocabulary) -> Option<String> {
+    vocabulary
+        .tokens
+        .iter()
+        .filter(|token| token.number == token_type)
+        .filter_map(|token| token.name.as_ref())
+        .find(|name| !name.starts_with("T__"))
+        .cloned()
+}
+
+fn structural_set_children(
+    inverted: bool,
+    elements: &[SetElement],
+    vocabulary: &Vocabulary,
+) -> BTreeMap<String, embedded::ChildCardinality> {
+    if inverted {
+        return BTreeMap::new();
+    }
+    let token_types = structural_set_token_types(inverted, elements, vocabulary);
+    let cardinality = embedded::ChildCardinality {
+        min: usize::from(token_types.len() == 1),
+        max: Some(1),
+    };
+    token_types
+        .into_iter()
+        .filter_map(|token_type| {
+            structural_token_child_target(token_type, vocabulary)
+                .map(|target| (target, cardinality))
+        })
+        .collect()
 }
 
 fn structural_context_children(
@@ -2698,8 +2724,10 @@ fn structural_context_children(
                     .unwrap_or_default()
             }
             ElementKind::Block(block) => structural_block_children(block, vocabulary),
+            ElementKind::Set { inverted, elements } => {
+                structural_set_children(*inverted, elements, vocabulary)
+            }
             ElementKind::Range(..)
-            | ElementKind::Set { .. }
             | ElementKind::Action { .. }
             | ElementKind::Predicate { .. }
             | ElementKind::Epsilon => BTreeMap::new(),
@@ -8357,12 +8385,13 @@ fn render_context_child_accessors(
     let mut out = String::new();
     let _ = writeln!(
         out,
-        "    pub fn child_count(&self) -> usize {{\n        match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.child_count(),\n            __GeneratedRuleContext::Active {{ context, .. }} => context.child_count(),\n        }}\n    }}\n\n    pub fn start(&self) -> __GeneratedTokenView {{\n        let token = match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.start(),\n            __GeneratedRuleContext::Active {{ context, tokens, .. }} => context.start(tokens),\n        }};\n        __GeneratedTokenView {{ text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }}\n    }}"
+        "    pub fn child_count(&self) -> usize {{\n        match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.child_count(),\n            __GeneratedRuleContext::Active {{ context, .. }} => context.child_count(),\n        }}\n    }}\n\n    pub fn start(&self) -> __GeneratedTokenView {{\n        let token = match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.start(),\n            __GeneratedRuleContext::Active {{ context, tokens, .. }} => context.start(tokens),\n        }};\n        __GeneratedTokenView {{ text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }}\n    }}\n\n    pub fn text(&self) -> String {{\n        match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.text(),\n            __GeneratedRuleContext::Active {{ context, storage, tokens }} => context.text(storage, tokens),\n        }}\n    }}"
     );
     let mut used_methods = BTreeSet::from([
         "child_count".to_owned(),
         "rule_node".to_owned(),
         "start".to_owned(),
+        "text".to_owned(),
     ]);
     for (child_index, child) in model
         .rules
@@ -8468,8 +8497,8 @@ fn render_context_child_accessors(
 ///
 /// * one `<Rule>Context` view per parser rule (plus one per labeled
 ///   alternative) with cardinality-aware rule, token, and label accessors,
-///   `child_count()`, `start()`, public attribute fields, and a `FromRuleNode`
-///   impl backing `ctx.downcast_ref::<XContext>()`;
+///   `child_count()`, `start()`, `text()`, public attribute fields, and a
+///   `FromRuleNode` impl backing `ctx.downcast_ref::<XContext>()`;
 /// * the `<Grammar>Listener` trait with defaulted `enter_/exit_<rule>` (and
 ///   per-labeled-alternative) callbacks plus terminal/error-node visitors;
 /// * a module-local `ParseTreeWalker` whose bridge dispatches the runtime
@@ -13011,6 +13040,34 @@ mod tests {
             .expect("e context display impl")
             .0;
         insta::assert_snapshot!("typed_context_accessors_e_context", e_context);
+    }
+
+    #[test]
+    fn typed_context_accessors_include_tokens_from_grouped_sets() {
+        let rendered = render_parser(
+            "TParser",
+            &parser_fixture_data("grouped-token-accessors/T.g4"),
+        )
+        .expect("parser should render");
+        let expression_context = rendered
+            .split_once("impl<'a, State> ExpressionContext<'a, State> {")
+            .expect("expression context impl")
+            .1
+            .split_once("impl<State> std::fmt::Display for ExpressionContext")
+            .expect("expression context display impl")
+            .0;
+        let sequence_context = rendered
+            .split_once("impl<'a, State> OperatorSequenceContext<'a, State> {")
+            .expect("operator sequence context impl")
+            .1
+            .split_once("impl<State> std::fmt::Display for OperatorSequenceContext")
+            .expect("operator sequence context display impl")
+            .0;
+        let context_surface = format!(
+            "ExpressionContext\n{expression_context}OperatorSequenceContext\n{sequence_context}"
+        );
+
+        insta::assert_snapshot!("typed_context_accessors_grouped_tokens", context_surface);
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2677,6 +2677,9 @@ fn structural_terminal_child_target(
 }
 
 fn structural_token_child_target(token_type: i32, vocabulary: &Vocabulary) -> Option<String> {
+    if token_type == TOKEN_EOF {
+        return Some("EOF".to_owned());
+    }
     vocabulary
         .tokens
         .iter()
@@ -13063,8 +13066,15 @@ mod tests {
             .split_once("impl<State> std::fmt::Display for OperatorSequenceContext")
             .expect("operator sequence context display impl")
             .0;
+        let eof_choice_context = rendered
+            .split_once("impl<'a, State> EofChoiceContext<'a, State> {")
+            .expect("EOF choice context impl")
+            .1
+            .split_once("impl<State> std::fmt::Display for EofChoiceContext")
+            .expect("EOF choice context display impl")
+            .0;
         let context_surface = format!(
-            "ExpressionContext\n{expression_context}OperatorSequenceContext\n{sequence_context}"
+            "ExpressionContext\n{expression_context}OperatorSequenceContext\n{sequence_context}EofChoiceContext\n{eof_choice_context}"
         );
 
         insta::assert_snapshot!("typed_context_accessors_grouped_tokens", context_surface);

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_e_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_e_context.snap
@@ -17,6 +17,13 @@ expression: e_context
         };
         __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
     }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
     pub fn e_children(&self) -> impl Iterator<Item = EContext<'a>> + '_ {
         __rule_children(self.__node, 1)
             .map(move |node| EContext::__from_child_node(node, &self.__invocation_states))

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_grouped_tokens.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_grouped_tokens.snap
@@ -1,0 +1,115 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: context_surface
+---
+ExpressionContext
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn expression_children(&self) -> impl Iterator<Item = ExpressionContext<'a>> + '_ {
+        __rule_children(self.__node, 1)
+            .map(move |node| ExpressionContext::__from_child_node(node, &self.__invocation_states))
+    }
+    pub fn identifier(&self) -> Option<IdentifierContext<'a>> {
+        __rule_children(self.__node, 3)
+            .next()
+            .map(|node| IdentifierContext::__from_child_node(node, &self.__invocation_states))
+    }
+    pub fn le_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 1)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn ge_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 2)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn equal_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 3)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn notequal_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 4)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn assign_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 5)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn add_assign_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 6)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn bop(&self) -> Option<TerminalNode<'a>> {
+        __token_children_matching(self.__node, &[1, 2, 3, 4, 5, 6])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+OperatorSequenceContext
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn le_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 1).map(TerminalNode::new)
+    }
+    pub fn ge_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 2).map(TerminalNode::new)
+    }
+    pub fn equal_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 3).map(TerminalNode::new)
+    }
+    pub fn notequal_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 4).map(TerminalNode::new)
+    }
+    pub fn assign_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 5).map(TerminalNode::new)
+    }
+    pub fn add_assign_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 6).map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_grouped_tokens.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_grouped_tokens.snap
@@ -30,7 +30,7 @@ ExpressionContext
             .map(move |node| ExpressionContext::__from_child_node(node, &self.__invocation_states))
     }
     pub fn identifier(&self) -> Option<IdentifierContext<'a>> {
-        __rule_children(self.__node, 3)
+        __rule_children(self.__node, 4)
             .next()
             .map(|node| IdentifierContext::__from_child_node(node, &self.__invocation_states))
     }
@@ -111,5 +111,40 @@ OperatorSequenceContext
     }
     pub fn add_assign_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 6).map(TerminalNode::new)
+    }
+}
+
+EofChoiceContext
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn eof_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, -1)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn le_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 1)
+            .next()
+            .map(TerminalNode::new)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_latest_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_latest_context.snap
@@ -17,6 +17,13 @@ expression: latest_context
         };
         __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
     }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
     pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a>> + '_ {
         __rule_children(self.__node, 2)
             .map(move |node| AtomContext::__from_child_node(node, &self.__invocation_states))

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_many_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_many_context.snap
@@ -17,6 +17,13 @@ expression: many_context
         };
         __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
     }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
     pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a>> + '_ {
         __rule_children(self.__node, 2)
             .map(move |node| AtomContext::__from_child_node(node, &self.__invocation_states))

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_s_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_s_context.snap
@@ -17,6 +17,13 @@ expression: s_context
         };
         __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
     }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
     pub fn e(&self) -> Result<EContext<'a>, MissingChildError> {
         __rule_children(self.__node, 1)
             .next()

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -448,6 +448,10 @@ mod grouped_token_tests {
         assert_eq!(operators.assign_tokens().count(), 1);
         assert_eq!(operators.add_assign_tokens().count(), 1);
         assert_eq!(operators.le_tokens().count(), 0);
+
+        let eof_choice = root.eof_choice().expect("EOF choice");
+        assert!(eof_choice.eof_token().is_some());
+        assert!(eof_choice.le_token().is_none());
     }
 }
 "#,

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -383,6 +383,78 @@ mod typed_label_tests {
 }
 
 #[test]
+fn grouped_literal_tokens_are_exposed_on_typed_contexts() {
+    let temp = temporary_directory("grouped-token-accessors");
+    let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/grouped-token-accessors/T.g4");
+    let out = temp.path().join("generated");
+
+    let output = run_antlr4_rust_gen(&[
+        grammar.as_os_str(),
+        OsStr::new("--out-dir"),
+        out.as_os_str(),
+    ]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    assert_generated_project(
+        temp.path(),
+        &["t_lexer.rs", "t_parser.rs"],
+        r#"
+#[cfg(test)]
+mod grouped_token_tests {
+    use super::t_lexer::TLexer;
+    use super::t_parser::*;
+    use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
+
+    #[test]
+    fn reads_grouped_operators_and_context_text() {
+        let lexer = TLexer::new(InputStream::new("left<=right=+="));
+        let tokens = CommonTokenStream::new(lexer);
+        let mut parser = TParser::new(tokens);
+        let root = parser.root().expect("operator input should parse");
+        assert_eq!(parser.number_of_syntax_errors(), 0);
+        let parsed = parser.into_parsed_file(root);
+        let root = parsed
+            .tree()
+            .as_rule()
+            .expect("root rule")
+            .downcast_ref::<RootContext>()
+            .expect("typed root context");
+        let expression = root.expression().expect("root expression");
+        assert_eq!(expression.text(), "left<=right");
+        assert_eq!(expression.bop().expect("operator label").to_string(), "<=");
+        assert!(expression.le_token().is_some());
+        assert!(expression.ge_token().is_none());
+        assert!(expression.equal_token().is_none());
+        assert!(expression.notequal_token().is_none());
+        assert!(expression.assign_token().is_none());
+        assert!(expression.add_assign_token().is_none());
+
+        let identifier = expression
+            .expression_children()
+            .next()
+            .expect("left expression")
+            .identifier()
+            .expect("left identifier");
+        assert_eq!(identifier.text(), "left");
+
+        let operators = root
+            .operator_sequence()
+            .expect("trailing operator sequence");
+        assert_eq!(operators.assign_tokens().count(), 1);
+        assert_eq!(operators.add_assign_tokens().count(), 1);
+        assert_eq!(operators.le_tokens().count(), 0);
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn visitor_and_typed_walk_dispatch_labeled_left_recursion() {
     let temp = temporary_directory("typed-tree-walkers");
     let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/tests/fixtures/antlr4-rust-gen/grouped-token-accessors/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/grouped-token-accessors/T.g4
@@ -1,0 +1,50 @@
+grammar T;
+
+root
+    : expression operatorSequence EOF
+    ;
+
+expression
+    : identifier
+    | expression bop = ('<=' | '>=' | '==' | '!=' | '=' | '+=') expression
+    ;
+
+operatorSequence
+    : ('<=' | '>=' | '==' | '!=' | '=' | '+=')+
+    ;
+
+identifier
+    : IDENTIFIER
+    ;
+
+LE
+    : '<='
+    ;
+
+GE
+    : '>='
+    ;
+
+EQUAL
+    : '=='
+    ;
+
+NOTEQUAL
+    : '!='
+    ;
+
+ASSIGN
+    : '='
+    ;
+
+ADD_ASSIGN
+    : '+='
+    ;
+
+IDENTIFIER
+    : [a-z]+
+    ;
+
+WS
+    : [ \t\r\n]+ -> skip
+    ;

--- a/tests/fixtures/antlr4-rust-gen/grouped-token-accessors/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/grouped-token-accessors/T.g4
@@ -1,7 +1,7 @@
 grammar T;
 
 root
-    : expression operatorSequence EOF
+    : expression operatorSequence eofChoice
     ;
 
 expression
@@ -11,6 +11,10 @@ expression
 
 operatorSequence
     : ('<=' | '>=' | '==' | '!=' | '=' | '+=')+
+    ;
+
+eofChoice
+    : (LE | EOF)
     ;
 
 identifier


### PR DESCRIPTION
## Summary

- include symbolic members of positive parser token sets in generated typed-context child accessors
- add `text()` to every typed context for both stored trees and active parser contexts
- add snapshot and compiled generated-parser coverage for grouped literals and repeated token sets

## Root cause

ANTLR's grammar transform reduces parenthesized token alternatives such as `bop = ('=' | '+=' | ...)` to `ElementKind::Set`. The structural child inventory ignored all set elements, so the group label survived through the separate reference inventory while each member token disappeared from the generated typed API.

## Impact

Consumers can now query assignment, equality, relational, increment, and decrement operators through typed contexts. Generated identifier-style contexts also expose their parse-tree text directly instead of requiring `rule_node().text()`.

The pinned grammars-v4 Java grammar now emits all accessors named in #177, including `assign_token`, the assignment family, `equal_token`, `notequal_token`, `le_token`, `ge_token`, `inc_token`, and `dec_token`; `IdentifierContext` and `TypeIdentifierContext` emit `text()`.

## Validation

- `cargo test --locked --all-features --workspace`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` (`357 passed, 0 failed`)
- generated the pinned grammars-v4 Java lexer/parser at `284602b3f23ca54dc30778204ab7ae9e969145e9` and inspected the concrete context surface

Closes #177

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generated typed rule-context views now expose a `text()` accessor.
  * Token accessors now correctly include tokens from grouped grammar sets.
  * Generated contexts provide accurate child counts and operator/text information for grouped tokens.

* **Bug Fixes**
  * Corrected handling of grouped set elements when resolving structural child nodes and tokens.

* **Tests**
  * Added coverage validating generated grouped-token accessors and runtime parse-tree behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->