### PR TITLE
perf(codegen): lower untranslated parser predicates as generatable Unknown templates

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -1072,7 +1072,7 @@ const fn predicate_template_disposition(
             predicate_template_disposition(Some(inner), policy)
         }
         Some(PredicateTemplate::Hook) => SemanticsDisposition::Hooked,
-        Some(PredicateTemplate::UnknownWithFailMessage { .. }) => {
+        Some(PredicateTemplate::UnknownWithFailMessage { .. } | PredicateTemplate::Unknown) => {
             policy.unknown_predicate_disposition()
         }
         Some(_) => SemanticsDisposition::Translated,
@@ -1259,7 +1259,15 @@ fn collect_parser_semantics_for_mode(
                     .predicates
                     .contains_key(&coordinate)
                     .then(|| "PortableBooleanLocal".to_owned())
-                    .or_else(|| template.map(|template| format!("{template:?}")))
+                    .or_else(|| {
+                        template
+                            // `Unknown` is an internal lowering of an
+                            // untranslated body, not a translation; the
+                            // manifest keeps reporting `template: null` so the
+                            // disposition remains the user-facing signal.
+                            .filter(|template| !matches!(template, PredicateTemplate::Unknown))
+                            .map(|template| format!("{template:?}"))
+                    })
             },
         });
     }
@@ -1399,6 +1407,15 @@ fn structural_predicate_templates(
                     coordinate,
                     PredicateTemplate::UnknownWithFailMessage { message },
                 ));
+            }
+            // An untranslated parser predicate still lowers (hook -> policy
+            // evaluator) so its rule keeps a generated body; an uncovered
+            // coordinate would cascade every calling rule onto the interpreter
+            // (issue #209). `parsed_body` keeps a `dispose = "error"` coordinate
+            // override uncovered: that override documents "no SemIR entry" and
+            // is enforced fatal before rendering.
+            (None, None) if parsed_body && kind == SemanticsKind::ParserPredicate => {
+                templates.push((coordinate, PredicateTemplate::Unknown));
             }
             (None, _) => {}
         }
@@ -10028,6 +10045,14 @@ enum PredicateTemplate {
     UnknownWithFailMessage {
         message: String,
     },
+    /// An untranslated parser predicate with no `<fail=...>` metadata.
+    /// Lowering it (instead of leaving the coordinate uncovered) keeps its
+    /// rule — and every caller of that rule — on the generated fast path
+    /// rather than cascading to the 5-6x slower interpreter (issue #209).
+    /// Evaluation follows the same hook -> unknown-policy fallback as
+    /// [`Self::UnknownWithFailMessage`], so typed/closure hooks stay
+    /// consulted and `--sem-unknown` dispositions apply unchanged.
+    Unknown,
     True,
     False,
     FalseWithMessage {
@@ -10074,6 +10099,7 @@ fn can_generate_parser_predicate(predicate: &PredicateTemplate) -> bool {
         predicate_effective_template(predicate),
         PredicateTemplate::Hook
             | PredicateTemplate::UnknownWithFailMessage { .. }
+            | PredicateTemplate::Unknown
             | PredicateTemplate::True
             | PredicateTemplate::False
             | PredicateTemplate::FalseWithMessage { .. }
@@ -10869,6 +10895,7 @@ fn render_lexer_predicate_expression(template: &PredicateTemplate) -> String {
         }
         PredicateTemplate::Hook
         | PredicateTemplate::UnknownWithFailMessage { .. }
+        | PredicateTemplate::Unknown
         | PredicateTemplate::Invoke { .. }
         | PredicateTemplate::FalseWithMessage { .. }
         | PredicateTemplate::LocalIntEquals { .. }
@@ -11712,7 +11739,9 @@ fn render_parser_semir_predicate_expr(
         PredicateTemplate::WithFailMessage { inner, .. } => {
             render_parser_semir_predicate_expr(inner, data)
         }
-        PredicateTemplate::Hook | PredicateTemplate::UnknownWithFailMessage { .. } => Ok(
+        PredicateTemplate::Hook
+        | PredicateTemplate::UnknownWithFailMessage { .. }
+        | PredicateTemplate::Unknown => Ok(
             "ir.expr(antlr4_runtime::semir::PExpr::Hook(antlr4_runtime::semir::HookId::new(0)))"
                 .to_owned(),
         ),
@@ -11795,7 +11824,9 @@ fn render_parser_predicate_array(
         let predicate = predicate_effective_template(predicate);
         let expression = match predicate {
             PredicateTemplate::True => "antlr4_runtime::ParserPredicate::True".to_owned(),
-            PredicateTemplate::Hook | PredicateTemplate::UnknownWithFailMessage { .. } => {
+            PredicateTemplate::Hook
+            | PredicateTemplate::UnknownWithFailMessage { .. }
+            | PredicateTemplate::Unknown => {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
                     "hook predicates lower only through parser SemIR",
@@ -13581,6 +13612,32 @@ mod tests {
     }
 
     #[test]
+    fn untranslated_parser_predicate_keeps_generated_rule() {
+        // Issue #209: an untranslated predicate body must lower as a
+        // generatable `Unknown` template (hook → unknown-policy chain), not
+        // leave its coordinate uncovered — an uncovered coordinate disables
+        // the rule's generated body and the drop cascades to every calling
+        // rule, forcing the whole grammar onto the 5-6x slower interpreter.
+        let templates = structural_predicate_templates(
+            &predicate_parser_data(),
+            SemanticsKind::ParserPredicate,
+            &SemPatternFile::default(),
+        )
+        .expect("templates should collect");
+        assert_eq!(templates, [((0, 0), PredicateTemplate::Unknown)]);
+
+        let rendered =
+            render_parser("SParser", &predicate_parser_data()).expect("parser should render");
+        assert!(
+            rendered.contains("parse_generated_rule_0_dispatch"),
+            "an untranslated predicate must not disable the generated rule"
+        );
+        // The coordinate reaches SemIR as a hook node, so an attached
+        // typed/closure hook is still consulted before the policy applies.
+        assert!(rendered.contains("PExpr::Hook"));
+    }
+
+    #[test]
     fn context_superclass_does_not_disable_generated_rules() {
         let data = parser_fixture_data("context-superclass/T.g4");
         let rendered = render_parser("TParser", &data).expect("parser should render");
@@ -14461,8 +14518,9 @@ mod tests {
     fn native_comparison_predicate_falls_through_instead_of_aborting() {
         // A native target-language comparison predicate merely contains a `<`
         // operator; it is not an ANTLR `<...>` StringTemplate, so it must fall
-        // through to the unknown-predicate policy (no template) rather than
-        // aborting codegen with "unsupported target predicate template".
+        // through to the unknown-predicate policy (as a generatable `Unknown`
+        // lowering) rather than aborting codegen with "unsupported target
+        // predicate template".
         let native = parser_fixture_data("native-comparison/T.g4");
         let templates = structural_predicate_templates(
             &native,
@@ -14471,9 +14529,12 @@ mod tests {
         )
         .expect("native comparison predicate must not abort generation");
         assert!(
-            templates.is_empty(),
-            "native `<` comparison yields no template, deferring to policy: {templates:?}"
+            templates
+                .iter()
+                .all(|(_, template)| matches!(template, PredicateTemplate::Unknown)),
+            "native `<` comparison lowers as Unknown, deferring to policy: {templates:?}"
         );
+        assert!(!templates.is_empty());
 
         // A genuine untranslated `<...>` StringTemplate still errors.
         let unsupported = parser_fixture_data("unsupported-predicate-template/T.g4");

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -13624,7 +13624,7 @@ mod tests {
             &SemPatternFile::default(),
         )
         .expect("templates should collect");
-        assert_eq!(templates, [((0, 0), PredicateTemplate::Unknown)]);
+        insta::assert_debug_snapshot!("untranslated_parser_predicate_templates", templates);
 
         let rendered =
             render_parser("SParser", &predicate_parser_data()).expect("parser should render");

--- a/src/bin/snapshots/antlr4_rust_gen__tests__untranslated_parser_predicate_templates.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__untranslated_parser_predicate_templates.snap
@@ -1,0 +1,13 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: templates
+---
+[
+    (
+        (
+            0,
+            0,
+        ),
+        Unknown,
+    ),
+]

--- a/tools/parse-bench/README.md
+++ b/tools/parse-bench/README.md
@@ -72,14 +72,17 @@ Rust generation keeps the pinned `JavaParser.g4` unchanged, including its
 `JavaParserBase` option and both semantic predicates. The generated benchmark
 parser uses the source compiler's historical `assume-true` policy for those
 target-language helpers, matching downstream generation while retaining the
-predicate metadata that controls runtime routing. Python and Go still use the
-equivalent portable rewrite because that grammars-v4 revision does not provide
-`JavaParserBase` implementations for those targets. The
-`issue-174-return-expression.java` fixture guards the resulting Java
-method-body performance path. JSON rows include a benchmark-variant tag, so
-the comparator skips only method changes such as this legacy-to-predicate
-transition and resumes Java regression checks once both reports use the same
-variant.
+predicate metadata that controls runtime routing; since #209 those
+untranslated coordinates lower as generatable hook-backed templates, so the
+predicate-bearing rules run generated bodies rather than the ATN interpreter.
+Python and Go still use the equivalent portable rewrite because that
+grammars-v4 revision does not provide `JavaParserBase` implementations for
+those targets. The `issue-174-return-expression.java` fixture guards the
+resulting Java method-body performance path. JSON rows include a
+benchmark-variant tag, so the comparator skips only method changes such as
+this legacy-to-predicate transition (or the #209 interpreter-to-generated
+routing change) and resumes Java regression checks once both reports use the
+same variant.
 
 Rust generation also keeps the pinned C# grammar unchanged. Its semantic
 helper names are described by `patterns/csharp.toml`, while the benchmark-owned

--- a/tools/parse-bench/run.py
+++ b/tools/parse-bench/run.py
@@ -26,7 +26,13 @@ DEFAULT_GRAMMARS_V4 = Path("/tmp/antlr-cleanroom/grammars-v4")
 # whose latest published module tag is v4.13.1.
 GO_ANTLR_RUNTIME = "v4.13.1"
 DEFAULT_BENCHMARK_VARIANT = "default"
-JAVA_RUST_PREDICATE_VARIANT = "java-upstream-parser-predicates-v1"
+# v2: untranslated predicate coordinates lower as generatable Unknown
+# templates (#209), so the untouched-grammar lane routes through generated
+# rule bodies instead of the ATN interpreter. The variant bump resets the
+# Java baseline across that methodology change; the comparator skips
+# mismatched-variant rows and resumes regression checks once both reports
+# carry v2.
+JAVA_RUST_PREDICATE_VARIANT = "java-upstream-parser-predicates-v2"
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
Fixes #209.

## Root cause

The 5–6× slowdown on predicate-carrying grammars was never per-evaluation predicate cost — it was **rule-compilation loss cascading through the call graph**:

1. An untranslated parser predicate body (e.g. the untouched grammars-v4 `JavaParser.g4`'s bare helper calls `{ this.IsNotIdentifierAssign() }?`, `{ this.DoLastRecordComponent() }?`) parses to no `PredicateTemplate`, so `structural_predicate_templates` pushed nothing for it.
2. Its coordinate then lands in `predicate_coordinates.all` but not `.generated`, and `compile_generated_parser_transition` refuses to compile the containing rule.
3. The grammar also carries one ANTLR-synthesized expression action, so `require_generated_callees` is true and `drop_rules_calling_disabled_rules` cascades the kill upward: **only 15 of 129 rules kept generated bodies**. Everything else routed through the interpreter.

## Fix

Lower such coordinates as a new `PredicateTemplate::Unknown` variant instead of leaving them uncovered, mirroring the existing `UnknownWithFailMessage` precedent:

- SemIR-lowered to `PExpr::Hook(HookId::new(0))`, so evaluation keeps the documented **hook → unknown-policy chain**: an attached typed/closure hook is still consulted, and a declining hook falls through to the configured `--sem-unknown` disposition. (A pure epsilon fold was rejected — it would silently stop consulting `with_typed_hooks` users, which work today via the interpreter.)
- Manifest output is unchanged: disposition still reports the policy (`assume-true` by default), `template` stays `null` — `Unknown` is an internal lowering, not a translation.
- `--sem-unknown=error` and `--require-full-semantics` still abort listing the coordinates; a per-coordinate `dispose = "error"` override still lowers to no SemIR entry (the `parsed_body` gate) and stays fatal.
- The legacy `ParserPredicate` table errors on `Unknown` exactly like `Hook` (SemIR is the active path).

## Results

3-way bench on `tools/parse-bench` fixtures (min ms, generated parsers for portable/stripped vs untouched vs hand-edited `{ true }?` grammar):

| fixture | untouched before | untouched after | lit-true | portable |
|---|---|---|---|---|
| mojang-data-result.java | 14.7 | **3.09** | 3.09 | 2.24 |
| google-closure-property.java | 4.1 | **0.88** | 0.84 | 0.59 |

The untouched grammar now generates all 129 rule dispatch bodies and matches the lit-true build within noise. The residual gap to fully-stripped portable is `allow_semantic_context` adaptive prediction at the two predicate-bearing decisions; a per-coordinate `dispose = "assume-true"` override (literal `True` template) remains available for the last bit.

## Verification

- **Conformance**: 357/357 passed (re-run after rebase) — descriptors with real predicates keep exact behavior.
- **Unit/integration**: 314 runtime + 739 generator + 31 CLI tests green; clippy with CI flags clean.
- New regression test `untranslated_parser_predicate_keeps_generated_rule` pins the generated-dispatch survival and the `PExpr::Hook` lowering.
- **Hook semantics end-to-end**: a typed hook returning `false` steers `annotationFieldValue` to its second alternative on the generated path (verified against the regenerated untouched Java parser).
- **Kotlin parity**: all snippets still match the antlr4-python3-runtime oracle byte-for-byte.
- Policy matrix spot-checked on the untouched Java grammar: default → 129 generated dispatches, manifest `assume-true`/`template: null`; `hook` → `hooked` + runtime Error policy installed; `error` / `--require-full-semantics` → generation aborts naming both coordinates.

## CI parse-bench: benchmark variant bumped to v2

The `parse-bench` job's first run flagged `java/bazel-sky-value-retriever.java` at 1.82× vs the base report. That is the methodology change this PR makes, not a runtime regression: the Java Rust lane benches the **untouched** predicate grammar, which previously ran through the ATN interpreter and now runs generated rule bodies. Per-fixture deltas are mixed by design — mojang 6.4→3.2 ms and google-closure 1.9→0.9 ms improve, while the bazel fixture's decision mix happens to favor the warmed interpreter DFA over the generated walker (the same shape exists on main between the portable-generated and interpreted lanes; nothing in the runtime changed).

`JAVA_RUST_PREDICATE_VARIANT` is bumped to `java-upstream-parser-predicates-v2` (304c1ac96), the same baseline-reset mechanism the v1 tag used for the legacy-to-predicate transition in #175: the comparator skips mismatched-variant rows on this PR and re-arms the 1.15× Java gate once the base branch report also carries v2. Verified locally by running the real harness Java lane (report rows tagged v2) and feeding it to `compare.py` against the failed run's v1 numbers — rows skip cleanly and the job passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generation and rendering behavior for untranslated parser predicates by treating them as “unknown” templates, ensuring runtime predicate evaluation still follows the configured policy.
  * Preserved the fast-path dispatch for parser rules when predicate bodies can’t be translated.
  * Fixed predicate handling for unsupported lexer/legacy predicate paths and corrected manifest output for unknown templates.
* **Tests**
  * Added/updated unit tests to confirm untranslated predicates and native comparison predicates follow the correct fallback behavior.
* **Documentation**
  * Updated parse benchmark documentation and switched benchmark routing to the newer predicate variant scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->