### PR TITLE
fix(codegen): guard generated rule dispatch against native stack overflow

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5216,20 +5216,22 @@ fn render_generated_rule_dispatch_with_rule_names(
             "\n    #[allow(dead_code)]\n    fn parse_generated_rule_{index}_dispatch(&mut self, precedence: i32, allow_fallback: bool) -> Result<antlr4_runtime::ParseTree, GeneratedRuleError> {{"
         )
         .expect("writing to a string cannot fail");
-        if rule.left_recursive {
-            writeln!(
-                out,
-                "        self.parse_generated_rule_{index}_precedence(precedence, allow_fallback)"
-            )
-            .expect("writing to a string cannot fail");
+        let target_call = if rule.left_recursive {
+            format!("self.parse_generated_rule_{index}_precedence(precedence, allow_fallback)")
         } else {
             writeln!(out, "        let _ = precedence;").expect("writing to a string cannot fail");
-            writeln!(
-                out,
-                "        self.parse_generated_rule_{index}(precedence, allow_fallback)"
-            )
-            .expect("writing to a string cannot fail");
-        }
+            format!("self.parse_generated_rule_{index}(precedence, allow_fallback)")
+        };
+        // Rule nesting maps onto native call depth; sample remaining stack
+        // capacity at the shared dispatch boundary so deeply nested input
+        // grows onto a segmented stack instead of aborting the process.
+        writeln!(
+            out,
+            "        if self.base.generated_rule_stack_check_due() {{\n            \
+             antlr4_runtime::grow_generated_rule_stack(|| {target_call})\n        \
+             }} else {{\n            {target_call}\n        }}"
+        )
+        .expect("writing to a string cannot fail");
         writeln!(out, "    }}").expect("writing to a string cannot fail");
         render_generated_rule_method(&mut out, rule, step_render_context);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ pub use parser::{
     BailErrorStrategy, BaseParser, ExpectedTokenSet, NoSemanticHooks, Parser, ParserAction,
     ParserMemberAction, ParserPredicate, ParserReturnAction, ParserRuleArg, ParserRuntimeOptions,
     ParserSemCtx, ParserSemanticAction, ParserSemanticPredicate, ParserSemantics, PredictionMode,
-    RecognitionArenaStats, SemanticHooks, UnknownSemanticPolicy,
+    RecognitionArenaStats, SemanticHooks, UnknownSemanticPolicy, grow_generated_rule_stack,
 };
 #[cfg(feature = "perf-counters")]
 pub use perf::{dump as dump_prediction_perf_counters, reset as reset_prediction_perf_counters};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -108,10 +108,26 @@ const RECOGNITION_DEPTH_LIMIT: usize = 32_768;
 const FAST_RECOGNIZE_STACK_CHECK_INTERVAL: usize = 8;
 const FAST_RECOGNIZE_RED_ZONE: usize = 1024 * 1024;
 const FAST_RECOGNIZE_STACK_SIZE: usize = 4 * 1024 * 1024;
+/// Generated recursive-descent rule methods map grammar-rule nesting onto
+/// native call depth. Their `_dispatch` boundary samples remaining stack
+/// capacity once per this many rule-context frames, so between two samples at
+/// most this many rule bodies of native growth can occur — far below the
+/// red zone.
+const GENERATED_RULE_STACK_CHECK_INTERVAL: usize = 8;
 /// Whole-rule direct adaptive execution is allowed to give up and fall back to
 /// the existing recognizer. Keep the guard at the same order of magnitude as
 /// speculative recognition so malformed cyclic ATNs cannot spin forever.
 const ADAPTIVE_DIRECT_STEP_LIMIT: usize = RECOGNITION_DEPTH_LIMIT;
+
+/// Runs a generated rule body after ensuring native stack capacity, growing
+/// onto a segmented stack when remaining capacity enters the red zone.
+///
+/// Generated `parse_generated_rule_*_dispatch` methods call this when
+/// [`BaseParser::generated_rule_stack_check_due`] fires so deeply nested input
+/// parses (or reports a syntax error) instead of aborting the process.
+pub fn grow_generated_rule_stack<R>(body: impl FnOnce() -> R) -> R {
+    stacker::maybe_grow(FAST_RECOGNIZE_RED_ZONE, FAST_RECOGNIZE_STACK_SIZE, body)
+}
 /// Probe window for deciding whether clean-pass memo entries are reusable
 /// enough to keep caching. High-cardinality parses mostly produce one-shot
 /// entries; compact ambiguous loops repeatedly hit the same keys.
@@ -5682,6 +5698,21 @@ where
         } else {
             NodeId::placeholder()
         }
+    }
+
+    /// Reports whether the generated rule dispatch should sample native stack
+    /// capacity before descending into the next rule body.
+    ///
+    /// Generated recursive-descent methods otherwise map unbounded grammar
+    /// nesting straight onto native call depth; sampling every
+    /// [`GENERATED_RULE_STACK_CHECK_INTERVAL`] rule-context frames keeps the
+    /// hot path free of per-call probes while guaranteeing a check runs before
+    /// the red zone can be crossed.
+    #[must_use]
+    pub const fn generated_rule_stack_check_due(&self) -> bool {
+        self.rule_context_stack
+            .len()
+            .is_multiple_of(GENERATED_RULE_STACK_CHECK_INTERVAL)
     }
 
     /// Enters a generated parser rule and returns the context object the

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1549,3 +1549,54 @@ mod midi_tests {{
         &test_source,
     );
 }
+
+#[test]
+fn deeply_nested_input_parses_without_native_stack_overflow() {
+    let temp = temporary_directory("deep-nesting");
+    let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4");
+    let out = temp.path().join("generated");
+
+    let output = run_antlr4_rust_gen(&[
+        grammar.as_os_str(),
+        OsStr::new("--out-dir"),
+        out.as_os_str(),
+    ]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+
+    // Every generated dispatch method must carry the stack guard; the rule
+    // chain here multiplies each `[` into ~6 native rule frames (issue #193).
+    let parser = fs::read_to_string(out.join("nest_parser.rs")).expect("parser should be emitted");
+    assert!(
+        parser.contains("antlr4_runtime::grow_generated_rule_stack("),
+        "generated dispatch must guard native stack growth\n{parser}"
+    );
+
+    assert_generated_project(
+        temp.path(),
+        &["nest_lexer.rs", "nest_parser.rs"],
+        r#"
+#[cfg(test)]
+mod deep_nesting_tests {
+    use super::nest_lexer::NestLexer;
+    use super::nest_parser::{parse, NestParser};
+
+    #[test]
+    fn ten_thousand_levels_parse_on_the_default_test_stack() {
+        // Rust test threads default to a 2 MiB stack; without segmented-stack
+        // growth this depth aborted the process (issue #193).
+        let depth = 10_000;
+        let source = format!("{}a{}", "[".repeat(depth), "]".repeat(depth));
+        let parsed = parse(&source, NestLexer::new, NestParser::s)
+            .expect("deeply nested input should parse");
+        assert!(parsed.tree().as_rule().is_some());
+    }
+}
+"#,
+    );
+}

--- a/tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4
+++ b/tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4
@@ -1,0 +1,43 @@
+// Mirrors the failure shape from issue #193: an expression grammar whose rule
+// chain multiplies input nesting into native call depth (CEL walks nine rules
+// per `[`). Deeply nested input must parse without exhausting the native
+// stack.
+grammar Nest;
+
+s
+    : expr EOF
+    ;
+
+expr
+    : disjunction
+    ;
+
+disjunction
+    : conjunction ('||' conjunction)*
+    ;
+
+conjunction
+    : relation ('&&' relation)*
+    ;
+
+relation
+    : unary
+    ;
+
+unary
+    : '!' unary
+    | primary
+    ;
+
+primary
+    : '[' expr ']'
+    | A
+    ;
+
+A
+    : 'a'
+    ;
+
+WS
+    : [ \t\r\n]+ -> skip
+    ;


### PR DESCRIPTION
Fixes #193.

## What

Generated recursive-descent rule methods mapped grammar-rule nesting directly onto native call depth — the CEL grammar walks ~9 rules per `[`, so ~850 nesting levels aborted the process on an 8 MiB stack. The interpreted path (`recognize_state_fast`, #147) and the tree walker were already segmented-stack safe; the generated parse path was the last unguarded recursion.

The generator now emits a stack-capacity probe at the shared `parse_generated_rule_N_dispatch` boundary:

```rust
if self.base.generated_rule_stack_check_due() {
    antlr4_runtime::grow_generated_rule_stack(|| self.parse_generated_rule_N(...))
} else {
    self.parse_generated_rule_N(...)
}
```

`generated_rule_stack_check_due` samples once per 8 rule-context frames (`rule_context_stack.len() % 8 == 0` — no new state), and `grow_generated_rule_stack` re-uses `recognize_state_fast`'s red-zone constants (1 MiB red zone, 4 MiB segments) via `stacker::maybe_grow`.

## Verification

- **New e2e test**: `deep-nesting/Nest.g4` (CEL-shaped 6-rule chain) parses 10 000 nesting levels on the default 2 MiB test-thread stack. Before the fix that input aborts the process.
- **CEL spike**: the exact #193 reproducer now parses at depth 100 000 (previously aborted at ~850).
- **Conformance**: full sweep 357 passed, 0 failed, 0 skipped.
- **Perf**: Kotlin-parity dumper, min of 3×30 iters, quiet machine, baseline = origin/main runtime + codegen:

  | snippet | pre-fix | guarded |
  |---|---|---|
  | 01-nested-types | 0.105 ms | 0.106 ms |
  | 02-dataframe | 0.767 ms | 0.774 ms |
  | 03-string-templates | 0.321 ms | 0.317 ms |

  Within noise (±1%). Parse trees byte-identical pre/post on all snippets.
- `cargo test --locked` (unit + doctests) and `cargo clippy --locked --all-targets --all-features -- -D warnings` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of deeply nested input to prevent native stack overflows.
  * Added safer handling for recursive parser calls.

* **Tests**
  * Added end-to-end coverage for parsing input nested 10,000 levels deep.
  * Added a grammar fixture covering nested expressions, unary operators, and whitespace handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->