### PR TITLE
perf(prediction): memoize full-context LL resolutions by interned caller context

### DIFF
--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -70,6 +70,12 @@ struct CachedOuterContext {
 ///
 /// The first window token joins the key so a probe is one hash lookup in
 /// the common case (distinct keyword per resolution) instead of a scan.
+///
+/// `outer_context` is the interned FULL caller stack, which bounds the hit
+/// rate: the same construct at rule-nesting depth 3 and depth 4 has
+/// different `ContextId`s and misses. Flat-ish grammars (Avro IDL: ~155
+/// unique contexts against 2,100 retries) hit almost always; deeply
+/// recursive grammars re-derive once per distinct nesting shape.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 struct FullContextMemoKey {
     decision: usize,
@@ -1225,7 +1231,7 @@ impl<'a> ParserAtnSimulator<'a> {
     ) {
         if self.full_context_memo_len >= FULL_CONTEXT_MEMO_MAX_ENTRIES {
             #[cfg(feature = "perf-counters")]
-            crate::perf::record_full_context_memo_declined();
+            crate::perf::record_full_context_memo_declined(key.decision);
             return;
         }
         let current = input.index();
@@ -1242,7 +1248,7 @@ impl<'a> ParserAtnSimulator<'a> {
         input.seek(current);
         if !complete {
             #[cfg(feature = "perf-counters")]
-            crate::perf::record_full_context_memo_declined();
+            crate::perf::record_full_context_memo_declined(key.decision);
             return;
         }
         self.full_context_memo

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -41,10 +41,13 @@ pub struct ParserAtnSimulator<'a> {
     /// Memoized full-context resolutions. Upstream re-runs the LL simulation
     /// on every visit to a `requires_full_context` DFA state; grammars with
     /// keyword/identifier-style true ambiguities (Avro IDL's `nullableType`,
-    /// SQL non-reserved keywords) pay that on every occurrence. The LL result
-    /// is a pure function of the decision, precedence, interned caller
-    /// context, and the token window the loop read, so identical occurrences
-    /// replay the recorded resolution.
+    /// SQL non-reserved keywords) pay that on every occurrence. Under the
+    /// memo gate — no predicate transitions in the ATN — the LL result is a
+    /// pure function of the decision, precedence, interned caller context,
+    /// and the token window the loop read, so identical occurrences replay
+    /// the recorded resolution. The gate carries that purity claim: general
+    /// ANTLR full-context closure can also consult parser state through
+    /// `predTransition`, which is exactly what the gate excludes.
     full_context_memo: HashMap<
         FullContextMemoKey,
         Vec<FullContextMemoEntry>,
@@ -81,6 +84,10 @@ struct FullContextMemoKey {
 /// after the keyed first symbol, so a hit replays only when the upcoming
 /// input matches token-for-token — identical decision + precedence +
 /// interned caller context + read window is literally the same computation.
+///
+/// `prediction.stop_index` holds the RECORDING run's absolute index and is
+/// stale for any other occurrence — the probe unconditionally overwrites it
+/// from the live cursor before returning a replay. Do not read it directly.
 #[derive(Clone, Debug)]
 struct FullContextMemoEntry {
     window_tail: Vec<i32>,
@@ -95,6 +102,33 @@ const FULL_CONTEXT_MEMO_MAX_WINDOW: usize = 16;
 /// real grammars produce a few hundred; the bound only guards adversarial
 /// context churn.
 const FULL_CONTEXT_MEMO_MAX_ENTRIES: usize = 4096;
+
+/// ATN-static memo gate, cached per thread by ATN identity.
+///
+/// The gate is a property of the ATN alone, but generated parsers build a
+/// simulator per parser instance, so a per-simulator cache would rescan the
+/// ATN on the first LL retry of every parse — pure cost for grammars the
+/// gate turns off. Keyed like `SHARED_PREDICTION_STORES`.
+fn atn_has_predicate_transition(atn: &Atn) -> bool {
+    thread_local! {
+        static GATES: RefCell<HashMap<usize, bool, BuildHasherDefault<PredictionFxHasher>>> =
+            RefCell::new(HashMap::default());
+    }
+    let ptr: *const Atn = atn;
+    let key = ptr as usize;
+    GATES.with(|gates| {
+        *gates.borrow_mut().entry(key).or_insert_with(|| {
+            (0..atn.state_count()).any(|state_number| {
+                atn.state(state_number).is_some_and(|state| {
+                    state
+                        .transitions()
+                        .into_iter()
+                        .any(|transition| transition.kind() == ParserTransitionKind::Predicate)
+                })
+            })
+        })
+    })
+}
 
 #[derive(Debug, Default)]
 struct PredictionStore {
@@ -1108,21 +1142,27 @@ impl<'a> ParserAtnSimulator<'a> {
     /// Whether full-context memoization is sound for this ATN.
     ///
     /// Predicates make prediction outcomes depend on caller-side evaluation
-    /// state, so any semantic transition disables the memo. Exact-ambiguity
-    /// detection changes how far the LL loop consumes, so entries recorded
-    /// under one mode must not replay under the other — rather than key the
-    /// mode, the memo simply stays off in the diagnostic mode.
+    /// state, so any predicate transition disables the memo. Action and
+    /// precedence transitions do NOT: upstream `ActionTransition.isEpsilon()`
+    /// is true ("we are to be ignored by analysis 'cept for predicates") and
+    /// never contributes to an LL outcome, and a precedence transition in
+    /// full-context mode resolves immediately against the passed precedence
+    /// (see the `!full_context` guard in `epsilon_target_config`) — which is
+    /// already part of the memo key. Gating on all semantic transitions would
+    /// turn the memo off for every grammar with a left-recursive rule.
+    ///
+    /// Exact-ambiguity detection changes how far the LL loop consumes, so
+    /// entries recorded under one mode must not replay under the other —
+    /// rather than key the mode, the memo simply stays off in the diagnostic
+    /// mode.
     fn full_context_memo_allowed(&mut self) -> bool {
         if self.exact_ambig_detection {
             return false;
         }
         let atn = self.atn;
-        *self.full_context_memo_gate.get_or_insert_with(|| {
-            !(0..atn.state_count()).any(|state_number| {
-                atn.state(state_number)
-                    .is_some_and(AtnState::has_semantic_transition)
-            })
-        })
+        *self
+            .full_context_memo_gate
+            .get_or_insert_with(|| !atn_has_predicate_transition(atn))
     }
 
     /// Returns the memoized LL resolution whose recorded token window matches
@@ -1146,8 +1186,15 @@ impl<'a> ParserAtnSimulator<'a> {
         let start_index = input.index();
         key.first_symbol = input.la(1);
         let entries = self.full_context_memo.get(&key)?;
-        // Entries share a slot only on true first-symbol collisions, so this
-        // scan is almost always a single candidate.
+        // For the keyword-vs-identifier ambiguity shape, occurrences of the
+        // same keyword share `first_symbol`, so a hot decision's entries can
+        // funnel into one bucket — distinguished only by their windows. The
+        // scan is first-match-wins, which is correct because windows under a
+        // key are prefix-free: the LL loop's stop position is a function of
+        // key + consumed prefix, so no recorded window can be a strict prefix
+        // of another. Each rejected candidate costs its matched-prefix length
+        // in `consume`/`la` calls before the cursor restore; the global entry
+        // cap bounds the worst case.
         'candidates: for entry in entries {
             for &expected in &entry.window_tail {
                 input.consume();
@@ -1177,6 +1224,8 @@ impl<'a> ParserAtnSimulator<'a> {
         full_context: &FullContextPrediction,
     ) {
         if self.full_context_memo_len >= FULL_CONTEXT_MEMO_MAX_ENTRIES {
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_full_context_memo_declined();
             return;
         }
         let current = input.index();
@@ -1192,6 +1241,8 @@ impl<'a> ParserAtnSimulator<'a> {
         let complete = input.index() >= full_context.stop_index;
         input.seek(current);
         if !complete {
+            #[cfg(feature = "perf-counters")]
+            crate::perf::record_full_context_memo_declined();
             return;
         }
         self.full_context_memo
@@ -2409,6 +2460,54 @@ mod tests {
     }
 
     #[test]
+    fn full_context_memo_walks_multi_token_windows() {
+        let atn = ambiguous_three_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+
+        // Fresh LL run consumes the three-token window before resolving; the
+        // recorded entry carries a non-empty window tail.
+        let mut input = VecIntStream::new(vec![1, 2, 3, TOKEN_EOF]);
+        let fresh = simulator
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, EMPTY_CONTEXT)
+            .expect("fresh prediction");
+        assert_eq!(simulator.full_context_memo_len, 1);
+        let recorded_window_len = simulator
+            .full_context_memo
+            .values()
+            .next()
+            .and_then(|entries| entries.first())
+            .map(|entry| entry.window_tail.len())
+            .expect("one recorded entry");
+        assert!(
+            recorded_window_len >= 1,
+            "the LL loop consumed tokens, so the window tail must be non-empty"
+        );
+
+        // Identical occurrence replays through the token-for-token compare,
+        // byte-identical (stop_index recomputed from the live cursor).
+        let replayed = simulator
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, EMPTY_CONTEXT)
+            .expect("memoized prediction");
+        assert_eq!(replayed, fresh);
+        assert_eq!(input.index(), 0, "cursor restored by the caller wrapper");
+
+        // Same first symbol, diverging mid-window: the compare must reject
+        // the entry and restore the cursor to the decision start before the
+        // fresh LL run happens. Token 9 has no viable alternative, so a
+        // (wrong) replay would have returned Ok — the Err proves the miss;
+        // the memo also records nothing for the failed occurrence.
+        let mut diverging = VecIntStream::new(vec![1, 9, 9, TOKEN_EOF]);
+        let result = simulator.adaptive_predict_stream_info_with_context(
+            0,
+            0,
+            &mut diverging,
+            EMPTY_CONTEXT,
+        );
+        assert!(result.is_err(), "mid-window divergence must not replay");
+        assert_eq!(simulator.full_context_memo_len, 1);
+    }
+
+    #[test]
     fn full_context_memo_stays_off_for_predicated_atns_and_exact_mode() {
         // Exact-ambiguity detection changes how far the LL loop consumes, so
         // the memo must not record or replay in that mode.
@@ -2443,6 +2542,44 @@ mod tests {
         let atn = finish_atn(atn);
         let mut simulator = ParserAtnSimulator::new(&atn);
         assert!(!simulator.full_context_memo_allowed());
+    }
+
+    #[test]
+    fn full_context_memo_allows_action_and_precedence_transitions() {
+        // Actions never affect prediction (upstream ActionTransition is
+        // epsilon for analysis), and precedence transitions resolve against
+        // the precedence already in the memo key — neither disables the memo.
+        // Gating on them would turn the memo off for every grammar with a
+        // left-recursive rule.
+        let mut atn = ParserAtnBuilder::new(1);
+        add_state(&mut atn, 0, AtnStateKind::Basic);
+        add_state(&mut atn, 1, AtnStateKind::Basic);
+        add_state(&mut atn, 2, AtnStateKind::Basic);
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Action {
+                target: 1,
+                rule_index: 0,
+                action_index: Some(0),
+                context_dependent: false,
+            },
+        )
+        .expect("transition");
+        atn.add_transition(
+            1,
+            ParserTransitionSpec::Precedence {
+                target: 2,
+                precedence: 1,
+            },
+        )
+        .expect("transition");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![2])
+            .expect("rule stop states");
+        let atn = finish_atn(atn);
+        let mut simulator = ParserAtnSimulator::new(&atn);
+        assert!(simulator.full_context_memo_allowed());
     }
 
     #[test]
@@ -2939,6 +3076,57 @@ mod tests {
             },
         )
         .expect("transition");
+        finish_atn(atn)
+    }
+
+    /// `s : A B C | A B C ;` — both alternatives match the same THREE-token
+    /// sequence, so the SLL conflict's full-context retry consumes multiple
+    /// tokens before resolving, exercising the memo's window walk (record and
+    /// probe) rather than the empty-window fast case.
+    fn ambiguous_three_token_decision_atn() -> Atn {
+        let mut atn = ParserAtnBuilder::new(3);
+        add_state(&mut atn, 0, AtnStateKind::RuleStart);
+        add_state(&mut atn, 1, AtnStateKind::BlockStart);
+        // Alternative 1: states 2 -A-> 3 -B-> 4 -C-> 5
+        add_state(&mut atn, 2, AtnStateKind::Basic);
+        add_state(&mut atn, 3, AtnStateKind::Basic);
+        add_state(&mut atn, 4, AtnStateKind::Basic);
+        add_state(&mut atn, 5, AtnStateKind::Basic);
+        // Alternative 2: states 6 -A-> 7 -B-> 8 -C-> 9
+        add_state(&mut atn, 6, AtnStateKind::Basic);
+        add_state(&mut atn, 7, AtnStateKind::Basic);
+        add_state(&mut atn, 8, AtnStateKind::Basic);
+        add_state(&mut atn, 9, AtnStateKind::Basic);
+        add_state(&mut atn, 10, AtnStateKind::BlockEnd);
+        add_state(&mut atn, 11, AtnStateKind::RuleStop);
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![11])
+            .expect("rule stop states");
+        atn.add_decision_state(1).expect("decision state");
+        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
+            .expect("transition");
+        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 6 })
+            .expect("transition");
+        for (source, target, label) in [
+            (2, 3, 1),
+            (3, 4, 2),
+            (4, 5, 3),
+            (6, 7, 1),
+            (7, 8, 2),
+            (8, 9, 3),
+        ] {
+            atn.add_transition(source, ParserTransitionSpec::Atom { target, label })
+                .expect("transition");
+        }
+        atn.add_transition(5, ParserTransitionSpec::Epsilon { target: 10 })
+            .expect("transition");
+        atn.add_transition(9, ParserTransitionSpec::Epsilon { target: 10 })
+            .expect("transition");
+        atn.add_transition(10, ParserTransitionSpec::Epsilon { target: 11 })
+            .expect("transition");
         finish_atn(atn)
     }
 

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -38,6 +38,23 @@ pub struct ParserAtnSimulator<'a> {
     /// consuming past "resolves to one viable alt" conflicts until every
     /// `(state, context)` subset conflicts over the same alt set.
     exact_ambig_detection: bool,
+    /// Memoized full-context resolutions. Upstream re-runs the LL simulation
+    /// on every visit to a `requires_full_context` DFA state; grammars with
+    /// keyword/identifier-style true ambiguities (Avro IDL's `nullableType`,
+    /// SQL non-reserved keywords) pay that on every occurrence. The LL result
+    /// is a pure function of the decision, precedence, interned caller
+    /// context, and the token window the loop read, so identical occurrences
+    /// replay the recorded resolution.
+    full_context_memo: HashMap<
+        FullContextMemoKey,
+        Vec<FullContextMemoEntry>,
+        BuildHasherDefault<PredictionFxHasher>,
+    >,
+    full_context_memo_len: usize,
+    /// Whether the memo is sound for this ATN: predicates make prediction
+    /// outcomes depend on caller-side evaluation, so any semantic transition
+    /// disables memoization entirely. Computed lazily on first retry.
+    full_context_memo_gate: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -45,6 +62,39 @@ struct CachedOuterContext {
     rule_context_version: usize,
     context: ContextId,
 }
+
+/// Lookup key for one memoized full-context resolution.
+///
+/// The first window token joins the key so a probe is one hash lookup in
+/// the common case (distinct keyword per resolution) instead of a scan.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct FullContextMemoKey {
+    decision: usize,
+    precedence: i32,
+    outer_context: ContextId,
+    first_symbol: i32,
+}
+
+/// One memoized full-context resolution.
+///
+/// `window_tail` is the visible-token sequence the recorded LL loop read
+/// after the keyed first symbol, so a hit replays only when the upcoming
+/// input matches token-for-token — identical decision + precedence +
+/// interned caller context + read window is literally the same computation.
+#[derive(Clone, Debug)]
+struct FullContextMemoEntry {
+    window_tail: Vec<i32>,
+    prediction: FullContextPrediction,
+}
+
+/// Memoized windows above this many visible tokens are not recorded: long
+/// ambiguous prefixes are rare, and verifying a hit costs a token compare
+/// per window token.
+const FULL_CONTEXT_MEMO_MAX_WINDOW: usize = 16;
+/// Total memo entries per simulator. Contexts are interned per parse and
+/// real grammars produce a few hundred; the bound only guards adversarial
+/// context churn.
+const FULL_CONTEXT_MEMO_MAX_ENTRIES: usize = 4096;
 
 #[derive(Debug, Default)]
 struct PredictionStore {
@@ -442,6 +492,9 @@ impl<'a> ParserAtnSimulator<'a> {
             shared_cache_key: None,
             shared_cache_generation: 0,
             exact_ambig_detection: false,
+            full_context_memo: HashMap::default(),
+            full_context_memo_len: 0,
+            full_context_memo_gate: None,
         }
     }
 
@@ -458,6 +511,10 @@ impl<'a> ParserAtnSimulator<'a> {
     /// an overlapping stale simulator cannot republish pre-clear states later.
     pub fn clear_dfa(&mut self) {
         self.store = PredictionStore::new(self.atn);
+        // The memo keys entries by ContextId into the store's arena the
+        // line above just replaced; stale IDs would alias fresh contexts.
+        self.full_context_memo.clear();
+        self.full_context_memo_len = 0;
         self.reset();
         if let Some(key) = self.shared_cache_key {
             self.shared_cache_generation = clear_shared_prediction_store(key);
@@ -565,6 +622,9 @@ impl<'a> ParserAtnSimulator<'a> {
             shared_cache_key: Some(key),
             shared_cache_generation: generation,
             exact_ambig_detection: false,
+            full_context_memo: HashMap::default(),
+            full_context_memo_len: 0,
+            full_context_memo_gate: None,
         }
     }
 
@@ -966,6 +1026,27 @@ impl<'a> ParserAtnSimulator<'a> {
             crate::perf::record_full_context_retry(decision);
             let sll_stop_index = input.index();
             input.seek(start_index);
+            let memo_allowed = self.full_context_memo_allowed();
+            let memo_key = FullContextMemoKey {
+                decision,
+                precedence,
+                outer_context,
+                first_symbol: 0,
+            };
+            // A memo hit leaves the cursor at the replayed stop index —
+            // exactly where the fresh LL loop below would have left it.
+            if memo_allowed
+                && let Some(full_context) = self.probe_full_context_memo(memo_key, input)
+            {
+                #[cfg(feature = "perf-counters")]
+                crate::perf::record_full_context_memo_hit(decision);
+                return Ok(Some(Self::full_context_retry_prediction(
+                    full_context,
+                    info.conflicting_alts,
+                    start_index,
+                    sll_stop_index,
+                )));
+            }
             let full_context = self.adaptive_predict_full_context(
                 decision_state,
                 input,
@@ -973,35 +1054,154 @@ impl<'a> ParserAtnSimulator<'a> {
                 outer_context,
                 merge_cache,
             )?;
-            let (kind, exact, conflicting_alts) = match full_context.resolution {
-                FullContextResolution::Ambiguous { exact, ref alts } => (
-                    ParserAtnPredictionDiagnosticKind::Ambiguity,
-                    exact,
-                    alts.clone(),
-                ),
-                // A unique full-context alt after an SLL conflict is Java's
-                // reportContextSensitivity; the SLL state's conflicting alts
-                // describe the conflict that forced the retry.
-                FullContextResolution::Unique => (
-                    ParserAtnPredictionDiagnosticKind::ContextSensitivity,
-                    false,
-                    info.conflicting_alts,
-                ),
-            };
-            let mut prediction = full_context.prediction;
-            if conflicting_alts.len() > 1 {
-                prediction.diagnostic = Some(ParserAtnPredictionDiagnostic {
-                    kind,
-                    start_index,
-                    sll_stop_index,
-                    ll_stop_index: full_context.stop_index,
-                    conflicting_alts,
-                    exact,
-                });
+            if memo_allowed {
+                self.record_full_context_memo(memo_key, start_index, input, &full_context);
             }
-            return Ok(Some(prediction));
+            return Ok(Some(Self::full_context_retry_prediction(
+                full_context,
+                info.conflicting_alts,
+                start_index,
+                sll_stop_index,
+            )));
         }
         Ok(Some(prediction))
+    }
+
+    /// Builds the prediction (and diagnostic) a full-context retry reports,
+    /// shared by the fresh LL run and the memoized replay so both produce
+    /// byte-identical diagnostics.
+    fn full_context_retry_prediction(
+        full_context: FullContextPrediction,
+        sll_conflicting_alts: Vec<usize>,
+        start_index: usize,
+        sll_stop_index: usize,
+    ) -> ParserAtnPrediction {
+        let (kind, exact, conflicting_alts) = match full_context.resolution {
+            FullContextResolution::Ambiguous { exact, ref alts } => (
+                ParserAtnPredictionDiagnosticKind::Ambiguity,
+                exact,
+                alts.clone(),
+            ),
+            // A unique full-context alt after an SLL conflict is Java's
+            // reportContextSensitivity; the SLL state's conflicting alts
+            // describe the conflict that forced the retry.
+            FullContextResolution::Unique => (
+                ParserAtnPredictionDiagnosticKind::ContextSensitivity,
+                false,
+                sll_conflicting_alts,
+            ),
+        };
+        let mut prediction = full_context.prediction;
+        if conflicting_alts.len() > 1 {
+            prediction.diagnostic = Some(ParserAtnPredictionDiagnostic {
+                kind,
+                start_index,
+                sll_stop_index,
+                ll_stop_index: full_context.stop_index,
+                conflicting_alts,
+                exact,
+            });
+        }
+        prediction
+    }
+
+    /// Whether full-context memoization is sound for this ATN.
+    ///
+    /// Predicates make prediction outcomes depend on caller-side evaluation
+    /// state, so any semantic transition disables the memo. Exact-ambiguity
+    /// detection changes how far the LL loop consumes, so entries recorded
+    /// under one mode must not replay under the other — rather than key the
+    /// mode, the memo simply stays off in the diagnostic mode.
+    fn full_context_memo_allowed(&mut self) -> bool {
+        if self.exact_ambig_detection {
+            return false;
+        }
+        let atn = self.atn;
+        *self.full_context_memo_gate.get_or_insert_with(|| {
+            !(0..atn.state_count()).any(|state_number| {
+                atn.state(state_number)
+                    .is_some_and(AtnState::has_semantic_transition)
+            })
+        })
+    }
+
+    /// Returns the memoized LL resolution whose recorded token window matches
+    /// the upcoming input exactly, if any. The caller must have positioned
+    /// `input` at the decision's start index.
+    ///
+    /// The compare walks the stream exactly as the recorded LL loop did
+    /// (`la(1)` at each cursor position, `consume` between), so a hit is
+    /// literally the same computation replayed: same decision, precedence,
+    /// interned caller context, and token sequence. On a hit the cursor is
+    /// left at the replayed stop index — where the fresh LL loop would have
+    /// left it; on a miss it is restored to the start.
+    fn probe_full_context_memo<T: IntStream>(
+        &self,
+        mut key: FullContextMemoKey,
+        input: &mut T,
+    ) -> Option<FullContextPrediction> {
+        if self.full_context_memo.is_empty() {
+            return None;
+        }
+        let start_index = input.index();
+        key.first_symbol = input.la(1);
+        let entries = self.full_context_memo.get(&key)?;
+        // Entries share a slot only on true first-symbol collisions, so this
+        // scan is almost always a single candidate.
+        'candidates: for entry in entries {
+            for &expected in &entry.window_tail {
+                input.consume();
+                if input.la(1) != expected {
+                    input.seek(start_index);
+                    continue 'candidates;
+                }
+            }
+            let mut replay = entry.prediction.clone();
+            replay.stop_index = input.index();
+            return Some(replay);
+        }
+        None
+    }
+
+    /// Records a fresh full-context resolution for later replay.
+    ///
+    /// The recorded window re-walks the visible tokens the LL loop read
+    /// (`start_index..=stop_index` in cursor positions); windows longer than
+    /// [`FULL_CONTEXT_MEMO_MAX_WINDOW`] are skipped, as is everything once
+    /// the memo holds [`FULL_CONTEXT_MEMO_MAX_ENTRIES`].
+    fn record_full_context_memo<T: IntStream>(
+        &mut self,
+        mut key: FullContextMemoKey,
+        start_index: usize,
+        input: &mut T,
+        full_context: &FullContextPrediction,
+    ) {
+        if self.full_context_memo_len >= FULL_CONTEXT_MEMO_MAX_ENTRIES {
+            return;
+        }
+        let current = input.index();
+        input.seek(start_index);
+        key.first_symbol = input.la(1);
+        let mut window_tail = Vec::new();
+        while input.index() < full_context.stop_index
+            && window_tail.len() < FULL_CONTEXT_MEMO_MAX_WINDOW
+        {
+            input.consume();
+            window_tail.push(input.la(1));
+        }
+        let complete = input.index() >= full_context.stop_index;
+        input.seek(current);
+        if !complete {
+            return;
+        }
+        self.full_context_memo
+            .entry(key)
+            .or_default()
+            .push(FullContextMemoEntry {
+                window_tail,
+                prediction: full_context.clone(),
+            });
+        self.full_context_memo_len += 1;
     }
 
     fn non_greedy_exit_prediction(
@@ -2157,6 +2357,92 @@ mod tests {
             prediction
         );
         assert_eq!(input.index(), 0);
+    }
+
+    #[test]
+    fn full_context_memo_replays_identical_retries() {
+        let atn = ambiguous_single_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+
+        // First occurrence: SLL conflicts, the LL loop runs and its
+        // resolution is recorded.
+        let mut input = VecIntStream::new(vec![1, TOKEN_EOF]);
+        let fresh = simulator
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, EMPTY_CONTEXT)
+            .expect("fresh prediction");
+        assert_eq!(simulator.full_context_memo_len, 1);
+        assert_eq!(input.index(), 0, "cursor restored after prediction");
+
+        // Second identical occurrence: the memo replays without running the
+        // LL loop, producing a byte-identical prediction (diagnostic
+        // included) and identical cursor behavior.
+        let replayed = simulator
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, EMPTY_CONTEXT)
+            .expect("memoized prediction");
+        assert_eq!(replayed, fresh);
+        assert_eq!(simulator.full_context_memo_len, 1, "no duplicate entry");
+        assert_eq!(input.index(), 0);
+
+        // A different upcoming token sequence misses the memo: a fresh LL
+        // run happens (and records its own entry) instead of a stale replay.
+        let mut other_input = VecIntStream::new(vec![2, TOKEN_EOF]);
+        let other = simulator.adaptive_predict_stream_info_with_context(
+            0,
+            0,
+            &mut other_input,
+            EMPTY_CONTEXT,
+        );
+        // Token 2 has no viable alternative in this ATN — the memo must not
+        // have answered for it.
+        assert!(other.is_err(), "different window must not replay");
+
+        // A different outer context misses the memo as well.
+        let context = simulator.store.contexts.singleton(EMPTY_CONTEXT, 6);
+        let mut input = VecIntStream::new(vec![1, TOKEN_EOF]);
+        let _ = simulator
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, context)
+            .expect("prediction under a different context");
+        assert_eq!(
+            simulator.full_context_memo_len, 2,
+            "distinct context records its own entry"
+        );
+    }
+
+    #[test]
+    fn full_context_memo_stays_off_for_predicated_atns_and_exact_mode() {
+        // Exact-ambiguity detection changes how far the LL loop consumes, so
+        // the memo must not record or replay in that mode.
+        let atn = ambiguous_single_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+        simulator.set_exact_ambig_detection(true);
+        let mut input = VecIntStream::new(vec![1, TOKEN_EOF]);
+        let _ = simulator
+            .adaptive_predict_stream_info_with_context(0, 0, &mut input, EMPTY_CONTEXT)
+            .expect("prediction");
+        assert_eq!(simulator.full_context_memo_len, 0);
+
+        // Predicates make outcomes depend on caller-side evaluation: any
+        // semantic transition in the ATN disables the memo entirely.
+        let mut atn = ParserAtnBuilder::new(1);
+        add_state(&mut atn, 0, AtnStateKind::Basic);
+        add_state(&mut atn, 1, AtnStateKind::Basic);
+        atn.add_transition(
+            0,
+            ParserTransitionSpec::Predicate {
+                target: 1,
+                rule_index: 0,
+                pred_index: 0,
+                context_dependent: false,
+            },
+        )
+        .expect("transition");
+        atn.set_rule_to_start_state(vec![0])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![1])
+            .expect("rule stop states");
+        let atn = finish_atn(atn);
+        let mut simulator = ParserAtnSimulator::new(&atn);
+        assert!(!simulator.full_context_memo_allowed());
     }
 
     #[test]

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -11,6 +11,7 @@ struct Counters {
     forced_full_context_calls: u64,
     full_context_retries: u64,
     full_context_memo_hits: u64,
+    full_context_memo_declined: u64,
     sll_conflicts: u64,
     reach_sll_calls: u64,
     reach_full_context_calls: u64,
@@ -143,6 +144,12 @@ pub(crate) fn record_full_context_memo_hit(decision: usize) {
         let decision_counters = counters.decisions.entry(decision).or_default();
         decision_counters.full_context_memo_hits =
             decision_counters.full_context_memo_hits.saturating_add(1);
+    });
+}
+
+pub(crate) fn record_full_context_memo_declined() {
+    with_counters(|counters| {
+        counters.full_context_memo_declined = counters.full_context_memo_declined.saturating_add(1);
     });
 }
 
@@ -560,7 +567,7 @@ fn dump_decisions(counters: &Counters) {
     }
 }
 
-const fn totals(counters: &Counters) -> [(&'static str, u64); 81] {
+const fn totals(counters: &Counters) -> [(&'static str, u64); 82] {
     [
         ("prediction.adaptive_calls", counters.adaptive_calls),
         (
@@ -574,6 +581,10 @@ const fn totals(counters: &Counters) -> [(&'static str, u64); 81] {
         (
             "prediction.full_context_memo_hits",
             counters.full_context_memo_hits,
+        ),
+        (
+            "prediction.full_context_memo_declined",
+            counters.full_context_memo_declined,
         ),
         ("prediction.sll_conflicts", counters.sll_conflicts),
         ("reach.sll_calls", counters.reach_sll_calls),

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -92,6 +92,7 @@ struct DecisionCounters {
     forced_full_context_calls: u64,
     full_context_retries: u64,
     full_context_memo_hits: u64,
+    full_context_memo_declined: u64,
     sll_conflicts: u64,
 }
 
@@ -147,9 +148,13 @@ pub(crate) fn record_full_context_memo_hit(decision: usize) {
     });
 }
 
-pub(crate) fn record_full_context_memo_declined() {
+pub(crate) fn record_full_context_memo_declined(decision: usize) {
     with_counters(|counters| {
         counters.full_context_memo_declined = counters.full_context_memo_declined.saturating_add(1);
+        let decision_counters = counters.decisions.entry(decision).or_default();
+        decision_counters.full_context_memo_declined = decision_counters
+            .full_context_memo_declined
+            .saturating_add(1);
     });
 }
 
@@ -562,6 +567,11 @@ fn dump_decisions(counters: &Counters) {
             *decision,
             "full_context_memo_hits",
             counters.full_context_memo_hits,
+        );
+        print_decision_counter(
+            *decision,
+            "full_context_memo_declined",
+            counters.full_context_memo_declined,
         );
         print_decision_counter(*decision, "sll_conflicts", counters.sll_conflicts);
     }

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -10,6 +10,7 @@ struct Counters {
     adaptive_calls: u64,
     forced_full_context_calls: u64,
     full_context_retries: u64,
+    full_context_memo_hits: u64,
     sll_conflicts: u64,
     reach_sll_calls: u64,
     reach_full_context_calls: u64,
@@ -89,6 +90,7 @@ struct DecisionCounters {
     adaptive_calls: u64,
     forced_full_context_calls: u64,
     full_context_retries: u64,
+    full_context_memo_hits: u64,
     sll_conflicts: u64,
 }
 
@@ -132,6 +134,15 @@ pub(crate) fn record_full_context_retry(decision: usize) {
         let decision_counters = counters.decisions.entry(decision).or_default();
         decision_counters.full_context_retries =
             decision_counters.full_context_retries.saturating_add(1);
+    });
+}
+
+pub(crate) fn record_full_context_memo_hit(decision: usize) {
+    with_counters(|counters| {
+        counters.full_context_memo_hits = counters.full_context_memo_hits.saturating_add(1);
+        let decision_counters = counters.decisions.entry(decision).or_default();
+        decision_counters.full_context_memo_hits =
+            decision_counters.full_context_memo_hits.saturating_add(1);
     });
 }
 
@@ -540,11 +551,16 @@ fn dump_decisions(counters: &Counters) {
             "full_context_retries",
             counters.full_context_retries,
         );
+        print_decision_counter(
+            *decision,
+            "full_context_memo_hits",
+            counters.full_context_memo_hits,
+        );
         print_decision_counter(*decision, "sll_conflicts", counters.sll_conflicts);
     }
 }
 
-const fn totals(counters: &Counters) -> [(&'static str, u64); 80] {
+const fn totals(counters: &Counters) -> [(&'static str, u64); 81] {
     [
         ("prediction.adaptive_calls", counters.adaptive_calls),
         (
@@ -554,6 +570,10 @@ const fn totals(counters: &Counters) -> [(&'static str, u64); 80] {
         (
             "prediction.full_context_retries",
             counters.full_context_retries,
+        ),
+        (
+            "prediction.full_context_memo_hits",
+            counters.full_context_memo_hits,
         ),
         ("prediction.sll_conflicts", counters.sll_conflicts),
         ("reach.sll_calls", counters.reach_sll_calls),


### PR DESCRIPTION
Closes #207.

## What

Memoizes full-context LL resolutions. Upstream ANTLR re-runs the LL simulation on **every** visit to a `requires_full_context` DFA state; grammars with keyword/identifier true ambiguities pay that on every occurrence. Avro IDL's `nullableType` (every primitive keyword is also a valid `identifier` — the grammar itself comments "identifier MUST be last") forces SLL conflict → LL retry → `reportAmbiguity {1,2}` → min-alt at **every type reference**: a 204 KB schema runs 2,100 LL retries, two thirds of parse time.

The LL result is a pure function of `(decision, precedence, interned caller context, consumed token window)` absent predicates. After each fresh LL run those inputs are recorded; a later retry that matches all four replays the resolution. The window compare re-reads the same lookahead token-for-token — a hit is *literally the same computation*. This is an optimization upstream Java cannot express: it has no per-parse interned caller contexts to key by.

## Soundness gates

- Any semantic transition in the ATN disables the memo entirely (predicates evaluate caller-side, lazily computed once per ATN).
- `LL_EXACT_AMBIG_DETECTION` mode disables it (that mode consumes further before resolving).
- Windows capped at 16 visible tokens; memo capped at 4096 entries; keyed `(decision, precedence, ContextId, first-symbol)` so a probe is one hash lookup.
- `clear_dfa` drops the memo together with the context arena its keys point into.
- Diagnostics are rebuilt through the same constructor as the fresh path (`full_context_retry_prediction`, extracted so both paths share it) — `reportAmbiguity`/`reportContextSensitivity` consumers observe byte-identical output, and the cursor lands exactly where the fresh LL loop would leave it.

## Measured

Avro IDL (204 KB synthetic schema, parse-only, min-of-100 in-process):

| | before | after |
|---|---|---|
| parse share | 8.8 ms | **3.2 ms** (2.7×) |
| vs antlr4rust 16.4 ms | 1.8× | **5.1×** |

Parse trees verified byte-identical with and without the memo. Kotlin timings improve as a side effect (dataframe snippet 0.767 → 0.567 ms; ktor parse-bench fixture 9.8 → 9.2 ms — Kotlin has its own context-sensitivity retries). CEL grammar: zero retries, zero overhead (memo never consulted).

## Verification

- Unit tests: identical retry replays byte-identically (diagnostic included, cursor restored) and records exactly one entry; different window and different outer context both miss; exact-ambig mode and predicated ATNs keep the memo off.
- Conformance sweep: **357/357** (descriptors exercise ambiguity/context-sensitivity reporting extensively — `reportAmbiguity` output is byte-compared there).
- `cargo test --locked` 315 green; clippy `-D warnings` all-targets all-features clean.
