### PR TITLE
[codex] Support capitalized lexer command aliases

### DIFF
--- a/src/bin_support/grammar/semantics.rs
+++ b/src/bin_support/grammar/semantics.rs
@@ -2447,7 +2447,15 @@ impl<'a> BindingCollector<'a> {
         &mut self,
         command: &super::model::LexerCommand,
     ) -> Option<ResolvedLexerCommand> {
-        let no_arg = match command.name.as_str() {
+        let Some(command_name) = canonical_lexer_command_name(&command.name) else {
+            self.diagnostics.push(Diagnostic::error(
+                "G4S049",
+                command.span.clone(),
+                format!("unsupported lexer command {}", command.name),
+            ));
+            return None;
+        };
+        let no_arg = match command_name {
             "skip" => Some(ResolvedLexerCommand::Skip),
             "more" => Some(ResolvedLexerCommand::More),
             "popMode" => Some(ResolvedLexerCommand::PopMode),
@@ -2465,18 +2473,6 @@ impl<'a> BindingCollector<'a> {
             return Some(resolved);
         }
 
-        let requires_arg = matches!(
-            command.name.as_str(),
-            "mode" | "pushMode" | "type" | "channel"
-        );
-        if !requires_arg {
-            self.diagnostics.push(Diagnostic::error(
-                "G4S049",
-                command.span.clone(),
-                format!("unsupported lexer command {}", command.name),
-            ));
-            return None;
-        }
         let Some(argument) = command.argument.as_deref() else {
             self.diagnostics.push(Diagnostic::error(
                 "G4S050",
@@ -2486,7 +2482,7 @@ impl<'a> BindingCollector<'a> {
             return None;
         };
 
-        match command.name.as_str() {
+        match command_name {
             "mode" | "pushMode" => {
                 if argument != "DEFAULT_MODE" && COMMON_CONSTANTS.contains(&argument) {
                     self.diagnostics.push(Diagnostic::error(
@@ -2515,7 +2511,7 @@ impl<'a> BindingCollector<'a> {
                     ));
                     return None;
                 };
-                if command.name == "mode" {
+                if command_name == "mode" {
                     Some(ResolvedLexerCommand::Mode(value))
                 } else {
                     Some(ResolvedLexerCommand::PushMode(value))
@@ -2586,6 +2582,20 @@ impl<'a> BindingCollector<'a> {
             }
             _ => unreachable!("required command set checked above"),
         }
+    }
+}
+
+fn canonical_lexer_command_name(name: &str) -> Option<&'static str> {
+    // ANTLR target templates expose these exact initial-cap aliases.
+    match name {
+        "skip" | "Skip" => Some("skip"),
+        "more" | "More" => Some("more"),
+        "popMode" | "PopMode" => Some("popMode"),
+        "mode" | "Mode" => Some("mode"),
+        "pushMode" | "PushMode" => Some("pushMode"),
+        "type" | "Type" => Some("type"),
+        "channel" | "Channel" => Some("channel"),
+        _ => None,
     }
 }
 
@@ -3319,6 +3329,73 @@ A : 'a' -> channel(COMMENTS);
                 .values()
                 .any(|binding| { binding.command == ResolvedLexerCommand::Channel(2) })
         );
+    }
+
+    #[test]
+    fn capitalized_standard_lexer_commands_resolve() {
+        let fixture = Fixture::new("capitalized-commands");
+        fixture.write(
+            "Commands.g4",
+            r#"
+lexer grammar Commands;
+tokens { REMAPPED }
+channels { COMMENTS }
+A : 'a' -> Skip;
+B : 'b' -> More;
+C : 'c' -> PopMode;
+D : 'd' -> Mode(DEFAULT_MODE);
+E : 'e' -> PushMode(OTHER);
+F : 'f' -> Type(REMAPPED);
+G : 'g' -> Channel(COMMENTS);
+mode OTHER;
+H : 'h';
+"#,
+        );
+
+        let semantic = compile(&fixture, "Commands.g4").expect("lexer should analyze");
+        let grammar = &semantic.grammars[0];
+        let commands = grammar
+            .bindings
+            .commands
+            .values()
+            .map(|binding| binding.command)
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!(
+            "capitalized_standard_lexer_commands",
+            (&grammar.recognizer.vocabulary.by_name, commands)
+        );
+    }
+
+    #[test]
+    fn capitalized_lexer_commands_keep_exact_spelling_diagnostics() {
+        let fixture = Fixture::new("capitalized-command-diagnostics");
+        fixture.write(
+            "Commands.g4",
+            r#"
+lexer grammar Commands;
+channels { COMMENTS }
+A : 'a' -> Skip(1);
+B : 'b' -> Channel;
+C : 'c' -> CHANNEL(COMMENTS);
+D : 'd' -> Channel(COMMENTS), Channel(COMMENTS);
+E : 'e' -> channel(COMMENTS), Channel(COMMENTS);
+F : 'f' -> skip, Channel(COMMENTS);
+"#,
+        );
+
+        let error = compile(&fixture, "Commands.g4").expect_err("invalid commands must fail");
+        let diagnostics = error
+            .diagnostics()
+            .iter()
+            .map(|diagnostic| {
+                (
+                    diagnostic.code,
+                    diagnostic.severity,
+                    diagnostic.message.as_str(),
+                )
+            })
+            .collect::<Vec<_>>();
+        insta::assert_debug_snapshot!("capitalized_lexer_command_diagnostics", diagnostics);
     }
 
     #[test]

--- a/src/bin_support/grammar/snapshots/antlr4_rust_gen__grammar__semantics__tests__capitalized_lexer_command_diagnostics.snap
+++ b/src/bin_support/grammar/snapshots/antlr4_rust_gen__grammar__semantics__tests__capitalized_lexer_command_diagnostics.snap
@@ -1,0 +1,26 @@
+---
+source: src/bin_support/grammar/semantics.rs
+expression: diagnostics
+---
+[
+    (
+        "G4S048",
+        Error,
+        "command Skip does not take an argument",
+    ),
+    (
+        "G4S050",
+        Error,
+        "command Channel requires an argument",
+    ),
+    (
+        "G4S049",
+        Error,
+        "unsupported lexer command CHANNEL",
+    ),
+    (
+        "G4S046",
+        Warning,
+        "duplicated command Channel",
+    ),
+]

--- a/src/bin_support/grammar/snapshots/antlr4_rust_gen__grammar__semantics__tests__capitalized_standard_lexer_commands.snap
+++ b/src/bin_support/grammar/snapshots/antlr4_rust_gen__grammar__semantics__tests__capitalized_standard_lexer_commands.snap
@@ -1,0 +1,35 @@
+---
+source: src/bin_support/grammar/semantics.rs
+expression: "(&grammar.recognizer.vocabulary.by_name, commands)"
+---
+(
+    {
+        "A": 2,
+        "B": 3,
+        "C": 4,
+        "D": 5,
+        "E": 6,
+        "EOF": -1,
+        "F": 7,
+        "G": 8,
+        "H": 9,
+        "REMAPPED": 1,
+    },
+    [
+        Skip,
+        More,
+        PopMode,
+        Mode(
+            0,
+        ),
+        PushMode(
+            1,
+        ),
+        Type(
+            1,
+        ),
+        Channel(
+            2,
+        ),
+    ],
+)


### PR DESCRIPTION
## Summary

- recognize ANTLR's exact initial-cap aliases for the seven standard lexer commands
- lower those aliases through the existing portable lexer-action path
- preserve original command spelling for Java-compatible duplicate, incompatibility, and token-numbering semantics
- add snapshots for successful resolution and argument/unknown-command diagnostics

## Root cause

ANTLR target templates accept commands such as `Channel(...)`, but the direct Rust grammar compiler only resolved the lowercase `channel(...)` spelling. The upstream grammars-v4 Rego lexer uses `Channel(COMMENTS_AND_FORMATTING)` for comments, whitespace, and line endings, so generation stopped with three `G4S049` errors even though custom channels already worked in lowering and at runtime.

The resolver now accepts only the exact aliases exposed by ANTLR's standard command templates. Matching is not generally case-insensitive, so spellings such as `CHANNEL` remain unsupported.

This enables Rego as a candidate corpus for #150; it does not close that optimization research issue.

## Validation

- `cargo fmt --check`
- `cargo test --locked --all-features --workspace`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` (`357 passed, 0 failed, 0 skipped`)
- generated the unchanged grammars-v4 Rego lexer/parser with `--require-generated-parser`
- parsed all 1,914 non-error Rego corpus fixtures without diagnostics
