### PR TITLE
ci: use Opus 5 for PR review and mount upstream ANTLR for comparison

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -40,6 +40,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      # This runtime is a port of ANTLR's reference implementation, so a faithful
+      # review of changes to the ported algorithms usually needs to compare
+      # against upstream behavior. Clone the reference tree into a side directory
+      # (kept out of the checkout above via a distinct `path`) the reviewer can
+      # read and grep. Pinned to the v4.13.2 tag the runtime targets everywhere
+      # else (see CLAUDE.md) — `master`/`dev` would surface post-4.13.2 changes a
+      # reviewer could wrongly flag as divergence. Shallow single-tag snapshot:
+      # the reviewer reads source, not git history. The directory name is
+      # deliberately non-hidden so ripgrep-backed search (Grep) descends into it.
+      - name: Checkout upstream ANTLR (reference for review comparisons)
+        uses: actions/checkout@v7
+        with:
+          repository: antlr/antlr4
+          ref: "4.13.2"
+          path: antlr-upstream
+          fetch-depth: 1
+
       - name: Install Dependencies
         run: |
           sudo apt-get update
@@ -90,7 +107,7 @@ jobs:
           use_sticky_comment: true
           claude_args: |
             --effort max
-            --model "claude-opus-4-8[1m]"
+            --model "claude-opus-5[1m]"
             --no-chrome
             --dangerously-skip-permissions
           plugins: "code-review@claude-code-plugins"
@@ -103,6 +120,14 @@ jobs:
           # yield: sub-agent results are available synchronously in-session.
           prompt: |
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            UPSTREAM REFERENCE: This crate ports ANTLR (antlr/antlr4). A read-only
+            checkout of tag v4.13.2 — the version it targets — is at `antlr-upstream/`
+            (Java runtime: `runtime/Java/src/org/antlr/v4/runtime/`; generator:
+            `tool/`). For changes to ported logic (ATN/prediction, lexer/parser
+            simulation, serialized-ATN decoding, generated-code shape), compare
+            against it and cite the upstream file:line. Flag unintended divergence
+            from ANTLR semantics; treat documented deviations as intentional.
 
             IMPORTANT (non-interactive CI run): You cannot pause and resume. Any
             sub-agents you spawn return their results synchronously within this same


### PR DESCRIPTION
## What

Two enhancements to the automated Claude Code review workflow (`.github/workflows/claude-code-review.yml`):

1. **Model → Opus 5.** `--model "claude-opus-4-8[1m]"` → `"claude-opus-5[1m]"`. Opus 5 shipped today; Opus 4.8 is now legacy. The `[1m]` suffix (Claude Code's 1M-context selector) is preserved.

2. **Mount upstream ANTLR for comparison.** A new `actions/checkout` step clones `antlr/antlr4` at tag **`4.13.2`** into `antlr-upstream/`, and the review prompt now points the reviewer there.

## Why

This crate is a Rust port of ANTLR's reference runtime + code generator. Most PRs touch ported logic — ATN/prediction, lexer/parser simulation, serialized-ATN decoding, generated-code shape — where a faithful review means checking the Rust behavior against the reference implementation.

- Pinned to **`4.13.2`** (the version CLAUDE.md targets everywhere), not `master` — otherwise the reviewer would flag post-4.13.2 upstream changes as false divergence.
- `path: antlr-upstream` keeps it out of the main checkout; `fetch-depth: 1` since the reviewer reads source, not history.
- Prompt guides the reviewer to catch *unintended* divergence while respecting documented deliberate deviations, and to cite the upstream `file:line`.

## Verification

- `actionlint .github/workflows/claude-code-review.yml` → clean
- `antlr/antlr4` tag `4.13.2` confirmed to exist; cited subpaths (`runtime/Java/src/org/antlr/v4/runtime/`, `tool/`) verified present at that tag.

## Notes

- This only touches the automated PR-review workflow. The `@claude` mention workflow (`claude.yml`) still uses the action's default model with no pin — let me know if it should get the same bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated code review workflows to compare implementation behavior against the ANTLR 4.13.2 reference source.
  * Enhanced review guidance to identify and document intentional differences from upstream semantics.
  * Updated the AI model used for automated reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->