### PR TITLE
fix(codegen): expose combined literal token constants

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -11099,9 +11099,7 @@ fn render_token_constants(data: &CodegenData<'_>) -> String {
             .filter(|name| name.starts_with("T__"))
         {
             let ident = sanitize_identifier(name);
-            if !seen.insert(ident.clone()) {
-                continue;
-            }
+            let _ = seen.insert(ident.clone());
             let token_type = vocabulary.by_name[name];
             writeln!(out, "pub const {ident}: i32 = {token_type};")
                 .expect("writing to a string cannot fail");

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -11091,6 +11091,22 @@ fn render_metadata_with_atn(
 fn render_token_constants(data: &CodegenData<'_>) -> String {
     let mut out = String::from("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\n");
     let mut seen = BTreeSet::new();
+    if let Some(semantic) = data.semantic {
+        let vocabulary = &semantic.recognizer.vocabulary;
+        for name in vocabulary
+            .name_order
+            .iter()
+            .filter(|name| name.starts_with("T__"))
+        {
+            let ident = sanitize_identifier(name);
+            if !seen.insert(ident.clone()) {
+                continue;
+            }
+            let token_type = vocabulary.by_name[name];
+            writeln!(out, "pub const {ident}: i32 = {token_type};")
+                .expect("writing to a string cannot fail");
+        }
+    }
     for (index, name) in data.symbolic_names.iter().enumerate() {
         let Some(name) = name else { continue };
         let ident = rust_const_name(name);

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -369,6 +369,7 @@ fn byte_order_mark_and_crlf_token_vocabularies_are_honored() {
     }
 }
 
+#[allow(clippy::disallowed_methods)] // `insta` assertion macros unwrap internal I/O.
 #[test]
 fn combined_literal_tokens_are_public_and_lexable() {
     let temp = temporary_directory("combined-literal-tokens");
@@ -395,18 +396,21 @@ fn combined_literal_tokens_are_public_and_lexable() {
         utf8(&output.stderr)
     );
 
-    for module in ["t_lexer.rs", "t_parser.rs"] {
+    let constants = ["t_lexer.rs", "t_parser.rs"].map(|module| {
         let generated =
             fs::read_to_string(out.join(module)).expect("generated module should be readable");
-        assert!(
-            generated.contains("pub const T__0: i32 = 1;"),
-            "{module} should expose the 'hello' token type"
-        );
-        assert!(
-            generated.contains("pub const T__1: i32 = 2;"),
-            "{module} should expose the 'world' token type"
-        );
-    }
+        let (_, after_eof) = generated
+            .split_once("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;")
+            .expect("generated token constants should start with EOF");
+        let (after_eof, _) = after_eof
+            .split_once("\n\n")
+            .expect("generated token constants should form their own block");
+        (
+            module,
+            format!("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;{after_eof}"),
+        )
+    });
+    insta::assert_debug_snapshot!("combined_literal_token_constants", constants);
 
     assert_generated_project(
         temp.path(),

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -370,6 +370,68 @@ fn byte_order_mark_and_crlf_token_vocabularies_are_honored() {
 }
 
 #[test]
+fn combined_literal_tokens_are_public_and_lexable() {
+    let temp = temporary_directory("combined-literal-tokens");
+    let grammar = temp.path().join("T.g4");
+    let out = temp.path().join("generated");
+    fs::write(
+        &grammar,
+        "grammar T;\n\
+         greeting : 'hello' NAME 'world' ;\n\
+         NAME : [a-zA-Z]+ ;\n\
+         WS : [ \\t\\r\\n]+ -> skip ;\n",
+    )
+    .expect("grammar should be writable");
+
+    let output = run_antlr4_rust_gen(&[
+        grammar.as_os_str(),
+        OsStr::new("--out-dir"),
+        out.as_os_str(),
+    ]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+
+    for module in ["t_lexer.rs", "t_parser.rs"] {
+        let generated =
+            fs::read_to_string(out.join(module)).expect("generated module should be readable");
+        assert!(
+            generated.contains("pub const T__0: i32 = 1;"),
+            "{module} should expose the 'hello' token type"
+        );
+        assert!(
+            generated.contains("pub const T__1: i32 = 2;"),
+            "{module} should expose the 'world' token type"
+        );
+    }
+
+    assert_generated_project(
+        temp.path(),
+        &["t_lexer.rs", "t_parser.rs"],
+        r#"
+#[cfg(test)]
+mod combined_literal_tests {
+    use super::t_lexer::TLexer;
+    use super::t_parser::TParser;
+    use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
+
+    #[test]
+    fn recognizes_implicit_literal_rules() {
+        let lexer = TLexer::new(InputStream::new("hello Alice world"));
+        let tokens = CommonTokenStream::new(lexer);
+        let mut parser = TParser::new(tokens);
+        parser.greeting().expect("literal input should parse");
+        assert_eq!(parser.number_of_syntax_errors(), 0);
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn combined_root_suffixes_alternative_contexts_and_listener_methods() {
     let temp = temporary_directory("combined-contexts");
     let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/tests/snapshots/antlr4_rust_gen_cli__combined_literal_token_constants.snap
+++ b/tests/snapshots/antlr4_rust_gen_cli__combined_literal_token_constants.snap
@@ -1,0 +1,14 @@
+---
+source: tests/antlr4_rust_gen_cli.rs
+expression: constants
+---
+[
+    (
+        "t_lexer.rs",
+        "pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\npub const T__0: i32 = 1;\npub const T__1: i32 = 2;\npub const NAME: i32 = 3;\npub const WS: i32 = 4;",
+    ),
+    (
+        "t_parser.rs",
+        "pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\npub const T__0: i32 = 1;\npub const T__1: i32 = 2;\npub const NAME: i32 = 3;\npub const WS: i32 = 4;",
+    ),
+]


### PR DESCRIPTION
Closes #224.

## What changed

- Emit implicit `T__n` token constants from the semantic vocabulary in both generated lexer and parser modules.
- Add an end-to-end CLI regression for the issue grammar that checks `T__0`/`T__1`, compiles the generated modules, and parses `hello Alice world` without syntax errors.

## Root cause

Combined grammars already synthesized implicit literal lexer rules into their rule metadata and serialized ATN. Generated Rust constants, however, were rendered only from `symbolic_names`, which intentionally omits anonymous `T__n` tokens. That made the allocated literal token types invisible in generated source and made the ATN-backed rules look absent.

Rendering the implicit names from the semantic vocabulary restores the same public token-type surface other ANTLR targets provide. The regression also pins the underlying recognition behavior so a vocabulary-only implementation cannot pass.

## Validation

| Check | Result |
| --- | --- |
| `cargo test --locked --all-features --workspace` | 1,063 passed |
| `cargo clippy --locked --all-targets --all-features -- -D warnings` | passed |
| `cargo fmt --check` | passed |
| `cargo run --release --quiet --bin antlr4-runtime-testsuite` | 357 passed, 0 failed, 0 skipped |
