### PR TITLE
feat(parser): configurable max rule-nesting depth to bound adversarial input

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5229,10 +5229,14 @@ fn render_generated_rule_dispatch_with_rule_names(
         // capacity at the shared dispatch boundary so deeply nested input
         // grows onto a segmented stack instead of aborting the process. The
         // optional depth cap aborts here — fatal, so recovery cannot resume a
-        // parse that exceeded its configured resource bound.
+        // parse that exceeded its configured resource bound. The cap check is
+        // gated on the inlined `has_rule_depth_cap` load so uncapped parses
+        // (the default) skip the out-of-line depth accounting entirely.
         writeln!(
             out,
-            "        if let Some(error) = self.base.rule_depth_limit_error() {{\n            \
+            "        if self.base.has_rule_depth_cap()\n            \
+             && let Some(error) = self.base.rule_depth_limit_error()\n        \
+             {{\n            \
              return Err(GeneratedRuleError::Fatal(error));\n        \
              }}\n        \
              if self.base.generated_rule_stack_check_due() {{\n            \
@@ -6943,10 +6947,13 @@ fn render_generated_left_recursive_loop(
     .expect("writing to a string cannot fail");
     // Each operator iteration deepens the tree without a rule frame; check
     // the depth cap here so token-only operator alternatives (no nested rule
-    // dispatch) still abort promptly instead of at the top-level drain.
+    // dispatch) still abort promptly instead of at the top-level drain. The
+    // inlined `has_rule_depth_cap` gate keeps uncapped loops branch-cheap.
     writeln!(
         out,
-        "{pad}            if let Some(__depth_error) = self.base.rule_depth_limit_error() {{\n\
+        "{pad}            if self.base.has_rule_depth_cap()\n\
+         {pad}                && let Some(__depth_error) = self.base.rule_depth_limit_error()\n\
+         {pad}            {{\n\
          {pad}                return Err(__depth_error);\n\
          {pad}            }}"
     )

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -12590,8 +12590,10 @@ mod tests {
             None,
         );
 
+        // A configured depth cap overrides the ATN preference: only generated
+        // bodies enforce the bound, so the guard admits either trigger.
         assert!(rendered.contains(
-            "0 if self.generated_only() => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
+            "0 if self.generated_only() || self.base.has_rule_depth_cap() => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
         ));
         assert!(!rendered.contains(
             "0 => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5184,9 +5184,12 @@ fn render_generated_rule_dispatch_with_rule_names(
             .copied()
             .unwrap_or_default()
         {
+            // The interpreted fast path never consults the depth cap, so a
+            // configured bound overrides the ATN preference: correctness of
+            // the resource limit beats the long-call-chain optimization.
             writeln!(
                 out,
-                "            {index} if self.generated_only() => Some(self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback)),"
+                "            {index} if self.generated_only() || self.base.has_rule_depth_cap() => Some(self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback)),"
             )
             .expect("writing to a string cannot fail");
         } else {
@@ -6936,6 +6939,16 @@ fn render_generated_left_recursive_loop(
     writeln!(
         out,
         "{pad}            self.base.push_new_recursion_context_with_previous({entry_state}isize, {rule_index}, &mut __ctx);"
+    )
+    .expect("writing to a string cannot fail");
+    // Each operator iteration deepens the tree without a rule frame; check
+    // the depth cap here so token-only operator alternatives (no nested rule
+    // dispatch) still abort promptly instead of at the top-level drain.
+    writeln!(
+        out,
+        "{pad}            if let Some(__depth_error) = self.base.rule_depth_limit_error() {{\n\
+         {pad}                return Err(__depth_error);\n\
+         {pad}            }}"
     )
     .expect("writing to a string cannot fail");
     render_generated_steps(out, body, indent + 3, render_context);
@@ -9751,6 +9764,10 @@ where
             // are preserved so a generated parent can surface a recovered child's
             // fail-loud coordinate at this boundary.
             self.base.reset_unknown_semantic_hits();
+            // Likewise drop a stale depth-cap violation: entry rules share one
+            // parser instance, and the sticky flag must not poison the next
+            // parse when the previous one exited through an error path.
+            let _ = self.base.take_rule_depth_error();
         }}
         let __rule_start = antlr4_runtime::IntStream::index(self.base.input());
         let __generated_only = self.generated_only();
@@ -9770,6 +9787,14 @@ where
                     if allow_generated_fallback {{
                         if let Some(semantic_error) = self.base.take_unknown_semantic_error() {{
                             return Err(semantic_error);
+                        }}
+                        // The depth-cap violation wins over an error derived
+                        // from it (e.g. a sync failure after recovery absorbed
+                        // the capped rule): the caller must learn the resource
+                        // bound was hit, and draining un-poisons the instance
+                        // for the next entry-rule call.
+                        if let Some(depth_error) = self.base.take_rule_depth_error() {{
+                            return Err(depth_error);
                         }}
                     }}
                     return Err(error.into_error());

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5228,15 +5228,14 @@ fn render_generated_rule_dispatch_with_rule_names(
         // Rule nesting maps onto native call depth; sample remaining stack
         // capacity at the shared dispatch boundary so deeply nested input
         // grows onto a segmented stack instead of aborting the process. The
-        // optional depth cap aborts here — fatal, so recovery cannot resume a
-        // parse that exceeded its configured resource bound. The cap check is
-        // gated on the inlined `has_rule_depth_cap` load so uncapped parses
-        // (the default) skip the out-of-line depth accounting entirely.
+        // optional depth-cap probe stays inline-cheap (one `Option` check
+        // when unset) and its error, while absorbed by rule-level recovery
+        // like any rule failure, stays sticky until the top-level entry
+        // drains it — that pairing is what actually enforces the abort.
+        // Plain `if let` keeps generated output edition-2021 compatible.
         writeln!(
             out,
-            "        if self.base.has_rule_depth_cap()\n            \
-             && let Some(error) = self.base.rule_depth_limit_error()\n        \
-             {{\n            \
+            "        if let Some(error) = self.base.rule_depth_cap_violation() {{\n            \
              return Err(GeneratedRuleError::Fatal(error));\n        \
              }}\n        \
              if self.base.generated_rule_stack_check_due() {{\n            \
@@ -5848,9 +5847,11 @@ fn render_generated_step(
             {
                 // ATN-preferred child: route through `parse_rule_precedence_from_generated`.
                 // The rule's `parse_generated_rule` dispatch arm is guarded by
-                // `generated_only()`, so in normal mode the generated probe returns
-                // `None` and the wrapper parses the child on the INTERPRETED path
-                // (preserving the ATN-preferred optimization).
+                // `generated_only() || has_rule_depth_cap()`: in normal uncapped
+                // mode the generated probe returns `None` and the wrapper parses
+                // the child on the INTERPRETED path (preserving the ATN-preferred
+                // optimization); a configured depth cap flips it to the generated
+                // body, which is the only path that enforces the cap.
                 from_generated_call
             } else {
                 generated_child_call
@@ -6940,22 +6941,22 @@ fn render_generated_left_recursive_loop(
         )
         .expect("writing to a string cannot fail");
     }
+    // Each operator iteration deepens the tree without a rule frame; probe
+    // the depth cap BEFORE the expansion push so the boundary matches the
+    // dispatch site (which checks before its rule-frame push): frames and
+    // expansions are both admitted up to the cap, and token-only operator
+    // alternatives (no nested rule dispatch) still abort promptly instead of
+    // at the top-level drain.
+    writeln!(
+        out,
+        "{pad}            if let Some(__depth_error) = self.base.rule_depth_cap_violation() {{\n\
+         {pad}                return Err(__depth_error);\n\
+         {pad}            }}"
+    )
+    .expect("writing to a string cannot fail");
     writeln!(
         out,
         "{pad}            self.base.push_new_recursion_context_with_previous({entry_state}isize, {rule_index}, &mut __ctx);"
-    )
-    .expect("writing to a string cannot fail");
-    // Each operator iteration deepens the tree without a rule frame; check
-    // the depth cap here so token-only operator alternatives (no nested rule
-    // dispatch) still abort promptly instead of at the top-level drain. The
-    // inlined `has_rule_depth_cap` gate keeps uncapped loops branch-cheap.
-    writeln!(
-        out,
-        "{pad}            if self.base.has_rule_depth_cap()\n\
-         {pad}                && let Some(__depth_error) = self.base.rule_depth_limit_error()\n\
-         {pad}            {{\n\
-         {pad}                return Err(__depth_error);\n\
-         {pad}            }}"
     )
     .expect("writing to a string cannot fail");
     render_generated_steps(out, body, indent + 3, render_context);

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5224,10 +5224,15 @@ fn render_generated_rule_dispatch_with_rule_names(
         };
         // Rule nesting maps onto native call depth; sample remaining stack
         // capacity at the shared dispatch boundary so deeply nested input
-        // grows onto a segmented stack instead of aborting the process.
+        // grows onto a segmented stack instead of aborting the process. The
+        // optional depth cap aborts here — fatal, so recovery cannot resume a
+        // parse that exceeded its configured resource bound.
         writeln!(
             out,
-            "        if self.base.generated_rule_stack_check_due() {{\n            \
+            "        if let Some(error) = self.base.rule_depth_limit_error() {{\n            \
+             return Err(GeneratedRuleError::Fatal(error));\n        \
+             }}\n        \
+             if self.base.generated_rule_stack_check_due() {{\n            \
              antlr4_runtime::grow_generated_rule_stack(|| {target_call})\n        \
              }} else {{\n            {target_call}\n        }}"
         )
@@ -9790,6 +9795,12 @@ where
             if let Some(error) = self.base.take_unknown_semantic_error() {{
                 return Err(error);
             }}
+            // A depth-cap violation is a resource bound, not a syntax error:
+            // rule-level recovery may have produced a tree anyway, but the
+            // parse must still fail (and a reused parser must start clean).
+            if let Some(error) = self.base.take_rule_depth_error() {{
+                return Err(error);
+            }}
         }}
         Ok(__tree)
     }}
@@ -9862,6 +9873,8 @@ where
     fn set_report_diagnostic_errors(&mut self, report: bool) {{ self.base.set_report_diagnostic_errors(report); }}
     fn prediction_mode(&self) -> antlr4_runtime::PredictionMode {{ self.base.prediction_mode() }}
     fn set_prediction_mode(&mut self, mode: antlr4_runtime::PredictionMode) {{ self.base.set_prediction_mode(mode); }}
+    fn max_rule_depth(&self) -> Option<usize> {{ self.base.max_rule_depth() }}
+    fn set_max_rule_depth(&mut self, depth: Option<usize>) {{ self.base.set_max_rule_depth(depth); }}
 }}
 {generated_footer}"#
     ))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5767,13 +5767,16 @@ where
     /// Returns the positioned error to abort with when the configured
     /// rule-nesting depth cap is exceeded, or `None` to keep parsing.
     ///
-    /// Generated rule dispatch consults this before entering each rule body so
-    /// callers parsing untrusted input can bound CPU and tree memory
+    /// Generated rule dispatch consults this — gated on the inlined
+    /// [`Self::has_rule_depth_cap`] so uncapped parses pay one predictable
+    /// branch — before entering each rule body, letting callers parsing
+    /// untrusted input bound CPU and tree memory
     /// ([`Parser::set_max_rule_depth`]). The violation is sticky: rule-level
     /// recovery would otherwise absorb the error and keep spending the very
     /// resources the cap exists to bound, so every rule entry after the first
     /// violation fails until [`Self::take_rule_depth_error`] drains it at the
     /// top-level entry.
+    #[cold]
     pub fn rule_depth_limit_error(&mut self) -> Option<AntlrError> {
         if let Some(error) = &self.rule_depth_error {
             return Some(error.clone());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1135,6 +1135,21 @@ pub trait Parser: Recognizer {
 
     /// Sets the prediction strategy for subsequent rule calls.
     fn set_prediction_mode(&mut self, _mode: PredictionMode) {}
+
+    /// Maximum rule-nesting depth accepted before the parse aborts, or `None`
+    /// for unlimited (the default).
+    fn max_rule_depth(&self) -> Option<usize> {
+        None
+    }
+
+    /// Bounds the rule-nesting depth for subsequent rule calls.
+    ///
+    /// Deeply nested input is parsed safely regardless (rule recursion grows
+    /// onto a segmented stack), but each nesting level still costs CPU and
+    /// tree memory. Callers parsing untrusted input can cap that work: when
+    /// the limit is exceeded the parse stops with a positioned syntax error
+    /// instead of consuming unbounded resources.
+    fn set_max_rule_depth(&mut self, _depth: Option<usize>) {}
 }
 
 #[derive(Debug)]
@@ -1180,6 +1195,15 @@ pub struct BaseParser<S, H = NoSemanticHooks> {
     /// recovering (ANTLR's `BailErrorStrategy`). Generated recognizers set it
     /// through `set_error_handler(BailErrorStrategy::new())`.
     bail_on_error: bool,
+    /// Optional cap on rule-nesting depth for adversarial-input hardening.
+    /// `None` (default) parses unbounded nesting; `Some(n)` aborts the parse
+    /// with a positioned syntax error once `n` rule frames are exceeded.
+    max_rule_depth: Option<usize>,
+    /// Sticky depth-cap violation. Rule-level recovery would otherwise absorb
+    /// the error and keep parsing; once set, every subsequent rule entry fails
+    /// immediately and the top-level entry returns this error even when
+    /// recovery produced a tree.
+    rule_depth_error: Option<AntlrError>,
     /// How to evaluate predicate coordinates missing from the active
     /// predicate table. Set from [`ParserRuntimeOptions`] at each parse entry.
     unknown_predicate_policy: UnknownSemanticPolicy,
@@ -4793,6 +4817,8 @@ where
             precedence_stack: vec![0],
             invoked_predicates: Vec::new(),
             bail_on_error: false,
+            max_rule_depth: None,
+            rule_depth_error: None,
             unknown_predicate_policy: UnknownSemanticPolicy::default(),
             unknown_predicate_hits: Vec::new(),
             unhandled_action_hits: Vec::new(),
@@ -4852,6 +4878,7 @@ where
         self.decision_override_generation = 0;
         self.unknown_predicate_hits.clear();
         self.unhandled_action_hits.clear();
+        self.rule_depth_error = None;
         self.reset_per_parse_caches();
         self.fast_first_set_prefilter = true;
         self.fast_recovery_enabled = true;
@@ -5713,6 +5740,47 @@ where
         self.rule_context_stack
             .len()
             .is_multiple_of(GENERATED_RULE_STACK_CHECK_INTERVAL)
+    }
+
+    /// Returns the positioned error to abort with when the configured
+    /// rule-nesting depth cap is exceeded, or `None` to keep parsing.
+    ///
+    /// Generated rule dispatch consults this before entering each rule body so
+    /// callers parsing untrusted input can bound CPU and tree memory
+    /// ([`Parser::set_max_rule_depth`]). The violation is sticky: rule-level
+    /// recovery would otherwise absorb the error and keep spending the very
+    /// resources the cap exists to bound, so every rule entry after the first
+    /// violation fails until [`Self::take_rule_depth_error`] drains it at the
+    /// top-level entry.
+    pub fn rule_depth_limit_error(&mut self) -> Option<AntlrError> {
+        if let Some(error) = &self.rule_depth_error {
+            return Some(error.clone());
+        }
+        let max = self.max_rule_depth?;
+        if self.rule_context_stack.len() < max {
+            return None;
+        }
+        let (line, column) = self
+            .input
+            .lt(1)
+            .map_or((0, 0), |token| (token.line(), token.column()));
+        let error = AntlrError::ParserError {
+            line,
+            column,
+            message: format!("rule nesting depth limit of {max} exceeded"),
+        };
+        self.rule_depth_error = Some(error.clone());
+        Some(error)
+    }
+
+    /// Drains the sticky depth-cap violation recorded by
+    /// [`Self::rule_depth_limit_error`], if any.
+    ///
+    /// Generated top-level rule entries call this after recognition so a
+    /// recovered parse that crossed the cap still fails, and so a reused
+    /// parser starts its next parse clean.
+    pub const fn take_rule_depth_error(&mut self) -> Option<AntlrError> {
+        self.rule_depth_error.take()
     }
 
     /// Enters a generated parser rule and returns the context object the
@@ -12511,6 +12579,14 @@ where
 
     fn set_prediction_mode(&mut self, mode: PredictionMode) {
         self.prediction_mode = mode;
+    }
+
+    fn max_rule_depth(&self) -> Option<usize> {
+        self.max_rule_depth
+    }
+
+    fn set_max_rule_depth(&mut self, depth: Option<usize>) {
+        self.max_rule_depth = depth;
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -5765,27 +5765,39 @@ where
     }
 
     /// Returns the positioned error to abort with when the configured
-    /// rule-nesting depth cap is exceeded, or `None` to keep parsing.
+    /// rule-nesting depth cap would be exceeded by one more level, or `None`
+    /// to keep parsing.
     ///
-    /// Generated rule dispatch consults this — gated on the inlined
-    /// [`Self::has_rule_depth_cap`] so uncapped parses pay one predictable
-    /// branch — before entering each rule body, letting callers parsing
-    /// untrusted input bound CPU and tree memory
-    /// ([`Parser::set_max_rule_depth`]). The violation is sticky: rule-level
-    /// recovery would otherwise absorb the error and keep spending the very
-    /// resources the cap exists to bound, so every rule entry after the first
-    /// violation fails until [`Self::take_rule_depth_error`] drains it at the
-    /// top-level entry.
-    #[cold]
-    pub fn rule_depth_limit_error(&mut self) -> Option<AntlrError> {
-        if let Some(error) = &self.rule_depth_error {
-            return Some(error.clone());
-        }
+    /// Generated rule dispatch calls this before deepening — ahead of the
+    /// rule-frame push at the dispatch boundary and ahead of each
+    /// left-recursive expansion — letting callers parsing untrusted input
+    /// bound CPU and tree memory ([`Parser::set_max_rule_depth`]). The
+    /// inline fast path is one `Option` check when no cap is set (the
+    /// default) and one addition plus compare when one is; only an actual
+    /// violation leaves the inline path.
+    ///
+    /// The violation is sticky: rule-level recovery absorbs the returned
+    /// error like any other rule failure and would otherwise keep spending
+    /// the very resources the cap exists to bound, so every check after the
+    /// first violation fails until [`Self::take_rule_depth_error`] drains it
+    /// at the top-level entry.
+    #[inline]
+    pub fn rule_depth_cap_violation(&mut self) -> Option<AntlrError> {
         let max = self.max_rule_depth?;
         // Left-recursive operator iterations deepen the tree without pushing
         // a rule frame, so they count alongside the rule-context stack.
-        if self.rule_context_stack.len() + self.recursion_expansions < max {
+        if self.rule_depth_error.is_none()
+            && self.rule_context_stack.len() + self.recursion_expansions < max
+        {
             return None;
+        }
+        Some(self.rule_depth_cap_violation_cold(max))
+    }
+
+    #[cold]
+    fn rule_depth_cap_violation_cold(&mut self, max: usize) -> AntlrError {
+        if let Some(error) = &self.rule_depth_error {
+            return error.clone();
         }
         let (line, column) = self
             .input
@@ -5797,11 +5809,11 @@ where
             message: format!("rule nesting depth limit of {max} exceeded"),
         };
         self.rule_depth_error = Some(error.clone());
-        Some(error)
+        error
     }
 
     /// Drains the sticky depth-cap violation recorded by
-    /// [`Self::rule_depth_limit_error`], if any.
+    /// [`Self::rule_depth_cap_violation`], if any.
     ///
     /// Generated top-level rule entries call this after recognition so a
     /// recovered parse that crossed the cap still fails, and so a reused

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1148,7 +1148,15 @@ pub trait Parser: Recognizer {
     /// onto a segmented stack), but each nesting level still costs CPU and
     /// tree memory. Callers parsing untrusted input can cap that work: when
     /// the limit is exceeded the parse stops with a positioned syntax error
-    /// instead of consuming unbounded resources.
+    /// instead of consuming unbounded resources. The measure counts rule
+    /// frames plus left-recursive operator expansions, matching what an
+    /// upstream-ANTLR rule-entry listener observes.
+    ///
+    /// The cap is enforced by generated recursive-descent rule bodies. When
+    /// one is set, generated dispatch routes ATN-preferred rules through
+    /// their generated bodies too, trading that fast path for enforcement.
+    /// Rules the generator emitted no body for (interpreter-only fallback)
+    /// do not check the cap.
     fn set_max_rule_depth(&mut self, _depth: Option<usize>) {}
 }
 
@@ -1204,6 +1212,16 @@ pub struct BaseParser<S, H = NoSemanticHooks> {
     /// immediately and the top-level entry returns this error even when
     /// recovery produced a tree.
     rule_depth_error: Option<AntlrError>,
+    /// Left-recursive expansions currently deepening the parse tree. Each
+    /// operator iteration wraps the previous context one level deeper without
+    /// pushing a rule frame, so the depth cap must count these separately —
+    /// upstream ANTLR fires a rule-entry listener event for exactly this case
+    /// (`Parser.pushNewRecursionContext` → `triggerEnterRuleEvent`).
+    recursion_expansions: usize,
+    /// Per-invocation snapshots of [`Self::recursion_expansions`], pushed by
+    /// `enter_recursion_rule` and restored by `unroll_recursion_context`, so a
+    /// finished left-recursive rule releases the depth its expansions added.
+    recursion_expansion_marks: Vec<usize>,
     /// How to evaluate predicate coordinates missing from the active
     /// predicate table. Set from [`ParserRuntimeOptions`] at each parse entry.
     unknown_predicate_policy: UnknownSemanticPolicy,
@@ -4819,6 +4837,8 @@ where
             bail_on_error: false,
             max_rule_depth: None,
             rule_depth_error: None,
+            recursion_expansions: 0,
+            recursion_expansion_marks: Vec::new(),
             unknown_predicate_policy: UnknownSemanticPolicy::default(),
             unknown_predicate_hits: Vec::new(),
             unhandled_action_hits: Vec::new(),
@@ -4879,6 +4899,8 @@ where
         self.unknown_predicate_hits.clear();
         self.unhandled_action_hits.clear();
         self.rule_depth_error = None;
+        self.recursion_expansions = 0;
+        self.recursion_expansion_marks.clear();
         self.reset_per_parse_caches();
         self.fast_first_set_prefilter = true;
         self.fast_recovery_enabled = true;
@@ -5757,7 +5779,9 @@ where
             return Some(error.clone());
         }
         let max = self.max_rule_depth?;
-        if self.rule_context_stack.len() < max {
+        // Left-recursive operator iterations deepen the tree without pushing
+        // a rule frame, so they count alongside the rule-context stack.
+        if self.rule_context_stack.len() + self.recursion_expansions < max {
             return None;
         }
         let (line, column) = self
@@ -5781,6 +5805,17 @@ where
     /// parser starts its next parse clean.
     pub const fn take_rule_depth_error(&mut self) -> Option<AntlrError> {
         self.rule_depth_error.take()
+    }
+
+    /// Reports whether a rule-nesting depth cap is configured.
+    ///
+    /// Generated dispatch consults this when selecting between the guarded
+    /// recursive-descent body and the ATN-preferred interpreted fast path:
+    /// only the generated body enforces the cap, so a configured bound
+    /// overrides the performance preference.
+    #[must_use]
+    pub const fn has_rule_depth_cap(&self) -> bool {
+        self.max_rule_depth.is_some()
     }
 
     /// Enters a generated parser rule and returns the context object the
@@ -6013,6 +6048,8 @@ where
         precedence: i32,
     ) -> ParserRuleContext {
         self.precedence_stack.push(precedence);
+        self.recursion_expansion_marks
+            .push(self.recursion_expansions);
         self.enter_rule(state, rule_index)
     }
 
@@ -6023,6 +6060,9 @@ where
         rule_index: usize,
     ) -> ParserRuleContext {
         self.set_state(state);
+        // Counts toward the depth cap: upstream treats this as rule entry
+        // (`Parser.pushNewRecursionContext` fires `triggerEnterRuleEvent`).
+        self.recursion_expansions += 1;
         ParserRuleContext::new(rule_index, state)
     }
 
@@ -6035,6 +6075,10 @@ where
         current: &mut ParserRuleContext,
     ) {
         self.set_state(state);
+        // Counts toward the depth cap: each operator iteration deepens the
+        // parse tree one level without pushing a rule frame, and upstream
+        // fires a rule-entry listener event for it.
+        self.recursion_expansions += 1;
         if let Some(stop) = self
             .rule_stop_token_index(self.input.index(), false)
             .and_then(|index| self.token_id_at(index))
@@ -6058,6 +6102,9 @@ where
     pub fn unroll_recursion_context(&mut self) {
         if self.precedence_stack.len() > 1 {
             self.precedence_stack.pop();
+        }
+        if let Some(mark) = self.recursion_expansion_marks.pop() {
+            self.recursion_expansions = mark;
         }
         self.exit_rule();
     }

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1585,16 +1585,47 @@ fn deeply_nested_input_parses_without_native_stack_overflow() {
 mod deep_nesting_tests {
     use super::nest_lexer::NestLexer;
     use super::nest_parser::{parse, NestParser};
+    use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
+
+    fn nested(depth: usize) -> String {
+        format!("{}a{}", "[".repeat(depth), "]".repeat(depth))
+    }
 
     #[test]
     fn ten_thousand_levels_parse_on_the_default_test_stack() {
         // Rust test threads default to a 2 MiB stack; without segmented-stack
         // growth this depth aborted the process (issue #193).
-        let depth = 10_000;
-        let source = format!("{}a{}", "[".repeat(depth), "]".repeat(depth));
-        let parsed = parse(&source, NestLexer::new, NestParser::s)
+        let parsed = parse(&nested(10_000), NestLexer::new, NestParser::s)
             .expect("deeply nested input should parse");
         assert!(parsed.tree().as_rule().is_some());
+    }
+
+    #[test]
+    fn max_rule_depth_bounds_adversarial_nesting() {
+        // Callers parsing untrusted input can cap rule nesting (issue #198):
+        // shallow input parses, input past the cap fails with a positioned
+        // error even though rule-level recovery would produce a tree, and the
+        // violation does not leak into the parser's next parse.
+        let lexer = NestLexer::new(InputStream::new(&nested(4)));
+        let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+        parser.set_max_rule_depth(Some(64));
+        assert!(parser.s().is_ok(), "shallow input parses under the cap");
+
+        let lexer = NestLexer::new(InputStream::new(&nested(1_000)));
+        let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+        parser.set_max_rule_depth(Some(64));
+        let error = parser.s().expect_err("cap must reject deep nesting");
+        assert!(
+            error.to_string().contains("rule nesting depth limit of 64"),
+            "unexpected error: {error}"
+        );
+
+        let lexer = NestLexer::new(InputStream::new(&nested(4)));
+        parser.set_token_stream(CommonTokenStream::new(lexer));
+        assert!(
+            parser.s().is_ok(),
+            "reused parser starts clean after a depth violation"
+        );
     }
 }
 "#,

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1605,9 +1605,9 @@ mod deep_nesting_tests {
         // Callers parsing untrusted input can cap rule nesting (issue #198):
         // shallow input parses, input past the cap fails with a positioned
         // error even though rule-level recovery would produce a tree, and the
-        // violation does not leak into the parser's next parse. The grammar's
-        // 8-rule leading-call chain makes these rules ATN-preferred, so this
-        // also pins that a configured cap overrides the interpreted fast path.
+        // violation does not leak into the parser's next parse. (No Nest rule
+        // is ATN-preferred — the cap-overrides-ATN-preference guard is pinned
+        // by the generator's dispatch-rendering unit test.)
         let lexer = NestLexer::new(InputStream::new(&nested(4)));
         let mut parser = NestParser::new(CommonTokenStream::new(lexer));
         parser.set_max_rule_depth(Some(64));
@@ -1657,6 +1657,38 @@ mod deep_nesting_tests {
         let mut parser = NestParser::new(CommonTokenStream::new(lexer));
         parser.set_max_rule_depth(Some(64));
         assert!(parser.s().is_ok(), "short operator chain fits the cap");
+    }
+
+    #[test]
+    fn max_rule_depth_expansion_boundary_matches_frame_boundary() {
+        // The expansion check runs BEFORE the expansion push, mirroring the
+        // dispatch site's check before its rule-frame push: each extra
+        // operator costs exactly one depth level. Pin that alignment by
+        // finding the minimal cap admitting an N-operator chain and asserting
+        // one more operator needs exactly one more level.
+        fn parses_at(cap: usize, operators: usize) -> bool {
+            let chain = vec!["a"; operators + 1].join("+");
+            let lexer = NestLexer::new(InputStream::new(&chain));
+            let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+            parser.set_max_rule_depth(Some(cap));
+            parser.s().is_ok()
+        }
+
+        let minimal_cap = (1..128)
+            .find(|cap| parses_at(*cap, 4))
+            .expect("some cap admits a 4-operator chain");
+        assert!(
+            !parses_at(minimal_cap - 1, 4),
+            "minimal cap should be exact"
+        );
+        assert!(
+            !parses_at(minimal_cap, 5),
+            "one more operator must exceed the same cap"
+        );
+        assert!(
+            parses_at(minimal_cap + 1, 5),
+            "one more operator must need exactly one more level"
+        );
     }
 
     #[test]

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1605,7 +1605,9 @@ mod deep_nesting_tests {
         // Callers parsing untrusted input can cap rule nesting (issue #198):
         // shallow input parses, input past the cap fails with a positioned
         // error even though rule-level recovery would produce a tree, and the
-        // violation does not leak into the parser's next parse.
+        // violation does not leak into the parser's next parse. The grammar's
+        // 8-rule leading-call chain makes these rules ATN-preferred, so this
+        // also pins that a configured cap overrides the interpreted fast path.
         let lexer = NestLexer::new(InputStream::new(&nested(4)));
         let mut parser = NestParser::new(CommonTokenStream::new(lexer));
         parser.set_max_rule_depth(Some(64));
@@ -1625,6 +1627,61 @@ mod deep_nesting_tests {
         assert!(
             parser.s().is_ok(),
             "reused parser starts clean after a depth violation"
+        );
+    }
+
+    #[test]
+    fn max_rule_depth_counts_left_recursive_expansions() {
+        // `a+a+a+...` deepens the tree one level per operator without pushing
+        // a rule frame. Upstream ANTLR fires a rule-entry listener event for
+        // each expansion, so listener-based depth counters reject it — the
+        // cap must too, or a 2000-term chain builds a 2000-deep tree under
+        // any configured bound.
+        let chain = vec!["a"; 2_000].join("+");
+        let lexer = NestLexer::new(InputStream::new(&chain));
+        let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+        parser.set_max_rule_depth(Some(64));
+        let error = parser
+            .s()
+            .expect_err("operator expansions must count toward the cap");
+        assert!(
+            error.to_string().contains("rule nesting depth limit of 64"),
+            "unexpected error: {error}"
+        );
+
+        // The same chain parses when uncapped, and a short chain fits.
+        let lexer = NestLexer::new(InputStream::new(&chain));
+        let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+        assert!(parser.s().is_ok(), "uncapped operator chain parses");
+        let lexer = NestLexer::new(InputStream::new("a+a+a"));
+        let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+        parser.set_max_rule_depth(Some(64));
+        assert!(parser.s().is_ok(), "short operator chain fits the cap");
+    }
+
+    #[test]
+    fn depth_violation_survives_recovery_and_does_not_poison_reuse() {
+        // A violation absorbed by mid-tree recovery must still fail the parse
+        // (the resource bound was hit), the reported error must be the depth
+        // cap rather than a derived syntax error, and a second entry-rule
+        // call on the same parser instance must not inherit the violation.
+        let source = format!("{}a", "[".repeat(200));
+        let lexer = NestLexer::new(InputStream::new(&source));
+        let mut parser = NestParser::new(CommonTokenStream::new(lexer));
+        parser.set_max_rule_depth(Some(64));
+        let error = parser
+            .s()
+            .expect_err("depth violation must fail the parse even after recovery");
+        assert!(
+            error.to_string().contains("rule nesting depth limit of 64"),
+            "depth cap must win over derived syntax errors: {error}"
+        );
+
+        let lexer = NestLexer::new(InputStream::new("a"));
+        parser.set_token_stream(CommonTokenStream::new(lexer));
+        assert!(
+            parser.expr().is_ok(),
+            "a different entry rule on the same instance starts clean"
         );
     }
 }

--- a/tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4
+++ b/tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4
@@ -1,7 +1,9 @@
 // Mirrors the failure shape from issue #193: an expression grammar whose rule
 // chain multiplies input nesting into native call depth (CEL walks nine rules
 // per `[`). Deeply nested input must parse without exhausting the native
-// stack.
+// stack. The chain is deliberately 8+ rules long so the ATN-preferred
+// classifier fires (issue #198: the depth cap must hold on that path too),
+// and `expr` is left-recursive so operator expansions count toward the cap.
 grammar Nest;
 
 s
@@ -9,7 +11,8 @@ s
     ;
 
 expr
-    : disjunction
+    : expr '+' expr
+    | disjunction
     ;
 
 disjunction
@@ -17,7 +20,11 @@ disjunction
     ;
 
 conjunction
-    : relation ('&&' relation)*
+    : equality ('&&' equality)*
+    ;
+
+equality
+    : relation ('==' relation)*
     ;
 
 relation

--- a/tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4
+++ b/tests/fixtures/antlr4-rust-gen/deep-nesting/Nest.g4
@@ -1,9 +1,12 @@
 // Mirrors the failure shape from issue #193: an expression grammar whose rule
 // chain multiplies input nesting into native call depth (CEL walks nine rules
 // per `[`). Deeply nested input must parse without exhausting the native
-// stack. The chain is deliberately 8+ rules long so the ATN-preferred
-// classifier fires (issue #198: the depth cap must hold on that path too),
-// and `expr` is left-recursive so operator expansions count toward the cap.
+// stack. `expr` is left-recursive so operator expansions count toward the
+// depth cap (issue #198). The chain does NOT make any rule ATN-preferred —
+// every decision here has an LL(1) fast path, so the classifier's
+// decision-cost gate never fires; the cap-overrides-ATN-preference dispatch
+// guard is pinned by the generator unit test
+// `renders_atn_preferred_dispatch_only_for_generated_only_mode` instead.
 grammar Nest;
 
 s


### PR DESCRIPTION
Fixes #198. Stacked on #194 (contains its commits; the depth cap builds on the same dispatch boundary the stack guard added).

## What

`Parser::set_max_rule_depth(Option<usize>)` — default `None` (unlimited). When set, generated rule dispatch aborts at the first rule entry past the cap with a positioned error:

```
parser error at 1:20: rule nesting depth limit of 200 exceeded
```

The violation is **sticky**: rule-level recovery would otherwise absorb the error and keep spending exactly the resources the cap exists to bound. Every subsequent rule entry fails immediately, the generated top-level entry drains the recorded violation and fails the parse even when recovery produced a tree, and `reset()`/`set_token_stream()` clear it so a reused parser starts clean.

## Why

After #193 deeply nested input no longer crashes — but it still costs unbounded CPU and tree memory. Consumers parsing attacker-supplied input need a parse-time bound: cel-rust (the `cel` crate, CEL policy engines) enforces depth 96 via an ANTLR parse listener (`RecursionListener`), an API we don't have. This gives its port a first-class replacement, checked at the same dispatch boundary as the stack guard (zero new state reads on the hot path when unset — one `Option` branch).

## Verification

- e2e (deep-nesting fixture): shallow input parses under the cap; depth-1000 input against cap 64 fails with the positioned message **even though recovery would produce a tree**; the same parser instance then parses clean input fine.
- Uncapped behavior unchanged: 10k/20k nesting still parses (#193 test still green).
- `cargo test --locked` all green; clippy `-D warnings` all-targets all-features clean.
- Conformance sweep: running, will report in a comment (no descriptor sets a cap, so 357/357 expected — the unset path is one `None` check).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable maximum rule-nesting depth for generated parsers via `max_rule_depth` / `set_max_rule_depth`.
  * Depth cap enforcement is improved across generated rule dispatch, including left-recursive operator expansions.
* **Bug Fixes**
  * Rule-depth violations now trigger early, prompt failures inside operator loops and are prioritized over other errors, including during/after recovery.
  * Parser instances now reliably clear stale depth-cap violations between parses.
* **Tests**
  * Expanded deep-nesting and recursive expression coverage, including parser reuse and cap boundary checks.
* **Documentation**
  * Updated the deep-nesting fixture grammar to better reflect depth-cap scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->