### PR TITLE
fix(codegen): emit label accessors nested in groups and mixed same-rule labels

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2589,7 +2589,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                             .is_some_and(|removed| removed.label.kind == LabelKind::List),
                         cardinality: embedded::ChildCardinality::ONE,
                         stable_accessor: true,
-                        choice_branch: None,
+                        choice_branch: Vec::new(),
                     }
                 });
             Some(structural_alt_model(alternative, leading_ref, vocabulary))
@@ -2659,7 +2659,7 @@ fn collect_structural_context_refs(
         refs,
         stable_accessor,
         embedded::ChildCardinality::ONE,
-        None,
+        &[],
         vocabulary,
     );
 }
@@ -2669,7 +2669,7 @@ fn collect_structural_context_refs_with_cardinality(
     refs: &mut Vec<embedded::ElementRef>,
     stable_accessor: bool,
     enclosing_cardinality: embedded::ChildCardinality,
-    choice_branch: Option<(usize, usize)>,
+    choice_branch: &[(usize, usize)],
     vocabulary: &Vocabulary,
 ) {
     for element in elements {
@@ -2691,7 +2691,7 @@ fn collect_structural_context_refs_with_cardinality(
                 is_list,
                 cardinality,
                 stable_accessor,
-                choice_branch,
+                choice_branch: choice_branch.to_vec(),
             }),
             ElementKind::Terminal(terminal) => {
                 refs.push(embedded::ElementRef {
@@ -2702,7 +2702,7 @@ fn collect_structural_context_refs_with_cardinality(
                     is_list,
                     cardinality,
                     stable_accessor,
-                    choice_branch,
+                    choice_branch: choice_branch.to_vec(),
                 });
             }
             ElementKind::Block(block) => {
@@ -2724,7 +2724,7 @@ fn collect_structural_context_refs_with_cardinality(
                         is_list,
                         cardinality,
                         stable_accessor,
-                        choice_branch,
+                        choice_branch: choice_branch.to_vec(),
                     });
                     continue;
                 }
@@ -2737,7 +2737,7 @@ fn collect_structural_context_refs_with_cardinality(
                         is_list,
                         cardinality,
                         stable_accessor: false,
-                        choice_branch,
+                        choice_branch: choice_branch.to_vec(),
                     });
                 }
                 // Refs from one alternative of a *choice* are present only when
@@ -2760,17 +2760,16 @@ fn collect_structural_context_refs_with_cardinality(
                     // consumers can tell mutually exclusive refs from sequential
                     // ones. A single-alternative block adds no exclusivity, so it
                     // keeps whatever tag it inherited.
-                    let nested_branch = if block.alternatives.len() > 1 {
-                        Some((block.syntax.index(), branch))
-                    } else {
-                        choice_branch
-                    };
+                    let mut nested_branch = choice_branch.to_vec();
+                    if block.alternatives.len() > 1 {
+                        nested_branch.push((block.syntax.index(), branch));
+                    }
                     collect_structural_context_refs_with_cardinality(
                         &alternative.elements,
                         refs,
                         stable_accessor,
                         branch_cardinality,
-                        nested_branch,
+                        &nested_branch,
                         vocabulary,
                     );
                 }
@@ -2784,7 +2783,7 @@ fn collect_structural_context_refs_with_cardinality(
                     is_list,
                     cardinality,
                     stable_accessor,
-                    choice_branch,
+                    choice_branch: choice_branch.to_vec(),
                 });
             }
             ElementKind::Range(..) if label.is_some() => refs.push(embedded::ElementRef {
@@ -2795,7 +2794,7 @@ fn collect_structural_context_refs_with_cardinality(
                 is_list,
                 cardinality,
                 stable_accessor: false,
-                choice_branch,
+                choice_branch: choice_branch.to_vec(),
             }),
             ElementKind::Range(..)
             | ElementKind::Action { .. }
@@ -9001,7 +9000,7 @@ fn context_label_accessor(
         is_list,
         cardinality: embedded::ChildCardinality::ONE,
         stable_accessor: true,
-        choice_branch: None,
+        choice_branch: Vec::new(),
     };
     let mut selector = None;
     let mut cardinalities = Vec::with_capacity(alternatives.len());

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2702,7 +2702,15 @@ fn collect_structural_context_refs_with_cardinality(
             }
             ElementKind::Block(block) => {
                 let token_types = structural_block_token_types(block, vocabulary);
-                if !token_types.is_empty() {
+                // A token-only block collapses into a single group ref, which is
+                // what makes `typeName=(Boolean | Int)` one labeled token child.
+                // That only holds when the label sits *on* the group: when the
+                // block is unlabeled and the labels sit inside it
+                // (`(doc=DocComment)?`), collapsing would swallow them, so
+                // descend and let the inner refs carry their own labels.
+                if !token_types.is_empty()
+                    && (label.is_some() || !structural_block_labels_inside(block))
+                {
                     refs.push(embedded::ElementRef {
                         label,
                         target: String::new(),
@@ -2725,13 +2733,27 @@ fn collect_structural_context_refs_with_cardinality(
                         stable_accessor: false,
                     });
                 }
-                let nested_stable = stable_accessor && block.alternatives.len() == 1;
+                // Refs from one alternative of a *choice* are present only when
+                // the parse took that branch, and the flattened CST does not
+                // record which. Clearing the lower bound states that honestly:
+                // a sibling alternative matching the same target then reads as
+                // inexact, so the occurrence-lookup guards in
+                // `context_label_accessor` reject exactly the layouts where
+                // positional access could resolve to another branch's child.
+                let branch_cardinality = if block.alternatives.len() > 1 {
+                    embedded::ChildCardinality {
+                        min: 0,
+                        max: cardinality.max,
+                    }
+                } else {
+                    cardinality
+                };
                 for alternative in &block.alternatives {
                     collect_structural_context_refs_with_cardinality(
                         &alternative.elements,
                         refs,
-                        nested_stable,
-                        cardinality,
+                        stable_accessor,
+                        branch_cardinality,
                         vocabulary,
                     );
                 }
@@ -2857,6 +2879,17 @@ fn structural_block_token_types(block: &Block, vocabulary: &Vocabulary) -> Vec<i
         token_types.extend(alternative_types);
     }
     token_types.into_iter().collect()
+}
+
+/// Whether any element directly inside `block` carries a label, i.e. the block
+/// is a grouping wrapper around labeled elements (`(doc=DocComment)?`) rather
+/// than a labeled token group (`typeName=(Boolean | Int)`).
+fn structural_block_labels_inside(block: &Block) -> bool {
+    block
+        .alternatives
+        .iter()
+        .flat_map(|alternative| &alternative.elements)
+        .any(|element| element.label.is_some())
 }
 
 fn structural_terminal_child_target(
@@ -14770,6 +14803,68 @@ mod tests {
             "optional labeled token shadowed by a following union match must drop its accessor\n{shadowed_context}"
         );
         insta::assert_snapshot!("multi_alternative_label_shadowed_context", shadowed_context);
+    }
+
+    /// Issue #201: labels nested inside an unlabeled grouping block, and a
+    /// single/list label pair on one rule, both reach the typed surface — while
+    /// layouts where positional lookup could resolve to another choice branch's
+    /// child still decline.
+    #[test]
+    fn grouped_and_mixed_same_rule_labels_emit_accessors_without_crossing_branches() {
+        let data = parser_fixture_data("multi-alternative-label/T.g4");
+        let rendered = render_parser("TParser", &data).expect("parser should render");
+
+        let context = |name: &str| {
+            rendered
+                .split_once(&format!("impl<'a, State> {name}<'a, State> {{"))
+                .unwrap_or_else(|| panic!("{name} impl"))
+                .1
+                .split_once(&format!("impl<State> std::fmt::Display for {name}"))
+                .unwrap_or_else(|| panic!("{name} display impl"))
+                .0
+                .to_owned()
+        };
+
+        // `(doc = IDENT)? (oneway = STAR | IN errors += unary ...)?`: the labels
+        // sit inside unlabeled grouping blocks, so collapsing each block into
+        // one token-group ref would swallow them.
+        insta::assert_snapshot!(
+            "multi_alternative_label_grouped_context",
+            context("GroupedContext")
+        );
+
+        // `name = unary ... errors += unary`: a single and a list label on the
+        // same rule must each resolve past the other's children.
+        insta::assert_snapshot!(
+            "multi_alternative_label_mixed_context",
+            context("MixedContext")
+        );
+
+        // A variable count of the label's own target ahead of it leaves no
+        // fixed `.skip(N)`.
+        let unbounded = context("MixedUnboundedContext");
+        assert!(
+            !unbounded.contains("pub fn errors("),
+            "a list label behind an unbounded run of its own target has no fixed skip\n{unbounded}"
+        );
+
+        // Only one branch supplies the label while its sibling matches the same
+        // target unlabeled, so `.nth(0)` could read the sibling's child.
+        let hazard = context("BranchHazardContext");
+        assert!(
+            !hazard.contains("pub fn pick("),
+            "a label whose sibling branch matches the same target unlabeled must decline\n{hazard}"
+        );
+
+        // Rival labels on the same target across branches must not read each
+        // other's child.
+        let rival = context("BranchRivalContext");
+        for label in ["pub fn left(", "pub fn right("] {
+            assert!(
+                !rival.contains(label),
+                "rival same-target labels across branches must decline {label}\n{rival}"
+            );
+        }
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2882,6 +2882,9 @@ fn collect_structural_context_refs_with_cardinality(
                 } else {
                     cardinality
                 };
+                // Where the expanded refs start, so the terminal state can be read
+                // back off what the branches actually emitted (below).
+                let refs_before_block = refs.len();
                 for (branch, alternative) in block.alternatives.iter().enumerate() {
                     // Tag each branch of a *choice* with `(block id, branch)` so
                     // consumers can tell mutually exclusive refs from sequential
@@ -2940,6 +2943,24 @@ fn collect_structural_context_refs_with_cardinality(
                         },
                         vocabulary,
                     );
+                }
+                // An expanded block still matched terminals, and the collapsibility
+                // helper below cannot see them: `structural_block_token_types`
+                // returns empty for any block that is not one-element-per-branch, so
+                // `(B y=C? | )` reported no tokens and left the *following* element
+                // marked as leading. That false state then let a mixed
+                // token/literal merge through in `(B y=C? | ) x=A | x='a'`.
+                //
+                // Read it back off the refs the branches actually emitted instead.
+                // `leading_terminal` is a *claim* that the element is the first
+                // terminal — which is what makes a block-positional index and a
+                // same-type index agree at 0 — so it has to hold on every path. Any
+                // branch that *can* match a terminal falsifies it, hence `any` over
+                // `cardinality.max != Some(0)` rather than agreement across branches.
+                if refs[refs_before_block..].iter().any(|candidate| {
+                    !candidate.token_types.is_empty() && candidate.cardinality.max != Some(0)
+                }) {
+                    seen_terminal = true;
                 }
             }
             ElementKind::Set { inverted, elements } => {
@@ -15595,6 +15616,30 @@ mod tests {
                 "x",
                 false,
                 "mixed-mode occurrence zero coincides only when no terminal precedes either side",
+            ),
+            (
+                "PrecedingSiblingBranch",
+                "x",
+                false,
+                "a same-target sibling *before* the label impersonates it as readily as one after",
+            ),
+            (
+                "ExpandedBlockTerminalState",
+                "x",
+                false,
+                "an expanded block still matched a terminal, so what follows it is not leading",
+            ),
+            (
+                "ListAliasAcrossModes",
+                "xs",
+                false,
+                "a list read has no form common to token and block mode, so aliases cannot merge",
+            ),
+            (
+                "ListLabelWithoutIterator",
+                "xs",
+                false,
+                "a list label whose target names no rule or token type has no iterator read",
             ),
             // Resolves: valid reads that must not be rejected.
             (

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9089,7 +9089,21 @@ fn context_label_selector(
     is_list: bool,
 ) -> Option<ContextLabelSelector> {
     let first_position = matching[0].0;
-    let start = exact_target_cardinality(&alternative.refs[..first_position], target)?;
+    let labeled = matching[0].1;
+    // A sibling branch that matches the same target supplies a child at the very
+    // position this accessor reads, but on a parse where the label is unset —
+    // `(left=unary | right=unary)` would let `right()` return `left`'s child.
+    // Positional lookup cannot tell them apart, so decline.
+    let sibling_supplies_target = alternative.refs.iter().any(|element| {
+        !element.can_coexist_with(labeled)
+            && context_ref_can_match_target(element, target)
+            && element.cardinality.max != Some(0)
+    });
+    if sibling_supplies_target {
+        return None;
+    }
+    let start =
+        exact_target_cardinality_on_path(&alternative.refs[..first_position], target, labeled)?;
     if is_list {
         let has_unlabeled_target = alternative.refs[first_position..].iter().any(|element| {
             context_ref_can_match_target(element, target)
@@ -9144,13 +9158,37 @@ fn context_ref_can_match_target(
         .any(|token_type| target.token_types.contains(token_type))
 }
 
+/// Number of `target`-matching children that precede a ref *on the same parse
+/// path* as `path`, or `None` when that number is not fixed.
+fn exact_target_cardinality_on_path(
+    refs: &[embedded::ElementRef],
+    target: &embedded::ElementRef,
+    path: &embedded::ElementRef,
+) -> Option<usize> {
+    // A ref in a branch `path` cannot reach never precedes it, so drop those
+    // before counting: in `(left=unary | right=unary)` the `left` ref must not
+    // shift `right` to occurrence 1.
+    let reachable = refs
+        .iter()
+        .filter(|element| element.can_coexist_with(path))
+        .cloned()
+        .collect::<Vec<_>>();
+    exact_target_cardinality(&reachable, target)
+}
+
 fn exact_target_cardinality(
     refs: &[embedded::ElementRef],
     target: &embedded::ElementRef,
 ) -> Option<usize> {
-    refs.iter().try_fold(0_usize, |total, element| {
+    // Refs are grouped by their innermost choice so that an *exhaustive* choice
+    // counts once rather than per branch. `(a=A | b=A) x=A` always contributes
+    // exactly one `A` before `x`, even though each branch ref alone reports
+    // `0..1`; summing them independently would read as inexact and drop `x()`.
+    let mut total = 0_usize;
+    let mut choice_totals: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
+    for element in refs {
         if !context_ref_can_match_target(element, target) {
-            return Some(total);
+            continue;
         }
         if !element.token_types.is_empty()
             && !element
@@ -9161,8 +9199,54 @@ fn exact_target_cardinality(
             return None;
         }
         let exact = element.cardinality.max?;
-        (element.cardinality.min == exact).then(|| total.saturating_add(exact))
-    })
+        // A ref inside a choice reports `min: 0` because its *branch* may not be
+        // taken, but within that branch it contributes its maximum exactly. Judge
+        // exactness per branch and let the cross-branch agreement check below
+        // decide whether the choice as a whole is exact.
+        let contribution = (element.cardinality.min == exact || !element.choice_branch.is_empty())
+            .then_some(exact);
+        match element.choice_branch.last() {
+            // Sequential: its count adds directly.
+            None => total = total.saturating_add(contribution?),
+            // Inside a choice: accumulate per branch, compare branches after.
+            Some(&key) => {
+                let branch = choice_totals.entry(key).or_insert(Some(0));
+                *branch = match (*branch, contribution) {
+                    (Some(sum), Some(next)) => Some(sum.saturating_add(next)),
+                    _ => None,
+                };
+            }
+        }
+    }
+    // A choice is exact only when every one of its branches contributes the same
+    // count. Branches with no matching ref never entered the map above yet still
+    // contribute zero, so the full branch set is recovered from `refs` — a choice
+    // whose branch count exceeds the entries seen has a zero-contributing branch
+    // and is therefore exact only if the others contribute zero too.
+    let mut branches_per_choice: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+    for element in refs {
+        for &(choice, branch) in &element.choice_branch {
+            branches_per_choice
+                .entry(choice)
+                .or_default()
+                .insert(branch);
+        }
+    }
+    let mut by_choice: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+    for ((choice, _), count) in choice_totals {
+        by_choice.entry(choice).or_default().push(count?);
+    }
+    for (choice, counts) in by_choice {
+        let expected = branches_per_choice.get(&choice).map_or(0, BTreeSet::len);
+        let first = counts.first().copied()?;
+        // Every branch must agree, and every branch must have been counted —
+        // otherwise some branch supplies a different number of children.
+        if counts.len() != expected || counts.iter().any(|count| *count != first) {
+            return None;
+        }
+        total = total.saturating_add(first);
+    }
+    Some(total)
 }
 
 fn sum_child_cardinalities(
@@ -14911,6 +14995,19 @@ mod tests {
         //   the sibling's child;
         // * `branch_rival` — rival labels on one target across branches must not
         //   read each other's child.
+        // An exhaustive choice keeps a following label's accessor (its prefix
+        // count is fixed at one however the choice branches), while a preceding
+        // *overlapping* token group does not (only some parses put a matching
+        // child ahead of the label).
+        insta::assert_snapshot!(
+            "multi_alternative_label_exhaustive_prefix_context",
+            context("ExhaustivePrefixContext")
+        );
+        insta::assert_snapshot!(
+            "multi_alternative_label_overlapping_group_context",
+            context("OverlappingGroupContext")
+        );
+
         for (name, snapshot) in [
             (
                 "MixedUnboundedContext",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9490,18 +9490,26 @@ fn exact_target_cardinality_on_path(
             // Drop the branch tags shared with `path`: on this path those branches
             // are taken, so their refs count as plain sequential children rather
             // than alternatives awaiting cross-branch agreement.
-            element
-                .choice_branch
-                .retain(|(choice, _)| !path.choice_branch.iter().any(|(taken, _)| taken == choice));
-            let keep = element.choice_branch.len();
-            element.choice_arity.truncate(keep);
-            element.choice_spans.truncate(keep);
+            element.retain_choices(|choice| {
+                !path.choice_branch.iter().any(|&(taken, _)| taken == choice)
+            });
             // Their cardinality on this path is the branch-local one — and when the
             // ref shares every optional group with the label, those groups are taken
             // wherever the label is bound, so even their quantifiers are satisfied.
             // `(A x=A)? EOF` has exactly one `A` before the label on every parse that
             // binds it, though both figures otherwise report `0..1` from the `?`.
+            //
+            // A *repeated* group not shared with the label is the exception: knowing
+            // it ran says nothing about how many times, so its contribution stays
+            // unfixed. `((A B)+ x=A)?` has a variable run of `A` ahead of the label
+            // even though the outer `?` is satisfied. This mirrors `on_taken_group`
+            // in the action-resolution path.
+            let closed_repeated_group = element
+                .group_spans
+                .iter()
+                .any(|group| group.repeated && !path.group_spans.contains(group));
             let shares_optional_groups = !element.group_spans.is_empty()
+                && !closed_repeated_group
                 && element
                     .group_spans
                     .iter()
@@ -15424,6 +15432,23 @@ mod tests {
         insta::assert_snapshot!(
             "multi_alternative_label_path_restricted_context",
             context("PathRestrictedContext")
+        );
+        // Two ways the on-path restriction can overstate what it knows, both
+        // declining as a result:
+        //
+        // * `closed_repeat_prefix` — sharing every *optional* group with the label
+        //   proves those groups ran, but a closed `+` inside them ran an unknown
+        //   number of times, so the prefix count stays unfixed;
+        // * `inner_choice_arity` — dropping the taken outer choice must drop its
+        //   arity too, or the surviving three-way inner choice is read as an
+        //   exhaustive two-way one and the prefix count is wrongly fixed at 1.
+        insta::assert_snapshot!(
+            "multi_alternative_label_closed_repeat_prefix_context",
+            context("ClosedRepeatPrefixContext")
+        );
+        insta::assert_snapshot!(
+            "multi_alternative_label_inner_choice_arity_context",
+            context("InnerChoiceArityContext")
         );
         // Nesting the exhaustive choice keeps the count fixed: the inner choice's
         // agreed contribution rolls up into the outer branch.

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2592,8 +2592,11 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                         choice_branch: Vec::new(),
                         choice_arity: Vec::new(),
                         choice_spans: Vec::new(),
+                        group_spans: Vec::new(),
+                        branch_spans: Vec::new(),
                         span: None,
                         branch_local_cardinality: embedded::ChildCardinality::ONE,
+                        group_local_cardinality: embedded::ChildCardinality::ONE,
                     }
                 });
             Some(structural_alt_model(alternative, leading_ref, vocabulary))
@@ -2668,6 +2671,8 @@ fn collect_structural_context_refs(
             choice_branch: &[],
             choice_arity: &[],
             choice_spans: &[],
+            group_spans: &[],
+            branch_spans: &[],
         },
         vocabulary,
     );
@@ -2684,6 +2689,8 @@ struct StructuralRefContext<'a> {
     choice_branch: &'a [(usize, usize)],
     choice_arity: &'a [usize],
     choice_spans: &'a [(usize, usize)],
+    group_spans: &'a [(usize, usize)],
+    branch_spans: &'a [(usize, usize)],
 }
 
 fn collect_structural_context_refs_with_cardinality(
@@ -2699,6 +2706,8 @@ fn collect_structural_context_refs_with_cardinality(
         choice_branch,
         choice_arity,
         choice_spans,
+        group_spans,
+        branch_spans,
     } = context;
     for element in elements {
         let label = element.label.as_ref().map(|label| label.name.clone());
@@ -2729,11 +2738,17 @@ fn collect_structural_context_refs_with_cardinality(
                 choice_branch: choice_branch.to_vec(),
                 choice_arity: choice_arity.to_vec(),
                 choice_spans: choice_spans.to_vec(),
+                group_spans: group_spans.to_vec(),
+                branch_spans: branch_spans.to_vec(),
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
                 )),
                 branch_local_cardinality: branch_local,
+                group_local_cardinality: quantified_cardinality(
+                    embedded::ChildCardinality::ONE,
+                    element.quantifier,
+                ),
             }),
             ElementKind::Terminal(terminal) => {
                 refs.push(embedded::ElementRef {
@@ -2747,11 +2762,17 @@ fn collect_structural_context_refs_with_cardinality(
                     choice_branch: choice_branch.to_vec(),
                     choice_arity: choice_arity.to_vec(),
                     choice_spans: choice_spans.to_vec(),
+                    group_spans: group_spans.to_vec(),
+                    branch_spans: branch_spans.to_vec(),
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
                     )),
                     branch_local_cardinality: branch_local,
+                    group_local_cardinality: quantified_cardinality(
+                        embedded::ChildCardinality::ONE,
+                        element.quantifier,
+                    ),
                 });
             }
             ElementKind::Block(block) => {
@@ -2776,11 +2797,17 @@ fn collect_structural_context_refs_with_cardinality(
                         choice_branch: choice_branch.to_vec(),
                         choice_arity: choice_arity.to_vec(),
                         choice_spans: choice_spans.to_vec(),
+                        group_spans: group_spans.to_vec(),
+                        branch_spans: branch_spans.to_vec(),
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
                         )),
                         branch_local_cardinality: branch_local,
+                        group_local_cardinality: quantified_cardinality(
+                            embedded::ChildCardinality::ONE,
+                            element.quantifier,
+                        ),
                     });
                     continue;
                 }
@@ -2796,11 +2823,17 @@ fn collect_structural_context_refs_with_cardinality(
                         choice_branch: choice_branch.to_vec(),
                         choice_arity: choice_arity.to_vec(),
                         choice_spans: choice_spans.to_vec(),
+                        group_spans: group_spans.to_vec(),
+                        branch_spans: branch_spans.to_vec(),
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
                         )),
                         branch_local_cardinality: branch_local,
+                        group_local_cardinality: quantified_cardinality(
+                            embedded::ChildCardinality::ONE,
+                            element.quantifier,
+                        ),
                     });
                 }
                 // Refs from one alternative of a *choice* are present only when
@@ -2826,12 +2859,23 @@ fn collect_structural_context_refs_with_cardinality(
                     let mut nested_branch = choice_branch.to_vec();
                     let mut nested_arity = choice_arity.to_vec();
                     let mut nested_spans = choice_spans.to_vec();
+                    // Every block counts here, single-alternative groups included.
+                    let mut nested_branch_spans = branch_spans.to_vec();
+                    let mut nested_groups = group_spans.to_vec();
+                    nested_groups.push((
+                        block.span.bytes.start as usize,
+                        block.span.bytes.end as usize,
+                    ));
                     if block.alternatives.len() > 1 {
                         nested_branch.push((block.syntax.index(), branch));
                         nested_arity.push(block.alternatives.len());
                         nested_spans.push((
                             block.span.bytes.start as usize,
                             block.span.bytes.end as usize,
+                        ));
+                        nested_branch_spans.push((
+                            alternative.span.bytes.start as usize,
+                            alternative.span.bytes.end as usize,
                         ));
                     }
                     collect_structural_context_refs_with_cardinality(
@@ -2846,6 +2890,8 @@ fn collect_structural_context_refs_with_cardinality(
                             choice_branch: &nested_branch,
                             choice_arity: &nested_arity,
                             choice_spans: &nested_spans,
+                            group_spans: &nested_groups,
+                            branch_spans: &nested_branch_spans,
                         },
                         vocabulary,
                     );
@@ -2863,11 +2909,17 @@ fn collect_structural_context_refs_with_cardinality(
                     choice_branch: choice_branch.to_vec(),
                     choice_arity: choice_arity.to_vec(),
                     choice_spans: choice_spans.to_vec(),
+                    group_spans: group_spans.to_vec(),
+                    branch_spans: branch_spans.to_vec(),
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
                     )),
                     branch_local_cardinality: branch_local,
+                    group_local_cardinality: quantified_cardinality(
+                        embedded::ChildCardinality::ONE,
+                        element.quantifier,
+                    ),
                 });
             }
             ElementKind::Range(..) if label.is_some() => refs.push(embedded::ElementRef {
@@ -2881,11 +2933,17 @@ fn collect_structural_context_refs_with_cardinality(
                 choice_branch: choice_branch.to_vec(),
                 choice_arity: choice_arity.to_vec(),
                 choice_spans: choice_spans.to_vec(),
+                group_spans: group_spans.to_vec(),
+                branch_spans: branch_spans.to_vec(),
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
                 )),
                 branch_local_cardinality: branch_local,
+                group_local_cardinality: quantified_cardinality(
+                    embedded::ChildCardinality::ONE,
+                    element.quantifier,
+                ),
             }),
             ElementKind::Range(..)
             | ElementKind::Action { .. }
@@ -9094,8 +9152,11 @@ fn context_label_accessor(
         choice_branch: Vec::new(),
         choice_arity: Vec::new(),
         choice_spans: Vec::new(),
+        group_spans: Vec::new(),
+        branch_spans: Vec::new(),
         span: None,
         branch_local_cardinality: embedded::ChildCardinality::ONE,
+        group_local_cardinality: embedded::ChildCardinality::ONE,
     };
     let mut selector = None;
     let mut cardinalities = Vec::with_capacity(alternatives.len());
@@ -9184,7 +9245,20 @@ fn context_label_selector(
                 && element.cardinality.max != Some(0)
                 && element.label.as_deref() != Some(label)
         });
-        return (!has_unlabeled_target).then_some(ContextLabelSelector::AllAfter(start));
+        // `AllAfter(start)` skips `start` children then takes the rest, so repeated
+        // declarations on one path are fine — the later ones fall inside the tail
+        // (`xs+=e (op xs+=e)*` skips 0 and collects every `e`). What it cannot serve
+        // is *mutually exclusive* declarations that begin at different offsets:
+        // `(A xs+=A | xs+=A)` needs skip 1 on one branch and 0 on the other.
+        let starts_agree = matching.iter().all(|(position, declaration)| {
+            if declaration.can_coexist_with(labeled) {
+                return true;
+            }
+            exact_target_cardinality_on_path(&alternative.refs[..*position], target, declaration)
+                == Some(start)
+        });
+        return (!has_unlabeled_target && starts_agree)
+            .then_some(ContextLabelSelector::AllAfter(start));
     }
     // Several declarations can share one positional read when they are mutually
     // exclusive and each sits at the same occurrence — `(x=A | x=B)` binds exactly
@@ -9204,6 +9278,24 @@ fn context_label_selector(
         let agreed = positions.first().copied()?;
         if !mutually_exclusive || positions.iter().any(|position| *position != agreed) {
             return None;
+        }
+        // Each declaration must also survive the single-label hazards: an *optional*
+        // one can be displaced by a following same-target child sliding into its
+        // slot, and the shared read cannot tell them apart either
+        // (`(x=A? B | x=B)` returns the unlabeled `B` when `x` is absent).
+        for (position, declaration) in matching {
+            // Optionality here means the *declaration's own* EBNF suffix — a `min: 0`
+            // that only reflects its branch possibly not being taken does not make it
+            // displaceable, since the read is chosen per branch anyway.
+            if declaration.branch_local_cardinality.min == 0
+                && alternative.refs[position + 1..].iter().any(|following| {
+                    context_ref_can_match_target(following, target)
+                        && following.cardinality.max != Some(0)
+                        && following.can_coexist_with(declaration)
+                })
+            {
+                return None;
+            }
         }
         // A *repeated* scalar declaration (`x=A+`) is overwritten each iteration, so
         // ANTLR exposes the last match — `nth` would pin the first.

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -15641,7 +15641,19 @@ mod tests {
                 false,
                 "a list label whose target names no rule or token type has no iterator read",
             ),
+            (
+                "InnerChoiceArityInAction",
+                "x",
+                false,
+                "dropping the taken outer choice must drop its arity, or a three-way inner choice reads as two-way",
+            ),
             // Resolves: valid reads that must not be rejected.
+            (
+                "ExhaustiveInnerChoiceInAction",
+                "x",
+                true,
+                "a genuinely exhaustive inner choice keeps its fixed prefix count of one",
+            ),
             (
                 "ActionInCollapsibleChoice",
                 "x",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9258,31 +9258,67 @@ fn exact_target_cardinality(
     }
     // A choice is exact only when every one of its branches contributes the same
     // count. Branches with no matching ref never entered the map above yet still
-    // contribute zero, so the full branch set is recovered from `refs` — a choice
-    // whose branch count exceeds the entries seen has a zero-contributing branch
-    // and is therefore exact only if the others contribute zero too.
+    // contribute zero, so the full branch set is recovered from `refs`.
+    //
+    // Nested choices are folded innermost-first: once an inner choice agrees, its
+    // count is attributed to the *enclosing* branch that contains it, so
+    // `((a=A | b=A) | c=A) x=A` — where every path yields one `A` — stays exact.
     let mut branches_per_choice: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+    let mut depth_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
     for element in refs {
-        for &(choice, branch) in &element.choice_branch {
+        for (depth, &(choice, branch)) in element.choice_branch.iter().enumerate() {
             branches_per_choice
                 .entry(choice)
                 .or_default()
                 .insert(branch);
+            depth_of_choice.insert(choice, depth);
         }
     }
-    let mut by_choice: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-    for ((choice, _), count) in choice_totals {
-        by_choice.entry(choice).or_default().push(count?);
+    // Ancestry per branch key, so an inner choice's total can be re-attributed.
+    let mut ancestry: BTreeMap<(usize, usize), Vec<(usize, usize)>> = BTreeMap::new();
+    for element in refs {
+        if let Some(&key) = element.choice_branch.last() {
+            ancestry.insert(key, element.choice_branch.clone());
+        }
     }
-    for (choice, counts) in by_choice {
+    let mut pending = choice_totals;
+    // Deepest choices first, so inner results roll up into their parents.
+    let mut choices = depth_of_choice
+        .iter()
+        .map(|(c, d)| (*d, *c))
+        .collect::<Vec<_>>();
+    choices.sort_unstable_by_key(|(depth, _)| std::cmp::Reverse(*depth));
+    for (_, choice) in choices {
+        let counts = pending
+            .iter()
+            .filter(|((candidate, _), _)| *candidate == choice)
+            .map(|((_, branch), count)| (*branch, *count))
+            .collect::<Vec<_>>();
+        if counts.is_empty() {
+            continue;
+        }
         let expected = branches_per_choice.get(&choice).map_or(0, BTreeSet::len);
-        let first = counts.first().copied()?;
-        // Every branch must agree, and every branch must have been counted —
-        // otherwise some branch supplies a different number of children.
-        if counts.len() != expected || counts.iter().any(|count| *count != first) {
+        let first = counts.first().and_then(|(_, count)| *count)?;
+        if counts.len() != expected || counts.iter().any(|(_, count)| *count != Some(first)) {
             return None;
         }
-        total = total.saturating_add(first);
+        for (branch, _) in &counts {
+            pending.remove(&(choice, *branch));
+        }
+        // Attribute this choice's agreed count to its own enclosing branch, if any.
+        let parent = counts.first().and_then(|(branch, _)| {
+            ancestry
+                .get(&(choice, *branch))
+                .and_then(|chain| chain.split_last().map(|(_, rest)| rest.last().copied()))
+                .flatten()
+        });
+        match parent {
+            Some(parent_key) => {
+                let slot = pending.entry(parent_key).or_insert(Some(0));
+                *slot = slot.map(|sum| sum.saturating_add(first));
+            }
+            None => total = total.saturating_add(first),
+        }
     }
     Some(total)
 }
@@ -15051,6 +15087,12 @@ mod tests {
         insta::assert_snapshot!(
             "multi_alternative_label_optional_prefix_context",
             context("OptionalPrefixContext")
+        );
+        // Nesting the exhaustive choice keeps the count fixed: the inner choice's
+        // agreed contribution rolls up into the outer branch.
+        insta::assert_snapshot!(
+            "multi_alternative_label_nested_exhaustive_prefix_context",
+            context("NestedExhaustivePrefixContext")
         );
 
         for (name, snapshot) in [

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2589,6 +2589,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                             .is_some_and(|removed| removed.label.kind == LabelKind::List),
                         cardinality: embedded::ChildCardinality::ONE,
                         stable_accessor: true,
+                        choice_branch: None,
                     }
                 });
             Some(structural_alt_model(alternative, leading_ref, vocabulary))
@@ -2658,6 +2659,7 @@ fn collect_structural_context_refs(
         refs,
         stable_accessor,
         embedded::ChildCardinality::ONE,
+        None,
         vocabulary,
     );
 }
@@ -2667,6 +2669,7 @@ fn collect_structural_context_refs_with_cardinality(
     refs: &mut Vec<embedded::ElementRef>,
     stable_accessor: bool,
     enclosing_cardinality: embedded::ChildCardinality,
+    choice_branch: Option<(usize, usize)>,
     vocabulary: &Vocabulary,
 ) {
     for element in elements {
@@ -2688,6 +2691,7 @@ fn collect_structural_context_refs_with_cardinality(
                 is_list,
                 cardinality,
                 stable_accessor,
+                choice_branch,
             }),
             ElementKind::Terminal(terminal) => {
                 refs.push(embedded::ElementRef {
@@ -2698,6 +2702,7 @@ fn collect_structural_context_refs_with_cardinality(
                     is_list,
                     cardinality,
                     stable_accessor,
+                    choice_branch,
                 });
             }
             ElementKind::Block(block) => {
@@ -2719,6 +2724,7 @@ fn collect_structural_context_refs_with_cardinality(
                         is_list,
                         cardinality,
                         stable_accessor,
+                        choice_branch,
                     });
                     continue;
                 }
@@ -2731,6 +2737,7 @@ fn collect_structural_context_refs_with_cardinality(
                         is_list,
                         cardinality,
                         stable_accessor: false,
+                        choice_branch,
                     });
                 }
                 // Refs from one alternative of a *choice* are present only when
@@ -2748,12 +2755,22 @@ fn collect_structural_context_refs_with_cardinality(
                 } else {
                     cardinality
                 };
-                for alternative in &block.alternatives {
+                for (branch, alternative) in block.alternatives.iter().enumerate() {
+                    // Tag each branch of a *choice* with `(block id, branch)` so
+                    // consumers can tell mutually exclusive refs from sequential
+                    // ones. A single-alternative block adds no exclusivity, so it
+                    // keeps whatever tag it inherited.
+                    let nested_branch = if block.alternatives.len() > 1 {
+                        Some((block.syntax.index(), branch))
+                    } else {
+                        choice_branch
+                    };
                     collect_structural_context_refs_with_cardinality(
                         &alternative.elements,
                         refs,
                         stable_accessor,
                         branch_cardinality,
+                        nested_branch,
                         vocabulary,
                     );
                 }
@@ -2767,6 +2784,7 @@ fn collect_structural_context_refs_with_cardinality(
                     is_list,
                     cardinality,
                     stable_accessor,
+                    choice_branch,
                 });
             }
             ElementKind::Range(..) if label.is_some() => refs.push(embedded::ElementRef {
@@ -2777,6 +2795,7 @@ fn collect_structural_context_refs_with_cardinality(
                 is_list,
                 cardinality,
                 stable_accessor: false,
+                choice_branch,
             }),
             ElementKind::Range(..)
             | ElementKind::Action { .. }
@@ -8982,6 +9001,7 @@ fn context_label_accessor(
         is_list,
         cardinality: embedded::ChildCardinality::ONE,
         stable_accessor: true,
+        choice_branch: None,
     };
     let mut selector = None;
     let mut cardinalities = Vec::with_capacity(alternatives.len());

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -15369,7 +15369,43 @@ mod tests {
                 false,
                 "one `AllAfter` skip cannot serve branches that begin at different offsets",
             ),
+            (
+                "InnerGroupClosedBeforeAction",
+                "x",
+                false,
+                "an inner group that closed before the action proves nothing about what matched",
+            ),
+            (
+                "AliasDifferingOccurrenceInAlt",
+                "x",
+                false,
+                "block and token occurrences are comparable only at zero",
+            ),
+            (
+                "DeclarationsDifferingOccurrence",
+                "x",
+                false,
+                "one positional read cannot serve declarations at different occurrences",
+            ),
+            (
+                "DeclarationsDifferingRepetition",
+                "x",
+                false,
+                "a repeated declaration needs a last-match read the others do not",
+            ),
             // Resolves: valid reads that must not be rejected.
+            (
+                "ListAliasDeclarations",
+                "xs",
+                true,
+                "list declarations name one token type through two source forms",
+            ),
+            (
+                "ChoicePrefixOutsideLabel",
+                "x",
+                true,
+                "a choice before the label contributes a fixed count when its branches agree",
+            ),
             (
                 "LiteralAliasSameOccurrence",
                 "x",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2712,9 +2712,19 @@ fn collect_structural_context_refs_with_cardinality(
     } = context;
     // Tracks whether any terminal-bearing ref has been emitted on this path, so an
     // element can record whether it is the first terminal.
+    // Only refs on *this* branch's path count: `refs` is shared across every branch
+    // of an enclosing choice, so terminals emitted for a sibling branch must not
+    // make this branch's elements look non-leading. `(x=A | x='a')` has each
+    // declaration first on its own path.
     let mut seen_terminal = branch_local_cardinality.max.is_none_or(|max| max != 0)
         && refs.iter().any(|existing| {
-            !existing.token_types.is_empty() && existing.cardinality.max != Some(0)
+            !existing.token_types.is_empty()
+                && existing.cardinality.max != Some(0)
+                && !existing.choice_branch.iter().any(|(choice, branch)| {
+                    choice_branch
+                        .iter()
+                        .any(|(mine, my_branch)| choice == mine && branch != my_branch)
+                })
         });
     for element in elements {
         let label = element.label.as_ref().map(|label| label.name.clone());
@@ -9273,17 +9283,37 @@ fn context_label_selector(
     // label too, and `context_label_accessor` already proved the declarations share
     // one read. Only an unlabeled (or differently-labeled) sibling child can be
     // mistaken for this label's.
+    let start =
+        exact_target_cardinality_on_path(&alternative.refs[..first_position], target, labeled)?;
+    // A sibling branch only collides when it can actually put a matching child at the
+    // position this accessor reads. `(A | A A x=A)` selects occurrence 2 while the
+    // sibling branch supplies at most one `A`, so `nth(2)` is safely empty there.
     let sibling_supplies_target = alternative.refs.iter().any(|element| {
-        element.label.as_deref() != Some(label)
-            && !element.can_coexist_with(labeled)
-            && context_ref_can_match_target(element, target)
-            && element.cardinality.max != Some(0)
+        if element.label.as_deref() == Some(label)
+            || element.can_coexist_with(labeled)
+            || !context_ref_can_match_target(element, target)
+            || element.cardinality.max == Some(0)
+        {
+            return false;
+        }
+        let position = alternative
+            .refs
+            .iter()
+            .position(|candidate| std::ptr::eq(candidate, element));
+        let reach = position.and_then(|position| {
+            let before =
+                exact_target_cardinality_on_path(&alternative.refs[..position], target, element)?;
+            // The highest occurrence this ref can occupy on its own path.
+            element
+                .cardinality
+                .max
+                .map(|max| before.saturating_add(max))
+        });
+        reach.is_none_or(|reach| reach > start)
     });
     if sibling_supplies_target {
         return None;
     }
-    let start =
-        exact_target_cardinality_on_path(&alternative.refs[..first_position], target, labeled)?;
     if is_list {
         let has_unlabeled_target = alternative.refs[first_position..].iter().any(|element| {
             context_ref_can_match_target(element, target)
@@ -9437,8 +9467,26 @@ fn exact_target_cardinality_on_path(
             let keep = element.choice_branch.len();
             element.choice_arity.truncate(keep);
             element.choice_spans.truncate(keep);
-            // Their cardinality on this path is the branch-local one.
-            element.cardinality = element.branch_local_cardinality;
+            // Their cardinality on this path is the branch-local one — and when the
+            // ref shares every optional group with the label, those groups are taken
+            // wherever the label is bound, so even their quantifiers are satisfied.
+            // `(A x=A)? EOF` has exactly one `A` before the label on every parse that
+            // binds it, though both figures otherwise report `0..1` from the `?`.
+            let shares_optional_groups = !element.group_spans.is_empty()
+                && element
+                    .group_spans
+                    .iter()
+                    .filter(|group| group.optional)
+                    .all(|group| path.group_spans.contains(group));
+            let on_path = if shares_optional_groups {
+                element.group_local_cardinality
+            } else {
+                element.branch_local_cardinality
+            };
+            element.cardinality = on_path;
+            // `exact_target_cardinality` judges exactness from the branch-local
+            // figure, so it has to see the same value.
+            element.branch_local_cardinality = on_path;
             element
         })
         .collect::<Vec<_>>();
@@ -15471,6 +15519,18 @@ mod tests {
                 "a shared last-match read would return a following unlabeled child on the non-repeated branch",
             ),
             (
+                "InitScalarRuleLabel",
+                "x",
+                false,
+                "a scalar rule read lowers to `.expect(...)`, which panics at rule entry",
+            ),
+            (
+                "AliasDeclarationsInChoice",
+                "x",
+                false,
+                "known limitation: alias declarations inside one nested choice still decline (see PR discussion)",
+            ),
+            (
                 "FallbackReadSiblingAlternative",
                 "x",
                 false,
@@ -15488,6 +15548,24 @@ mod tests {
                 "x",
                 true,
                 "a token-only choice holding an action keeps its branch spans",
+            ),
+            (
+                "OptionalGroupSharedWithLabel",
+                "x",
+                true,
+                "an optional group shared with the label is taken wherever the label is bound",
+            ),
+            (
+                "SiblingBranchShorterThanOccurrence",
+                "x",
+                true,
+                "a sibling branch that cannot reach the selected occurrence is no collision",
+            ),
+            (
+                "IdenticalDeclarationsInChoice",
+                "x",
+                true,
+                "isolating one declaration must not reclassify its twin as an impostor",
             ),
             (
                 "MandatoryInnerGroupClosed",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2590,6 +2590,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                         cardinality: embedded::ChildCardinality::ONE,
                         stable_accessor: true,
                         choice_branch: Vec::new(),
+                        choice_arity: Vec::new(),
                         span: None,
                         branch_local_cardinality: embedded::ChildCardinality::ONE,
                     }
@@ -2664,6 +2665,7 @@ fn collect_structural_context_refs(
             enclosing_cardinality: embedded::ChildCardinality::ONE,
             branch_local_cardinality: embedded::ChildCardinality::ONE,
             choice_branch: &[],
+            choice_arity: &[],
         },
         vocabulary,
     );
@@ -2678,6 +2680,7 @@ struct StructuralRefContext<'a> {
     /// The same, but assuming each enclosing choice took this branch.
     branch_local_cardinality: embedded::ChildCardinality,
     choice_branch: &'a [(usize, usize)],
+    choice_arity: &'a [usize],
 }
 
 fn collect_structural_context_refs_with_cardinality(
@@ -2691,6 +2694,7 @@ fn collect_structural_context_refs_with_cardinality(
         enclosing_cardinality,
         branch_local_cardinality,
         choice_branch,
+        choice_arity,
     } = context;
     for element in elements {
         let label = element.label.as_ref().map(|label| label.name.clone());
@@ -2719,6 +2723,7 @@ fn collect_structural_context_refs_with_cardinality(
                 cardinality,
                 stable_accessor,
                 choice_branch: choice_branch.to_vec(),
+                choice_arity: choice_arity.to_vec(),
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
@@ -2735,6 +2740,7 @@ fn collect_structural_context_refs_with_cardinality(
                     cardinality,
                     stable_accessor,
                     choice_branch: choice_branch.to_vec(),
+                    choice_arity: choice_arity.to_vec(),
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
@@ -2762,6 +2768,7 @@ fn collect_structural_context_refs_with_cardinality(
                         cardinality,
                         stable_accessor,
                         choice_branch: choice_branch.to_vec(),
+                        choice_arity: choice_arity.to_vec(),
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
@@ -2780,6 +2787,7 @@ fn collect_structural_context_refs_with_cardinality(
                         cardinality,
                         stable_accessor: false,
                         choice_branch: choice_branch.to_vec(),
+                        choice_arity: choice_arity.to_vec(),
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
@@ -2808,8 +2816,10 @@ fn collect_structural_context_refs_with_cardinality(
                     // ones. A single-alternative block adds no exclusivity, so it
                     // keeps whatever tag it inherited.
                     let mut nested_branch = choice_branch.to_vec();
+                    let mut nested_arity = choice_arity.to_vec();
                     if block.alternatives.len() > 1 {
                         nested_branch.push((block.syntax.index(), branch));
+                        nested_arity.push(block.alternatives.len());
                     }
                     collect_structural_context_refs_with_cardinality(
                         &alternative.elements,
@@ -2821,6 +2831,7 @@ fn collect_structural_context_refs_with_cardinality(
                             // applies, but the choice split does not.
                             branch_local_cardinality: branch_local,
                             choice_branch: &nested_branch,
+                            choice_arity: &nested_arity,
                         },
                         vocabulary,
                     );
@@ -2836,6 +2847,7 @@ fn collect_structural_context_refs_with_cardinality(
                     cardinality,
                     stable_accessor,
                     choice_branch: choice_branch.to_vec(),
+                    choice_arity: choice_arity.to_vec(),
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
@@ -2852,6 +2864,7 @@ fn collect_structural_context_refs_with_cardinality(
                 cardinality,
                 stable_accessor: false,
                 choice_branch: choice_branch.to_vec(),
+                choice_arity: choice_arity.to_vec(),
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
@@ -9063,6 +9076,7 @@ fn context_label_accessor(
         cardinality: embedded::ChildCardinality::ONE,
         stable_accessor: true,
         choice_branch: Vec::new(),
+        choice_arity: Vec::new(),
         span: None,
         branch_local_cardinality: embedded::ChildCardinality::ONE,
     };
@@ -9263,6 +9277,15 @@ fn exact_target_cardinality(
     // Nested choices are folded innermost-first: once an inner choice agrees, its
     // count is attributed to the *enclosing* branch that contains it, so
     // `((a=A | b=A) | c=A) x=A` — where every path yields one `A` — stays exact.
+    // Arity comes from the recorded `choice_arity`, not from the branches seen: an
+    // *empty* alternative emits no ref, so `(a=A | )` would otherwise look like a
+    // one-branch choice that always yields an `A`.
+    let mut arity_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
+    for element in refs {
+        for (&(choice, _), &arity) in element.choice_branch.iter().zip(&element.choice_arity) {
+            arity_of_choice.insert(choice, arity);
+        }
+    }
     let mut branches_per_choice: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
     let mut depth_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
     for element in refs {
@@ -9297,7 +9320,10 @@ fn exact_target_cardinality(
         if counts.is_empty() {
             continue;
         }
-        let expected = branches_per_choice.get(&choice).map_or(0, BTreeSet::len);
+        let expected = arity_of_choice
+            .get(&choice)
+            .copied()
+            .unwrap_or_else(|| branches_per_choice.get(&choice).map_or(0, BTreeSet::len));
         let first = counts.first().and_then(|(_, count)| *count)?;
         if counts.len() != expected || counts.iter().any(|(_, count)| *count != Some(first)) {
             return None;

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -15550,6 +15550,12 @@ mod tests {
                 "a token-only choice holding an action keeps its branch spans",
             ),
             (
+                "ForwardBlockLabel",
+                "x",
+                true,
+                "a forward label's prefix is entirely in the action's future, so it cannot make the index inexact",
+            ),
+            (
                 "OptionalGroupSharedWithLabel",
                 "x",
                 true,

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2703,11 +2703,11 @@ fn collect_structural_context_refs_with_cardinality(
             ElementKind::Block(block) => {
                 let token_types = structural_block_token_types(block, vocabulary);
                 // A token-only block collapses into a single group ref, which is
-                // what makes `typeName=(Boolean | Int)` one labeled token child.
-                // That only holds when the label sits *on* the group: when the
-                // block is unlabeled and the labels sit inside it
-                // (`(doc=DocComment)?`), collapsing would swallow them, so
-                // descend and let the inner refs carry their own labels.
+                // what makes `x=(A | B)` one labeled token child. That only
+                // holds when the label sits *on* the group: when the block is
+                // unlabeled and the labels sit inside it (`(x=A)?`), collapsing
+                // would swallow them, so descend and let the inner refs carry
+                // their own labels.
                 if !token_types.is_empty()
                     && (label.is_some() || !structural_block_labels_inside(block))
                 {
@@ -2882,8 +2882,8 @@ fn structural_block_token_types(block: &Block, vocabulary: &Vocabulary) -> Vec<i
 }
 
 /// Whether any element directly inside `block` carries a label, i.e. the block
-/// is a grouping wrapper around labeled elements (`(doc=DocComment)?`) rather
-/// than a labeled token group (`typeName=(Boolean | Int)`).
+/// is a grouping wrapper around labeled elements (`(x=A)?`) rather than a
+/// labeled token group (`x=(A | B)`).
 fn structural_block_labels_inside(block: &Block) -> bool {
     block
         .alternatives

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -15550,6 +15550,12 @@ mod tests {
                 "a token-only choice holding an action keeps its branch spans",
             ),
             (
+                "ReassignedAfterAction",
+                "x",
+                true,
+                "a declaration after the action has not assigned the label yet, so it cannot conflict",
+            ),
+            (
                 "ForwardBlockLabel",
                 "x",
                 true,

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2594,6 +2594,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                         choice_spans: Vec::new(),
                         group_spans: Vec::new(),
                         branch_spans: Vec::new(),
+                        leading_terminal: true,
                         span: None,
                         branch_local_cardinality: embedded::ChildCardinality::ONE,
                         group_local_cardinality: embedded::ChildCardinality::ONE,
@@ -2709,6 +2710,12 @@ fn collect_structural_context_refs_with_cardinality(
         group_spans,
         branch_spans,
     } = context;
+    // Tracks whether any terminal-bearing ref has been emitted on this path, so an
+    // element can record whether it is the first terminal.
+    let mut seen_terminal = branch_local_cardinality.max.is_none_or(|max| max != 0)
+        && refs.iter().any(|existing| {
+            !existing.token_types.is_empty() && existing.cardinality.max != Some(0)
+        });
     for element in elements {
         let label = element.label.as_ref().map(|label| label.name.clone());
         let is_list = element
@@ -2740,6 +2747,7 @@ fn collect_structural_context_refs_with_cardinality(
                 choice_spans: choice_spans.to_vec(),
                 group_spans: group_spans.to_vec(),
                 branch_spans: branch_spans.to_vec(),
+                leading_terminal: !seen_terminal,
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
@@ -2764,6 +2772,7 @@ fn collect_structural_context_refs_with_cardinality(
                     choice_spans: choice_spans.to_vec(),
                     group_spans: group_spans.to_vec(),
                     branch_spans: branch_spans.to_vec(),
+                    leading_terminal: !seen_terminal,
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
@@ -2783,8 +2792,14 @@ fn collect_structural_context_refs_with_cardinality(
                 // unlabeled and the labels sit inside it (`(x=A)?`), collapsing
                 // would swallow them, so descend and let the inner refs carry
                 // their own labels.
+                // A block holding an action or predicate must also stay expanded even
+                // when it is token-only: collapsing it discards the per-branch spans
+                // that place the action, so `x=A? (A | B {$x.text})` could not tell
+                // that the action runs only where the sibling `A` cannot shadow `x`.
                 if !token_types.is_empty()
-                    && (label.is_some() || !structural_block_labels_inside(block))
+                    && (label.is_some()
+                        || !(structural_block_labels_inside(block)
+                            || structural_block_holds_action(block)))
                 {
                     refs.push(embedded::ElementRef {
                         label,
@@ -2799,6 +2814,7 @@ fn collect_structural_context_refs_with_cardinality(
                         choice_spans: choice_spans.to_vec(),
                         group_spans: group_spans.to_vec(),
                         branch_spans: branch_spans.to_vec(),
+                        leading_terminal: !seen_terminal,
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
@@ -2825,6 +2841,7 @@ fn collect_structural_context_refs_with_cardinality(
                         choice_spans: choice_spans.to_vec(),
                         group_spans: group_spans.to_vec(),
                         branch_spans: branch_spans.to_vec(),
+                        leading_terminal: !seen_terminal,
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
@@ -2911,6 +2928,7 @@ fn collect_structural_context_refs_with_cardinality(
                     choice_spans: choice_spans.to_vec(),
                     group_spans: group_spans.to_vec(),
                     branch_spans: branch_spans.to_vec(),
+                    leading_terminal: !seen_terminal,
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
@@ -2935,6 +2953,7 @@ fn collect_structural_context_refs_with_cardinality(
                 choice_spans: choice_spans.to_vec(),
                 group_spans: group_spans.to_vec(),
                 branch_spans: branch_spans.to_vec(),
+                leading_terminal: !seen_terminal,
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
@@ -2949,6 +2968,9 @@ fn collect_structural_context_refs_with_cardinality(
             | ElementKind::Action { .. }
             | ElementKind::Predicate { .. }
             | ElementKind::Epsilon => {}
+        }
+        if !structural_element_token_types(element, vocabulary).is_empty() {
+            seen_terminal = true;
         }
     }
 }
@@ -3046,6 +3068,21 @@ fn structural_block_token_types(block: &Block, vocabulary: &Vocabulary) -> Vec<i
         token_types.extend(alternative_types);
     }
     token_types.into_iter().collect()
+}
+
+/// Whether `block` contains an action or predicate at any depth. Such a block must
+/// not collapse into a single token-group ref: the collapse discards the per-branch
+/// spans that decide which branch an action sits in.
+fn structural_block_holds_action(block: &Block) -> bool {
+    block
+        .alternatives
+        .iter()
+        .flat_map(|alternative| &alternative.elements)
+        .any(|element| match &element.kind {
+            ElementKind::Action { .. } | ElementKind::Predicate { .. } => true,
+            ElementKind::Block(nested) => structural_block_holds_action(nested),
+            _ => false,
+        })
 }
 
 /// Whether any element anywhere inside `block` carries a label, i.e. the block
@@ -9154,6 +9191,7 @@ fn context_label_accessor(
         choice_spans: Vec::new(),
         group_spans: Vec::new(),
         branch_spans: Vec::new(),
+        leading_terminal: true,
         span: None,
         branch_local_cardinality: embedded::ChildCardinality::ONE,
         group_local_cardinality: embedded::ChildCardinality::ONE,
@@ -15393,7 +15431,49 @@ mod tests {
                 false,
                 "a repeated declaration needs a last-match read the others do not",
             ),
+            (
+                "RepeatedBlockLabel",
+                "x",
+                false,
+                "a repeated block label exposes its last match, which a positional read cannot express",
+            ),
+            (
+                "RepeatedSiblingSpansIndex",
+                "x",
+                false,
+                "a repeated sibling spans a range of terminal positions, not just its start",
+            ),
+            (
+                "MixedModeLeadingTerminal",
+                "x",
+                false,
+                "mixed-mode occurrence zero coincides only when no terminal precedes either side",
+            ),
             // Resolves: valid reads that must not be rejected.
+            (
+                "ActionInCollapsibleChoice",
+                "x",
+                true,
+                "a token-only choice holding an action keeps its branch spans",
+            ),
+            (
+                "InlineActionBeforeLabel",
+                "x",
+                true,
+                "an inline action sees no children, so a later unbounded run cannot poison it",
+            ),
+            (
+                "SiblingDeclarationIrrelevant",
+                "x",
+                true,
+                "a branch-confined action never sees a sibling branch's declaration",
+            ),
+            (
+                "NestedChoiceInsideConfinedBranch",
+                "x",
+                true,
+                "confinement to an outer branch does not restrict a nested choice inside it",
+            ),
             (
                 "ListAliasDeclarations",
                 "xs",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2835,6 +2835,10 @@ fn collect_structural_context_refs_with_cardinality(
                             element.quantifier,
                         ),
                     });
+                    // The collapsed group *is* a terminal child, so record it before
+                    // skipping the rest of the loop body — otherwise the next element
+                    // would also be classified as leading.
+                    seen_terminal = true;
                     continue;
                 }
                 if label.is_some() {
@@ -15575,6 +15579,18 @@ mod tests {
                 "a token-only choice holding an action keeps its branch spans",
             ),
             (
+                "CollapsedBlockIsTerminal",
+                "x",
+                false,
+                "a collapsed token group is itself a terminal child, so what follows is not leading",
+            ),
+            (
+                "UnrelatedLaterChoiceConfinement",
+                "x",
+                false,
+                "confinement to a later choice says nothing about an earlier sibling",
+            ),
+            (
                 "ListPrefixRepeatsWithLabel",
                 "xs",
                 false,
@@ -15585,6 +15601,12 @@ mod tests {
                 "x",
                 false,
                 "a closed repeated group still contributes an unfixed number of preceding children",
+            ),
+            (
+                "RecoveredDeletedTokenIndex",
+                "x",
+                true,
+                "the positional block read skips deleted-token errors, so recovery cannot shift its index",
             ),
             (
                 "ReassignedAfterAction",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2591,6 +2591,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                         stable_accessor: true,
                         choice_branch: Vec::new(),
                         choice_arity: Vec::new(),
+                        choice_spans: Vec::new(),
                         span: None,
                         branch_local_cardinality: embedded::ChildCardinality::ONE,
                     }
@@ -2666,6 +2667,7 @@ fn collect_structural_context_refs(
             branch_local_cardinality: embedded::ChildCardinality::ONE,
             choice_branch: &[],
             choice_arity: &[],
+            choice_spans: &[],
         },
         vocabulary,
     );
@@ -2681,6 +2683,7 @@ struct StructuralRefContext<'a> {
     branch_local_cardinality: embedded::ChildCardinality,
     choice_branch: &'a [(usize, usize)],
     choice_arity: &'a [usize],
+    choice_spans: &'a [(usize, usize)],
 }
 
 fn collect_structural_context_refs_with_cardinality(
@@ -2695,6 +2698,7 @@ fn collect_structural_context_refs_with_cardinality(
         branch_local_cardinality,
         choice_branch,
         choice_arity,
+        choice_spans,
     } = context;
     for element in elements {
         let label = element.label.as_ref().map(|label| label.name.clone());
@@ -2724,6 +2728,7 @@ fn collect_structural_context_refs_with_cardinality(
                 stable_accessor,
                 choice_branch: choice_branch.to_vec(),
                 choice_arity: choice_arity.to_vec(),
+                choice_spans: choice_spans.to_vec(),
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
@@ -2741,6 +2746,7 @@ fn collect_structural_context_refs_with_cardinality(
                     stable_accessor,
                     choice_branch: choice_branch.to_vec(),
                     choice_arity: choice_arity.to_vec(),
+                    choice_spans: choice_spans.to_vec(),
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
@@ -2769,6 +2775,7 @@ fn collect_structural_context_refs_with_cardinality(
                         stable_accessor,
                         choice_branch: choice_branch.to_vec(),
                         choice_arity: choice_arity.to_vec(),
+                        choice_spans: choice_spans.to_vec(),
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
@@ -2788,6 +2795,7 @@ fn collect_structural_context_refs_with_cardinality(
                         stable_accessor: false,
                         choice_branch: choice_branch.to_vec(),
                         choice_arity: choice_arity.to_vec(),
+                        choice_spans: choice_spans.to_vec(),
                         span: Some((
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
@@ -2817,9 +2825,14 @@ fn collect_structural_context_refs_with_cardinality(
                     // keeps whatever tag it inherited.
                     let mut nested_branch = choice_branch.to_vec();
                     let mut nested_arity = choice_arity.to_vec();
+                    let mut nested_spans = choice_spans.to_vec();
                     if block.alternatives.len() > 1 {
                         nested_branch.push((block.syntax.index(), branch));
                         nested_arity.push(block.alternatives.len());
+                        nested_spans.push((
+                            block.span.bytes.start as usize,
+                            block.span.bytes.end as usize,
+                        ));
                     }
                     collect_structural_context_refs_with_cardinality(
                         &alternative.elements,
@@ -2832,6 +2845,7 @@ fn collect_structural_context_refs_with_cardinality(
                             branch_local_cardinality: branch_local,
                             choice_branch: &nested_branch,
                             choice_arity: &nested_arity,
+                            choice_spans: &nested_spans,
                         },
                         vocabulary,
                     );
@@ -2848,6 +2862,7 @@ fn collect_structural_context_refs_with_cardinality(
                     stable_accessor,
                     choice_branch: choice_branch.to_vec(),
                     choice_arity: choice_arity.to_vec(),
+                    choice_spans: choice_spans.to_vec(),
                     span: Some((
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
@@ -2865,6 +2880,7 @@ fn collect_structural_context_refs_with_cardinality(
                 stable_accessor: false,
                 choice_branch: choice_branch.to_vec(),
                 choice_arity: choice_arity.to_vec(),
+                choice_spans: choice_spans.to_vec(),
                 span: Some((
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
@@ -9077,6 +9093,7 @@ fn context_label_accessor(
         stable_accessor: true,
         choice_branch: Vec::new(),
         choice_arity: Vec::new(),
+        choice_spans: Vec::new(),
         span: None,
         branch_local_cardinality: embedded::ChildCardinality::ONE,
     };
@@ -9146,8 +9163,13 @@ fn context_label_selector(
     // position this accessor reads, but on a parse where the label is unset —
     // `(left=unary | right=unary)` would let `right()` return `left`'s child.
     // Positional lookup cannot tell them apart, so decline.
+    // Another *declaration* of the same label is not an impostor — it binds the
+    // label too, and `context_label_accessor` already proved the declarations share
+    // one read. Only an unlabeled (or differently-labeled) sibling child can be
+    // mistaken for this label's.
     let sibling_supplies_target = alternative.refs.iter().any(|element| {
-        !element.can_coexist_with(labeled)
+        element.label.as_deref() != Some(label)
+            && !element.can_coexist_with(labeled)
             && context_ref_can_match_target(element, target)
             && element.cardinality.max != Some(0)
     });
@@ -9164,8 +9186,26 @@ fn context_label_selector(
         });
         return (!has_unlabeled_target).then_some(ContextLabelSelector::AllAfter(start));
     }
+    // Several declarations can share one positional read when they are mutually
+    // exclusive and each sits at the same occurrence — `(x=A | x=B)` binds exactly
+    // one token on every parse, and the accessor's unioned token set selects it.
     if matching.len() != 1 {
-        return None;
+        let mutually_exclusive = matching.iter().enumerate().all(|(index, (_, left))| {
+            matching[index + 1..]
+                .iter()
+                .all(|(_, right)| !left.can_coexist_with(right))
+        });
+        let positions = matching
+            .iter()
+            .map(|(position, element)| {
+                exact_target_cardinality_on_path(&alternative.refs[..*position], target, element)
+            })
+            .collect::<Option<Vec<_>>>()?;
+        let agreed = positions.first().copied()?;
+        if !mutually_exclusive || positions.iter().any(|position| *position != agreed) {
+            return None;
+        }
+        return Some(ContextLabelSelector::Nth(agreed));
     }
     let element = matching[0].1;
     if !element.cardinality.is_repeated() {
@@ -9217,6 +9257,10 @@ fn exact_target_cardinality_on_path(
     target: &embedded::ElementRef,
     path: &embedded::ElementRef,
 ) -> Option<usize> {
+    // Filtering to one path and then demanding cross-branch agreement are mutually
+    // exclusive: the other branches were removed deliberately, so requiring them to
+    // contribute would reject `(A x=A | B)`, where the retained `A` still carries
+    // the choice's full arity of two.
     // A ref in a branch `path` cannot reach never precedes it, so drop those
     // before counting: in `(left=unary | right=unary)` the `left` ref must not
     // shift `right` to occurrence 1.
@@ -9224,6 +9268,20 @@ fn exact_target_cardinality_on_path(
         .iter()
         .filter(|element| element.can_coexist_with(path))
         .cloned()
+        .map(|mut element| {
+            // Drop the branch tags shared with `path`: on this path those branches
+            // are taken, so their refs count as plain sequential children rather
+            // than alternatives awaiting cross-branch agreement.
+            element
+                .choice_branch
+                .retain(|(choice, _)| !path.choice_branch.iter().any(|(taken, _)| taken == choice));
+            let keep = element.choice_branch.len();
+            element.choice_arity.truncate(keep);
+            element.choice_spans.truncate(keep);
+            // Their cardinality on this path is the branch-local one.
+            element.cardinality = element.branch_local_cardinality;
+            element
+        })
         .collect::<Vec<_>>();
     exact_target_cardinality(&reachable, target)
 }
@@ -15113,6 +15171,17 @@ mod tests {
         insta::assert_snapshot!(
             "multi_alternative_label_optional_prefix_context",
             context("OptionalPrefixContext")
+        );
+        // One label over mutually exclusive branches merges into a single read; and
+        // restricting to the label's own path lets a sibling branch be ignored
+        // rather than demanded.
+        insta::assert_snapshot!(
+            "multi_alternative_label_merged_rivals_context",
+            context("MergedRivalsContext")
+        );
+        insta::assert_snapshot!(
+            "multi_alternative_label_path_restricted_context",
+            context("PathRestrictedContext")
         );
         // Nesting the exhaustive choice keeps the count fixed: the inner choice's
         // agreed contribution rolls up into the outer branch.

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2591,6 +2591,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                         stable_accessor: true,
                         choice_branch: Vec::new(),
                         span: None,
+                        branch_local_cardinality: embedded::ChildCardinality::ONE,
                     }
                 });
             Some(structural_alt_model(alternative, leading_ref, vocabulary))
@@ -2658,21 +2659,39 @@ fn collect_structural_context_refs(
     collect_structural_context_refs_with_cardinality(
         elements,
         refs,
-        stable_accessor,
-        embedded::ChildCardinality::ONE,
-        &[],
+        StructuralRefContext {
+            stable_accessor,
+            enclosing_cardinality: embedded::ChildCardinality::ONE,
+            branch_local_cardinality: embedded::ChildCardinality::ONE,
+            choice_branch: &[],
+        },
         vocabulary,
     );
+}
+
+/// Traversal state threaded down while flattening an alternative's elements.
+#[derive(Clone, Copy)]
+struct StructuralRefContext<'a> {
+    stable_accessor: bool,
+    /// Cardinality contributed by every enclosing quantifier *and* choice split.
+    enclosing_cardinality: embedded::ChildCardinality,
+    /// The same, but assuming each enclosing choice took this branch.
+    branch_local_cardinality: embedded::ChildCardinality,
+    choice_branch: &'a [(usize, usize)],
 }
 
 fn collect_structural_context_refs_with_cardinality(
     elements: &[Element],
     refs: &mut Vec<embedded::ElementRef>,
-    stable_accessor: bool,
-    enclosing_cardinality: embedded::ChildCardinality,
-    choice_branch: &[(usize, usize)],
+    context: StructuralRefContext<'_>,
     vocabulary: &Vocabulary,
 ) {
+    let StructuralRefContext {
+        stable_accessor,
+        enclosing_cardinality,
+        branch_local_cardinality,
+        choice_branch,
+    } = context;
     for element in elements {
         let label = element.label.as_ref().map(|label| label.name.clone());
         let is_list = element
@@ -2681,6 +2700,13 @@ fn collect_structural_context_refs_with_cardinality(
             .is_some_and(|label| label.kind == LabelKind::List);
         let cardinality = multiply_child_cardinalities(
             enclosing_cardinality,
+            quantified_cardinality(embedded::ChildCardinality::ONE, element.quantifier),
+        );
+        // Same product, but against the cardinality this element would have if
+        // every enclosing choice took its branch — so a `min: 0` here comes only
+        // from a quantifier, never from branch membership.
+        let branch_local = multiply_child_cardinalities(
+            branch_local_cardinality,
             quantified_cardinality(embedded::ChildCardinality::ONE, element.quantifier),
         );
         match &element.kind {
@@ -2697,6 +2723,7 @@ fn collect_structural_context_refs_with_cardinality(
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
                 )),
+                branch_local_cardinality: branch_local,
             }),
             ElementKind::Terminal(terminal) => {
                 refs.push(embedded::ElementRef {
@@ -2712,6 +2739,7 @@ fn collect_structural_context_refs_with_cardinality(
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
                     )),
+                    branch_local_cardinality: branch_local,
                 });
             }
             ElementKind::Block(block) => {
@@ -2738,6 +2766,7 @@ fn collect_structural_context_refs_with_cardinality(
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
                         )),
+                        branch_local_cardinality: branch_local,
                     });
                     continue;
                 }
@@ -2755,6 +2784,7 @@ fn collect_structural_context_refs_with_cardinality(
                             element.span.bytes.start as usize,
                             element.span.bytes.end as usize,
                         )),
+                        branch_local_cardinality: branch_local,
                     });
                 }
                 // Refs from one alternative of a *choice* are present only when
@@ -2784,9 +2814,14 @@ fn collect_structural_context_refs_with_cardinality(
                     collect_structural_context_refs_with_cardinality(
                         &alternative.elements,
                         refs,
-                        stable_accessor,
-                        branch_cardinality,
-                        &nested_branch,
+                        StructuralRefContext {
+                            stable_accessor,
+                            enclosing_cardinality: branch_cardinality,
+                            // Inside a branch the group's own quantifier still
+                            // applies, but the choice split does not.
+                            branch_local_cardinality: branch_local,
+                            choice_branch: &nested_branch,
+                        },
                         vocabulary,
                     );
                 }
@@ -2805,6 +2840,7 @@ fn collect_structural_context_refs_with_cardinality(
                         element.span.bytes.start as usize,
                         element.span.bytes.end as usize,
                     )),
+                    branch_local_cardinality: branch_local,
                 });
             }
             ElementKind::Range(..) if label.is_some() => refs.push(embedded::ElementRef {
@@ -2820,6 +2856,7 @@ fn collect_structural_context_refs_with_cardinality(
                     element.span.bytes.start as usize,
                     element.span.bytes.end as usize,
                 )),
+                branch_local_cardinality: branch_local,
             }),
             ElementKind::Range(..)
             | ElementKind::Action { .. }
@@ -9027,6 +9064,7 @@ fn context_label_accessor(
         stable_accessor: true,
         choice_branch: Vec::new(),
         span: None,
+        branch_local_cardinality: embedded::ChildCardinality::ONE,
     };
     let mut selector = None;
     let mut cardinalities = Vec::with_capacity(alternatives.len());
@@ -9200,11 +9238,11 @@ fn exact_target_cardinality(
         }
         let exact = element.cardinality.max?;
         // A ref inside a choice reports `min: 0` because its *branch* may not be
-        // taken, but within that branch it contributes its maximum exactly. Judge
-        // exactness per branch and let the cross-branch agreement check below
-        // decide whether the choice as a whole is exact.
-        let contribution = (element.cardinality.min == exact || !element.choice_branch.is_empty())
-            .then_some(exact);
+        // taken, but within that branch it contributes its branch-local count
+        // exactly. Judge exactness against that, so an *optional* choice
+        // (`(a=A | b=A)? x=A`) stays inexact — the group may yield nothing.
+        let local = element.branch_local_cardinality;
+        let contribution = (local.min == exact && local.max == Some(exact)).then_some(exact);
         match element.choice_branch.last() {
             // Sequential: its count adds directly.
             None => total = total.saturating_add(contribution?),
@@ -15006,6 +15044,13 @@ mod tests {
         insta::assert_snapshot!(
             "multi_alternative_label_overlapping_group_context",
             context("OverlappingGroupContext")
+        );
+        // Making that same choice optional removes the fixed position, so the
+        // following label loses its accessor — the branch-local cardinality is
+        // what distinguishes the two.
+        insta::assert_snapshot!(
+            "multi_alternative_label_optional_prefix_context",
+            context("OptionalPrefixContext")
         );
 
         for (name, snapshot) in [

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2690,7 +2690,7 @@ struct StructuralRefContext<'a> {
     choice_branch: &'a [(usize, usize)],
     choice_arity: &'a [usize],
     choice_spans: &'a [(usize, usize)],
-    group_spans: &'a [(usize, usize)],
+    group_spans: &'a [embedded::GroupSpan],
     branch_spans: &'a [(usize, usize)],
 }
 
@@ -2879,10 +2879,17 @@ fn collect_structural_context_refs_with_cardinality(
                     // Every block counts here, single-alternative groups included.
                     let mut nested_branch_spans = branch_spans.to_vec();
                     let mut nested_groups = group_spans.to_vec();
-                    nested_groups.push((
-                        block.span.bytes.start as usize,
-                        block.span.bytes.end as usize,
-                    ));
+                    nested_groups.push(embedded::GroupSpan {
+                        start: block.span.bytes.start as usize,
+                        end: block.span.bytes.end as usize,
+                        // Only a quantifier that can yield nothing relaxes the
+                        // elements inside.
+                        optional: quantified_cardinality(
+                            embedded::ChildCardinality::ONE,
+                            element.quantifier,
+                        )
+                        .min == 0,
+                    });
                     if block.alternatives.len() > 1 {
                         nested_branch.push((block.syntax.index(), branch));
                         nested_arity.push(block.alternatives.len());
@@ -15464,6 +15471,12 @@ mod tests {
                 "a shared last-match read would return a following unlabeled child on the non-repeated branch",
             ),
             (
+                "FallbackReadSiblingAlternative",
+                "x",
+                false,
+                "a `last()` fallback can select any terminal, so a non-declaring alternative satisfies it",
+            ),
+            (
                 "MixedModeLeadingTerminal",
                 "x",
                 false,
@@ -15475,6 +15488,12 @@ mod tests {
                 "x",
                 true,
                 "a token-only choice holding an action keeps its branch spans",
+            ),
+            (
+                "MandatoryInnerGroupClosed",
+                "x",
+                true,
+                "a mandatory inner group relaxes nothing, so its closing before the action is irrelevant",
             ),
             (
                 "InlineActionBeforeLabel",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2881,15 +2881,23 @@ fn structural_block_token_types(block: &Block, vocabulary: &Vocabulary) -> Vec<i
     token_types.into_iter().collect()
 }
 
-/// Whether any element directly inside `block` carries a label, i.e. the block
+/// Whether any element anywhere inside `block` carries a label, i.e. the block
 /// is a grouping wrapper around labeled elements (`(x=A)?`) rather than a
 /// labeled token group (`x=(A | B)`).
+///
+/// The search descends nested blocks: extra grouping levels (`((x=A))?`) are
+/// syntactically inert, so a label buried under them must still prevent the
+/// collapse that would discard it.
 fn structural_block_labels_inside(block: &Block) -> bool {
     block
         .alternatives
         .iter()
         .flat_map(|alternative| &alternative.elements)
-        .any(|element| element.label.is_some())
+        .any(|element| {
+            element.label.is_some()
+                || matches!(&element.kind, ElementKind::Block(nested)
+                    if structural_block_labels_inside(nested))
+        })
 }
 
 fn structural_terminal_child_target(
@@ -14865,6 +14873,14 @@ mod tests {
                 "rival same-target labels across branches must decline {label}\n{rival}"
             );
         }
+
+        // A label buried under redundant grouping levels still reaches the
+        // surface — the collapse check descends nested blocks.
+        let nested = context("NestedGroupContext");
+        assert!(
+            nested.contains("pub fn deep("),
+            "a label under extra grouping levels must still emit an accessor\n{nested}"
+        );
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -14848,39 +14848,40 @@ mod tests {
             context("MixedContext")
         );
 
-        // A variable count of the label's own target ahead of it leaves no
-        // fixed `.skip(N)`.
-        let unbounded = context("MixedUnboundedContext");
-        assert!(
-            !unbounded.contains("pub fn errors("),
-            "a list label behind an unbounded run of its own target has no fixed skip\n{unbounded}"
-        );
-
-        // Only one branch supplies the label while its sibling matches the same
-        // target unlabeled, so `.nth(0)` could read the sibling's child.
-        let hazard = context("BranchHazardContext");
-        assert!(
-            !hazard.contains("pub fn pick("),
-            "a label whose sibling branch matches the same target unlabeled must decline\n{hazard}"
-        );
-
-        // Rival labels on the same target across branches must not read each
-        // other's child.
-        let rival = context("BranchRivalContext");
-        for label in ["pub fn left(", "pub fn right("] {
-            assert!(
-                !rival.contains(label),
-                "rival same-target labels across branches must decline {label}\n{rival}"
-            );
-        }
-
         // A label buried under redundant grouping levels still reaches the
         // surface — the collapse check descends nested blocks.
-        let nested = context("NestedGroupContext");
-        assert!(
-            nested.contains("pub fn deep("),
-            "a label under extra grouping levels must still emit an accessor\n{nested}"
+        insta::assert_snapshot!(
+            "multi_alternative_label_nested_group_context",
+            context("NestedGroupContext")
         );
+
+        // The three declining shapes are snapshotted whole rather than probed
+        // with `!contains`, so the absent accessor is visible alongside
+        // everything the context *does* expose:
+        //
+        // * `mixed_unbounded` — a variable count of the label's own target ahead
+        //   of it leaves no fixed `.skip(N)`;
+        // * `branch_hazard` — only one branch supplies the label while its
+        //   sibling matches the same target unlabeled, so `.nth(0)` could read
+        //   the sibling's child;
+        // * `branch_rival` — rival labels on one target across branches must not
+        //   read each other's child.
+        for (name, snapshot) in [
+            (
+                "MixedUnboundedContext",
+                "multi_alternative_label_mixed_unbounded_context",
+            ),
+            (
+                "BranchHazardContext",
+                "multi_alternative_label_branch_hazard_context",
+            ),
+            (
+                "BranchRivalContext",
+                "multi_alternative_label_branch_rival_context",
+            ),
+        ] {
+            insta::assert_snapshot!(snapshot, context(name));
+        }
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9336,11 +9336,25 @@ fn context_label_selector(
             }
         }
         // A *repeated* scalar declaration (`x=A+`) is overwritten each iteration, so
-        // ANTLR exposes the last match — `nth` would pin the first.
+        // ANTLR exposes the last match — `nth` would pin the first. But `LastAfter`
+        // applies to every branch, so it is only sound when no branch has a matching
+        // child *after* its declaration: in `(x=A A B | x=A+ C)` the first branch's
+        // trailing unlabeled `A` would become the `last()`.
         if matching
             .iter()
             .any(|(_, element)| element.cardinality.is_repeated())
         {
+            let followed = matching.iter().any(|(position, declaration)| {
+                alternative.refs[position + 1..].iter().any(|following| {
+                    following.label.as_deref() != Some(label)
+                        && context_ref_can_match_target(following, target)
+                        && following.cardinality.max != Some(0)
+                        && following.can_coexist_with(declaration)
+                })
+            });
+            if followed {
+                return None;
+            }
             return Some(ContextLabelSelector::LastAfter(agreed));
         }
         return Some(ContextLabelSelector::Nth(agreed));
@@ -15442,6 +15456,12 @@ mod tests {
                 "x",
                 false,
                 "a repeated sibling spans a range of terminal positions, not just its start",
+            ),
+            (
+                "RepeatedMergeFollowedByMatch",
+                "x",
+                false,
+                "a shared last-match read would return a following unlabeled child on the non-repeated branch",
             ),
             (
                 "MixedModeLeadingTerminal",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9205,6 +9205,14 @@ fn context_label_selector(
         if !mutually_exclusive || positions.iter().any(|position| *position != agreed) {
             return None;
         }
+        // A *repeated* scalar declaration (`x=A+`) is overwritten each iteration, so
+        // ANTLR exposes the last match — `nth` would pin the first.
+        if matching
+            .iter()
+            .any(|(_, element)| element.cardinality.is_repeated())
+        {
+            return Some(ContextLabelSelector::LastAfter(agreed));
+        }
         return Some(ContextLabelSelector::Nth(agreed));
     }
     let element = matching[0].1;
@@ -15178,6 +15186,12 @@ mod tests {
         insta::assert_snapshot!(
             "multi_alternative_label_merged_rivals_context",
             context("MergedRivalsContext")
+        );
+        // Repeated scalar declarations merge as a *last*-match read, since ANTLR
+        // overwrites a scalar label on every iteration.
+        insta::assert_snapshot!(
+            "multi_alternative_label_merged_repeats_context",
+            context("MergedRepeatsContext")
         );
         insta::assert_snapshot!(
             "multi_alternative_label_path_restricted_context",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2899,6 +2899,13 @@ fn collect_structural_context_refs_with_cardinality(
                             element.quantifier,
                         )
                         .min == 0,
+                        // A star/plus group can run more than once, so even a group
+                        // known to have run contributes an unfixed count.
+                        repeated: quantified_cardinality(
+                            embedded::ChildCardinality::ONE,
+                            element.quantifier,
+                        )
+                        .is_repeated(),
                     });
                     if block.alternatives.len() > 1 {
                         nested_branch.push((block.syntax.index(), branch));
@@ -9320,6 +9327,24 @@ fn context_label_selector(
                 && element.cardinality.max != Some(0)
                 && element.label.as_deref() != Some(label)
         });
+        // A same-target ref *before* the label normally just shifts `start`, but if
+        // the two share a repeated group it recurs on every iteration and interleaves
+        // with the labeled children: `(A xs+=A)+` skips one `A` and then collects the
+        // second iteration's unlabeled prefix too. No `skip` can separate them.
+        let repeats_with_prefix = alternative.refs[..first_position].iter().any(|element| {
+            context_ref_can_match_target(element, target)
+                && element.cardinality.max != Some(0)
+                && element.label.as_deref() != Some(label)
+                && element.group_spans.iter().any(|group| {
+                    // Shared and repeatable: `max` is not one, so the group can run
+                    // more than once.
+                    labeled.group_spans.contains(group)
+                        && !matches!(element.cardinality.max, Some(0 | 1))
+                })
+        });
+        if repeats_with_prefix {
+            return None;
+        }
         // `AllAfter(start)` skips `start` children then takes the rest, so repeated
         // declarations on one path are fine — the later ones fall inside the tail
         // (`xs+=e (op xs+=e)*` skips 0 and collects every `e`). What it cannot serve
@@ -15548,6 +15573,18 @@ mod tests {
                 "x",
                 true,
                 "a token-only choice holding an action keeps its branch spans",
+            ),
+            (
+                "ListPrefixRepeatsWithLabel",
+                "xs",
+                false,
+                "a same-target prefix sharing a repeated group interleaves with the labeled children",
+            ),
+            (
+                "ClosedRepeatedGroupPrefix",
+                "x",
+                false,
+                "a closed repeated group still contributes an unfixed number of preceding children",
             ),
             (
                 "ReassignedAfterAction",

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -15314,6 +15314,161 @@ mod tests {
         }
     }
 
+    /// Every label shape whose *resolution outcome* this module decides, kept in
+    /// one place so a change to any guard shows up as a diff here rather than as a
+    /// silent behaviour change in a grammar nobody tests.
+    ///
+    /// A label resolves only when the read `translate_element_read` emits provably
+    /// selects that label's own element. `resolve` means the grammar generates;
+    /// `decline` means resolution fails loudly (`cannot translate $x`), which is
+    /// always preferable to a read that returns some *other* child. Each entry
+    /// records why, because the two outcomes are easy to swap by accident — most
+    /// of these were originally over-rejections introduced while fixing a
+    /// miscompile, or vice versa.
+    #[test]
+    fn label_resolution_corpus_matches_expected_outcomes() {
+        // (fixture, label, resolves, why). `label` is the accessor/read the case
+        // turns on: rendering succeeds either way for a grammar without actions, so
+        // a declined *accessor* shows up as the method being absent rather than as
+        // a render error.
+        const CORPUS: &[(&str, &str, bool, &str)] = &[
+            // Declines: the read would select a child the label never bound.
+            (
+                "SiblingUnlabeledSameTarget",
+                "xs",
+                false,
+                "an action after a choice runs for every branch, so a sibling's token is not the label's",
+            ),
+            (
+                "OptionalBlockFollowedByTerminal",
+                "x",
+                false,
+                "an absent optional block lets the follower occupy its index",
+            ),
+            (
+                "ActionAfterNestedChoice",
+                "xs",
+                false,
+                "a list read would fold in the sibling branch's child",
+            ),
+            (
+                "LiteralAliasDifferingOccurrence",
+                "x",
+                false,
+                "block and token reads index in different units, so occurrence 1 means different children",
+            ),
+            (
+                "MergedDeclarationOptionalFollower",
+                "x",
+                false,
+                "an absent optional declaration lets the follower slide into the merged read",
+            ),
+            (
+                "ListDeclarationsDifferingStart",
+                "xs",
+                false,
+                "one `AllAfter` skip cannot serve branches that begin at different offsets",
+            ),
+            // Resolves: valid reads that must not be rejected.
+            (
+                "LiteralAliasSameOccurrence",
+                "x",
+                true,
+                "block and token reads coincide at occurrence zero",
+            ),
+            (
+                "NestedChoiceSatisfiability",
+                "x",
+                true,
+                "nested choices fold rather than sum: the alternative builds one child",
+            ),
+            (
+                "RepeatedScalarMerge",
+                "x",
+                true,
+                "a repeated scalar label exposes its last match",
+            ),
+            (
+                "ActionInsideTakenGroup",
+                "x",
+                true,
+                "the enclosing group's quantifier is satisfied wherever the action runs",
+            ),
+            (
+                "ActionOnlyBranch",
+                "x",
+                true,
+                "a branch holding only an action still identifies itself by span",
+            ),
+            (
+                "InitActionBeforeChildren",
+                "xs",
+                true,
+                "an `@init` body runs before any child exists, so no read can be polluted",
+            ),
+            (
+                "ExhaustiveChoicePrefix",
+                "x",
+                true,
+                "an exhaustive choice contributes a fixed count",
+            ),
+            (
+                "NotSetLabelBeforeTerminal",
+                "t",
+                true,
+                "ANTLR's `Sets/ParserNotTokenWithLabel` shape",
+            ),
+            (
+                "ConjuredLiteralLabel",
+                "x",
+                true,
+                "ANTLR's `ParserErrors/ConjuringUpToken` shape",
+            ),
+        ];
+
+        let mut wrong = Vec::new();
+        for &(fixture, label, resolves, why) in CORPUS {
+            let data = parser_fixture_data(&format!("label-resolution/{fixture}.g4"));
+            let rendered = render_parser_with_options(
+                &format!("{fixture}Parser"),
+                &data,
+                ParserRenderOptions {
+                    embedded: true,
+                    ..ParserRenderOptions::default()
+                },
+            );
+            // Which signal reports the decision depends on how the fixture reads its
+            // label. A grammar whose *action* reads it fails to render outright when
+            // resolution declines; one that relies on the typed accessor renders
+            // either way, and the decision surfaces as the method's presence.
+            let source = fs::read_to_string(
+                Path::new(env!("CARGO_MANIFEST_DIR"))
+                    .join("tests/fixtures/antlr4-rust-gen/label-resolution")
+                    .join(format!("{fixture}.g4")),
+            )
+            .expect("fixture should be readable");
+            let reads_via_action = source.contains(&format!("${label}"));
+            let resolved = rendered.as_ref().is_ok_and(|parser| {
+                reads_via_action || parser.contains(&format!("pub fn {label}("))
+            });
+            if resolved != resolves {
+                let outcome = if resolves { "resolve" } else { "decline" };
+                let error = rendered
+                    .err()
+                    .map(|error| error.to_string())
+                    .unwrap_or_default();
+                wrong.push(format!(
+                    "  {fixture} (${label}): expected {outcome} — {why} {error}"
+                ));
+            }
+        }
+        assert!(
+            wrong.is_empty(),
+            "label resolution changed:\n{}",
+            wrong.join("\n")
+        );
+    }
+
     #[test]
     fn non_embedded_parser_action_disables_generated_rule() {
         let rendered =

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2590,6 +2590,7 @@ fn structural_rule_alternatives(rule: &Rule, vocabulary: &Vocabulary) -> Vec<emb
                         cardinality: embedded::ChildCardinality::ONE,
                         stable_accessor: true,
                         choice_branch: Vec::new(),
+                        span: None,
                     }
                 });
             Some(structural_alt_model(alternative, leading_ref, vocabulary))
@@ -2692,6 +2693,10 @@ fn collect_structural_context_refs_with_cardinality(
                 cardinality,
                 stable_accessor,
                 choice_branch: choice_branch.to_vec(),
+                span: Some((
+                    element.span.bytes.start as usize,
+                    element.span.bytes.end as usize,
+                )),
             }),
             ElementKind::Terminal(terminal) => {
                 refs.push(embedded::ElementRef {
@@ -2703,6 +2708,10 @@ fn collect_structural_context_refs_with_cardinality(
                     cardinality,
                     stable_accessor,
                     choice_branch: choice_branch.to_vec(),
+                    span: Some((
+                        element.span.bytes.start as usize,
+                        element.span.bytes.end as usize,
+                    )),
                 });
             }
             ElementKind::Block(block) => {
@@ -2725,6 +2734,10 @@ fn collect_structural_context_refs_with_cardinality(
                         cardinality,
                         stable_accessor,
                         choice_branch: choice_branch.to_vec(),
+                        span: Some((
+                            element.span.bytes.start as usize,
+                            element.span.bytes.end as usize,
+                        )),
                     });
                     continue;
                 }
@@ -2738,6 +2751,10 @@ fn collect_structural_context_refs_with_cardinality(
                         cardinality,
                         stable_accessor: false,
                         choice_branch: choice_branch.to_vec(),
+                        span: Some((
+                            element.span.bytes.start as usize,
+                            element.span.bytes.end as usize,
+                        )),
                     });
                 }
                 // Refs from one alternative of a *choice* are present only when
@@ -2784,6 +2801,10 @@ fn collect_structural_context_refs_with_cardinality(
                     cardinality,
                     stable_accessor,
                     choice_branch: choice_branch.to_vec(),
+                    span: Some((
+                        element.span.bytes.start as usize,
+                        element.span.bytes.end as usize,
+                    )),
                 });
             }
             ElementKind::Range(..) if label.is_some() => refs.push(embedded::ElementRef {
@@ -2795,6 +2816,10 @@ fn collect_structural_context_refs_with_cardinality(
                 cardinality,
                 stable_accessor: false,
                 choice_branch: choice_branch.to_vec(),
+                span: Some((
+                    element.span.bytes.start as usize,
+                    element.span.bytes.end as usize,
+                )),
             }),
             ElementKind::Range(..)
             | ElementKind::Action { .. }
@@ -9001,6 +9026,7 @@ fn context_label_accessor(
         cardinality: embedded::ChildCardinality::ONE,
         stable_accessor: true,
         choice_branch: Vec::new(),
+        span: None,
     };
     let mut selector = None;
     let mut cardinalities = Vec::with_capacity(alternatives.len());

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -26,6 +26,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -50,6 +51,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: Some(
                     (
                         135,
@@ -79,6 +81,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: Some(
                     (
                         146,
@@ -134,6 +137,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -158,6 +162,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: Some(
                     (
                         190,
@@ -187,6 +192,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: Some(
                     (
                         201,
@@ -242,6 +248,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                choice_arity: [],
                 span: Some(
                     (
                         238,

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -26,6 +26,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: None,
             },
             ElementRef {
                 label: None,
@@ -43,6 +44,12 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: Some(
+                    (
+                        135,
+                        139,
+                    ),
+                ),
             },
             ElementRef {
                 label: Some(
@@ -60,6 +67,12 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: Some(
+                    (
+                        146,
+                        147,
+                    ),
+                ),
             },
         ],
         children: {
@@ -103,6 +116,7 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: None,
             },
             ElementRef {
                 label: None,
@@ -120,6 +134,12 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: Some(
+                    (
+                        190,
+                        194,
+                    ),
+                ),
             },
             ElementRef {
                 label: Some(
@@ -137,6 +157,12 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: Some(
+                    (
+                        201,
+                        202,
+                    ),
+                ),
             },
         ],
         children: {
@@ -180,6 +206,12 @@ expression: "model.rules[1].alts"
                 },
                 stable_accessor: true,
                 choice_branch: [],
+                span: Some(
+                    (
+                        238,
+                        241,
+                    ),
+                ),
             },
         ],
         children: {

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -27,6 +27,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -52,6 +53,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: Some(
                     (
                         135,
@@ -82,6 +84,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: Some(
                     (
                         146,
@@ -138,6 +141,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -163,6 +167,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: Some(
                     (
                         190,
@@ -193,6 +198,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: Some(
                     (
                         201,
@@ -249,6 +255,7 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 choice_arity: [],
+                choice_spans: [],
                 span: Some(
                     (
                         238,

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -27,6 +27,12 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 span: None,
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
             ElementRef {
                 label: None,
@@ -50,6 +56,12 @@ expression: "model.rules[1].alts"
                         139,
                     ),
                 ),
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
             ElementRef {
                 label: Some(
@@ -73,6 +85,12 @@ expression: "model.rules[1].alts"
                         147,
                     ),
                 ),
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
         ],
         children: {
@@ -117,6 +135,12 @@ expression: "model.rules[1].alts"
                 stable_accessor: true,
                 choice_branch: [],
                 span: None,
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
             ElementRef {
                 label: None,
@@ -140,6 +164,12 @@ expression: "model.rules[1].alts"
                         194,
                     ),
                 ),
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
             ElementRef {
                 label: Some(
@@ -163,6 +193,12 @@ expression: "model.rules[1].alts"
                         202,
                     ),
                 ),
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
         ],
         children: {
@@ -212,6 +248,12 @@ expression: "model.rules[1].alts"
                         241,
                     ),
                 ),
+                branch_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
             },
         ],
         children: {

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -28,6 +28,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -54,6 +62,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: Some(
                     (
                         135,
@@ -85,6 +101,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: Some(
                     (
                         146,
@@ -142,6 +166,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -168,6 +200,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: Some(
                     (
                         190,
@@ -199,6 +239,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: Some(
                     (
                         201,
@@ -256,6 +304,14 @@ expression: "model.rules[1].alts"
                 choice_branch: [],
                 choice_arity: [],
                 choice_spans: [],
+                group_local_cardinality: ChildCardinality {
+                    min: 1,
+                    max: Some(
+                        1,
+                    ),
+                },
+                group_spans: [],
+                branch_spans: [],
                 span: Some(
                     (
                         238,

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -25,6 +25,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
             ElementRef {
                 label: None,
@@ -41,6 +42,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
             ElementRef {
                 label: Some(
@@ -57,6 +59,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
         ],
         children: {
@@ -99,6 +102,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
             ElementRef {
                 label: None,
@@ -115,6 +119,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
             ElementRef {
                 label: Some(
@@ -131,6 +136,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
         ],
         children: {
@@ -173,6 +179,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
+                choice_branch: None,
             },
         ],
         children: {

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -25,7 +25,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
             ElementRef {
                 label: None,
@@ -42,7 +42,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
             ElementRef {
                 label: Some(
@@ -59,7 +59,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
         ],
         children: {
@@ -102,7 +102,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
             ElementRef {
                 label: None,
@@ -119,7 +119,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
             ElementRef {
                 label: Some(
@@ -136,7 +136,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
         ],
         children: {
@@ -179,7 +179,7 @@ expression: "model.rules[1].alts"
                     ),
                 },
                 stable_accessor: true,
-                choice_branch: None,
+                choice_branch: [],
             },
         ],
         children: {

--- a/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__left_recursive_label_alternatives.snap
@@ -36,6 +36,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: true,
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -70,6 +71,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: true,
                 span: Some(
                     (
                         135,
@@ -109,6 +111,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: false,
                 span: Some(
                     (
                         146,
@@ -174,6 +177,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: true,
                 span: None,
                 branch_local_cardinality: ChildCardinality {
                     min: 1,
@@ -208,6 +212,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: true,
                 span: Some(
                     (
                         190,
@@ -247,6 +252,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: false,
                 span: Some(
                     (
                         201,
@@ -312,6 +318,7 @@ expression: "model.rules[1].alts"
                 },
                 group_spans: [],
                 branch_spans: [],
+                leading_terminal: true,
                 span: Some(
                     (
                         238,

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_hazard_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_hazard_context.snap
@@ -1,0 +1,44 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: context(name)
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary(&self) -> Result<UnaryContext<'a>, MissingChildError> {
+        __rule_children(self.__node, 4)
+            .next()
+            .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+            .ok_or_else(|| MissingChildError::new("BranchHazardContext", "unary"))
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("BranchHazardContext", "NUM"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_rival_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_rival_context.snap
@@ -1,0 +1,39 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: context(name)
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary(&self) -> Result<UnaryContext<'a>, MissingChildError> {
+        __rule_children(self.__node, 4)
+            .next()
+            .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+            .ok_or_else(|| MissingChildError::new("BranchRivalContext", "unary"))
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("BranchRivalContext", "NUM"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_closed_repeat_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_closed_repeat_prefix_context.snap
@@ -1,0 +1,39 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"ClosedRepeatPrefixContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 8).map(TerminalNode::new)
+    }
+    pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 13).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("ClosedRepeatPrefixContext", "NUM"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_exhaustive_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_exhaustive_prefix_context.snap
@@ -1,0 +1,43 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"ExhaustivePrefixContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("ExhaustivePrefixContext", "NUM"))
+    }
+    pub fn pick(&self) -> Result<UnaryContext<'a>, MissingChildError> {
+        __rule_children(self.__node, 4)
+            .nth(1)
+            .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+            .ok_or_else(|| MissingChildError::new("ExhaustivePrefixContext", "pick"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_grouped_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_grouped_context.snap
@@ -1,0 +1,70 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"GroupedContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn in_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 7)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("GroupedContext", "NUM"))
+    }
+    pub fn comma_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 15).map(TerminalNode::new)
+    }
+    pub fn doc(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+    pub fn errors(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .skip(0)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn oneway(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_grouped_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_grouped_context.snap
@@ -53,7 +53,7 @@ expression: "context(\"GroupedContext\")"
         __token_children(self.__node, 15).map(TerminalNode::new)
     }
     pub fn doc(&self) -> Option<TerminalNode<'a>> {
-        __token_children(self.__node, 13)
+        __labeled_token_children(self.__node, 13)
             .nth(0)
             .map(TerminalNode::new)
     }
@@ -63,7 +63,7 @@ expression: "context(\"GroupedContext\")"
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
     }
     pub fn oneway(&self) -> Option<TerminalNode<'a>> {
-        __token_children(self.__node, 8)
+        __labeled_token_children(self.__node, 8)
             .nth(0)
             .map(TerminalNode::new)
     }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_inner_choice_arity_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_inner_choice_arity_context.snap
@@ -1,0 +1,39 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"InnerChoiceArityContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn param(&self) -> Option<ParamContext<'a>> {
+        __rule_children(self.__node, 8)
+            .next()
+            .map(|node| ParamContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
@@ -30,6 +30,12 @@ expression: "context(\"MergedRepeatsContext\")"
     pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 14).map(TerminalNode::new)
     }
+    pub fn lparen_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 16)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MergedRepeatsContext", "LPAREN"))
+    }
     pub fn last_pick(&self) -> Option<TerminalNode<'a>> {
         __labeled_token_children_matching(self.__node, &[13, 14])
             .skip(0).last()

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
@@ -1,0 +1,38 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"MergedRepeatsContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 13).map(TerminalNode::new)
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+    pub fn last_pick(&self) -> Option<TerminalNode<'a>> {
+        __token_children_matching(self.__node, &[13, 14])
+            .skip(0).last()
+            .map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
@@ -31,7 +31,7 @@ expression: "context(\"MergedRepeatsContext\")"
         __token_children(self.__node, 14).map(TerminalNode::new)
     }
     pub fn last_pick(&self) -> Option<TerminalNode<'a>> {
-        __token_children_matching(self.__node, &[13, 14])
+        __labeled_token_children_matching(self.__node, &[13, 14])
             .skip(0).last()
             .map(TerminalNode::new)
     }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_rivals_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_rivals_context.snap
@@ -33,7 +33,7 @@ expression: "context(\"MergedRivalsContext\")"
         __token_children(self.__node, 14).map(TerminalNode::new)
     }
     pub fn pick(&self) -> Option<TerminalNode<'a>> {
-        __token_children_matching(self.__node, &[13, 14])
+        __labeled_token_children_matching(self.__node, &[13, 14])
             .nth(0)
             .map(TerminalNode::new)
     }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_rivals_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_rivals_context.snap
@@ -1,0 +1,40 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"MergedRivalsContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+    pub fn pick(&self) -> Option<TerminalNode<'a>> {
+        __token_children_matching(self.__node, &[13, 14])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_context.snap
@@ -1,0 +1,66 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"MixedContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn param_children(&self) -> impl Iterator<Item = ParamContext<'a>> + '_ {
+        __rule_children(self.__node, 8)
+            .map(move |node| ParamContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn in_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 7)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn comma_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 15).map(TerminalNode::new)
+    }
+    pub fn lparen_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 16)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MixedContext", "LPAREN"))
+    }
+    pub fn rparen_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 17)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MixedContext", "RPAREN"))
+    }
+    pub fn errors(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .skip(1)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn name(&self) -> Result<UnaryContext<'a>, MissingChildError> {
+        __rule_children(self.__node, 4)
+            .nth(0)
+            .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+            .ok_or_else(|| MissingChildError::new("MixedContext", "name"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_unbounded_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_unbounded_context.snap
@@ -1,0 +1,37 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: context(name)
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn in_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 7)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MixedUnboundedContext", "IN"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_exhaustive_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_exhaustive_prefix_context.snap
@@ -1,0 +1,43 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"NestedExhaustivePrefixContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("NestedExhaustivePrefixContext", "NUM"))
+    }
+    pub fn chosen(&self) -> Result<UnaryContext<'a>, MissingChildError> {
+        __rule_children(self.__node, 4)
+            .nth(1)
+            .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+            .ok_or_else(|| MissingChildError::new("NestedExhaustivePrefixContext", "chosen"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_group_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_group_context.snap
@@ -1,0 +1,43 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"NestedGroupContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("NestedGroupContext", "NUM"))
+    }
+    pub fn deep(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_group_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_group_context.snap
@@ -36,7 +36,7 @@ expression: "context(\"NestedGroupContext\")"
             .ok_or_else(|| MissingChildError::new("NestedGroupContext", "NUM"))
     }
     pub fn deep(&self) -> Option<TerminalNode<'a>> {
-        __token_children(self.__node, 13)
+        __labeled_token_children(self.__node, 13)
             .nth(0)
             .map(TerminalNode::new)
     }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_optional_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_optional_prefix_context.snap
@@ -1,0 +1,37 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"OptionalPrefixContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("OptionalPrefixContext", "NUM"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_overlapping_group_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_overlapping_group_context.snap
@@ -1,0 +1,35 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"OverlappingGroupContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 13).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_path_restricted_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_path_restricted_context.snap
@@ -1,0 +1,39 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"PathRestrictedContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+    pub fn tail(&self) -> Option<UnaryContext<'a>> {
+        __rule_children(self.__node, 4)
+            .nth(1)
+            .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+}

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -59,6 +59,11 @@ impl ChildCardinality {
     }
 }
 
+/// Suffix marking a label that was temporarily renamed while resolving a *sibling*
+/// declaration of the same label in isolation. Grammar labels are identifiers, so
+/// this cannot collide with a real one.
+const SIBLING_DECLARATION_SUFFIX: &str = " (sibling declaration)";
+
 /// One enclosing block: its byte extent, and whether its own quantifier relaxes
 /// the lower bound of the elements inside it.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -466,14 +471,19 @@ impl TranslationCtx<'_> {
         let rule = self.rule();
         if self.site == ActionSite::Init {
             // An `@init` body runs at rule entry, before any child exists, so every
-            // read over children is empty and nothing can pollute it. Applying the
-            // after-rule hazards here would reject valid actions.
-            return rule
+            // read over children is empty and nothing can pollute it — no hazard
+            // applies. Most reads degrade gracefully (an iterator yields nothing, a
+            // `.text` read yields `""`), but a *scalar rule* label lowers to
+            // `.nth(i).expect("labeled rule child")`, which panics on every parse.
+            // Decline that one rather than emit code that cannot run.
+            let element = rule
                 .alts
                 .iter()
                 .flat_map(|alt| alt.refs.iter())
-                .find(|element| element.label.as_deref() == Some(label))
-                .map(|element| (element.clone(), 0));
+                .find(|element| element.label.as_deref() == Some(label))?;
+            let panics_when_absent =
+                !element.is_list && element.token_types.is_empty() && !element.target.is_empty();
+            return (!panics_when_absent).then(|| (element.clone(), 0));
         }
         if let Some((offset, alt)) = self
             .body_offset
@@ -880,7 +890,13 @@ impl TranslationCtx<'_> {
             .filter(|element| element.label.as_deref() == Some(label))
             .collect::<Vec<_>>();
         let element = *declarations.first()?;
-        let declares_label = |candidate: &ElementRef| candidate.label.as_deref() == Some(label);
+        // A renamed sibling declaration (see the isolation below) still counts as
+        // declaring the label: it binds it too, so it can never impersonate it.
+        let declares_label = |candidate: &ElementRef| {
+            candidate.label.as_deref().is_some_and(|name| {
+                name == label || name.strip_suffix(SIBLING_DECLARATION_SUFFIX) == Some(label)
+            })
+        };
         // The generated read queries by rule index or *token type*, so a
         // differently-spelled terminal with the same type is the same child as
         // far as the read is concerned (`A : 'a';` makes `A` and `'a'` aliases).
@@ -1107,11 +1123,16 @@ impl TranslationCtx<'_> {
                     .iter()
                     .position(|other| std::ptr::eq(other, *candidate))?;
                 let mut alone = alt.clone();
-                // Keep this declaration's label and drop the others', so the
-                // recursion resolves exactly one.
+                // Isolate this declaration by *renaming* the others rather than
+                // clearing their labels. Clearing would reclassify a fellow
+                // declaration as an unlabeled impostor and trip the shadow check —
+                // `(x=A | x=A)` would reject itself. Renaming keeps them labeled, so
+                // `declares_label` still exempts them, while only one answers to
+                // `label`.
+                let shadow_name = format!("{label}{SIBLING_DECLARATION_SUFFIX}");
                 for (index, ref_at) in alone.refs.iter_mut().enumerate() {
                     if index != position && ref_at.label.as_deref() == Some(label) {
-                        ref_at.label = None;
+                        ref_at.label = Some(shadow_name.clone());
                     }
                 }
                 resolutions.push(Self::resolve_label_in_alt(&alone, label, action_offset)?);
@@ -1125,10 +1146,14 @@ impl TranslationCtx<'_> {
             }
             return Some(first);
         }
+        // `element` is borrowed from `alt.refs`, so identity holds — but compare by
+        // value as a fallback, because the sibling-isolation rename above clones the
+        // alternative and a filtered `declarations` list can outlive that borrow.
         let position = alt
             .refs
             .iter()
-            .position(|candidate| std::ptr::eq(candidate, element))?;
+            .position(|candidate| std::ptr::eq(candidate, element))
+            .or_else(|| alt.refs.iter().position(|candidate| candidate == element))?;
         let (before, after) = (&alt.refs[..position], &alt.refs[position + 1..]);
         // `translate_element_read` routes on `is_block`, which covers labeled
         // groups and *literal* terminals alike (`x='b'`), so the occurrence has to
@@ -1157,7 +1182,14 @@ impl TranslationCtx<'_> {
             // let any surviving tag force cross-branch agreement.
             let counted = before
                 .iter()
-                .filter(|candidate| !candidate.token_types.is_empty() && on_action_path(candidate))
+                .filter(|candidate| {
+                    !candidate.token_types.is_empty()
+                        && on_action_path(candidate)
+                        // A ref in a branch this label cannot reach never precedes it:
+                        // in `(x=A | x='a')` the sibling declaration is not a prefix
+                        // terminal of the literal's path.
+                        && candidate.can_coexist_with(element)
+                })
                 .cloned()
                 .map(|mut candidate| {
                     if let Some(branches) = action_branches.as_ref() {
@@ -1188,7 +1220,11 @@ impl TranslationCtx<'_> {
                 // the same index.
                 let sibling_at_index = !branch_confined
                     && alt.refs.iter().any(|candidate| {
-                        !candidate.can_coexist_with(element)
+                        // Another declaration of the same label binds it too, so it
+                        // can never impersonate it — `(x=A | x='a')` is one label
+                        // over two branches, not a label and an impostor.
+                        !declares_label(candidate)
+                            && !candidate.can_coexist_with(element)
                             && !candidate.token_types.is_empty()
                             && candidate.cardinality.max != Some(0)
                             && Self::can_occupy_terminal_index(alt, candidate, index)

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -59,6 +59,16 @@ impl ChildCardinality {
     }
 }
 
+/// One enclosing block: its byte extent, and whether its own quantifier relaxes
+/// the lower bound of the elements inside it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) struct GroupSpan {
+    pub(crate) start: usize,
+    pub(crate) end: usize,
+    /// `true` for `(…)?` / `(…)*` — the group may contribute nothing.
+    pub(crate) optional: bool,
+}
+
 /// One element reference inside an alternative: a rule ref, token ref, or a
 /// labeled sub-block, in source order.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -104,11 +114,13 @@ pub(crate) struct ElementRef {
     /// preceding `A` is exactly-once even though both `cardinality` and
     /// `branch_local_cardinality` report `0..1` from the group's `?`.
     pub(crate) group_local_cardinality: ChildCardinality,
-    /// Byte spans of *every* enclosing block, including single-alternative groups
-    /// that `choice_spans` omits. An action inside such a group only runs when the
-    /// group was taken, so refs sharing the group have run even though their
-    /// cardinality reports `min: 0` from the group's `?`.
-    pub(crate) group_spans: Vec<(usize, usize)>,
+    /// Byte span and lower-bound-relaxing flag of *every* enclosing block, including
+    /// single-alternative groups that `choice_spans` omits. The flag says whether
+    /// that group's own quantifier is what made this element optional (`(…)?` or
+    /// `(…)*`), so a group known taken can have *its* contribution removed without
+    /// disturbing the others: in `((q) x=q {…})?` the outer `?` is satisfied when the
+    /// action runs while the inner `(q)` is mandatory and already closed.
+    pub(crate) group_spans: Vec<GroupSpan>,
     /// Byte span of each enclosing choice *alternative* (the branch itself), in the
     /// same order as `choice_branch`. Lets an action be attributed to the branch
     /// whose text contains it, including a branch holding only actions or
@@ -565,6 +577,12 @@ impl TranslationCtx<'_> {
         candidate: &ElementRef,
         occurrence: usize,
     ) -> bool {
+        // `usize::MAX` is the sentinel for "no fixed index, the read falls back to
+        // `last()`" — not a position. Any terminal the alternative builds can be that
+        // last child, so every candidate can occupy it.
+        if occurrence == usize::MAX {
+            return true;
+        }
         let Some(start) = Self::exact_terminal_index(alt, candidate) else {
             // No fixed start: the candidate could be anywhere.
             return true;
@@ -962,13 +980,23 @@ impl TranslationCtx<'_> {
         // *Every* group the ref sits in must enclose the action, not merely one: an
         // inner group that closed before the action proves nothing, so
         // `((q)? x=q {…})?` must not treat the inner `(q)?` as matched.
+        // A ref is exactly-once on the action's path when every group that *relaxed*
+        // its lower bound is one the action also sits inside — the action running
+        // proves those groups were taken. Groups that impose nothing (a mandatory
+        // `(…)`) are irrelevant whether or not they enclose the action, so requiring
+        // all of them to would reject `((q) x=q {…})?`, where the inner group is
+        // mandatory and already closed.
         let on_taken_group = |candidate: &ElementRef| {
             action_offset.is_some_and(|offset| {
-                !candidate.group_spans.is_empty()
-                    && candidate
-                        .group_spans
+                let relaxing = candidate
+                    .group_spans
+                    .iter()
+                    .filter(|group| group.optional)
+                    .collect::<Vec<_>>();
+                !relaxing.is_empty()
+                    && relaxing
                         .iter()
-                        .all(|&(start, end)| start <= offset && offset < end)
+                        .all(|group| group.start <= offset && offset < group.end)
             })
         };
         // Whether a ref can have run before the action, given that ancestry. An

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -389,14 +389,14 @@ impl TranslationCtx<'_> {
         // alternative the parse took: taking the first match would emit that
         // alternative's lookup and silently yield a default on the others.
         let mut resolved: Option<(ElementRef, usize)> = None;
+        let mut non_declaring = Vec::new();
         for alt in &rule.alts {
             let declares = alt
                 .refs
                 .iter()
                 .any(|element| element.label.as_deref() == Some(label));
-            // Alternatives that never mention the label put no children of their
-            // own in the way, so they neither constrain nor veto the read.
             if !declares {
+                non_declaring.push(alt);
                 continue;
             }
             let candidate = Self::resolve_label_in_alt(alt, label)?;
@@ -408,16 +408,53 @@ impl TranslationCtx<'_> {
             }
             resolved = Some(candidate);
         }
-        resolved
+        let (element, occurrence) = resolved?;
+        // An alternative that never declares the label leaves it unset, so the
+        // read must come up empty there. It will not if that alternative happens
+        // to build a child the read would select anyway (`r : x=A | A`), which
+        // would report a value for a label the parse never bound.
+        for alt in non_declaring {
+            if Self::alt_can_satisfy_read(alt, &element, occurrence) {
+                return None;
+            }
+        }
+        Some((element, occurrence))
+    }
+
+    /// Whether `alt` builds a child that the read for `element` would select,
+    /// even though `alt` does not declare the label.
+    fn alt_can_satisfy_read(alt: &AltModel, element: &ElementRef, occurrence: usize) -> bool {
+        if element.target.is_empty() {
+            // Block reads take the last terminal child, so any terminal matches.
+            return alt.refs.iter().any(|candidate| {
+                !candidate.token_types.is_empty() && candidate.cardinality.max != Some(0)
+            });
+        }
+        let available = alt
+            .refs
+            .iter()
+            .filter(|candidate| candidate.target == element.target)
+            .try_fold(0_usize, |total, candidate| {
+                Some(total.saturating_add(candidate.cardinality.max?))
+            });
+        // A list read selects any same-target child; a positional read needs one
+        // at `occurrence`. An unbounded count can always reach either.
+        available.is_none_or(|available| available > occurrence)
     }
 
     /// Whether two per-alternative resolutions lower to the same read, so one
-    /// translation can stand for both.
+    /// translation can stand for both. The fields compared are exactly those
+    /// `translate_element_read` consumes to pick a read: list mode, block mode,
+    /// and the target it queries. Two block labels are equivalent regardless of
+    /// their token sets, because the block read ignores them.
     fn same_label_read(left: &(ElementRef, usize), right: &(ElementRef, usize)) -> bool {
-        left.1 == right.1
-            && left.0.target == right.0.target
-            && left.0.is_list == right.0.is_list
-            && left.0.token_types == right.0.token_types
+        if left.0.is_list != right.0.is_list || left.0.is_block != right.0.is_block {
+            return false;
+        }
+        if left.0.is_block && left.0.target.is_empty() && right.0.target.is_empty() {
+            return true;
+        }
+        left.1 == right.1 && left.0.target == right.0.target
     }
 
     fn resolve_label_in_alt(alt: &AltModel, label: &str) -> Option<(ElementRef, usize)> {
@@ -443,10 +480,18 @@ impl TranslationCtx<'_> {
             if element.target.is_empty() {
                 return None;
             }
-            // A list read yields every same-target child, so repeated
-            // declarations are the normal idiom (`xs+=e (op xs+=e)+`) — they all
-            // feed the one iteration. What it cannot express is exclusion, so the
-            // label resolves only when no same-target element sits *outside* it.
+            // A list read yields every child of *one* target, so repeated
+            // declarations are the normal idiom (`xs+=e (op xs+=e)+`) only while
+            // they all name that same target. `xs+=A xs+=B` would iterate `A`
+            // alone and silently drop every `B`.
+            if declarations
+                .iter()
+                .any(|candidate| candidate.target != element.target || !candidate.is_list)
+            {
+                return None;
+            }
+            // What the read cannot express is exclusion, so the label resolves
+            // only when no same-target element sits *outside* it.
             let exclusive = alt
                 .refs
                 .iter()
@@ -1326,6 +1371,141 @@ mod tests {
         let translated = translate_body("$x.text", &ctx).expect("translates");
         assert!(translated.contains("terminal_children"), "{translated}");
         assert!(translated.contains(".last()"), "{translated}");
+    }
+
+    /// An alternative that does not declare the label leaves it unset, so the
+    /// read has to come up empty there. `r : x=A | A` breaks that: the second
+    /// alternative builds an `A` the read would select, reporting a value for a
+    /// label the parse never bound. Conversely `r : x=A | B` is fine.
+    #[test]
+    fn unscoped_reads_reject_alternatives_that_would_satisfy_them_unbound() {
+        let token_ref = |label: Option<&str>, target: &str, token_type| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: target.to_owned(),
+            token_types: vec![token_type],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        let translate = |second: ElementRef| {
+            let mut statement = rule("s");
+            for (index, refs) in [vec![token_ref(Some("x"), "A", 1)], vec![second]]
+                .into_iter()
+                .enumerate()
+            {
+                statement.alts.push(AltModel {
+                    label: None,
+                    span: (index * 10, index * 10 + 10),
+                    refs,
+                    children: BTreeMap::new(),
+                    leading_target: None,
+                });
+            }
+            let m = model(vec![statement]);
+            let toks = tokens(&[("A", 1), ("B", 2)]);
+            let ctx = TranslationCtx {
+                model: &m,
+                rule_index: 0,
+                body_offset: None,
+                site: ActionSite::After,
+                token_types: &toks,
+            };
+            translate_body("$x.text", &ctx).map_err(|error| error.to_string())
+        };
+
+        // `x=A | A`: the unlabeled `A` satisfies the read with `x` unset.
+        let error = translate(token_ref(None, "A", 1))
+            .expect_err("an unbound label must not read another alternative's child");
+        assert!(error.contains("cannot translate $x"), "{error}");
+
+        // `x=A | B`: nothing in the second alternative can be mistaken for `x`.
+        let translated =
+            translate(token_ref(None, "B", 2)).expect("disjoint alternative keeps the read");
+        assert!(translated.contains(".nth(0)"), "{translated}");
+    }
+
+    /// A list read iterates one target, so every declaration of the label must
+    /// name that target: `xs+=A xs+=B` would iterate `A` and drop every `B`.
+    /// Equivalent *block* labels across alternatives (`x=(A | B) | x=(C | D)`)
+    /// conversely stay resolvable, because the block read ignores token sets.
+    #[test]
+    fn list_declarations_must_share_a_target_while_block_reads_ignore_token_sets() {
+        let list_ref = |target: &str, token_type| ElementRef {
+            label: Some("xs".to_owned()),
+            target: target.to_owned(),
+            token_types: vec![token_type],
+            is_block: false,
+            is_list: true,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![list_ref("A", 1), list_ref("B", 2)],
+            children: BTreeMap::new(),
+            leading_target: None,
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1), ("B", 2)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+        let error = translate_body("$xs", &ctx).expect_err("mixed list targets must not resolve");
+        assert!(
+            error.to_string().contains("cannot translate $xs"),
+            "{error}"
+        );
+
+        // Two block labels over different token sets lower to the same read.
+        let block_ref = |token_types: Vec<i32>| ElementRef {
+            label: Some("x".to_owned()),
+            target: String::new(),
+            token_types,
+            is_block: true,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        let mut choice = rule("s");
+        for (index, refs) in [vec![block_ref(vec![1, 2])], vec![block_ref(vec![3, 4])]]
+            .into_iter()
+            .enumerate()
+        {
+            choice.alts.push(AltModel {
+                label: None,
+                span: (index * 10, index * 10 + 10),
+                refs,
+                children: BTreeMap::new(),
+                leading_target: None,
+            });
+        }
+        let m = model(vec![choice]);
+        let toks = tokens(&[("A", 1), ("B", 2), ("C", 3), ("D", 4)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: None,
+            site: ActionSite::After,
+            token_types: &toks,
+        };
+        let translated = translate_body("$x.text", &ctx).expect("equivalent block reads resolve");
+        assert!(translated.contains("terminal_children"), "{translated}");
     }
 
     /// Reads that `translate_element_read` cannot express must stay unresolved

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -77,6 +77,24 @@ pub(crate) struct ElementRef {
     /// label accessor. Single-alternative EBNF groups preserve it; choices opt
     /// out because their flattened CST children do not retain the chosen path.
     pub(crate) stable_accessor: bool,
+    /// `(choice id, alternative index)` of the innermost enclosing *multi*-
+    /// alternative block, if any. Two refs tagged with the same choice id but
+    /// different alternative indexes are mutually exclusive: no parse contains
+    /// both. `None` means the ref is on the rule's own sequential path.
+    pub(crate) choice_branch: Option<(usize, usize)>,
+}
+
+impl ElementRef {
+    /// Whether `self` and `other` can both appear in one parse. Refs from
+    /// different alternatives of the same choice never do.
+    pub(crate) const fn can_coexist_with(&self, other: &Self) -> bool {
+        match (self.choice_branch, other.choice_branch) {
+            (Some((left_choice, left_alt)), Some((right_choice, right_alt))) => {
+                left_choice != right_choice || left_alt == right_alt
+            }
+            _ => true,
+        }
+    }
 }
 
 /// One top-level alternative of a parser rule.
@@ -544,14 +562,15 @@ impl TranslationCtx<'_> {
                 (candidate.cardinality.min == max).then(|| total.saturating_add(max))
             })?;
         // An optional label is displaced by a *following* same-target child that
-        // slides into its position. Only children that are certain to be matched
-        // can do that: a ref from a sibling choice branch reports `min: 0` and
-        // never coexists with this label, so counting it would reject valid
+        // can slide into its position. Sequential followers can, whether they are
+        // mandatory (`x=A? A`) or optional (`(pred x=A)? A?` — the follower may
+        // consume the only token). A ref from a sibling branch of the same choice
+        // cannot, since no parse contains both, so counting it would reject valid
         // mid-rule actions like `r : (x=A {$x.text} B | A C)`.
         let shadowed_when_absent = element.cardinality.min == 0
             && after
                 .iter()
-                .any(|candidate| same_target(candidate) && candidate.cardinality.min > 0);
+                .any(|candidate| same_target(candidate) && candidate.can_coexist_with(element));
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
 }
@@ -676,6 +695,7 @@ fn translate_reference(
             is_list: false,
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
+            choice_branch: None,
         };
         let _ = target_rule;
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
@@ -689,6 +709,7 @@ fn translate_reference(
             is_list: false,
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
+            choice_branch: None,
         };
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
     }
@@ -1029,6 +1050,7 @@ mod tests {
                     is_list: false,
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
+                    choice_branch: None,
                 },
                 ElementRef {
                     label: Some("right".to_owned()),
@@ -1038,6 +1060,7 @@ mod tests {
                     is_list: false,
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
+                    choice_branch: None,
                 },
             ],
             children: BTreeMap::from([(
@@ -1092,6 +1115,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1136,6 +1160,7 @@ mod tests {
             is_list: false,
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
+            choice_branch: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1174,6 +1199,7 @@ mod tests {
             is_list: false,
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
+            choice_branch: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1215,6 +1241,7 @@ mod tests {
             is_list: true,
             cardinality: ChildCardinality { min: 1, max },
             stable_accessor: true,
+            choice_branch: None,
         };
         let single_ref = ElementRef {
             label: Some("name".to_owned()),
@@ -1227,6 +1254,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         let translate = |max| {
             let mut statement = rule("s");
@@ -1280,6 +1308,7 @@ mod tests {
                         max: Some(1),
                     },
                     stable_accessor: true,
+                    choice_branch: None,
                 },
                 ElementRef {
                     label: Some("errors".to_owned()),
@@ -1289,6 +1318,7 @@ mod tests {
                     is_list: true,
                     cardinality: ChildCardinality { min: 0, max: None },
                     stable_accessor: true,
+                    choice_branch: None,
                 },
             ],
             children: BTreeMap::new(),
@@ -1341,6 +1371,7 @@ mod tests {
                         max: Some(1),
                     },
                     stable_accessor: true,
+                    choice_branch: None,
                 },
                 ElementRef {
                     label: None,
@@ -1353,6 +1384,7 @@ mod tests {
                         max: Some(1),
                     },
                     stable_accessor: true,
+                    choice_branch: None,
                 },
             ],
             children: BTreeMap::new(),
@@ -1390,6 +1422,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         let translate = |second: ElementRef| {
             let mut statement = rule("s");
@@ -1445,6 +1478,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -1481,6 +1515,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         let mut choice = rule("s");
         for (index, refs) in [vec![block_ref(vec![1, 2])], vec![block_ref(vec![3, 4])]]
@@ -1545,6 +1580,7 @@ mod tests {
             is_list: true,
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
+            choice_branch: None,
         };
         let error = translate(group_list, "$xs").expect_err("no target to iterate");
         assert!(error.contains("cannot translate $xs"), "{error}");
@@ -1557,6 +1593,7 @@ mod tests {
             is_list: false,
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
+            choice_branch: None,
         };
         let error = translate(repeated_single, "$x.text").expect_err("no last-occurrence read");
         assert!(error.contains("cannot translate $x"), "{error}");
@@ -1568,7 +1605,8 @@ mod tests {
     #[test]
     fn sibling_branch_children_do_not_shadow_an_optional_label() {
         let mut statement = rule("s");
-        let branch_ref = |label: Option<&str>| ElementRef {
+        // Two branches of one choice: same choice id, different branch index.
+        let branch_ref = |label: Option<&str>, branch| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: "A".to_owned(),
             token_types: vec![1],
@@ -1580,11 +1618,12 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: Some((7, branch)),
         };
         statement.alts.push(AltModel {
             label: None,
             span: (10, 20),
-            refs: vec![branch_ref(Some("x")), branch_ref(None)],
+            refs: vec![branch_ref(Some("x"), 0), branch_ref(None, 1)],
             children: BTreeMap::new(),
             leading_target: Some("A".to_owned()),
         });
@@ -1600,6 +1639,42 @@ mod tests {
 
         let translated = translate_body("$x.text", &ctx).expect("translates");
         assert!(translated.contains(".nth(0)"), "{translated}");
+
+        // The sequential counterpart — `(pred x=A)? A?`, both on the rule's own
+        // path — *is* a hazard: the follower may consume the only token while the
+        // label is unset. Cardinality alone cannot tell these two apart, which is
+        // what `choice_branch` exists for.
+        let mut sequential = rule("s");
+        let sequential_ref = |label: Option<&str>| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "A".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+            choice_branch: None,
+        };
+        sequential.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![sequential_ref(Some("x")), sequential_ref(None)],
+            children: BTreeMap::new(),
+            leading_target: Some("A".to_owned()),
+        });
+        let m = model(vec![sequential]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+        let error = translate_body("$x.text", &ctx).expect_err("sequential follower shadows");
+        assert!(error.to_string().contains("cannot translate $x"), "{error}");
     }
 
     /// A list label repeated within one alternative is the ordinary
@@ -1618,6 +1693,7 @@ mod tests {
             is_list: true,
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
+            choice_branch: None,
         };
         let token_ref = ElementRef {
             label: None,
@@ -1630,6 +1706,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         let mut statement = rule("s");
         for (index, refs) in [
@@ -1680,6 +1757,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         let translate = |second: Vec<ElementRef>| {
             let mut statement = rule("s");
@@ -1737,6 +1815,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
+            choice_branch: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1814,6 +1893,7 @@ mod tests {
                     is_list: true,
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
+                    choice_branch: None,
                 },
                 ElementRef {
                     label: Some("ids".to_owned()),
@@ -1823,6 +1903,7 @@ mod tests {
                     is_list: true,
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
+                    choice_branch: None,
                 },
             ],
             children: BTreeMap::new(),

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -528,27 +528,41 @@ impl TranslationCtx<'_> {
         // after it is still in the future and cannot affect the read; a ref in a
         // branch the action does not sit inside cannot have run either. An
         // `@after` body runs after everything, so every ref counts.
-        // Whether the action sits *inside* the labeled element's own branch. Only
-        // then can a sibling branch be ruled out: an action written after the
-        // whole choice (`(x=A | A) {$x}`) runs for either branch, so the sibling's
-        // match really can be the child its read finds. Inclusion is decided from
-        // the label's span — the action follows it and precedes whatever ends the
-        // branch, so a same-branch action lies before any later-branch ref.
-        let action_inside_label_branch = || match (action_offset, element.span) {
-            (Some(offset), Some((_, label_end))) => {
-                offset >= label_end
-                    && alt.refs.iter().all(|candidate| {
-                        candidate.can_coexist_with(element)
-                            || candidate.span.is_none_or(|(start, _)| start > offset)
-                    })
+        // The choice ancestry the action itself sits in, derived from spans: the
+        // action belongs to the innermost branch whose refs bracket its offset.
+        // Refs from any *other* branch of those choices cannot have run.
+        let action_branches = action_offset.map(|offset| {
+            let mut enclosing: Vec<(usize, usize)> = Vec::new();
+            for candidate in &alt.refs {
+                let Some((start, _)) = candidate.span else {
+                    continue;
+                };
+                // A ref before the action shares its path only if no later ref of
+                // the same branch-set is closer; taking the nearest preceding ref
+                // gives the branch the action was written inside.
+                if start < offset && candidate.choice_branch.len() >= enclosing.len() {
+                    enclosing.clone_from(&candidate.choice_branch);
+                }
             }
-            _ => false,
+            enclosing
+        });
+        // Whether a ref can have run before the action, given that ancestry. An
+        // action after the whole choice (`(x=A | A) {$x}`) has no branch tag, so
+        // every branch counts; one written inside a branch excludes its siblings —
+        // including when the label itself is in another branch (`(e | xs+=e {…})`).
+        let on_action_path = |candidate: &ElementRef| {
+            action_branches.as_ref().is_none_or(|branches| {
+                !candidate.choice_branch.iter().any(|(choice, branch)| {
+                    branches
+                        .iter()
+                        .any(|(a_choice, a_branch)| choice == a_choice && branch != a_branch)
+                })
+            })
         };
-        let branch_confined = action_inside_label_branch();
         let matched_at_action = |candidate: &ElementRef| {
             action_offset.is_none_or(|offset| {
                 let started = candidate.span.is_none_or(|(start, _)| start < offset);
-                started && (!branch_confined || candidate.can_coexist_with(element))
+                started && on_action_path(candidate)
             })
         };
         // Two declarations can share one read when the generated query is the
@@ -609,24 +623,38 @@ impl TranslationCtx<'_> {
             .iter()
             .position(|candidate| std::ptr::eq(candidate, element))?;
         let (before, after) = (&alt.refs[..position], &alt.refs[position + 1..]);
-        if element.target.is_empty() {
-            // Block/wildcard labels read the most recent terminal child, which is
-            // the block's own token only while no *other* terminal was matched
-            // between the block and the action. Spans make that decidable: a
-            // terminal written after the action has not run yet, which is what
-            // ANTLR's `t=~'x' 'z' {$t.text}` descriptors rely on
-            // (`Sets/ParserNotTokenWithLabel`), while one between the label and
-            // the action displaces it (`((x=(A | B))) C {$x.text}` reads `C`).
-            let displaced = after.iter().any(|candidate| {
-                !candidate.token_types.is_empty()
-                    && candidate.cardinality.max != Some(0)
-                    && matched_at_action(candidate)
-                    && !candidate
-                        .token_types
-                        .iter()
-                        .all(|token_type| element.token_types.contains(token_type))
-            });
-            return (!displaced).then(|| (element.clone(), 0));
+        // `translate_element_read` routes on `is_block`, which covers labeled
+        // groups and *literal* terminals alike (`x='b'`), so the occurrence has to
+        // be computed the same way for both — keying on an empty target here would
+        // leave a literal label counting same-target children while its read walks
+        // every terminal.
+        if element.is_block {
+            // A block label has no single target to query, so its read walks the
+            // context's terminal children by position. The index is the number of
+            // terminals matched ahead of the block on this parse path — every
+            // terminal counts, not just ones sharing the block's token set, since
+            // each is a distinct child of the same context.
+            let terminals_before = before
+                .iter()
+                .filter(|candidate| !candidate.token_types.is_empty() && on_action_path(candidate))
+                .try_fold(0_usize, |total, candidate| {
+                    let max = candidate.cardinality.max?;
+                    (candidate.cardinality.min == max || !candidate.choice_branch.is_empty())
+                        .then(|| total.saturating_add(max))
+                });
+            // Without a fixed index the read falls back to the most recent
+            // terminal, which is only right when nothing has been matched since.
+            return terminals_before.map_or_else(
+                || {
+                    let displaced = after.iter().any(|candidate| {
+                        !candidate.token_types.is_empty()
+                            && candidate.cardinality.max != Some(0)
+                            && matched_at_action(candidate)
+                    });
+                    (!displaced).then(|| (element.clone(), usize::MAX))
+                },
+                |index| Some((element.clone(), index)),
+            );
         }
 
         // A repeated single label (`(x=A)+`) is overwritten on every iteration,
@@ -907,19 +935,28 @@ fn translate_element_read(
         }
     }
     if element.is_block {
-        // A labeled `(...)` block over tokens: `$myset.stop` / `$myset.text`
-        // read the token the block matched — the most recent terminal child.
-        // A bare `$myset` read denotes the Token object itself (Java prints
-        // `Token.toString()`), which is the same rendering as start/stop.
+        // A labeled `(...)` block over tokens: `$myset.stop` / `$myset.text` read
+        // the token the block matched. A bare `$myset` read denotes the Token
+        // object itself (Java prints `Token.toString()`), the same rendering as
+        // start/stop.
+        //
+        // The block has no target to query, so the read walks the context's
+        // terminal children and picks by *position*: `occurrence` is the number of
+        // terminals matched ahead of the block on this parse path. `usize::MAX`
+        // means the position is not fixed, in which case the most recent terminal
+        // is the best available answer — the historical behaviour.
+        let pick = if occurrence == usize::MAX {
+            "last()".to_owned()
+        } else {
+            format!("nth({occurrence})")
+        };
         return match suffix {
-            None | Some("stop" | "start") => Ok(
-                "__ctx.terminal_children(self.base.parse_tree_storage(), self.base.token_store()).last().map(|__t| __t.symbol().to_string()).unwrap_or_default()"
-                    .to_owned(),
-            ),
-            Some("text") => Ok(
-                "__ctx.terminal_children(self.base.parse_tree_storage(), self.base.token_store()).last().map(|__t| __t.text().to_owned()).unwrap_or_default()"
-                    .to_owned(),
-            ),
+            None | Some("stop" | "start") => Ok(format!(
+                "__ctx.terminal_children(self.base.parse_tree_storage(), self.base.token_store()).{pick}.map(|__t| __t.symbol().to_string()).unwrap_or_default()"
+            )),
+            Some("text") => Ok(format!(
+                "__ctx.terminal_children(self.base.parse_tree_storage(), self.base.token_store()).{pick}.map(|__t| __t.text().to_owned()).unwrap_or_default()"
+            )),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 format!("unsupported block-label read in embedded action: {body}"),
@@ -1468,13 +1505,13 @@ mod tests {
         assert!(name.contains(".nth(0)"), "{name}");
     }
 
-    /// A block label reads the most recent terminal child, so whether that is the
-    /// label's own token depends on where the action sits. Spans make it
-    /// decidable: an action before the trailing terminal still reads the block
-    /// (ANTLR's `t=~'x' 'z' {$t.text}` shape, `Sets/ParserNotTokenWithLabel`),
-    /// while one after it would read that terminal and must decline (issue #233).
+    /// A block label has no target to query, so its read walks the context's
+    /// terminal children by *position*: the count of terminals matched ahead of
+    /// the block. That is what makes `t=~'x' 'z' {$t.text}` read the token the
+    /// label bound rather than the trailing `'z'` the old `last()` picked
+    /// (issue #233). Where the count is not fixed, `last()` remains the fallback.
     #[test]
-    fn block_labels_resolve_only_while_no_later_terminal_has_matched() {
+    fn block_labels_read_the_terminal_the_label_bound() {
         let translate = |action_offset| {
             let mut statement = rule("s");
             statement.alts.push(AltModel {
@@ -1525,14 +1562,17 @@ mod tests {
             translate_body("$x.text", &ctx).map_err(|error| error.to_string())
         };
 
-        // Action between the block and `C`: only the block has matched.
-        let translated = translate(25).expect("the trailing terminal has not run yet");
-        assert!(translated.contains("terminal_children"), "{translated}");
-        assert!(translated.contains(".last()"), "{translated}");
-
-        // Action after `C`: `last()` would be `C`, not the block's token.
-        let error = translate(40).expect_err("a matched later terminal displaces the read");
-        assert!(error.contains("cannot translate $x"), "{error}");
+        // The block is the first terminal either way, so the read is `nth(0)` and
+        // the trailing `C` cannot be mistaken for it — regardless of whether the
+        // action precedes or follows `C`.
+        for offset in [25, 40] {
+            let translated = translate(offset).expect("a fixed terminal position resolves");
+            assert!(translated.contains("terminal_children"), "{translated}");
+            assert!(
+                translated.contains(".nth(0)"),
+                "offset {offset}: {translated}"
+            );
+        }
     }
 
     /// A mid-rule action executes at its own source position, so refs written
@@ -1646,6 +1686,58 @@ mod tests {
         let aliased = translate(decl(1, true, (30, 33)), None)
             .expect("token-type equivalence ignores source form");
         assert!(aliased.contains(".nth(0)"), "{aliased}");
+    }
+
+    /// A *literal* terminal label (`x='b'`) is `is_block` too, so it must take the
+    /// same positional terminal count as a labeled group — keying the count on an
+    /// empty target instead would leave it counting same-target children while its
+    /// read walks every terminal. This is ANTLR's
+    /// `ParserErrors/ConjuringUpToken` shape, where `'a'` precedes the label.
+    #[test]
+    fn literal_terminal_labels_count_every_preceding_terminal() {
+        let terminal = |label: Option<&str>, target: &str, token_type, span| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: target.to_owned(),
+            token_types: vec![token_type],
+            // Literals and groups alike route through the block read.
+            is_block: true,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+            choice_branch: Vec::new(),
+            span: Some(span),
+        };
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (0, 100),
+            // `'a' x='b' {action} 'c'`
+            refs: vec![
+                terminal(None, "'a'", 1, (10, 13)),
+                terminal(Some("x"), "'b'", 2, (14, 17)),
+                terminal(None, "'c'", 3, (40, 43)),
+            ],
+            children: BTreeMap::new(),
+            leading_target: None,
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(20),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let translated = translate_body("$x", &ctx).expect("translates");
+        assert!(translated.contains("terminal_children"), "{translated}");
+        // `'a'` is terminal 0, so the label is terminal 1 — not `last()`, which
+        // would become `'c'` once that matched.
+        assert!(translated.contains(".nth(1)"), "{translated}");
     }
 
     /// An alternative that does not declare the label leaves it unset, so the

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -837,6 +837,33 @@ impl TranslationCtx<'_> {
         total
     }
 
+    /// Whether the action sits inside the branch that separates `element` from
+    /// `candidate` — i.e. inside the label's own branch of the choice that makes the
+    /// two mutually exclusive. Only then can the candidate be dismissed: the action
+    /// cannot run on the branch that would supply it.
+    ///
+    /// Judged per choice rather than rule-wide, because an action confined to some
+    /// *unrelated* later choice says nothing about an earlier one.
+    fn action_inside_separating_branch(
+        element: &ElementRef,
+        candidate: &ElementRef,
+        action_branches: Option<&[(usize, usize)]>,
+    ) -> bool {
+        let Some(branches) = action_branches else {
+            // An unscoped body runs whatever branch matched.
+            return false;
+        };
+        element.choice_branch.iter().any(|&(choice, branch)| {
+            // A choice that separates them...
+            candidate
+                .choice_branch
+                .iter()
+                .any(|&(other, other_branch)| other == choice && other_branch != branch)
+                // ...and whose label-side branch encloses the action.
+                && branches.contains(&(choice, branch))
+        })
+    }
+
     /// Whether two per-alternative resolutions lower to the same read, so one
     /// translation can stand for both. The fields compared are exactly those
     /// `translate_element_read` consumes to pick a read: list mode, block mode,
@@ -1391,10 +1418,17 @@ impl TranslationCtx<'_> {
                     // A sibling branch's child cannot slide into the label's slot
                     // *within a parse that bound the label* — the two never coexist.
                     // It is still a hazard when the read may run with the label
-                    // unset, which is precisely when the action is not confined to
-                    // the label's branch: an `@after` body, or a mid-rule action
-                    // written after the whole choice (`(x=A | A) {$x}`).
-                    && (candidate.can_coexist_with(element) || !branch_confined)
+                    // unset, which is when the action is not inside the branch that
+                    // separates them. That has to be judged per *choice*: a
+                    // rule-wide flag would let an action confined to some unrelated
+                    // later choice exempt an earlier sibling
+                    // (`({false}? x=A | A) (B {$x} | C)`).
+                    && (candidate.can_coexist_with(element)
+                        || !Self::action_inside_separating_branch(
+                            element,
+                            candidate,
+                            action_branches.as_deref(),
+                        ))
             });
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
@@ -1641,7 +1675,11 @@ fn translate_element_read(
         // start/stop.
         //
         // The block has no target to query, so the read walks the context's
-        // terminal children and picks by *position*: `occurrence` is the number of
+        // terminal children and picks by *position*. It uses the *labeled* iterator,
+        // which skips deleted-token errors while keeping inserted missing ones —
+        // a grammar-derived index knows nothing about recovery, and a deleted token
+        // would otherwise shift every later position (see #235 for the same rule on
+        // token accessors): `occurrence` is the number of
         // terminals matched ahead of the block on this parse path. `usize::MAX`
         // means the position is not fixed, in which case the most recent terminal
         // is the best available answer — the historical behaviour.
@@ -1652,10 +1690,10 @@ fn translate_element_read(
         };
         return match suffix {
             None | Some("stop" | "start") => Ok(format!(
-                "__ctx.terminal_children(self.base.parse_tree_storage(), self.base.token_store()).{pick}.map(|__t| __t.symbol().to_string()).unwrap_or_default()"
+                "__ctx.labeled_terminal_children(self.base.parse_tree_storage(), self.base.token_store()).{pick}.map(|__t| __t.symbol().to_string()).unwrap_or_default()"
             )),
             Some("text") => Ok(format!(
-                "__ctx.terminal_children(self.base.parse_tree_storage(), self.base.token_store()).{pick}.map(|__t| __t.text().to_owned()).unwrap_or_default()"
+                "__ctx.labeled_terminal_children(self.base.parse_tree_storage(), self.base.token_store()).{pick}.map(|__t| __t.text().to_owned()).unwrap_or_default()"
             )),
             _ => Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -387,7 +387,7 @@ impl TranslationCtx<'_> {
                 // and their reads ignore the index, so they neither consume nor
                 // contribute to an occurrence bucket. Sharing the empty-target
                 // bucket would let unrelated groups poison each other.
-                if element.target.is_empty() || element.is_list {
+                if element.target.is_empty() {
                     if labeled {
                         return Some((element.clone(), 0));
                     }
@@ -398,7 +398,11 @@ impl TranslationCtx<'_> {
                     .or_insert(Some(0));
                 let current = *occurrence;
                 // An inexact ref leaves every later same-target position
-                // floating, so poison the running count rather than guess.
+                // floating, so poison the running count rather than guess. A
+                // list ref (`xs+=e`) still contributes children here, so it
+                // must go through the same accounting: its usually-unbounded
+                // count is what stops a later same-target label from trusting
+                // a fixed position.
                 *occurrence = match (current, element.cardinality.max) {
                     (Some(total), Some(max)) if element.cardinality.min == max => {
                         Some(total.saturating_add(max))
@@ -406,6 +410,11 @@ impl TranslationCtx<'_> {
                     _ => None,
                 };
                 if labeled {
+                    // A list read iterates every same-target child, so it never
+                    // consults the index and stays resolvable regardless.
+                    if element.is_list {
+                        return Some((element.clone(), 0));
+                    }
                     let shadowed_when_absent = element.cardinality.min == 0
                         && alt.refs[position + 1..].iter().any(|following| {
                             following.target == element.target
@@ -1064,6 +1073,64 @@ mod tests {
         let translated = translate_body("$x.text", &ctx).expect("translates");
         assert!(translated.contains("terminal_children"), "{translated}");
         assert!(translated.contains(".last()"), "{translated}");
+    }
+
+    /// A list label ahead of a same-target single label still contributes
+    /// children, so it must go through the occurrence accounting rather than be
+    /// skipped: `r : xs+=e name=e` puts one `e` before `name` (exact, countable
+    /// → `nth(1)`), while `r : xs+=e+ name=e` puts an unbounded run there and
+    /// leaves no fixed position at all.
+    #[test]
+    fn list_refs_ahead_of_a_single_label_are_counted_then_poison_when_unbounded() {
+        let list_ref = |max| ElementRef {
+            label: Some("xs".to_owned()),
+            target: "e".to_owned(),
+            token_types: Vec::new(),
+            is_block: false,
+            is_list: true,
+            cardinality: ChildCardinality { min: 1, max },
+            stable_accessor: true,
+        };
+        let single_ref = ElementRef {
+            label: Some("name".to_owned()),
+            target: "e".to_owned(),
+            token_types: Vec::new(),
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        let translate = |max| {
+            let mut statement = rule("s");
+            statement.alts.push(AltModel {
+                label: None,
+                span: (10, 20),
+                refs: vec![list_ref(max), single_ref.clone()],
+                children: BTreeMap::new(),
+                leading_target: Some("e".to_owned()),
+            });
+            let m = model(vec![statement, rule("e")]);
+            let toks = tokens(&[]);
+            let ctx = TranslationCtx {
+                model: &m,
+                rule_index: 0,
+                body_offset: Some(15),
+                site: ActionSite::Body,
+                token_types: &toks,
+            };
+            translate_body("$name.text", &ctx).map_err(|error| error.to_string())
+        };
+
+        // Exactly one preceding `e`: the position is known.
+        let exact = translate(Some(1)).expect("exact list count still resolves");
+        assert!(exact.contains(".nth(1)"), "{exact}");
+
+        // Unbounded run of `e` ahead of the label: no fixed index exists.
+        let error = translate(None).expect_err("unbounded list must not resolve");
+        assert!(error.contains("cannot translate $name"), "{error}");
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -359,20 +359,26 @@ impl TranslationCtx<'_> {
 
     /// Resolves a label to `(ref, occurrence-among-same-target-in-alt)`.
     ///
-    /// The occurrence is a positional index into the flattened CST children, so
-    /// it only means anything when the label's position among same-target
-    /// children is fixed. Two things make it float, and either one reports the
-    /// label unresolved so the caller fails loudly rather than translating to a
-    /// read that silently yields the wrong element:
+    /// Every read `translate_element_read` can emit is a *positional* query over
+    /// the flattened CST children — `nth(i)` for a single label, "all children of
+    /// this target" for a list label, "the last terminal child" for a block
+    /// label. None of those retain which grammar branch built a child, so a
+    /// label only resolves when its read provably selects the label's own
+    /// element and nothing else. When it cannot, this returns `None` and the
+    /// caller fails loudly rather than translating to a silently wrong read.
     ///
-    /// * a preceding ref with inexact cardinality — refs drawn from sibling
-    ///   branches of a choice are mutually exclusive and report `min: 0`, so
-    ///   counting them would index past the children the parse built;
-    /// * an *optional* label with a following same-target child, which slides
-    ///   into the label's position whenever the label itself is absent.
+    /// The conditions that make a read unfaithful, by label kind:
     ///
-    /// List and block labels are exempt: their reads iterate or take the last
-    /// terminal child, so they never consult the occurrence index.
+    /// * **single** — a preceding ref with inexact cardinality (sibling branches
+    ///   of a choice are mutually exclusive and report `min: 0`, so counting
+    ///   them indexes past what the parse built), or an *optional* label with a
+    ///   following same-target child that slides into its position when absent;
+    /// * **list** — any same-target child outside the label, since the read
+    ///   cannot exclude it;
+    /// * **block** — a following terminal, which would become the `last()` the
+    ///   read takes;
+    /// * **any kind** — a second declaration of the same label that this one
+    ///   read cannot also serve.
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
         let alts: Vec<&AltModel> = self
@@ -380,54 +386,63 @@ impl TranslationCtx<'_> {
             .and_then(|offset| rule.alt_at(offset))
             .map_or_else(|| rule.alts.iter().collect(), |alt| vec![alt]);
         for alt in alts {
-            let mut occurrence_by_target: BTreeMap<&str, Option<usize>> = BTreeMap::new();
-            for (position, element) in alt.refs.iter().enumerate() {
-                let labeled = element.label.as_deref() == Some(label);
-                // Token groups and wildcards carry no target to count against,
-                // and their reads ignore the index, so they neither consume nor
-                // contribute to an occurrence bucket. Sharing the empty-target
-                // bucket would let unrelated groups poison each other.
-                if element.target.is_empty() {
-                    if labeled {
-                        return Some((element.clone(), 0));
-                    }
-                    continue;
-                }
-                let occurrence = occurrence_by_target
-                    .entry(element.target.as_str())
-                    .or_insert(Some(0));
-                let current = *occurrence;
-                // An inexact ref leaves every later same-target position
-                // floating, so poison the running count rather than guess. A
-                // list ref (`xs+=e`) still contributes children here, so it
-                // must go through the same accounting: its usually-unbounded
-                // count is what stops a later same-target label from trusting
-                // a fixed position.
-                *occurrence = match (current, element.cardinality.max) {
-                    (Some(total), Some(max)) if element.cardinality.min == max => {
-                        Some(total.saturating_add(max))
-                    }
-                    _ => None,
-                };
-                if labeled {
-                    // A list read iterates every same-target child, so it never
-                    // consults the index and stays resolvable regardless.
-                    if element.is_list {
-                        return Some((element.clone(), 0));
-                    }
-                    let shadowed_when_absent = element.cardinality.min == 0
-                        && alt.refs[position + 1..].iter().any(|following| {
-                            following.target == element.target
-                                && following.cardinality.max != Some(0)
-                        });
-                    if shadowed_when_absent {
-                        return None;
-                    }
-                    return current.map(|current| (element.clone(), current));
-                }
+            if let Some(resolved) = Self::resolve_label_in_alt(alt, label) {
+                return Some(resolved);
             }
         }
         None
+    }
+
+    fn resolve_label_in_alt(alt: &AltModel, label: &str) -> Option<(ElementRef, usize)> {
+        let declarations = alt
+            .refs
+            .iter()
+            .filter(|element| element.label.as_deref() == Some(label))
+            .collect::<Vec<_>>();
+        let element = *declarations.first()?;
+        // `(x=A | x=B)` declares one label over disjoint targets; a single
+        // positional read cannot serve both, and picking the first silently
+        // yields an empty value on the other branch.
+        if declarations.len() > 1 {
+            return None;
+        }
+        let position = alt
+            .refs
+            .iter()
+            .position(|candidate| std::ptr::eq(candidate, element))?;
+        let (before, after) = (&alt.refs[..position], &alt.refs[position + 1..]);
+        let same_target = |candidate: &ElementRef| {
+            !candidate.target.is_empty()
+                && candidate.target == element.target
+                && candidate.cardinality.max != Some(0)
+        };
+
+        if element.is_list {
+            // The read yields every same-target child, so any same-target
+            // element outside this label would be folded into the label's value.
+            let exclusive = !before.iter().any(same_target) && !after.iter().any(same_target);
+            return exclusive.then(|| (element.clone(), 0));
+        }
+        if element.target.is_empty() {
+            // Block/wildcard labels read the last terminal child, so a later
+            // terminal would take its place.
+            let followed_by_terminal = after
+                .iter()
+                .any(|following| !following.token_types.is_empty());
+            return (!followed_by_terminal).then(|| (element.clone(), 0));
+        }
+
+        // Single label: count the same-target children ahead of it, bailing as
+        // soon as one contributes an unfixed number.
+        let occurrence = before
+            .iter()
+            .filter(|candidate| candidate.target == element.target)
+            .try_fold(0_usize, |total, candidate| {
+                let max = candidate.cardinality.max?;
+                (candidate.cardinality.min == max).then(|| total.saturating_add(max))
+            })?;
+        let shadowed_when_absent = element.cardinality.min == 0 && after.iter().any(same_target);
+        (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
 }
 
@@ -1131,6 +1146,155 @@ mod tests {
         // Unbounded run of `e` ahead of the label: no fixed index exists.
         let error = translate(None).expect_err("unbounded list must not resolve");
         assert!(error.contains("cannot translate $name"), "{error}");
+    }
+
+    /// A list read yields *every* same-target child, so it can only stand for
+    /// the label when no same-target element sits outside it. In the `mixed`
+    /// shape (`name=e ... errors+=e`) a `$errors` read would fold in `name`'s
+    /// child, so the label must not resolve.
+    #[test]
+    fn list_labels_sharing_a_target_with_another_label_stay_unresolved() {
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![
+                ElementRef {
+                    label: Some("name".to_owned()),
+                    target: "e".to_owned(),
+                    token_types: Vec::new(),
+                    is_block: false,
+                    is_list: false,
+                    cardinality: ChildCardinality {
+                        min: 1,
+                        max: Some(1),
+                    },
+                    stable_accessor: true,
+                },
+                ElementRef {
+                    label: Some("errors".to_owned()),
+                    target: "e".to_owned(),
+                    token_types: Vec::new(),
+                    is_block: false,
+                    is_list: true,
+                    cardinality: ChildCardinality { min: 0, max: None },
+                    stable_accessor: true,
+                },
+            ],
+            children: BTreeMap::new(),
+            leading_target: Some("e".to_owned()),
+        });
+        let m = model(vec![statement, rule("e")]);
+        let toks = tokens(&[]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let error = translate_body("$errors", &ctx).expect_err("must not translate");
+        assert!(
+            error.to_string().contains("cannot translate $errors"),
+            "{error}"
+        );
+
+        // `name` is still resolvable: it precedes the list, so its own index is
+        // fixed at 0 and the list contributes nothing ahead of it.
+        let name = translate_body("$name.text", &ctx).expect("translates");
+        assert!(name.contains(".nth(0)"), "{name}");
+    }
+
+    /// A block label reads the last terminal child, so a following terminal
+    /// would take its place: `r : ((x=(A | B))) C {$x...}` must not resolve.
+    #[test]
+    fn block_labels_followed_by_a_terminal_stay_unresolved() {
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![
+                ElementRef {
+                    label: Some("x".to_owned()),
+                    target: String::new(),
+                    token_types: vec![1, 2],
+                    is_block: true,
+                    is_list: false,
+                    cardinality: ChildCardinality {
+                        min: 1,
+                        max: Some(1),
+                    },
+                    stable_accessor: true,
+                },
+                ElementRef {
+                    label: None,
+                    target: "C".to_owned(),
+                    token_types: vec![3],
+                    is_block: false,
+                    is_list: false,
+                    cardinality: ChildCardinality {
+                        min: 1,
+                        max: Some(1),
+                    },
+                    stable_accessor: true,
+                },
+            ],
+            children: BTreeMap::new(),
+            leading_target: None,
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1), ("B", 2), ("C", 3)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let error = translate_body("$x.text", &ctx).expect_err("must not translate");
+        assert!(error.to_string().contains("cannot translate $x"), "{error}");
+    }
+
+    /// One label declared over disjoint targets (`r : (x=A | x=B)`) cannot be
+    /// served by a single positional read: picking the first declaration yields
+    /// an empty value whenever the parse took the other branch.
+    #[test]
+    fn labels_repeated_over_disjoint_targets_stay_unresolved() {
+        let mut statement = rule("s");
+        let token_ref = |target: &str, token_type| ElementRef {
+            label: Some("x".to_owned()),
+            target: target.to_owned(),
+            token_types: vec![token_type],
+            is_block: false,
+            is_list: false,
+            // Mutually exclusive branches.
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![token_ref("A", 1), token_ref("B", 2)],
+            children: BTreeMap::new(),
+            leading_target: None,
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1), ("B", 2)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let error = translate_body("$x.text", &ctx).expect_err("must not translate");
+        assert!(error.to_string().contains("cannot translate $x"), "{error}");
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -637,14 +637,35 @@ impl TranslationCtx<'_> {
         if element.cardinality.is_repeated() {
             return None;
         }
-        // Single label: count the same-target children ahead of it, bailing as
-        // soon as one contributes an unfixed number.
+        // Single label: count the children ahead of it that the read would also
+        // select, bailing as soon as one contributes an unfixed number. A token
+        // *group* has no target yet still produces a child of the label's token
+        // type when their sets overlap (`(A | B) x=A`), so it must be counted —
+        // and since only some of its members match, its contribution is not
+        // exact and the label declines.
+        let counts_toward_occurrence = |candidate: &ElementRef| {
+            if element.token_types.is_empty() || candidate.token_types.is_empty() {
+                return candidate.target == element.target;
+            }
+            candidate
+                .token_types
+                .iter()
+                .any(|token_type| element.token_types.contains(token_type))
+        };
         let occurrence = before
             .iter()
-            .filter(|candidate| candidate.target == element.target)
+            .filter(|candidate| counts_toward_occurrence(candidate))
             .try_fold(0_usize, |total, candidate| {
                 let max = candidate.cardinality.max?;
-                (candidate.cardinality.min == max).then(|| total.saturating_add(max))
+                // A group only *sometimes* yields a matching child, so its count
+                // is exact only when every member is one the read selects.
+                let all_match = candidate
+                    .token_types
+                    .iter()
+                    .all(|token_type| element.token_types.contains(token_type));
+                (candidate.cardinality.min == max
+                    && (candidate.token_types.is_empty() || all_match))
+                    .then(|| total.saturating_add(max))
             })?;
         // An optional label is displaced by a following same-target child that can
         // slide into its position, whether that child is mandatory (`x=A? A`) or

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -1084,6 +1084,24 @@ impl TranslationCtx<'_> {
             });
             return exclusive.then(|| (element.clone(), 0));
         }
+        // Only declarations the action can actually observe constrain its read. Two
+        // rule it out: one in a sibling branch, which never runs alongside a
+        // branch-confined action (`(x=A {$x} | x=A+ B)`), and one *after* the action,
+        // which has not assigned the label yet (`x=A {$x} x=A` reads the first
+        // assignment unambiguously).
+        let relevant = declarations
+            .iter()
+            .copied()
+            .filter(|candidate| {
+                (!branch_confined || on_action_path(candidate)) && matched_at_action(candidate)
+            })
+            .collect::<Vec<_>>();
+        let declarations = if relevant.is_empty() {
+            declarations
+        } else {
+            relevant
+        };
+        let element = *declarations.first()?;
         // A single label read is one positional lookup. Several declarations can
         // still share it when each lowers to the same query — mutually exclusive
         // branches holding `x=A` at the same occurrence do. What cannot be served
@@ -1101,20 +1119,6 @@ impl TranslationCtx<'_> {
         // results to agree, so one read demonstrably serves every branch:
         // `(A x=A B | x=A C)` wants occurrence 1 then 0, and `(x=A B | x=A+ C)`
         // wants a first-match read then a last-match one.
-        // An action confined to one branch never sees a sibling branch's declaration,
-        // so requiring agreement with it would reject a read that is unambiguous
-        // where the action actually runs (`(x=A {$x} | x=A+ B)`).
-        let relevant = declarations
-            .iter()
-            .copied()
-            .filter(|candidate| !branch_confined || on_action_path(candidate))
-            .collect::<Vec<_>>();
-        let declarations = if relevant.is_empty() {
-            declarations
-        } else {
-            relevant
-        };
-        let element = *declarations.first()?;
         if declarations.len() > 1 {
             let mut resolutions = Vec::with_capacity(declarations.len());
             for candidate in &declarations {

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -90,6 +90,14 @@ pub(crate) struct ElementRef {
     /// action executes at *its* source position, so only refs that start before
     /// the action's offset have been matched when its body runs.
     pub(crate) span: Option<(usize, usize)>,
+    /// Cardinality this element would have if every enclosing choice took the
+    /// branch containing it — i.e. with only the *quantifiers* applied, not the
+    /// `min: 0` that `choice_branch` membership imposes.
+    ///
+    /// `(a=A | b=A) x=A` and `(a=A | b=A)? x=A` give their branch refs the same
+    /// `cardinality` (`0..1`), yet the first choice always yields one `A` and the
+    /// second may yield none. Only this field separates them.
+    pub(crate) branch_local_cardinality: ChildCardinality,
 }
 
 impl ElementRef {
@@ -467,10 +475,21 @@ impl TranslationCtx<'_> {
                 !candidate.token_types.is_empty() && candidate.cardinality.max != Some(0)
             });
         }
+        // The read queries by token *type*, so a differently-spelled terminal with
+        // the same type is the same child (`A : 'a';` makes `A` and `'a'` one).
+        let same_read_target = |candidate: &ElementRef| {
+            if element.token_types.is_empty() || candidate.token_types.is_empty() {
+                return candidate.target == element.target;
+            }
+            candidate
+                .token_types
+                .iter()
+                .any(|token_type| element.token_types.contains(token_type))
+        };
         let available = alt
             .refs
             .iter()
-            .filter(|candidate| candidate.target == element.target)
+            .filter(|candidate| same_read_target(candidate))
             .try_fold(0_usize, |total, candidate| {
                 Some(total.saturating_add(candidate.cardinality.max?))
             });
@@ -512,11 +531,14 @@ impl TranslationCtx<'_> {
         // differently-spelled terminal with the same type is the same child as
         // far as the read is concerned (`A : 'a';` makes `A` and `'a'` aliases).
         let same_target = |candidate: &ElementRef| {
-            if candidate.target.is_empty() || candidate.cardinality.max == Some(0) {
+            if candidate.cardinality.max == Some(0) {
                 return false;
             }
+            // A token *group* has no target yet still contributes a child of the
+            // label's type when their sets overlap (`(xs+=A)? (A | B)`), so match
+            // on token types whenever both sides have them — empty target or not.
             if element.token_types.is_empty() || candidate.token_types.is_empty() {
-                return candidate.target == element.target;
+                return !candidate.target.is_empty() && candidate.target == element.target;
             }
             candidate
                 .token_types
@@ -836,6 +858,7 @@ fn translate_reference(
             stable_accessor: false,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let _ = target_rule;
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
@@ -851,6 +874,7 @@ fn translate_reference(
             stable_accessor: false,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
     }
@@ -1202,6 +1226,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: Some("right".to_owned()),
@@ -1213,6 +1238,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::from([(
@@ -1269,6 +1295,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1315,6 +1342,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1355,6 +1383,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1398,6 +1427,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let single_ref = ElementRef {
             label: Some("name".to_owned()),
@@ -1412,6 +1442,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |max| {
             let mut statement = rule("s");
@@ -1467,6 +1498,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: Some("errors".to_owned()),
@@ -1478,6 +1510,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::new(),
@@ -1531,6 +1564,7 @@ mod tests {
                         stable_accessor: true,
                         choice_branch: Vec::new(),
                         span: Some((10, 20)),
+                        branch_local_cardinality: ChildCardinality::ONE,
                     },
                     ElementRef {
                         label: None,
@@ -1545,6 +1579,7 @@ mod tests {
                         stable_accessor: true,
                         choice_branch: Vec::new(),
                         span: Some((30, 31)),
+                        branch_local_cardinality: ChildCardinality::ONE,
                     },
                 ],
                 children: BTreeMap::new(),
@@ -1594,6 +1629,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -1651,6 +1687,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: vec![(5, branch)],
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |second: ElementRef, offset| {
             let mut statement = rule("s");
@@ -1709,6 +1746,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -1759,6 +1797,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |second: ElementRef| {
             let mut statement = rule("s");
@@ -1816,6 +1855,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -1854,6 +1894,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut choice = rule("s");
         for (index, refs) in [vec![block_ref(vec![1, 2])], vec![block_ref(vec![3, 4])]]
@@ -1920,6 +1961,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let error = translate(group_list, "$xs").expect_err("no target to iterate");
         assert!(error.contains("cannot translate $xs"), "{error}");
@@ -1934,6 +1976,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let error = translate(repeated_single, "$x.text").expect_err("no last-occurrence read");
         assert!(error.contains("cannot translate $x"), "{error}");
@@ -1958,6 +2001,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: branches,
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2005,6 +2049,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: vec![(3, branch)],
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2066,6 +2111,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: None,
@@ -2081,6 +2127,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::new(),
@@ -2124,6 +2171,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: vec![(7, branch)],
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -2167,6 +2215,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: Some(span),
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         sequential.alts.push(AltModel {
             label: None,
@@ -2209,6 +2258,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let token_ref = ElementRef {
             label: None,
@@ -2223,6 +2273,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         for (index, refs) in [
@@ -2275,6 +2326,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |second: Vec<ElementRef>| {
             let mut statement = rule("s");
@@ -2334,6 +2386,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
+            branch_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -2413,6 +2466,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: Some("ids".to_owned()),
@@ -2424,6 +2478,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     span: None,
+                    branch_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::new(),

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -921,6 +921,15 @@ impl TranslationCtx<'_> {
             if left.0.is_block == right.0.is_block {
                 return left.1 == right.1;
             }
+            // The mixed-mode merge works because both sides lower to the same
+            // *scalar* `nth(0)`. A list read has no such common form: token mode
+            // yields an iterator (`child_tokens(A)`), block mode a `String` — it
+            // resolves `target` against `ctx.token_types`, and a literal target
+            // (`xs+='a'`) is not a key there, so it falls through to the positional
+            // block read. Merging the two emitted `.collect()` on a `String`.
+            if left.0.is_list {
+                return false;
+            }
             return left.1 == 0
                 && right.1 == 0
                 && left.0.leading_terminal
@@ -1437,26 +1446,40 @@ impl TranslationCtx<'_> {
         } else {
             element.cardinality.min == 0
         };
+        // A sibling branch's child cannot slide into the label's slot *within a
+        // parse that bound the label* — the two never coexist. It is still a hazard
+        // when the read may run with the label unset, which is when the action is
+        // not inside the branch that separates them. That has to be judged per
+        // *choice*: a rule-wide flag would let an action confined to some unrelated
+        // later choice exempt an earlier sibling
+        // (`({false}? x=A | A) (B {$x} | C)`).
+        let excluded_by_confinement = |candidate: &ElementRef| {
+            !candidate.can_coexist_with(element)
+                && Self::action_inside_separating_branch(
+                    element,
+                    candidate,
+                    action_branches.as_deref(),
+                )
+        };
         let shadowed_when_absent = element_optional_here
-            && after.iter().any(|candidate| {
+            && (after.iter().any(|candidate| {
                 !declares_label(candidate)
                     && same_target(candidate)
                     && matched_at_action(candidate)
-                    // A sibling branch's child cannot slide into the label's slot
-                    // *within a parse that bound the label* — the two never coexist.
-                    // It is still a hazard when the read may run with the label
-                    // unset, which is when the action is not inside the branch that
-                    // separates them. That has to be judged per *choice*: a
-                    // rule-wide flag would let an action confined to some unrelated
-                    // later choice exempt an earlier sibling
-                    // (`({false}? x=A | A) (B {$x} | C)`).
-                    && (candidate.can_coexist_with(element)
-                        || !Self::action_inside_separating_branch(
-                            element,
-                            candidate,
-                            action_branches.as_deref(),
-                        ))
-            });
+                    && !excluded_by_confinement(candidate)
+            })
+            // A same-target sibling *before* the label impersonates it just as well:
+            // in `(A | x=A) {$x}` the unlabeled `A` is the only child of its type on
+            // its own branch, so `child_tokens(A).nth(0)` reports it. Only
+            // non-coexisting refs matter here — a ref the label coexists with is a
+            // genuine prefix and is already folded into `occurrence`.
+            || before.iter().any(|candidate| {
+                !declares_label(candidate)
+                    && same_target(candidate)
+                    && matched_at_action(candidate)
+                    && !candidate.can_coexist_with(element)
+                    && !excluded_by_confinement(candidate)
+            }));
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
 }
@@ -1694,6 +1717,18 @@ fn translate_element_read(
                 "__ctx.child_tokens(self.base.parse_tree_storage(), self.base.token_store(), {token_type})"
             ));
         }
+        // A list label whose target names neither a rule nor a token type has no
+        // iterator form: the block read below picks *one* terminal and renders it as
+        // a `String`, so falling through emitted `.collect()` on a `String` for
+        // `xs+='a'` (a literal is not a `token_types` key). Decline instead of
+        // generating code that does not compile.
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "cannot translate list label ${} in embedded action: {body}",
+                element.label.as_deref().unwrap_or_default()
+            ),
+        ));
     }
     if element.is_block {
         // A labeled `(...)` block over tokens: `$myset.stop` / `$myset.text` read

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -1185,6 +1185,12 @@ impl TranslationCtx<'_> {
                 .filter(|candidate| {
                     !candidate.token_types.is_empty()
                         && on_action_path(candidate)
+                        // Only children already matched when the action runs affect
+                        // its read. For a *forward* label (`A {$x.text} B? x=(C|D)`)
+                        // the prefix is entirely in the future, so counting `B?`
+                        // made the index inexact and fell back to `last()` — which
+                        // returns the already-matched `A`.
+                        && matched_at_action(candidate)
                         // A ref in a branch this label cannot reach never precedes it:
                         // in `(x=A | x='a')` the sibling declaration is not a prefix
                         // terminal of the literal's path.

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -98,6 +98,23 @@ pub(crate) struct ElementRef {
     /// after the group) from `(A x=A {…} | B)` (action inside it), since both put
     /// branch refs on either side of the action.
     pub(crate) choice_spans: Vec<(usize, usize)>,
+    /// Cardinality with every *enclosing* quantifier and choice split treated as
+    /// satisfied — only this element's own EBNF suffix applies. An action inside
+    /// `(A x=A {…})?` runs only when the group matched, so on that path the
+    /// preceding `A` is exactly-once even though both `cardinality` and
+    /// `branch_local_cardinality` report `0..1` from the group's `?`.
+    pub(crate) group_local_cardinality: ChildCardinality,
+    /// Byte spans of *every* enclosing block, including single-alternative groups
+    /// that `choice_spans` omits. An action inside such a group only runs when the
+    /// group was taken, so refs sharing the group have run even though their
+    /// cardinality reports `min: 0` from the group's `?`.
+    pub(crate) group_spans: Vec<(usize, usize)>,
+    /// Byte span of each enclosing choice *alternative* (the branch itself), in the
+    /// same order as `choice_branch`. Lets an action be attributed to the branch
+    /// whose text contains it, including a branch holding only actions or
+    /// predicates — such a branch emits no `ElementRef` at all, so ref spans alone
+    /// would attribute the action to a neighbouring branch.
+    pub(crate) branch_spans: Vec<(usize, usize)>,
     /// Byte span of the element in the grammar source, when known. A mid-rule
     /// action executes at *its* source position, so only refs that start before
     /// the action's offset have been matched when its body runs.
@@ -564,7 +581,7 @@ impl TranslationCtx<'_> {
                 candidate.choice_arity.truncate(keep);
                 candidate.choice_spans.truncate(keep);
                 if candidate.choice_branch.is_empty() {
-                    candidate.cardinality = candidate.branch_local_cardinality;
+                    candidate.cardinality = candidate.group_local_cardinality;
                 }
                 candidate
             })
@@ -771,11 +788,19 @@ impl TranslationCtx<'_> {
         if left.0.is_list != right.0.is_list {
             return false;
         }
-        // Token-backed resolutions are equivalent when they query the same token
-        // type, regardless of source form: `x=A` resolves in token mode while
-        // `x='a'` is block mode, yet both lower to `child_tokens(A)`.
+        // Token-backed resolutions can be equivalent across source forms (`x=A` is
+        // token-mode, `x='a'` is block-mode) because both lower to the same
+        // `child_tokens(A)` query — but their occurrences are counted in different
+        // units: a block read indexes *every* terminal child, a token read only
+        // same-type children. Comparing the raw numbers merged `x='a' | A x=A`,
+        // where each side reports 1 but means a different child. Both must
+        // therefore agree on the occurrence *and*, when the modes differ, that
+        // occurrence must be zero — the one index where the two systems coincide.
         if !left.0.token_types.is_empty() && left.0.token_types == right.0.token_types {
-            return left.1 == right.1;
+            if left.1 != right.1 {
+                return false;
+            }
+            return left.0.is_block == right.0.is_block || left.1 == 0;
         }
         if left.0.is_block != right.0.is_block {
             return false;
@@ -851,47 +876,40 @@ impl TranslationCtx<'_> {
             // offset and no ref of a *later* sibling does — source order means a
             // later branch having started implies the action is past this one.
             let mut chosen: Vec<(usize, usize)> = Vec::new();
-            let mut choices: Vec<usize> = Vec::new();
+            // Every (choice, branch) whose *branch text* contains the action. This
+            // reads the branch's own span rather than inferring from ref positions,
+            // so a branch holding only an action or predicate — which emits no
+            // `ElementRef` — is still identified (`x=A? (A | {$x.text})`).
             for candidate in &alt.refs {
-                for &(choice, _) in &candidate.choice_branch {
-                    if !choices.contains(&choice) {
-                        choices.push(choice);
+                for ((&key, &(branch_start, branch_end)), &(choice_start, choice_end)) in candidate
+                    .choice_branch
+                    .iter()
+                    .zip(&candidate.branch_spans)
+                    .zip(&candidate.choice_spans)
+                {
+                    let inside_choice = choice_start <= offset && offset < choice_end;
+                    let inside_branch = branch_start <= offset && offset < branch_end;
+                    if inside_choice && inside_branch && !chosen.contains(&key) {
+                        chosen.push(key);
                     }
                 }
             }
-            for choice in choices {
-                // Only choices whose block encloses the action are in play.
-                let encloses = alt.refs.iter().any(|candidate| {
-                    candidate
-                        .choice_branch
-                        .iter()
-                        .zip(&candidate.choice_spans)
-                        .any(|(&(candidate_choice, _), &(start, end))| {
-                            candidate_choice == choice && start <= offset && offset < end
-                        })
-                });
-                if !encloses {
-                    continue;
-                }
-                let started_before = |branch: usize| {
-                    alt.refs.iter().any(|candidate| {
-                        candidate.span.is_some_and(|(start, _)| start < offset)
-                            && candidate
-                                .choice_branch
-                                .iter()
-                                .any(|&(c, b)| c == choice && b == branch)
-                    })
-                };
-                let branches = alt
-                    .refs
-                    .iter()
-                    .flat_map(|candidate| candidate.choice_branch.iter())
-                    .filter(|&&(c, _)| c == choice)
-                    .map(|&(_, b)| b)
-                    .collect::<BTreeSet<_>>();
-                // The last branch that has started is the one containing the action.
-                if let Some(branch) = branches.into_iter().rfind(|&branch| started_before(branch)) {
-                    chosen.push((choice, branch));
+            // A choice enclosing the action but with no branch claiming it means the
+            // action sits in a ref-free branch: nothing of that branch has matched,
+            // so record it as its own branch so siblings are excluded.
+            for candidate in &alt.refs {
+                for (&(choice, _), &(choice_start, choice_end)) in
+                    candidate.choice_branch.iter().zip(&candidate.choice_spans)
+                {
+                    if choice_start <= offset
+                        && offset < choice_end
+                        && !chosen
+                            .iter()
+                            .any(|&(chosen_choice, _)| chosen_choice == choice)
+                    {
+                        // usize::MAX marks "a branch with no refs of its own".
+                        chosen.push((choice, usize::MAX));
+                    }
                 }
             }
             chosen
@@ -899,6 +917,19 @@ impl TranslationCtx<'_> {
         let branch_confined = action_branches
             .as_ref()
             .is_some_and(|branches| !branches.is_empty());
+        // A ref inside an enclosing group that the action also sits inside has run:
+        // the action only executes when that group was taken. Its cardinality still
+        // reports `min: 0` from the group's `?`, so use the branch-local figure for
+        // those refs — `(A x=A {…})?` has exactly one `A` before the label whenever
+        // the action runs at all.
+        let on_taken_group = |candidate: &ElementRef| {
+            action_offset.is_some_and(|offset| {
+                candidate
+                    .group_spans
+                    .iter()
+                    .any(|&(start, end)| start <= offset && offset < end)
+            })
+        };
         // Whether a ref can have run before the action, given that ancestry. An
         // action after the whole choice (`(x=A | A) {$x}`) has no branch tag, so
         // every branch counts; one written inside a branch excludes its siblings —
@@ -1020,7 +1051,12 @@ impl TranslationCtx<'_> {
                 // ROOT J: a fixed index is not enough when the label is *optional* —
                 // `x=(A | B)? C {…}` puts `C` at index 0 whenever the block is
                 // absent, so the read would report it as the label's token.
-                if element.cardinality.min == 0
+                let optional_here = if on_taken_group(element) {
+                    element.group_local_cardinality.min == 0
+                } else {
+                    element.cardinality.min == 0
+                };
+                if optional_here
                     && after.iter().any(|candidate| {
                         !candidate.token_types.is_empty()
                             && candidate.cardinality.max != Some(0)
@@ -1082,9 +1118,23 @@ impl TranslationCtx<'_> {
         // is confined to a branch — count the surviving branch as that path rather
         // than demanding agreement from branches already filtered out.
         let occurrence = Self::exact_child_count(
-            before.iter().filter(|candidate| {
-                counts_toward_occurrence(candidate) && candidate.can_coexist_with(element)
-            }),
+            before
+                .iter()
+                .filter(|candidate| {
+                    counts_toward_occurrence(candidate) && candidate.can_coexist_with(element)
+                })
+                .cloned()
+                .map(|mut candidate| {
+                    if on_taken_group(&candidate) {
+                        // The enclosing group is taken on the action's path, so the
+                        // group's own quantifier no longer relaxes this ref.
+                        candidate.cardinality = candidate.group_local_cardinality;
+                        candidate.branch_local_cardinality = candidate.group_local_cardinality;
+                    }
+                    candidate
+                })
+                .collect::<Vec<_>>()
+                .iter(),
             true,
         )?;
         // An optional label is displaced by a following same-target child that can
@@ -1098,7 +1148,15 @@ impl TranslationCtx<'_> {
         // exclude siblings for an action that runs after the whole choice.
         // Another *declaration* of the same label is not a shadow — it binds the
         // label too, and the guard above already proved they share one read.
-        let shadowed_when_absent = element.cardinality.min == 0
+        // The label's own `min: 0` may come from a group the action shares, in which
+        // case it is *not* optional relative to the action: `(A x=A {…})?` only runs
+        // the action when the group matched, so `x` is bound.
+        let element_optional_here = if on_taken_group(element) {
+            element.group_local_cardinality.min == 0
+        } else {
+            element.cardinality.min == 0
+        };
+        let shadowed_when_absent = element_optional_here
             && after.iter().any(|candidate| {
                 !declares_label(candidate) && same_target(candidate) && matched_at_action(candidate)
             });
@@ -1229,8 +1287,11 @@ fn translate_reference(
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let _ = target_rule;
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
@@ -1247,8 +1308,11 @@ fn translate_reference(
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
     }
@@ -1601,8 +1665,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: Some("right".to_owned()),
@@ -1615,8 +1682,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::from([(
@@ -1677,9 +1747,15 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             // Optional on its own path, so the count ahead of the label floats.
             branch_local_cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            group_local_cardinality: ChildCardinality {
                 min: 0,
                 max: Some(1),
             },
@@ -1730,8 +1806,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1775,8 +1854,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality { min, max: Some(1) },
+            group_local_cardinality: ChildCardinality { min, max: Some(1) },
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1821,8 +1903,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let single_ref = ElementRef {
             label: Some("name".to_owned()),
@@ -1838,8 +1923,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |max| {
             let mut statement = rule("s");
@@ -1896,8 +1984,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: Some("errors".to_owned()),
@@ -1910,8 +2001,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::new(),
@@ -1966,8 +2060,11 @@ mod tests {
                         choice_branch: Vec::new(),
                         choice_arity: Vec::new(),
                         choice_spans: Vec::new(),
+                        group_spans: Vec::new(),
+                        branch_spans: Vec::new(),
                         span: Some((10, 20)),
                         branch_local_cardinality: ChildCardinality::ONE,
+                        group_local_cardinality: ChildCardinality::ONE,
                     },
                     ElementRef {
                         label: None,
@@ -1983,8 +2080,11 @@ mod tests {
                         choice_branch: Vec::new(),
                         choice_arity: Vec::new(),
                         choice_spans: Vec::new(),
+                        group_spans: Vec::new(),
+                        branch_spans: Vec::new(),
                         span: Some((30, 31)),
                         branch_local_cardinality: ChildCardinality::ONE,
+                        group_local_cardinality: ChildCardinality::ONE,
                     },
                 ],
                 children: BTreeMap::new(),
@@ -2035,8 +2135,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2095,8 +2198,11 @@ mod tests {
             choice_branch: vec![(5, branch)],
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |second: ElementRef, offset| {
             let mut statement = rule("s");
@@ -2156,8 +2262,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2209,8 +2318,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |second: ElementRef| {
             let mut statement = rule("s");
@@ -2269,8 +2381,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2310,8 +2425,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut choice = rule("s");
         for (index, refs) in [vec![block_ref(vec![1, 2])], vec![block_ref(vec![3, 4])]]
@@ -2379,8 +2497,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let error = translate(group_list, "$xs").expect_err("no target to iterate");
         assert!(error.contains("cannot translate $xs"), "{error}");
@@ -2396,8 +2517,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let error = translate(repeated_single, "$x.text").expect_err("no last-occurrence read");
         assert!(error.contains("cannot translate $x"), "{error}");
@@ -2423,8 +2547,11 @@ mod tests {
             choice_branch: branches,
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2473,8 +2600,11 @@ mod tests {
             choice_branch: vec![(3, branch)],
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -2537,8 +2667,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: None,
@@ -2555,8 +2688,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::new(),
@@ -2601,8 +2737,11 @@ mod tests {
             choice_branch: vec![(7, branch)],
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -2647,8 +2786,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         sequential.alts.push(AltModel {
             label: None,
@@ -2692,8 +2834,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let token_ref = ElementRef {
             label: None,
@@ -2709,8 +2854,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let mut statement = rule("s");
         for (index, refs) in [
@@ -2764,8 +2912,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         let translate = |second: Vec<ElementRef>| {
             let mut statement = rule("s");
@@ -2826,8 +2977,11 @@ mod tests {
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
             choice_spans: Vec::new(),
+            group_spans: Vec::new(),
+            branch_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
+            group_local_cardinality: ChildCardinality::ONE,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -2908,8 +3062,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
                 ElementRef {
                     label: Some("ids".to_owned()),
@@ -2922,8 +3079,11 @@ mod tests {
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
                     choice_spans: Vec::new(),
+                    group_spans: Vec::new(),
+                    branch_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
+                    group_local_cardinality: ChildCardinality::ONE,
                 },
             ],
             children: BTreeMap::new(),

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -86,6 +86,12 @@ pub(crate) struct ElementRef {
     /// `((x=e | f) | e)` the labeled `x` and the trailing `e` are separated by
     /// the *outer* choice, which an innermost-only tag would lose.
     pub(crate) choice_branch: Vec<(usize, usize)>,
+    /// Alternative count of each choice named in `choice_branch`, in the same
+    /// order. Recorded at collection time because an *empty* alternative emits no
+    /// ref at all, so the branch count cannot be recovered from the refs alone —
+    /// `(a=A | )` would otherwise look like a one-branch choice that always
+    /// yields an `A`.
+    pub(crate) choice_arity: Vec<usize>,
     /// Byte span of the element in the grammar source, when known. A mid-rule
     /// action executes at *its* source position, so only refs that start before
     /// the action's offset have been matched when its body runs.
@@ -486,13 +492,39 @@ impl TranslationCtx<'_> {
                 .iter()
                 .any(|token_type| element.token_types.contains(token_type))
         };
-        let available = alt
+        // The most matching children *one parse* can build: sequential refs add,
+        // but branches of a choice are alternatives, so the largest branch wins.
+        // Summing them all would overstate the count and reject valid reads —
+        // `A x=A | (A B? | A C?)` builds at most one `A` in the second alternative.
+        let mut sequential = Some(0_usize);
+        let mut per_branch: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
+        for candidate in alt
             .refs
             .iter()
             .filter(|candidate| same_read_target(candidate))
-            .try_fold(0_usize, |total, candidate| {
-                Some(total.saturating_add(candidate.cardinality.max?))
-            });
+        {
+            let slot = match candidate.choice_branch.last() {
+                None => &mut sequential,
+                Some(&key) => per_branch.entry(key).or_insert(Some(0)),
+            };
+            *slot = match (*slot, candidate.cardinality.max) {
+                (Some(total), Some(max)) => Some(total.saturating_add(max)),
+                _ => None,
+            };
+        }
+        let mut widest_by_choice: BTreeMap<usize, Option<usize>> = BTreeMap::new();
+        for ((choice, _), count) in per_branch {
+            let slot = widest_by_choice.entry(choice).or_insert(Some(0));
+            *slot = match (*slot, count) {
+                (Some(current), Some(next)) => Some(current.max(next)),
+                _ => None,
+            };
+        }
+        let available = sequential.and_then(|base| {
+            widest_by_choice
+                .into_values()
+                .try_fold(base, |total, count| Some(total.saturating_add(count?)))
+        });
         // A list read selects any same-target child; a positional read needs one
         // at `occurrence`. An unbounded count can always reach either.
         available.is_none_or(|available| available > occurrence)
@@ -519,9 +551,17 @@ impl TranslationCtx<'_> {
         let mut total = 0_usize;
         let mut per_branch: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
         let mut branches_seen: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+        // Recorded arity, so an empty alternative (which emits no ref) still counts
+        // toward the branches that must agree.
+        let mut arity_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
         for candidate in &refs {
             for &(choice, branch) in &candidate.choice_branch {
                 branches_seen.entry(choice).or_default().insert(branch);
+            }
+            for (&(choice, _), &arity) in
+                candidate.choice_branch.iter().zip(&candidate.choice_arity)
+            {
+                arity_of_choice.insert(choice, arity);
             }
         }
         for candidate in &refs {
@@ -544,7 +584,10 @@ impl TranslationCtx<'_> {
             by_choice.entry(choice).or_default().push(count?);
         }
         for (choice, counts) in by_choice {
-            let expected = branches_seen.get(&choice).map_or(0, BTreeSet::len);
+            let expected = arity_of_choice
+                .get(&choice)
+                .copied()
+                .unwrap_or_else(|| branches_seen.get(&choice).map_or(0, BTreeSet::len));
             let first = counts.first().copied()?;
             // Every branch must agree *and* be accounted for — `(A A | B)` has
             // branch counts 2 and 1, so the prefix is not a fixed position.
@@ -929,6 +972,7 @@ fn translate_reference(
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -945,6 +989,7 @@ fn translate_reference(
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1297,6 +1342,7 @@ mod tests {
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1309,6 +1355,7 @@ mod tests {
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1366,6 +1413,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1413,6 +1461,7 @@ mod tests {
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1456,6 +1505,7 @@ mod tests {
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality { min, max: Some(1) },
         };
@@ -1500,6 +1550,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1515,6 +1566,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1571,6 +1623,7 @@ mod tests {
                     },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1583,6 +1636,7 @@ mod tests {
                     cardinality: ChildCardinality { min: 0, max: None },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1637,6 +1691,7 @@ mod tests {
                         },
                         stable_accessor: true,
                         choice_branch: Vec::new(),
+                        choice_arity: Vec::new(),
                         span: Some((10, 20)),
                         branch_local_cardinality: ChildCardinality::ONE,
                     },
@@ -1652,6 +1707,7 @@ mod tests {
                         },
                         stable_accessor: true,
                         choice_branch: Vec::new(),
+                        choice_arity: Vec::new(),
                         span: Some((30, 31)),
                         branch_local_cardinality: ChildCardinality::ONE,
                     },
@@ -1702,6 +1758,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1760,6 +1817,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: vec![(5, branch)],
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1819,6 +1877,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1870,6 +1929,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1928,6 +1988,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1967,6 +2028,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2034,6 +2096,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2049,6 +2112,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2074,6 +2138,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: branches,
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2122,6 +2187,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: vec![(3, branch)],
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2184,6 +2250,7 @@ mod tests {
                     },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -2200,6 +2267,7 @@ mod tests {
                     },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -2244,6 +2312,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: vec![(7, branch)],
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2288,6 +2357,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2331,6 +2401,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2346,6 +2417,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2399,6 +2471,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2459,6 +2532,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            choice_arity: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2539,6 +2613,7 @@ mod tests {
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -2551,6 +2626,7 @@ mod tests {
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    choice_arity: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -424,12 +424,21 @@ impl TranslationCtx<'_> {
             return exclusive.then(|| (element.clone(), 0));
         }
         if element.target.is_empty() {
-            // Block/wildcard labels read the last terminal child, so a later
-            // terminal would take its place.
-            let followed_by_terminal = after
-                .iter()
-                .any(|following| !following.token_types.is_empty());
-            return (!followed_by_terminal).then(|| (element.clone(), 0));
+            // Block/wildcard labels read the most recent terminal child. That is
+            // the block's own token exactly when no other terminal has been
+            // matched between the block and the action — and because a mid-rule
+            // action executes at its own source position, a terminal written
+            // *after* the action never interferes. ANTLR's `t=~'x' 'z' {$t.text}`
+            // descriptors depend on that (`Sets/ParserNotTokenWithLabel`).
+            //
+            // `ElementRef` carries no source span, so the action's position
+            // relative to these refs is not recoverable here and the read is
+            // accepted as-is. A label read *across* an intervening terminal
+            // (`((x=(A | B))) C {$x.text}` reads `C`) is therefore still wrong;
+            // fixing it needs element spans in the model, tracked separately
+            // rather than papered over with a guard that would reject the
+            // conformance shapes above.
+            return Some((element.clone(), 0));
         }
 
         // Single label: count the same-target children ahead of it, bailing as
@@ -1206,10 +1215,14 @@ mod tests {
         assert!(name.contains(".nth(0)"), "{name}");
     }
 
-    /// A block label reads the last terminal child, so a following terminal
-    /// would take its place: `r : ((x=(A | B))) C {$x...}` must not resolve.
+    /// A block label reads the most recent terminal child, which is correct for
+    /// ANTLR's `t=~'x' 'z' {$t.text}` conformance shapes because a mid-rule
+    /// action runs at its own source position. `ElementRef` carries no span, so
+    /// that ordering is not recoverable here and the read is accepted as-is —
+    /// this test pins the resulting behaviour, including the known limitation
+    /// that a read across an intervening terminal picks the later token.
     #[test]
-    fn block_labels_followed_by_a_terminal_stay_unresolved() {
+    fn block_labels_resolve_to_the_most_recent_terminal_read() {
         let mut statement = rule("s");
         statement.alts.push(AltModel {
             label: None,
@@ -1253,8 +1266,9 @@ mod tests {
             token_types: &toks,
         };
 
-        let error = translate_body("$x.text", &ctx).expect_err("must not translate");
-        assert!(error.to_string().contains("cannot translate $x"), "{error}");
+        let translated = translate_body("$x.text", &ctx).expect("translates");
+        assert!(translated.contains("terminal_children"), "{translated}");
+        assert!(translated.contains(".last()"), "{translated}");
     }
 
     /// One label declared over disjoint targets (`r : (x=A | x=B)`) cannot be

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -86,6 +86,10 @@ pub(crate) struct ElementRef {
     /// `((x=e | f) | e)` the labeled `x` and the trailing `e` are separated by
     /// the *outer* choice, which an innermost-only tag would lose.
     pub(crate) choice_branch: Vec<(usize, usize)>,
+    /// Byte span of the element in the grammar source, when known. A mid-rule
+    /// action executes at *its* source position, so only refs that start before
+    /// the action's offset have been matched when its body runs.
+    pub(crate) span: Option<(usize, usize)>,
 }
 
 impl ElementRef {
@@ -405,10 +409,14 @@ impl TranslationCtx<'_> {
     ///   read cannot also serve.
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
-        if let Some(alt) = self.body_offset.and_then(|offset| rule.alt_at(offset)) {
-            // A mid-rule action is confined to the branch it is written in, so a
-            // sibling branch's children can be excluded.
-            return Self::resolve_label_in_alt(alt, label, true);
+        if let Some((offset, alt)) = self
+            .body_offset
+            .and_then(|offset| rule.alt_at(offset).map(|alt| (offset, alt)))
+        {
+            // A mid-rule action executes at its own source position, so only refs
+            // starting before it have been matched, and only branches enclosing
+            // that position can have run.
+            return Self::resolve_label_in_alt(alt, label, Some(offset));
         }
         // `@after` / `@init` bodies are not scoped to an alternative, so the
         // label may be declared in several. One read has to serve whichever
@@ -428,7 +436,7 @@ impl TranslationCtx<'_> {
             // An `@after` / `@init` body runs whichever branch the parse took, so
             // a sibling branch's match *can* be the child present when the read
             // executes — sibling exclusion does not apply here.
-            let candidate = Self::resolve_label_in_alt(alt, label, false)?;
+            let candidate = Self::resolve_label_in_alt(alt, label, None)?;
             if resolved
                 .as_ref()
                 .is_some_and(|existing| !Self::same_label_read(existing, &candidate))
@@ -486,10 +494,12 @@ impl TranslationCtx<'_> {
         left.1 == right.1 && left.0.target == right.0.target
     }
 
+    /// `action_offset` is the byte offset of a *mid-rule* action body, or `None`
+    /// for an `@after` / `@init` body that runs after the whole rule.
     fn resolve_label_in_alt(
         alt: &AltModel,
         label: &str,
-        exclude_sibling_branches: bool,
+        action_offset: Option<usize>,
     ) -> Option<(ElementRef, usize)> {
         let declarations = alt
             .refs
@@ -513,6 +523,45 @@ impl TranslationCtx<'_> {
                 .iter()
                 .any(|token_type| element.token_types.contains(token_type))
         };
+        // Whether `candidate` has been matched by the time the action body runs.
+        // A mid-rule action executes at its source position, so a ref that starts
+        // after it is still in the future and cannot affect the read; a ref in a
+        // branch the action does not sit inside cannot have run either. An
+        // `@after` body runs after everything, so every ref counts.
+        // Whether the action sits *inside* the labeled element's own branch. Only
+        // then can a sibling branch be ruled out: an action written after the
+        // whole choice (`(x=A | A) {$x}`) runs for either branch, so the sibling's
+        // match really can be the child its read finds. Inclusion is decided from
+        // the label's span — the action follows it and precedes whatever ends the
+        // branch, so a same-branch action lies before any later-branch ref.
+        let action_inside_label_branch = || match (action_offset, element.span) {
+            (Some(offset), Some((_, label_end))) => {
+                offset >= label_end
+                    && alt.refs.iter().all(|candidate| {
+                        candidate.can_coexist_with(element)
+                            || candidate.span.is_none_or(|(start, _)| start > offset)
+                    })
+            }
+            _ => false,
+        };
+        let branch_confined = action_inside_label_branch();
+        let matched_at_action = |candidate: &ElementRef| {
+            action_offset.is_none_or(|offset| {
+                let started = candidate.span.is_none_or(|(start, _)| start < offset);
+                started && (!branch_confined || candidate.can_coexist_with(element))
+            })
+        };
+        // Two declarations can share one read when the generated query is the
+        // same. For token-backed refs that is the token type, not the source form:
+        // `x=A` and `x='a'` differ in spelling and block-ness yet query alike.
+        let same_read_as_element = |candidate: &ElementRef| {
+            candidate.is_list == element.is_list
+                && if candidate.token_types.is_empty() || element.token_types.is_empty() {
+                    candidate.target == element.target && candidate.is_block == element.is_block
+                } else {
+                    candidate.token_types == element.token_types
+                }
+        };
 
         if element.is_list {
             // `translate_element_read` lowers a list label to a per-target child
@@ -534,17 +583,25 @@ impl TranslationCtx<'_> {
                 return None;
             }
             // What the read cannot express is exclusion, so the label resolves
-            // only when no same-target element sits *outside* it.
-            let exclusive = alt
-                .refs
-                .iter()
-                .all(|candidate| declares_label(candidate) || !same_target(candidate));
+            // only when no *already-matched* same-target element sits outside it.
+            // A trailing `A` in `r : xs+=A {$xs} A;` has not been matched when the
+            // action runs, so it cannot pollute the iterator.
+            let exclusive = alt.refs.iter().all(|candidate| {
+                declares_label(candidate)
+                    || !same_target(candidate)
+                    || !matched_at_action(candidate)
+            });
             return exclusive.then(|| (element.clone(), 0));
         }
-        // A single label read is one positional lookup, so a second declaration
-        // (`(x=A | x=B)`) cannot be served: picking the first silently yields an
-        // empty value whenever the parse took the other branch.
-        if declarations.len() > 1 {
+        // A single label read is one positional lookup. Several declarations can
+        // still share it when each lowers to the same query — mutually exclusive
+        // branches holding `x=A` at the same occurrence do. What cannot be served
+        // is declarations that query differently (`(x=A | x=B)`), or that could
+        // both be present and so want different positions.
+        if declarations.iter().any(|candidate| {
+            !same_read_as_element(candidate)
+                || (!std::ptr::eq(*candidate, element) && candidate.can_coexist_with(element))
+        }) {
             return None;
         }
         let position = alt
@@ -553,20 +610,23 @@ impl TranslationCtx<'_> {
             .position(|candidate| std::ptr::eq(candidate, element))?;
         let (before, after) = (&alt.refs[..position], &alt.refs[position + 1..]);
         if element.target.is_empty() {
-            // Block/wildcard labels read the most recent terminal child. That is
-            // the block's own token exactly when no other terminal has been
-            // matched between the block and the action — and because a mid-rule
-            // action executes at its own source position, a terminal written
-            // *after* the action never interferes. ANTLR's `t=~'x' 'z' {$t.text}`
-            // descriptors depend on that (`Sets/ParserNotTokenWithLabel`).
-            //
-            // `ElementRef` carries no source span, so the action's position
-            // relative to these refs is not recoverable here and the read is
-            // accepted as-is. A label read *across* an intervening terminal
-            // (`((x=(A | B))) C {$x.text}` reads `C`) is therefore still wrong;
-            // fixing it needs element spans in the model (issue #233) rather
-            // than a guard that would reject the conformance shapes above.
-            return Some((element.clone(), 0));
+            // Block/wildcard labels read the most recent terminal child, which is
+            // the block's own token only while no *other* terminal was matched
+            // between the block and the action. Spans make that decidable: a
+            // terminal written after the action has not run yet, which is what
+            // ANTLR's `t=~'x' 'z' {$t.text}` descriptors rely on
+            // (`Sets/ParserNotTokenWithLabel`), while one between the label and
+            // the action displaces it (`((x=(A | B))) C {$x.text}` reads `C`).
+            let displaced = after.iter().any(|candidate| {
+                !candidate.token_types.is_empty()
+                    && candidate.cardinality.max != Some(0)
+                    && matched_at_action(candidate)
+                    && !candidate
+                        .token_types
+                        .iter()
+                        .all(|token_type| element.token_types.contains(token_type))
+            });
+            return (!displaced).then(|| (element.clone(), 0));
         }
 
         // A repeated single label (`(x=A)+`) is overwritten on every iteration,
@@ -586,16 +646,20 @@ impl TranslationCtx<'_> {
                 let max = candidate.cardinality.max?;
                 (candidate.cardinality.min == max).then(|| total.saturating_add(max))
             })?;
-        // An optional label is displaced by a *following* same-target child that
-        // can slide into its position. Sequential followers can, whether they are
-        // mandatory (`x=A? A`) or optional (`(pred x=A)? A?` — the follower may
-        // consume the only token). A ref from a sibling branch of the same choice
-        // cannot, since no parse contains both, so counting it would reject valid
-        // mid-rule actions like `r : (x=A {$x.text} B | A C)`.
+        // An optional label is displaced by a following same-target child that can
+        // slide into its position, whether that child is mandatory (`x=A? A`) or
+        // optional (`(pred x=A)? A?` — the follower may consume the only token).
+        // Two kinds cannot: a ref from a sibling branch of the same choice, since
+        // no parse contains both, and — for a mid-rule action — a ref that starts
+        // after the action and so has not been matched when the read runs.
+        // `matched_at_action` already folds in coexistence when the action is
+        // confined to the label's branch; applying it again here would also
+        // exclude siblings for an action that runs after the whole choice.
+        // Another *declaration* of the same label is not a shadow — it binds the
+        // label too, and the guard above already proved they share one read.
         let shadowed_when_absent = element.cardinality.min == 0
             && after.iter().any(|candidate| {
-                same_target(candidate)
-                    && (!exclude_sibling_branches || candidate.can_coexist_with(element))
+                !declares_label(candidate) && same_target(candidate) && matched_at_action(candidate)
             });
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
@@ -722,6 +786,7 @@ fn translate_reference(
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
             choice_branch: Vec::new(),
+            span: None,
         };
         let _ = target_rule;
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
@@ -736,6 +801,7 @@ fn translate_reference(
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
             choice_branch: Vec::new(),
+            span: None,
         };
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
     }
@@ -1077,6 +1143,7 @@ mod tests {
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
                 ElementRef {
                     label: Some("right".to_owned()),
@@ -1087,6 +1154,7 @@ mod tests {
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
             ],
             children: BTreeMap::from([(
@@ -1142,6 +1210,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1187,6 +1256,7 @@ mod tests {
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1226,6 +1296,7 @@ mod tests {
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1268,6 +1339,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let single_ref = ElementRef {
             label: Some("name".to_owned()),
@@ -1281,6 +1353,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let translate = |max| {
             let mut statement = rule("s");
@@ -1335,6 +1408,7 @@ mod tests {
                     },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
                 ElementRef {
                     label: Some("errors".to_owned()),
@@ -1345,6 +1419,7 @@ mod tests {
                     cardinality: ChildCardinality { min: 0, max: None },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
             ],
             children: BTreeMap::new(),
@@ -1372,63 +1447,184 @@ mod tests {
         assert!(name.contains(".nth(0)"), "{name}");
     }
 
-    /// A block label reads the most recent terminal child, which is correct for
-    /// ANTLR's `t=~'x' 'z' {$t.text}` conformance shapes because a mid-rule
-    /// action runs at its own source position. `ElementRef` carries no span, so
-    /// that ordering is not recoverable here and the read is accepted as-is —
-    /// this test pins the resulting behaviour, including the known limitation
-    /// that a read across an intervening terminal picks the later token
-    /// (issue #233).
+    /// A block label reads the most recent terminal child, so whether that is the
+    /// label's own token depends on where the action sits. Spans make it
+    /// decidable: an action before the trailing terminal still reads the block
+    /// (ANTLR's `t=~'x' 'z' {$t.text}` shape, `Sets/ParserNotTokenWithLabel`),
+    /// while one after it would read that terminal and must decline (issue #233).
     #[test]
-    fn block_labels_resolve_to_the_most_recent_terminal_read() {
+    fn block_labels_resolve_only_while_no_later_terminal_has_matched() {
+        let translate = |action_offset| {
+            let mut statement = rule("s");
+            statement.alts.push(AltModel {
+                label: None,
+                span: (0, 100),
+                refs: vec![
+                    ElementRef {
+                        label: Some("x".to_owned()),
+                        target: String::new(),
+                        token_types: vec![1, 2],
+                        is_block: true,
+                        is_list: false,
+                        cardinality: ChildCardinality {
+                            min: 1,
+                            max: Some(1),
+                        },
+                        stable_accessor: true,
+                        choice_branch: Vec::new(),
+                        span: Some((10, 20)),
+                    },
+                    ElementRef {
+                        label: None,
+                        target: "C".to_owned(),
+                        token_types: vec![3],
+                        is_block: false,
+                        is_list: false,
+                        cardinality: ChildCardinality {
+                            min: 1,
+                            max: Some(1),
+                        },
+                        stable_accessor: true,
+                        choice_branch: Vec::new(),
+                        span: Some((30, 31)),
+                    },
+                ],
+                children: BTreeMap::new(),
+                leading_target: None,
+            });
+            let m = model(vec![statement]);
+            let toks = tokens(&[("A", 1), ("B", 2), ("C", 3)]);
+            let ctx = TranslationCtx {
+                model: &m,
+                rule_index: 0,
+                body_offset: Some(action_offset),
+                site: ActionSite::Body,
+                token_types: &toks,
+            };
+            translate_body("$x.text", &ctx).map_err(|error| error.to_string())
+        };
+
+        // Action between the block and `C`: only the block has matched.
+        let translated = translate(25).expect("the trailing terminal has not run yet");
+        assert!(translated.contains("terminal_children"), "{translated}");
+        assert!(translated.contains(".last()"), "{translated}");
+
+        // Action after `C`: `last()` would be `C`, not the block's token.
+        let error = translate(40).expect_err("a matched later terminal displaces the read");
+        assert!(error.contains("cannot translate $x"), "{error}");
+    }
+
+    /// A mid-rule action executes at its own source position, so refs written
+    /// after it have not been matched and cannot affect its read. Spans decide
+    /// this: `r : xs+=A {$xs} A;` iterates the sole child available at the action,
+    /// while the same refs read from `@after` see both and must decline.
+    #[test]
+    fn future_children_do_not_constrain_a_mid_rule_read() {
+        let token_ref = |label: Option<&str>, is_list, span| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "A".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+            choice_branch: Vec::new(),
+            span: Some(span),
+        };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
             label: None,
-            span: (10, 20),
+            span: (0, 100),
+            // `xs+=A {action at 20} A`
             refs: vec![
-                ElementRef {
-                    label: Some("x".to_owned()),
-                    target: String::new(),
-                    token_types: vec![1, 2],
-                    is_block: true,
-                    is_list: false,
-                    cardinality: ChildCardinality {
-                        min: 1,
-                        max: Some(1),
-                    },
-                    stable_accessor: true,
-                    choice_branch: Vec::new(),
-                },
-                ElementRef {
-                    label: None,
-                    target: "C".to_owned(),
-                    token_types: vec![3],
-                    is_block: false,
-                    is_list: false,
-                    cardinality: ChildCardinality {
-                        min: 1,
-                        max: Some(1),
-                    },
-                    stable_accessor: true,
-                    choice_branch: Vec::new(),
-                },
+                token_ref(Some("xs"), true, (10, 11)),
+                token_ref(None, false, (30, 31)),
             ],
             children: BTreeMap::new(),
             leading_target: None,
         });
         let m = model(vec![statement]);
-        let toks = tokens(&[("A", 1), ("B", 2), ("C", 3)]);
-        let ctx = TranslationCtx {
+        let toks = tokens(&[("A", 1)]);
+        let mid_rule = TranslationCtx {
             model: &m,
             rule_index: 0,
-            body_offset: Some(15),
+            body_offset: Some(20),
             site: ActionSite::Body,
             token_types: &toks,
         };
+        let translated = translate_body("$xs", &mid_rule).expect("trailing A has not matched yet");
+        assert!(translated.contains("child_tokens"), "{translated}");
 
-        let translated = translate_body("$x.text", &ctx).expect("translates");
-        assert!(translated.contains("terminal_children"), "{translated}");
-        assert!(translated.contains(".last()"), "{translated}");
+        // Read from `@after`, the trailing `A` has matched and would be iterated.
+        let after = TranslationCtx {
+            body_offset: None,
+            site: ActionSite::After,
+            ..mid_rule
+        };
+        let error = translate_body("$xs", &after).expect_err("both children are present by then");
+        assert!(
+            error.to_string().contains("cannot translate $xs"),
+            "{error}"
+        );
+    }
+
+    /// Several declarations of one label can share a single read when each lowers
+    /// to the same query and they are mutually exclusive: `(x=A e {$x} | x=A f
+    /// {$x})` resolves, while `x=A | x='a'` resolves too because token-backed
+    /// equivalence is by *type*, not by source form or block-ness.
+    #[test]
+    fn compatible_declarations_share_one_read() {
+        let decl = |branch, is_block, span| ElementRef {
+            label: Some("x".to_owned()),
+            target: if is_block { "'a'" } else { "A" }.to_owned(),
+            token_types: vec![1],
+            is_block,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+            choice_branch: vec![(5, branch)],
+            span: Some(span),
+        };
+        let translate = |second: ElementRef, offset| {
+            let mut statement = rule("s");
+            statement.alts.push(AltModel {
+                label: None,
+                span: (0, 100),
+                refs: vec![decl(0, false, (10, 11)), second],
+                children: BTreeMap::new(),
+                leading_target: None,
+            });
+            let m = model(vec![statement]);
+            let toks = tokens(&[("A", 1)]);
+            let ctx = TranslationCtx {
+                model: &m,
+                rule_index: 0,
+                body_offset: offset,
+                site: if offset.is_some() {
+                    ActionSite::Body
+                } else {
+                    ActionSite::After
+                },
+                token_types: &toks,
+            };
+            translate_body("$x.text", &ctx).map_err(|error| error.to_string())
+        };
+
+        // `(x=A e {action} | x=A f {action})`: same query, exclusive branches.
+        let translated = translate(decl(1, false, (30, 31)), Some(20))
+            .expect("identical reads in exclusive branches share one lookup");
+        assert!(translated.contains(".nth(0)"), "{translated}");
+
+        // `x=A | x='a'` from `@after`: literal vs symbolic, same token type.
+        let aliased = translate(decl(1, true, (30, 33)), None)
+            .expect("token-type equivalence ignores source form");
+        assert!(aliased.contains(".nth(0)"), "{aliased}");
     }
 
     /// An alternative that does not declare the label leaves it unset, so the
@@ -1449,6 +1645,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let translate = |second: ElementRef| {
             let mut statement = rule("s");
@@ -1505,6 +1702,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -1542,6 +1740,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let mut choice = rule("s");
         for (index, refs) in [vec![block_ref(vec![1, 2])], vec![block_ref(vec![3, 4])]]
@@ -1607,6 +1806,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let error = translate(group_list, "$xs").expect_err("no target to iterate");
         assert!(error.contains("cannot translate $xs"), "{error}");
@@ -1620,6 +1820,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let error = translate(repeated_single, "$x.text").expect_err("no last-occurrence read");
         assert!(error.contains("cannot translate $x"), "{error}");
@@ -1631,7 +1832,7 @@ mod tests {
     /// independent and reject a valid action.
     #[test]
     fn nested_choices_keep_their_outer_branch_ancestry() {
-        let rule_ref = |label: Option<&str>, branches: Vec<(usize, usize)>| ElementRef {
+        let rule_ref = |label: Option<&str>, branches: Vec<(usize, usize)>, span| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: "e".to_owned(),
             token_types: Vec::new(),
@@ -1643,16 +1844,17 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: branches,
+            span: Some(span),
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
             label: None,
-            span: (10, 20),
+            span: (0, 100),
             refs: vec![
                 // Outer choice 1 branch 0, then inner choice 2 branch 0.
-                rule_ref(Some("x"), vec![(1, 0), (2, 0)]),
+                rule_ref(Some("x"), vec![(1, 0), (2, 0)], (10, 11)),
                 // Outer choice 1 branch 1 — excluded by the *outer* choice alone.
-                rule_ref(None, vec![(1, 1)]),
+                rule_ref(None, vec![(1, 1)], (30, 31)),
             ],
             children: BTreeMap::new(),
             leading_target: Some("e".to_owned()),
@@ -1677,7 +1879,7 @@ mod tests {
     /// unlabeled branch's `A` is present when the read executes.
     #[test]
     fn unscoped_bodies_treat_sibling_matches_as_hazards() {
-        let branch_ref = |label: Option<&str>, branch| ElementRef {
+        let branch_ref = |label: Option<&str>, branch, span| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: "A".to_owned(),
             token_types: vec![1],
@@ -1689,12 +1891,16 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: vec![(3, branch)],
+            span: Some(span),
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
             label: None,
-            span: (10, 20),
-            refs: vec![branch_ref(Some("x"), 0), branch_ref(None, 1)],
+            span: (0, 100),
+            refs: vec![
+                branch_ref(Some("x"), 0, (10, 11)),
+                branch_ref(None, 1, (20, 21)),
+            ],
             children: BTreeMap::new(),
             leading_target: Some("A".to_owned()),
         });
@@ -1746,6 +1952,7 @@ mod tests {
                     },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
                 ElementRef {
                     label: None,
@@ -1760,6 +1967,7 @@ mod tests {
                     },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
             ],
             children: BTreeMap::new(),
@@ -1789,7 +1997,7 @@ mod tests {
     fn sibling_branch_children_do_not_shadow_an_optional_label() {
         let mut statement = rule("s");
         // Two branches of one choice: same choice id, different branch index.
-        let branch_ref = |label: Option<&str>, branch| ElementRef {
+        let branch_ref = |label: Option<&str>, branch, span| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: "A".to_owned(),
             token_types: vec![1],
@@ -1802,11 +2010,16 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: vec![(7, branch)],
+            span: Some(span),
         };
         statement.alts.push(AltModel {
             label: None,
-            span: (10, 20),
-            refs: vec![branch_ref(Some("x"), 0), branch_ref(None, 1)],
+            span: (0, 100),
+            // `(x=A {action} B | A C)`: the action sits inside branch 0.
+            refs: vec![
+                branch_ref(Some("x"), 0, (10, 11)),
+                branch_ref(None, 1, (30, 31)),
+            ],
             children: BTreeMap::new(),
             leading_target: Some("A".to_owned()),
         });
@@ -1828,7 +2041,7 @@ mod tests {
         // label is unset. Cardinality alone cannot tell these two apart, which is
         // what `choice_branch` exists for.
         let mut sequential = rule("s");
-        let sequential_ref = |label: Option<&str>| ElementRef {
+        let sequential_ref = |label: Option<&str>, span| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: "A".to_owned(),
             token_types: vec![1],
@@ -1840,11 +2053,16 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: Some(span),
         };
         sequential.alts.push(AltModel {
             label: None,
-            span: (10, 20),
-            refs: vec![sequential_ref(Some("x")), sequential_ref(None)],
+            span: (0, 100),
+            // `(pred x=A)? A?` with the action last: both have matched by then.
+            refs: vec![
+                sequential_ref(Some("x"), (10, 11)),
+                sequential_ref(None, (12, 13)),
+            ],
             children: BTreeMap::new(),
             leading_target: Some("A".to_owned()),
         });
@@ -1877,6 +2095,7 @@ mod tests {
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let token_ref = ElementRef {
             label: None,
@@ -1890,6 +2109,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let mut statement = rule("s");
         for (index, refs) in [
@@ -1941,6 +2161,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         let translate = |second: Vec<ElementRef>| {
             let mut statement = rule("s");
@@ -1999,6 +2220,7 @@ mod tests {
             },
             stable_accessor: true,
             choice_branch: Vec::new(),
+            span: None,
         };
         statement.alts.push(AltModel {
             label: None,
@@ -2077,6 +2299,7 @@ mod tests {
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
                 ElementRef {
                     label: Some("ids".to_owned()),
@@ -2087,6 +2310,7 @@ mod tests {
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
                     choice_branch: Vec::new(),
+                    span: None,
                 },
             ],
             children: BTreeMap::new(),

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -360,12 +360,19 @@ impl TranslationCtx<'_> {
     /// Resolves a label to `(ref, occurrence-among-same-target-in-alt)`.
     ///
     /// The occurrence is a positional index into the flattened CST children, so
-    /// it only means anything when the number of same-target children ahead of
-    /// the label is fixed. Refs drawn from sibling branches of a choice are
-    /// mutually exclusive and report `min: 0` — counting them would index past
-    /// the children the parse actually built. Such a label is reported
-    /// unresolved so the caller fails loudly instead of translating to a read
-    /// that silently yields the wrong element.
+    /// it only means anything when the label's position among same-target
+    /// children is fixed. Two things make it float, and either one reports the
+    /// label unresolved so the caller fails loudly rather than translating to a
+    /// read that silently yields the wrong element:
+    ///
+    /// * a preceding ref with inexact cardinality — refs drawn from sibling
+    ///   branches of a choice are mutually exclusive and report `min: 0`, so
+    ///   counting them would index past the children the parse built;
+    /// * an *optional* label with a following same-target child, which slides
+    ///   into the label's position whenever the label itself is absent.
+    ///
+    /// List and block labels are exempt: their reads iterate or take the last
+    /// terminal child, so they never consult the occurrence index.
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
         let alts: Vec<&AltModel> = self
@@ -374,7 +381,18 @@ impl TranslationCtx<'_> {
             .map_or_else(|| rule.alts.iter().collect(), |alt| vec![alt]);
         for alt in alts {
             let mut occurrence_by_target: BTreeMap<&str, Option<usize>> = BTreeMap::new();
-            for element in &alt.refs {
+            for (position, element) in alt.refs.iter().enumerate() {
+                let labeled = element.label.as_deref() == Some(label);
+                // Token groups and wildcards carry no target to count against,
+                // and their reads ignore the index, so they neither consume nor
+                // contribute to an occurrence bucket. Sharing the empty-target
+                // bucket would let unrelated groups poison each other.
+                if element.target.is_empty() || element.is_list {
+                    if labeled {
+                        return Some((element.clone(), 0));
+                    }
+                    continue;
+                }
                 let occurrence = occurrence_by_target
                     .entry(element.target.as_str())
                     .or_insert(Some(0));
@@ -387,7 +405,15 @@ impl TranslationCtx<'_> {
                     }
                     _ => None,
                 };
-                if element.label.as_deref() == Some(label) {
+                if labeled {
+                    let shadowed_when_absent = element.cardinality.min == 0
+                        && alt.refs[position + 1..].iter().any(|following| {
+                            following.target == element.target
+                                && following.cardinality.max != Some(0)
+                        });
+                    if shadowed_when_absent {
+                        return None;
+                    }
                     return current.map(|current| (element.clone(), current));
                 }
             }
@@ -959,6 +985,85 @@ mod tests {
         let error = translate_body("$x.text", &ctx).expect_err("must not translate");
         assert_eq!(error.kind(), io::ErrorKind::InvalidData);
         assert!(error.to_string().contains("cannot translate $x"), "{error}");
+    }
+
+    /// An *optional* label with a following same-target child has no fixed
+    /// position either: in `r : ({false}? x=A)? A {$x...}` the mandatory `A`
+    /// slides into `nth(0)` whenever the optional group is skipped, so the
+    /// action would receive a value for an unset label.
+    #[test]
+    fn optional_labels_shadowed_by_a_following_child_stay_unresolved() {
+        let mut statement = rule("s");
+        let token_ref = |label: Option<&str>, min| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "A".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality { min, max: Some(1) },
+            stable_accessor: true,
+        };
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            // `x=A?` then a mandatory `A`.
+            refs: vec![token_ref(Some("x"), 0), token_ref(None, 1)],
+            children: BTreeMap::new(),
+            leading_target: Some("A".to_owned()),
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let error = translate_body("$x.text", &ctx).expect_err("must not translate");
+        assert!(error.to_string().contains("cannot translate $x"), "{error}");
+    }
+
+    /// Token groups carry no target, so they must not share one occurrence
+    /// bucket: an optional disjoint group ahead of a labeled group
+    /// (`r : (A | B)? x=(C | D) {$x...}`) must not poison it. Block-label reads
+    /// take the last terminal child and never consult the index at all.
+    #[test]
+    fn disjoint_token_groups_do_not_poison_a_later_block_label() {
+        let mut statement = rule("s");
+        let group_ref = |label: Option<&str>, token_types: Vec<i32>, min| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: String::new(),
+            token_types,
+            is_block: true,
+            is_list: false,
+            cardinality: ChildCardinality { min, max: Some(1) },
+            stable_accessor: true,
+        };
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![
+                group_ref(None, vec![1, 2], 0),
+                group_ref(Some("x"), vec![3, 4], 1),
+            ],
+            children: BTreeMap::new(),
+            leading_target: None,
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1), ("B", 2), ("C", 3), ("D", 4)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let translated = translate_body("$x.text", &ctx).expect("translates");
+        assert!(translated.contains("terminal_children"), "{translated}");
+        assert!(translated.contains(".last()"), "{translated}");
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -72,6 +72,9 @@ pub(crate) struct GroupSpan {
     pub(crate) end: usize,
     /// `true` for `(…)?` / `(…)*` — the group may contribute nothing.
     pub(crate) optional: bool,
+    /// `true` for `(…)*` / `(…)+` — the group may run more than once, so the number
+    /// of children it contributes is not fixed even when it is known to have run.
+    pub(crate) repeated: bool,
 }
 
 /// One element reference inside an alternative: a rule ref, token ref, or a
@@ -1004,15 +1007,23 @@ impl TranslationCtx<'_> {
         // mandatory and already closed.
         let on_taken_group = |candidate: &ElementRef| {
             action_offset.is_some_and(|offset| {
+                let encloses = |group: &GroupSpan| group.start <= offset && offset < group.end;
+                // A *repeated* group that has closed still contributes an unknown
+                // number of children, so knowing it ran does not fix the count:
+                // `((A B)+ x=A {…})?` has a variable run of `A` before the label.
+                if candidate
+                    .group_spans
+                    .iter()
+                    .any(|group| group.repeated && !encloses(group))
+                {
+                    return false;
+                }
                 let relaxing = candidate
                     .group_spans
                     .iter()
                     .filter(|group| group.optional)
                     .collect::<Vec<_>>();
-                !relaxing.is_empty()
-                    && relaxing
-                        .iter()
-                        .all(|group| group.start <= offset && offset < group.end)
+                !relaxing.is_empty() && relaxing.iter().all(|group| encloses(group))
             })
         };
         // Whether a ref can have run before the action, given that ancestry. An

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -358,6 +358,14 @@ impl TranslationCtx<'_> {
     }
 
     /// Resolves a label to `(ref, occurrence-among-same-target-in-alt)`.
+    ///
+    /// The occurrence is a positional index into the flattened CST children, so
+    /// it only means anything when the number of same-target children ahead of
+    /// the label is fixed. Refs drawn from sibling branches of a choice are
+    /// mutually exclusive and report `min: 0` — counting them would index past
+    /// the children the parse actually built. Such a label is reported
+    /// unresolved so the caller fails loudly instead of translating to a read
+    /// that silently yields the wrong element.
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
         let alts: Vec<&AltModel> = self
@@ -365,15 +373,22 @@ impl TranslationCtx<'_> {
             .and_then(|offset| rule.alt_at(offset))
             .map_or_else(|| rule.alts.iter().collect(), |alt| vec![alt]);
         for alt in alts {
-            let mut occurrence_by_target: BTreeMap<&str, usize> = BTreeMap::new();
+            let mut occurrence_by_target: BTreeMap<&str, Option<usize>> = BTreeMap::new();
             for element in &alt.refs {
                 let occurrence = occurrence_by_target
                     .entry(element.target.as_str())
-                    .or_insert(0);
+                    .or_insert(Some(0));
                 let current = *occurrence;
-                *occurrence += 1;
+                // An inexact ref leaves every later same-target position
+                // floating, so poison the running count rather than guess.
+                *occurrence = match (current, element.cardinality.max) {
+                    (Some(total), Some(max)) if element.cardinality.min == max => {
+                        Some(total.saturating_add(max))
+                    }
+                    _ => None,
+                };
                 if element.label.as_deref() == Some(label) {
-                    return Some((element.clone(), current));
+                    return current.map(|current| (element.clone(), current));
                 }
             }
         }
@@ -895,6 +910,55 @@ mod tests {
             translated.contains("generated_attrs::<__RuleAttrs1>"),
             "{translated}"
         );
+    }
+
+    /// A label preceded by a same-target ref from a *sibling* choice branch has
+    /// no fixed CST position: `r : (e | x=e) {$x...}` builds one `e` child, so
+    /// counting the flattened refs would emit `nth(1)` and silently read an
+    /// element the parse never produced. Such a label must stay unresolved and
+    /// surface as a translation error.
+    #[test]
+    fn inexact_preceding_refs_leave_labels_unresolved_instead_of_misindexing() {
+        let mut statement = rule("s");
+        let branch_ref = |label: Option<&str>| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "e".to_owned(),
+            token_types: Vec::new(),
+            is_block: false,
+            is_list: false,
+            // Sibling branches of a choice are mutually exclusive.
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![branch_ref(None), branch_ref(Some("x"))],
+            children: BTreeMap::from([(
+                "e".to_owned(),
+                ChildCardinality {
+                    min: 1,
+                    max: Some(1),
+                },
+            )]),
+            leading_target: Some("e".to_owned()),
+        });
+        let m = model(vec![statement, rule("e")]);
+        let toks = tokens(&[]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let error = translate_body("$x.text", &ctx).expect_err("must not translate");
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(error.to_string().contains("cannot translate $x"), "{error}");
     }
 
     #[test]

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -520,39 +520,16 @@ impl TranslationCtx<'_> {
                 .iter()
                 .any(|token_type| element.token_types.contains(token_type))
         };
-        // The most matching children *one parse* can build: sequential refs add,
-        // but branches of a choice are alternatives, so the largest branch wins.
-        // Summing them all would overstate the count and reject valid reads —
-        // `A x=A | (A B? | A C?)` builds at most one `A` in the second alternative.
-        let mut sequential = Some(0_usize);
-        let mut per_branch: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
-        for candidate in alt
-            .refs
-            .iter()
-            .filter(|candidate| same_read_target(candidate))
-        {
-            let slot = match candidate.choice_branch.last() {
-                None => &mut sequential,
-                Some(&key) => per_branch.entry(key).or_insert(Some(0)),
-            };
-            *slot = match (*slot, candidate.cardinality.max) {
-                (Some(total), Some(max)) => Some(total.saturating_add(max)),
-                _ => None,
-            };
-        }
-        let mut widest_by_choice: BTreeMap<usize, Option<usize>> = BTreeMap::new();
-        for ((choice, _), count) in per_branch {
-            let slot = widest_by_choice.entry(choice).or_insert(Some(0));
-            *slot = match (*slot, count) {
-                (Some(current), Some(next)) => Some(current.max(next)),
-                _ => None,
-            };
-        }
-        let available = sequential.and_then(|base| {
-            widest_by_choice
-                .into_values()
-                .try_fold(base, |total, count| Some(total.saturating_add(count?)))
-        });
+        // The most matching children *one parse* can build. Sequential refs add;
+        // branches of a choice are alternatives, so the widest branch wins. Nested
+        // choices must fold innermost-first — reducing each choice independently
+        // and then summing would double-count, rejecting valid reads such as
+        // `q x=q | ((q|b)|(q|c))` where the second alternative builds one `q`.
+        let available = Self::widest_child_count(
+            alt.refs
+                .iter()
+                .filter(|candidate| same_read_target(candidate)),
+        );
         // A list read selects any same-target child; a positional read needs one
         // at `occurrence`. An unbounded count can always reach either.
         available.is_none_or(|available| available > occurrence)
@@ -565,12 +542,34 @@ impl TranslationCtx<'_> {
             .refs
             .iter()
             .position(|candidate| std::ptr::eq(candidate, element))?;
-        Self::exact_child_count(
-            alt.refs[..position].iter().filter(|candidate| {
+        // `can_coexist_with` keeps everything a ref *after* the choice coexists
+        // with — both branches — so it does not by itself select one path. Strip the
+        // tags of choices the element is inside (those branches are taken on its
+        // path) and leave the rest tagged, so `exact_child_count` still demands
+        // cross-branch agreement for choices the element is not part of.
+        let on_path = alt.refs[..position]
+            .iter()
+            .filter(|candidate| {
                 !candidate.token_types.is_empty() && candidate.can_coexist_with(element)
-            }),
-            true,
-        )
+            })
+            .cloned()
+            .map(|mut candidate| {
+                candidate.choice_branch.retain(|(choice, _)| {
+                    !element
+                        .choice_branch
+                        .iter()
+                        .any(|(taken, _)| taken == choice)
+                });
+                let keep = candidate.choice_branch.len();
+                candidate.choice_arity.truncate(keep);
+                candidate.choice_spans.truncate(keep);
+                if candidate.choice_branch.is_empty() {
+                    candidate.cardinality = candidate.branch_local_cardinality;
+                }
+                candidate
+            })
+            .collect::<Vec<_>>();
+        Self::exact_child_count(on_path.iter(), false)
     }
 
     /// Total children contributed by `refs`, or `None` when that total is not the
@@ -688,13 +687,97 @@ impl TranslationCtx<'_> {
         Some(total)
     }
 
+    /// Greatest number of children `refs` can contribute on any single parse, or
+    /// `None` when unbounded. Sequential refs add; branches of a choice are
+    /// alternatives, so the widest one wins. Choices fold innermost-first so a
+    /// nested choice's maximum lands in its enclosing branch rather than being
+    /// summed alongside it.
+    fn widest_child_count<'a>(refs: impl Iterator<Item = &'a ElementRef>) -> Option<usize> {
+        let refs = refs.collect::<Vec<_>>();
+        let mut total = Some(0_usize);
+        let mut per_branch: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
+        let mut depth_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut ancestry: BTreeMap<(usize, usize), Vec<(usize, usize)>> = BTreeMap::new();
+        for candidate in &refs {
+            for (depth, &(choice, branch)) in candidate.choice_branch.iter().enumerate() {
+                depth_of_choice
+                    .entry(choice)
+                    .and_modify(|existing| *existing = (*existing).min(depth))
+                    .or_insert(depth);
+                ancestry.insert((choice, branch), candidate.choice_branch[..=depth].to_vec());
+            }
+        }
+        let add = |slot: &mut Option<usize>, value: Option<usize>| {
+            *slot = match (*slot, value) {
+                (Some(total), Some(next)) => Some(total.saturating_add(next)),
+                _ => None,
+            };
+        };
+        for candidate in &refs {
+            match candidate.choice_branch.last() {
+                None => add(&mut total, candidate.cardinality.max),
+                Some(&key) => {
+                    let slot = per_branch.entry(key).or_insert(Some(0));
+                    add(slot, candidate.cardinality.max);
+                }
+            }
+        }
+        let mut processed: BTreeSet<usize> = BTreeSet::new();
+        while let Some(choice) = per_branch
+            .keys()
+            .map(|(choice, _)| *choice)
+            .filter(|choice| !processed.contains(choice))
+            .max_by_key(|choice| depth_of_choice.get(choice).copied().unwrap_or(0))
+        {
+            processed.insert(choice);
+            let counts = per_branch
+                .iter()
+                .filter(|((candidate, _), _)| *candidate == choice)
+                .map(|((_, branch), count)| (*branch, *count))
+                .collect::<Vec<_>>();
+            if counts.is_empty() {
+                continue;
+            }
+            let widest = counts
+                .iter()
+                .try_fold(0_usize, |widest, (_, count)| Some(widest.max((*count)?)));
+            let parent = counts.first().and_then(|(branch, _)| {
+                ancestry.get(&(choice, *branch)).and_then(|chain| {
+                    chain
+                        .split_last()
+                        .and_then(|(_, rest)| rest.last().copied())
+                })
+            });
+            for (branch, _) in &counts {
+                per_branch.remove(&(choice, *branch));
+            }
+            match parent {
+                Some(parent_key) => {
+                    let slot = per_branch.entry(parent_key).or_insert(Some(0));
+                    add(slot, widest);
+                }
+                None => add(&mut total, widest),
+            }
+        }
+        total
+    }
+
     /// Whether two per-alternative resolutions lower to the same read, so one
     /// translation can stand for both. The fields compared are exactly those
     /// `translate_element_read` consumes to pick a read: list mode, block mode,
     /// and the target it queries. Two block labels are equivalent regardless of
     /// their token sets, because the block read ignores them.
     fn same_label_read(left: &(ElementRef, usize), right: &(ElementRef, usize)) -> bool {
-        if left.0.is_list != right.0.is_list || left.0.is_block != right.0.is_block {
+        if left.0.is_list != right.0.is_list {
+            return false;
+        }
+        // Token-backed resolutions are equivalent when they query the same token
+        // type, regardless of source form: `x=A` resolves in token mode while
+        // `x='a'` is block mode, yet both lower to `child_tokens(A)`.
+        if !left.0.token_types.is_empty() && left.0.token_types == right.0.token_types {
+            return left.1 == right.1;
+        }
+        if left.0.is_block != right.0.is_block {
             return false;
         }
         // Block reads are positional now, so two block labels agree only when
@@ -758,27 +841,60 @@ impl TranslationCtx<'_> {
         // either side of the action — but the block's own extent can: in the first
         // the action sits after the closing paren, in the second inside it.
         let action_branches = action_offset.map(|offset| {
-            let mut enclosing: Vec<(usize, usize)> = Vec::new();
+            // For each enclosing choice, the *one* branch the action sits in: the
+            // branch whose own refs span the offset. Refs of an earlier sibling
+            // also precede the action and share the choice's block span, so
+            // collecting every preceding ref's tags would record mutually
+            // conflicting branches (`(B | C x=A? A {…})` would claim both).
+            //
+            // A branch contains the action when some ref of it starts before the
+            // offset and no ref of a *later* sibling does — source order means a
+            // later branch having started implies the action is past this one.
+            let mut chosen: Vec<(usize, usize)> = Vec::new();
+            let mut choices: Vec<usize> = Vec::new();
             for candidate in &alt.refs {
-                let inside_all = candidate
-                    .choice_spans
-                    .iter()
-                    .all(|&(start, end)| start <= offset && offset < end);
-                if !inside_all || candidate.choice_branch.is_empty() {
-                    continue;
-                }
-                // Only the branch actually containing the action counts, so require
-                // the candidate itself to be positioned around it.
-                let brackets = candidate.span.is_some_and(|(start, _)| start < offset);
-                if brackets {
-                    for &key in &candidate.choice_branch {
-                        if !enclosing.contains(&key) {
-                            enclosing.push(key);
-                        }
+                for &(choice, _) in &candidate.choice_branch {
+                    if !choices.contains(&choice) {
+                        choices.push(choice);
                     }
                 }
             }
-            enclosing
+            for choice in choices {
+                // Only choices whose block encloses the action are in play.
+                let encloses = alt.refs.iter().any(|candidate| {
+                    candidate
+                        .choice_branch
+                        .iter()
+                        .zip(&candidate.choice_spans)
+                        .any(|(&(candidate_choice, _), &(start, end))| {
+                            candidate_choice == choice && start <= offset && offset < end
+                        })
+                });
+                if !encloses {
+                    continue;
+                }
+                let started_before = |branch: usize| {
+                    alt.refs.iter().any(|candidate| {
+                        candidate.span.is_some_and(|(start, _)| start < offset)
+                            && candidate
+                                .choice_branch
+                                .iter()
+                                .any(|&(c, b)| c == choice && b == branch)
+                    })
+                };
+                let branches = alt
+                    .refs
+                    .iter()
+                    .flat_map(|candidate| candidate.choice_branch.iter())
+                    .filter(|&&(c, _)| c == choice)
+                    .map(|&(_, b)| b)
+                    .collect::<BTreeSet<_>>();
+                // The last branch that has started is the one containing the action.
+                if let Some(branch) = branches.into_iter().rfind(|&branch| started_before(branch)) {
+                    chosen.push((choice, branch));
+                }
+            }
+            chosen
         });
         let branch_confined = action_branches
             .as_ref()
@@ -885,13 +1001,32 @@ impl TranslationCtx<'_> {
             // child this read selects on a parse where the label is unset:
             // `((x=(A | B)) | C) {$x}` reads `C` on the `C` branch.
             if let Some(index) = terminals_before {
-                let sibling_at_index = alt.refs.iter().any(|candidate| {
-                    !candidate.can_coexist_with(element)
-                        && !candidate.token_types.is_empty()
-                        && candidate.cardinality.max != Some(0)
-                        && Self::exact_terminal_index(alt, candidate).is_none_or(|at| at == index)
-                });
+                // A sibling branch's terminal can only be mistaken for the label
+                // when the read actually runs on that branch. An action confined to
+                // the label's own branch never executes there, so the sibling is
+                // irrelevant — `(x=(A | B) {…} | C)` is safe even though `C` sits at
+                // the same index.
+                let sibling_at_index = !branch_confined
+                    && alt.refs.iter().any(|candidate| {
+                        !candidate.can_coexist_with(element)
+                            && !candidate.token_types.is_empty()
+                            && candidate.cardinality.max != Some(0)
+                            && Self::exact_terminal_index(alt, candidate)
+                                .is_none_or(|at| at == index)
+                    });
                 if sibling_at_index {
+                    return None;
+                }
+                // ROOT J: a fixed index is not enough when the label is *optional* —
+                // `x=(A | B)? C {…}` puts `C` at index 0 whenever the block is
+                // absent, so the read would report it as the label's token.
+                if element.cardinality.min == 0
+                    && after.iter().any(|candidate| {
+                        !candidate.token_types.is_empty()
+                            && candidate.cardinality.max != Some(0)
+                            && matched_at_action(candidate)
+                    })
+                {
                     return None;
                 }
             }

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -168,6 +168,36 @@ impl ElementRef {
                 })
         })
     }
+
+    /// Drops the choices `discard` selects, keeping every parallel choice array
+    /// aligned with `choice_branch`.
+    ///
+    /// `choice_arity`, `choice_spans`, and `branch_spans` are indexed *by position*
+    /// in `choice_branch`, so removing an entry must remove the same position from
+    /// each. Truncating to the surviving length instead keeps the outermost
+    /// entries — which is wrong whenever an *outer* choice is the one dropped:
+    /// `((q | q | b) x=q | c)` would then read the outer choice's arity of 2
+    /// against the surviving inner choice, mistaking a three-way choice for an
+    /// exhaustive two-way one.
+    pub(crate) fn retain_choices(&mut self, mut keep: impl FnMut(usize) -> bool) {
+        let mask = self
+            .choice_branch
+            .iter()
+            .map(|&(choice, _)| keep(choice))
+            .collect::<Vec<_>>();
+        fn retain_by_mask<T>(list: &mut Vec<T>, mask: &[bool]) {
+            let mut index = 0;
+            list.retain(|_| {
+                let kept = mask.get(index).copied().unwrap_or(true);
+                index += 1;
+                kept
+            });
+        }
+        retain_by_mask(&mut self.choice_branch, &mask);
+        retain_by_mask(&mut self.choice_arity, &mask);
+        retain_by_mask(&mut self.choice_spans, &mask);
+        retain_by_mask(&mut self.branch_spans, &mask);
+    }
 }
 
 /// One top-level alternative of a parser rule.
@@ -1241,12 +1271,9 @@ impl TranslationCtx<'_> {
                 .cloned()
                 .map(|mut candidate| {
                     if let Some(branches) = action_branches.as_ref() {
-                        candidate.choice_branch.retain(|(choice, _)| {
-                            !branches.iter().any(|(taken, _)| taken == choice)
+                        candidate.retain_choices(|choice| {
+                            !branches.iter().any(|&(taken, _)| taken == choice)
                         });
-                        let keep = candidate.choice_branch.len();
-                        candidate.choice_arity.truncate(keep);
-                        candidate.choice_spans.truncate(keep);
                     }
                     candidate
                 })

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -659,15 +659,12 @@ impl TranslationCtx<'_> {
             })
             .cloned()
             .map(|mut candidate| {
-                candidate.choice_branch.retain(|(choice, _)| {
+                candidate.retain_choices(|choice| {
                     !element
                         .choice_branch
                         .iter()
-                        .any(|(taken, _)| taken == choice)
+                        .any(|&(taken, _)| taken == choice)
                 });
-                let keep = candidate.choice_branch.len();
-                candidate.choice_arity.truncate(keep);
-                candidate.choice_spans.truncate(keep);
                 if candidate.choice_branch.is_empty() {
                     candidate.cardinality = candidate.group_local_cardinality;
                 }
@@ -1408,15 +1405,12 @@ impl TranslationCtx<'_> {
                 // tags carry no remaining alternation. Tags that survive belong to
                 // choices the label sits outside of, whose branches are genuinely
                 // alternative.
-                candidate.choice_branch.retain(|(choice, _)| {
+                candidate.retain_choices(|choice| {
                     !element
                         .choice_branch
                         .iter()
-                        .any(|(taken, _)| taken == choice)
+                        .any(|&(taken, _)| taken == choice)
                 });
-                let keep = candidate.choice_branch.len();
-                candidate.choice_arity.truncate(keep);
-                candidate.choice_spans.truncate(keep);
                 candidate
             })
             .collect::<Vec<_>>();

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -381,16 +381,43 @@ impl TranslationCtx<'_> {
     ///   read cannot also serve.
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
-        let alts: Vec<&AltModel> = self
-            .body_offset
-            .and_then(|offset| rule.alt_at(offset))
-            .map_or_else(|| rule.alts.iter().collect(), |alt| vec![alt]);
-        for alt in alts {
-            if let Some(resolved) = Self::resolve_label_in_alt(alt, label) {
-                return Some(resolved);
-            }
+        if let Some(alt) = self.body_offset.and_then(|offset| rule.alt_at(offset)) {
+            return Self::resolve_label_in_alt(alt, label);
         }
-        None
+        // `@after` / `@init` bodies are not scoped to an alternative, so the
+        // label may be declared in several. One read has to serve whichever
+        // alternative the parse took: taking the first match would emit that
+        // alternative's lookup and silently yield a default on the others.
+        let mut resolved: Option<(ElementRef, usize)> = None;
+        for alt in &rule.alts {
+            let declares = alt
+                .refs
+                .iter()
+                .any(|element| element.label.as_deref() == Some(label));
+            // Alternatives that never mention the label put no children of their
+            // own in the way, so they neither constrain nor veto the read.
+            if !declares {
+                continue;
+            }
+            let candidate = Self::resolve_label_in_alt(alt, label)?;
+            if resolved
+                .as_ref()
+                .is_some_and(|existing| !Self::same_label_read(existing, &candidate))
+            {
+                return None;
+            }
+            resolved = Some(candidate);
+        }
+        resolved
+    }
+
+    /// Whether two per-alternative resolutions lower to the same read, so one
+    /// translation can stand for both.
+    fn same_label_read(left: &(ElementRef, usize), right: &(ElementRef, usize)) -> bool {
+        left.1 == right.1
+            && left.0.target == right.0.target
+            && left.0.is_list == right.0.is_list
+            && left.0.token_types == right.0.token_types
     }
 
     fn resolve_label_in_alt(alt: &AltModel, label: &str) -> Option<(ElementRef, usize)> {
@@ -400,9 +427,27 @@ impl TranslationCtx<'_> {
             .filter(|element| element.label.as_deref() == Some(label))
             .collect::<Vec<_>>();
         let element = *declarations.first()?;
-        // `(x=A | x=B)` declares one label over disjoint targets; a single
-        // positional read cannot serve both, and picking the first silently
-        // yields an empty value on the other branch.
+        let declares_label = |candidate: &ElementRef| candidate.label.as_deref() == Some(label);
+        let same_target = |candidate: &ElementRef| {
+            !candidate.target.is_empty()
+                && candidate.target == element.target
+                && candidate.cardinality.max != Some(0)
+        };
+
+        if element.is_list {
+            // A list read yields every same-target child, so repeated
+            // declarations are the normal idiom (`xs+=e (op xs+=e)+`) — they all
+            // feed the one iteration. What it cannot express is exclusion, so the
+            // label resolves only when no same-target element sits *outside* it.
+            let exclusive = alt
+                .refs
+                .iter()
+                .all(|candidate| declares_label(candidate) || !same_target(candidate));
+            return exclusive.then(|| (element.clone(), 0));
+        }
+        // A single label read is one positional lookup, so a second declaration
+        // (`(x=A | x=B)`) cannot be served: picking the first silently yields an
+        // empty value whenever the parse took the other branch.
         if declarations.len() > 1 {
             return None;
         }
@@ -411,18 +456,6 @@ impl TranslationCtx<'_> {
             .iter()
             .position(|candidate| std::ptr::eq(candidate, element))?;
         let (before, after) = (&alt.refs[..position], &alt.refs[position + 1..]);
-        let same_target = |candidate: &ElementRef| {
-            !candidate.target.is_empty()
-                && candidate.target == element.target
-                && candidate.cardinality.max != Some(0)
-        };
-
-        if element.is_list {
-            // The read yields every same-target child, so any same-target
-            // element outside this label would be folded into the label's value.
-            let exclusive = !before.iter().any(same_target) && !after.iter().any(same_target);
-            return exclusive.then(|| (element.clone(), 0));
-        }
         if element.target.is_empty() {
             // Block/wildcard labels read the most recent terminal child. That is
             // the block's own token exactly when no other terminal has been
@@ -1269,6 +1302,123 @@ mod tests {
         let translated = translate_body("$x.text", &ctx).expect("translates");
         assert!(translated.contains("terminal_children"), "{translated}");
         assert!(translated.contains(".last()"), "{translated}");
+    }
+
+    /// A list label repeated within one alternative is the ordinary
+    /// comma-separated idiom (`xs+=e (op xs+=e)+`) — every declaration feeds the
+    /// same iteration, so repeats must not be mistaken for a conflict. This is
+    /// the shape of ANTLR's `ParserExec/ListLabelsOnRuleRefStartOfAlt`
+    /// descriptor, read from `@after` across alternatives that declare it plus
+    /// one that does not.
+    #[test]
+    fn repeated_list_declarations_across_alternatives_still_resolve() {
+        let list_ref = || ElementRef {
+            label: Some("args".to_owned()),
+            target: "e".to_owned(),
+            token_types: Vec::new(),
+            is_block: false,
+            is_list: true,
+            cardinality: ChildCardinality { min: 1, max: None },
+            stable_accessor: true,
+        };
+        let token_ref = ElementRef {
+            label: None,
+            target: "ID".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        let mut statement = rule("s");
+        for (index, refs) in [
+            // `args+=e (AND args+=e)+` — two declarations, one iteration.
+            vec![list_ref(), list_ref()],
+            // An alternative that never mentions the label at all.
+            vec![token_ref],
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            statement.alts.push(AltModel {
+                label: None,
+                span: (index * 10, index * 10 + 10),
+                refs,
+                children: BTreeMap::new(),
+                leading_target: None,
+            });
+        }
+        let m = model(vec![statement, rule("e")]);
+        let toks = tokens(&[("ID", 1)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: None,
+            site: ActionSite::After,
+            token_types: &toks,
+        };
+
+        let translated = translate_body("$args", &ctx).expect("list label resolves");
+        assert!(translated.contains("child_rule_trees"), "{translated}");
+    }
+
+    /// `@after` / `@init` bodies are not scoped to an alternative, so one read
+    /// has to serve whichever alternative the parse took. `r : x=A | x=B` with an
+    /// `@after` read of `$x` would emit the `A` lookup and yield a default on the
+    /// `B` branch, while `r : x=A B | x=A C` resolves identically in both.
+    #[test]
+    fn unscoped_bodies_reject_labels_that_resolve_differently_per_alternative() {
+        let token_ref = |label: Option<&str>, target: &str, token_type| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: target.to_owned(),
+            token_types: vec![token_type],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 1,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        let translate = |second: Vec<ElementRef>| {
+            let mut statement = rule("s");
+            for (index, refs) in [vec![token_ref(Some("x"), "A", 1)], second]
+                .into_iter()
+                .enumerate()
+            {
+                statement.alts.push(AltModel {
+                    label: None,
+                    span: (index * 10, index * 10 + 10),
+                    refs,
+                    children: BTreeMap::new(),
+                    leading_target: None,
+                });
+            }
+            let m = model(vec![statement]);
+            let toks = tokens(&[("A", 1), ("B", 2), ("C", 3)]);
+            let ctx = TranslationCtx {
+                model: &m,
+                rule_index: 0,
+                // `@after`: no offset, so no single owning alternative.
+                body_offset: None,
+                site: ActionSite::After,
+                token_types: &toks,
+            };
+            translate_body("$x.text", &ctx).map_err(|error| error.to_string())
+        };
+
+        // `x=A | x=B`: the two alternatives need different token lookups.
+        let error = translate(vec![token_ref(Some("x"), "B", 2)])
+            .expect_err("conflicting per-alternative reads must not translate");
+        assert!(error.contains("cannot translate $x"), "{error}");
+
+        // `x=A B | x=A C`: both resolve to the same `A` lookup at occurrence 0.
+        let agreed = translate(vec![token_ref(Some("x"), "A", 1), token_ref(None, "C", 3)])
+            .expect("agreeing per-alternative reads still translate");
+        assert!(agreed.contains(".nth(0)"), "{agreed}");
     }
 
     /// One label declared over disjoint targets (`r : (x=A | x=B)`) cannot be

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -792,15 +792,19 @@ impl TranslationCtx<'_> {
         // token-mode, `x='a'` is block-mode) because both lower to the same
         // `child_tokens(A)` query — but their occurrences are counted in different
         // units: a block read indexes *every* terminal child, a token read only
-        // same-type children. Comparing the raw numbers merged `x='a' | A x=A`,
-        // where each side reports 1 but means a different child. Both must
-        // therefore agree on the occurrence *and*, when the modes differ, that
-        // occurrence must be zero — the one index where the two systems coincide.
+        // same-type children. `x='a' | A x=A` has both reporting 1 while meaning
+        // different children, and `A x='a' B | A x=A C` has them meaning the same
+        // child while reporting 1 and 1 only by coincidence.
+        //
+        // Rather than guess, mixed-mode pairs merge only at occurrence zero — the
+        // one index where the two systems provably coincide, since "no terminal
+        // before" and "no same-type token before" agree there. Same-mode pairs
+        // compare directly.
         if !left.0.token_types.is_empty() && left.0.token_types == right.0.token_types {
-            if left.1 != right.1 {
-                return false;
+            if left.0.is_block == right.0.is_block {
+                return left.1 == right.1;
             }
-            return left.0.is_block == right.0.is_block || left.1 == 0;
+            return left.1 == 0 && right.1 == 0;
         }
         if left.0.is_block != right.0.is_block {
             return false;
@@ -917,17 +921,22 @@ impl TranslationCtx<'_> {
         let branch_confined = action_branches
             .as_ref()
             .is_some_and(|branches| !branches.is_empty());
-        // A ref inside an enclosing group that the action also sits inside has run:
-        // the action only executes when that group was taken. Its cardinality still
-        // reports `min: 0` from the group's `?`, so use the branch-local figure for
-        // those refs — `(A x=A {…})?` has exactly one `A` before the label whenever
-        // the action runs at all.
+        // A ref inside a group that also encloses the action has run: the action
+        // only executes when that group was taken. Its cardinality still reports
+        // `min: 0` from the group's `?`, so use the quantifier-free figure —
+        // `(A x=A {…})?` has exactly one `A` before the label whenever the action
+        // runs at all.
+        //
+        // *Every* group the ref sits in must enclose the action, not merely one: an
+        // inner group that closed before the action proves nothing, so
+        // `((q)? x=q {…})?` must not treat the inner `(q)?` as matched.
         let on_taken_group = |candidate: &ElementRef| {
             action_offset.is_some_and(|offset| {
-                candidate
-                    .group_spans
-                    .iter()
-                    .any(|&(start, end)| start <= offset && offset < end)
+                !candidate.group_spans.is_empty()
+                    && candidate
+                        .group_spans
+                        .iter()
+                        .all(|&(start, end)| start <= offset && offset < end)
             })
         };
         // Whether a ref can have run before the action, given that ancestry. An
@@ -970,13 +979,21 @@ impl TranslationCtx<'_> {
             if element.target.is_empty() {
                 return None;
             }
-            // A list read yields every child of *one* target, so repeated
-            // declarations are the normal idiom (`xs+=e (op xs+=e)+`) only while
-            // they all name that same target. `xs+=A xs+=B` would iterate `A`
-            // alone and silently drop every `B`.
+            // A list read yields every child of *one* query, so repeated declarations
+            // are the normal idiom (`xs+=e (op xs+=e)+`) only while they all name that
+            // same query. `xs+=A xs+=B` would iterate `A` alone and drop every `B`.
+            // The query is the token type for token-backed refs, not the spelling:
+            // `xs+=A B | xs+='a' C` binds one type through two source forms.
+            let same_query = |candidate: &ElementRef| {
+                if element.token_types.is_empty() || candidate.token_types.is_empty() {
+                    candidate.target == element.target
+                } else {
+                    candidate.token_types == element.token_types
+                }
+            };
             if declarations
                 .iter()
-                .any(|candidate| candidate.target != element.target || !candidate.is_list)
+                .any(|candidate| !same_query(candidate) || !candidate.is_list)
             {
                 return None;
             }
@@ -1001,6 +1018,38 @@ impl TranslationCtx<'_> {
                 || (!std::ptr::eq(*candidate, element) && candidate.can_coexist_with(element))
         }) {
             return None;
+        }
+        // Deriving the read from the *first* declaration and probing the others
+        // property-by-property kept missing a dimension — occurrence and repetition
+        // among them. Instead resolve each declaration on its own and require the
+        // results to agree, so one read demonstrably serves every branch:
+        // `(A x=A B | x=A C)` wants occurrence 1 then 0, and `(x=A B | x=A+ C)`
+        // wants a first-match read then a last-match one.
+        if declarations.len() > 1 {
+            let mut resolutions = Vec::with_capacity(declarations.len());
+            for candidate in &declarations {
+                let position = alt
+                    .refs
+                    .iter()
+                    .position(|other| std::ptr::eq(other, *candidate))?;
+                let mut alone = alt.clone();
+                // Keep this declaration's label and drop the others', so the
+                // recursion resolves exactly one.
+                for (index, ref_at) in alone.refs.iter_mut().enumerate() {
+                    if index != position && ref_at.label.as_deref() == Some(label) {
+                        ref_at.label = None;
+                    }
+                }
+                resolutions.push(Self::resolve_label_in_alt(&alone, label, action_offset)?);
+            }
+            let first = resolutions.first()?.clone();
+            if resolutions
+                .iter()
+                .any(|resolution| !Self::same_label_read(resolution, &first))
+            {
+                return None;
+            }
+            return Some(first);
         }
         let position = alt
             .refs
@@ -1117,26 +1166,42 @@ impl TranslationCtx<'_> {
         // Count only children on the label's own parse path, and — when the action
         // is confined to a branch — count the surviving branch as that path rather
         // than demanding agreement from branches already filtered out.
-        let occurrence = Self::exact_child_count(
-            before
-                .iter()
-                .filter(|candidate| {
-                    counts_toward_occurrence(candidate) && candidate.can_coexist_with(element)
-                })
-                .cloned()
-                .map(|mut candidate| {
-                    if on_taken_group(&candidate) {
-                        // The enclosing group is taken on the action's path, so the
-                        // group's own quantifier no longer relaxes this ref.
-                        candidate.cardinality = candidate.group_local_cardinality;
-                        candidate.branch_local_cardinality = candidate.group_local_cardinality;
-                    }
-                    candidate
-                })
-                .collect::<Vec<_>>()
-                .iter(),
-            true,
-        )?;
+        let counted = before
+            .iter()
+            .filter(|candidate| {
+                counts_toward_occurrence(candidate) && candidate.can_coexist_with(element)
+            })
+            .cloned()
+            .map(|mut candidate| {
+                if on_taken_group(&candidate) {
+                    // The enclosing group is taken on the action's path, so the
+                    // group's own quantifier no longer relaxes this ref.
+                    candidate.cardinality = candidate.group_local_cardinality;
+                    candidate.branch_local_cardinality = candidate.group_local_cardinality;
+                }
+                // Choices the *label* is inside are settled on its path, so those
+                // tags carry no remaining alternation. Tags that survive belong to
+                // choices the label sits outside of, whose branches are genuinely
+                // alternative.
+                candidate.choice_branch.retain(|(choice, _)| {
+                    !element
+                        .choice_branch
+                        .iter()
+                        .any(|(taken, _)| taken == choice)
+                });
+                let keep = candidate.choice_branch.len();
+                candidate.choice_arity.truncate(keep);
+                candidate.choice_spans.truncate(keep);
+                candidate
+            })
+            .collect::<Vec<_>>();
+        // `can_coexist_with` keeps every branch of a choice the label is outside of,
+        // so it does not by itself select one path: `(A B | A C) x=A` would sum both
+        // prefixes. Only claim path-restriction once no alternation remains.
+        let restricted = counted
+            .iter()
+            .all(|candidate| candidate.choice_branch.is_empty());
+        let occurrence = Self::exact_child_count(counted.iter(), restricted)?;
         // An optional label is displaced by a following same-target child that can
         // slide into its position, whether that child is mandatory (`x=A? A`) or
         // optional (`(pred x=A)? A?` — the follower may consume the only token).
@@ -1158,7 +1223,16 @@ impl TranslationCtx<'_> {
         };
         let shadowed_when_absent = element_optional_here
             && after.iter().any(|candidate| {
-                !declares_label(candidate) && same_target(candidate) && matched_at_action(candidate)
+                !declares_label(candidate)
+                    && same_target(candidate)
+                    && matched_at_action(candidate)
+                    // A sibling branch's child cannot slide into the label's slot
+                    // *within a parse that bound the label* — the two never coexist.
+                    // It is still a hazard when the read may run with the label
+                    // unset, which is precisely when the action is not confined to
+                    // the label's branch: an `@after` body, or a mid-rule action
+                    // written after the whole choice (`(x=A | A) {$x}`).
+                    && (candidate.can_coexist_with(element) || !branch_confined)
             });
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
@@ -2184,6 +2258,9 @@ mod tests {
     /// equivalence is by *type*, not by source form or block-ness.
     #[test]
     fn compatible_declarations_share_one_read() {
+        // Each declaration is mandatory *within its branch* — `min: 0` on
+        // `cardinality` would say the label is genuinely optional, which is a
+        // different (and displaceable) shape.
         let decl = |branch, is_block, span| ElementRef {
             label: Some("x".to_owned()),
             target: if is_block { "'a'" } else { "A" }.to_owned(),
@@ -2191,7 +2268,7 @@ mod tests {
             is_block,
             is_list: false,
             cardinality: ChildCardinality {
-                min: 0,
+                min: 1,
                 max: Some(1),
             },
             stable_accessor: true,
@@ -2204,15 +2281,32 @@ mod tests {
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
         };
-        let translate = |second: ElementRef, offset| {
+        // `separate_alts` models `x=… | x=…` written as *top-level* alternatives,
+        // which the collector emits as two `AltModel`s — the shape a real grammar
+        // produces. Both in one `AltModel` instead models a nested `(… | …)` choice.
+        let translate = |second: ElementRef, offset, separate_alts: bool| {
             let mut statement = rule("s");
-            statement.alts.push(AltModel {
-                label: None,
-                span: (0, 100),
-                refs: vec![decl(0, false, (10, 11)), second],
-                children: BTreeMap::new(),
-                leading_target: None,
-            });
+            if separate_alts {
+                for (index, declaration) in
+                    [decl(0, false, (10, 11)), second].into_iter().enumerate()
+                {
+                    statement.alts.push(AltModel {
+                        label: None,
+                        span: (index * 50, index * 50 + 50),
+                        refs: vec![declaration],
+                        children: BTreeMap::new(),
+                        leading_target: None,
+                    });
+                }
+            } else {
+                statement.alts.push(AltModel {
+                    label: None,
+                    span: (0, 100),
+                    refs: vec![decl(0, false, (10, 11)), second],
+                    children: BTreeMap::new(),
+                    leading_target: None,
+                });
+            }
             let m = model(vec![statement]);
             let toks = tokens(&[("A", 1)]);
             let ctx = TranslationCtx {
@@ -2229,13 +2323,16 @@ mod tests {
             translate_body("$x.text", &ctx).map_err(|error| error.to_string())
         };
 
-        // `(x=A e {action} | x=A f {action})`: same query, exclusive branches.
-        let translated = translate(decl(1, false, (30, 31)), Some(20))
+        // `(x=A e {action} | x=A f {action})`: same query, exclusive branches of one
+        // nested choice.
+        let translated = translate(decl(1, false, (30, 31)), Some(20), false)
             .expect("identical reads in exclusive branches share one lookup");
         assert!(translated.contains(".nth(0)"), "{translated}");
 
-        // `x=A | x='a'` from `@after`: literal vs symbolic, same token type.
-        let aliased = translate(decl(1, true, (30, 33)), None)
+        // `r @after {…} : x=A | x='a';` — literal and symbolic forms of one token
+        // type, as *top-level* alternatives. Both resolve at occurrence zero, the
+        // index where the block and token coordinate systems coincide.
+        let aliased = translate(decl(1, true, (60, 63)), None, true)
             .expect("token-type equivalence ignores source form");
         assert!(aliased.contains(".nth(0)"), "{aliased}");
     }

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -435,6 +435,14 @@ impl TranslationCtx<'_> {
         };
 
         if element.is_list {
+            // `translate_element_read` lowers a list label to a per-target child
+            // iterator, which needs a rule or token *target*. A list over a token
+            // group (`xs+=(A | B)`) has none, so the read would fall through to
+            // the scalar block path and emit `.last()…collect()` — code that does
+            // not compile. Leave it unresolved instead.
+            if element.target.is_empty() {
+                return None;
+            }
             // A list read yields every same-target child, so repeated
             // declarations are the normal idiom (`xs+=e (op xs+=e)+`) — they all
             // feed the one iteration. What it cannot express is exclusion, so the
@@ -473,6 +481,14 @@ impl TranslationCtx<'_> {
             return Some((element.clone(), 0));
         }
 
+        // A repeated single label (`(x=A)+`) is overwritten on every iteration,
+        // so ANTLR exposes the *latest* match. The read here is a fixed
+        // `nth(i)`, which would pin the first one; only the accessor path can
+        // express `.last()`. Leave it unresolved rather than read the wrong
+        // iteration.
+        if element.cardinality.is_repeated() {
+            return None;
+        }
         // Single label: count the same-target children ahead of it, bailing as
         // soon as one contributes an unfixed number.
         let occurrence = before
@@ -482,7 +498,15 @@ impl TranslationCtx<'_> {
                 let max = candidate.cardinality.max?;
                 (candidate.cardinality.min == max).then(|| total.saturating_add(max))
             })?;
-        let shadowed_when_absent = element.cardinality.min == 0 && after.iter().any(same_target);
+        // An optional label is displaced by a *following* same-target child that
+        // slides into its position. Only children that are certain to be matched
+        // can do that: a ref from a sibling choice branch reports `min: 0` and
+        // never coexists with this label, so counting it would reject valid
+        // mid-rule actions like `r : (x=A {$x.text} B | A C)`.
+        let shadowed_when_absent = element.cardinality.min == 0
+            && after
+                .iter()
+                .any(|candidate| same_target(candidate) && candidate.cardinality.min > 0);
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
 }
@@ -1302,6 +1326,100 @@ mod tests {
         let translated = translate_body("$x.text", &ctx).expect("translates");
         assert!(translated.contains("terminal_children"), "{translated}");
         assert!(translated.contains(".last()"), "{translated}");
+    }
+
+    /// Reads that `translate_element_read` cannot express must stay unresolved
+    /// rather than fall through to a different read: a list over a *token group*
+    /// (`xs+=(A | B)`) has no target to iterate and would emit
+    /// `.last()…collect()` — Rust that does not compile — and a *repeated* single
+    /// label (`(x=A)+`) is overwritten each iteration, so a fixed `nth(0)` pins
+    /// the first match where ANTLR exposes the latest.
+    #[test]
+    fn reads_the_translator_cannot_express_stay_unresolved() {
+        let translate = |element: ElementRef, read: &str| {
+            let mut statement = rule("s");
+            statement.alts.push(AltModel {
+                label: None,
+                span: (10, 20),
+                refs: vec![element],
+                children: BTreeMap::new(),
+                leading_target: None,
+            });
+            let m = model(vec![statement]);
+            let toks = tokens(&[("A", 1), ("B", 2)]);
+            let ctx = TranslationCtx {
+                model: &m,
+                rule_index: 0,
+                body_offset: Some(15),
+                site: ActionSite::Body,
+                token_types: &toks,
+            };
+            translate_body(read, &ctx).map_err(|error| error.to_string())
+        };
+
+        let group_list = ElementRef {
+            label: Some("xs".to_owned()),
+            target: String::new(),
+            token_types: vec![1, 2],
+            is_block: true,
+            is_list: true,
+            cardinality: ChildCardinality { min: 1, max: None },
+            stable_accessor: true,
+        };
+        let error = translate(group_list, "$xs").expect_err("no target to iterate");
+        assert!(error.contains("cannot translate $xs"), "{error}");
+
+        let repeated_single = ElementRef {
+            label: Some("x".to_owned()),
+            target: "A".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality { min: 1, max: None },
+            stable_accessor: true,
+        };
+        let error = translate(repeated_single, "$x.text").expect_err("no last-occurrence read");
+        assert!(error.contains("cannot translate $x"), "{error}");
+    }
+
+    /// A same-target ref in a *sibling* choice branch never coexists with the
+    /// label, so it cannot displace an optional one: `r : (x=A {$x.text} B | A C)`
+    /// must still translate. Only a certainly-matched following child shadows.
+    #[test]
+    fn sibling_branch_children_do_not_shadow_an_optional_label() {
+        let mut statement = rule("s");
+        let branch_ref = |label: Option<&str>| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "A".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list: false,
+            // Mutually exclusive branches both report `min: 0`.
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+        };
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![branch_ref(Some("x")), branch_ref(None)],
+            children: BTreeMap::new(),
+            leading_target: Some("A".to_owned()),
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let translated = translate_body("$x.text", &ctx).expect("translates");
+        assert!(translated.contains(".nth(0)"), "{translated}");
     }
 
     /// A list label repeated within one alternative is the ordinary

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -92,6 +92,12 @@ pub(crate) struct ElementRef {
     /// `(a=A | )` would otherwise look like a one-branch choice that always
     /// yields an `A`.
     pub(crate) choice_arity: Vec<usize>,
+    /// Byte span of each enclosing choice *block*, in the same order as
+    /// `choice_branch`. An action lies inside a branch only when its offset falls
+    /// within the block's span — refs alone cannot tell `(A | xs+=A) {…}` (action
+    /// after the group) from `(A x=A {…} | B)` (action inside it), since both put
+    /// branch refs on either side of the action.
+    pub(crate) choice_spans: Vec<(usize, usize)>,
     /// Byte span of the element in the grammar source, when known. A mid-rule
     /// action executes at *its* source position, so only refs that start before
     /// the action's offset have been matched when its body runs.
@@ -423,6 +429,17 @@ impl TranslationCtx<'_> {
     ///   read cannot also serve.
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
+        if self.site == ActionSite::Init {
+            // An `@init` body runs at rule entry, before any child exists, so every
+            // read over children is empty and nothing can pollute it. Applying the
+            // after-rule hazards here would reject valid actions.
+            return rule
+                .alts
+                .iter()
+                .flat_map(|alt| alt.refs.iter())
+                .find(|element| element.label.as_deref() == Some(label))
+                .map(|element| (element.clone(), 0));
+        }
         if let Some((offset, alt)) = self
             .body_offset
             .and_then(|offset| rule.alt_at(offset).map(|alt| (offset, alt)))
@@ -475,11 +492,22 @@ impl TranslationCtx<'_> {
     /// Whether `alt` builds a child that the read for `element` would select,
     /// even though `alt` does not declare the label.
     fn alt_can_satisfy_read(alt: &AltModel, element: &ElementRef, occurrence: usize) -> bool {
-        if element.target.is_empty() {
-            // Block reads take the last terminal child, so any terminal matches.
-            return alt.refs.iter().any(|candidate| {
-                !candidate.token_types.is_empty() && candidate.cardinality.max != Some(0)
-            });
+        // Route on `is_block`, matching `translate_element_read`: a *literal* label
+        // (`x='a'`) is block-mode yet keeps a non-empty source target, so keying on
+        // an empty target here would fall through to token-type matching while the
+        // read actually ignores token type entirely.
+        if element.is_block {
+            // A positional block read selects a terminal by index, so the
+            // alternative can satisfy it whenever it builds a terminal there.
+            return alt
+                .refs
+                .iter()
+                .filter(|candidate| {
+                    !candidate.token_types.is_empty() && candidate.cardinality.max != Some(0)
+                })
+                .any(|candidate| {
+                    Self::exact_terminal_index(alt, candidate).is_none_or(|at| at == occurrence)
+                });
         }
         // The read queries by token *type*, so a differently-spelled terminal with
         // the same type is the same child (`A : 'a';` makes `A` and `'a'` one).
@@ -537,35 +565,60 @@ impl TranslationCtx<'_> {
             .refs
             .iter()
             .position(|candidate| std::ptr::eq(candidate, element))?;
-        Self::exact_terminal_count(alt.refs[..position].iter().filter(|candidate| {
-            !candidate.token_types.is_empty() && candidate.can_coexist_with(element)
-        }))
+        Self::exact_child_count(
+            alt.refs[..position].iter().filter(|candidate| {
+                !candidate.token_types.is_empty() && candidate.can_coexist_with(element)
+            }),
+            true,
+        )
     }
 
-    /// Total terminals contributed by `refs`, or `None` when not fixed. Refs are
-    /// grouped by their innermost choice so an *exhaustive* choice counts once
-    /// rather than per branch; the choice is exact only when every branch it has
-    /// contributes the same number.
-    fn exact_terminal_count<'a>(refs: impl Iterator<Item = &'a ElementRef>) -> Option<usize> {
+    /// Total children contributed by `refs`, or `None` when that total is not the
+    /// same on every parse.
+    ///
+    /// Refs are grouped by their enclosing choices and folded **innermost-first**:
+    /// once a choice's branches agree, its count is attributed to the enclosing
+    /// branch that contains it, so nested exhaustive choices
+    /// (`((a=A | b=A) | c=A)`) stay exact while nested *differing* ones
+    /// (`((a=A | b=B) C | D)`) correctly do not.
+    ///
+    /// `restricted_to_one_path` says the caller already filtered `refs` down to a
+    /// single parse path. Cross-branch agreement is then meaningless — the other
+    /// branches were removed on purpose — so each surviving branch simply counts.
+    fn exact_child_count<'a>(
+        refs: impl Iterator<Item = &'a ElementRef>,
+        restricted_to_one_path: bool,
+    ) -> Option<usize> {
         let refs = refs.collect::<Vec<_>>();
         let mut total = 0_usize;
         let mut per_branch: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
-        let mut branches_seen: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
-        // Recorded arity, so an empty alternative (which emits no ref) still counts
-        // toward the branches that must agree.
+        // Arity is recorded, not observed: an *empty* alternative emits no ref, so
+        // `(a=A | )` would otherwise look like a one-branch choice.
         let mut arity_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut depth_of_choice: BTreeMap<usize, usize> = BTreeMap::new();
+        let mut ancestry: BTreeMap<(usize, usize), Vec<(usize, usize)>> = BTreeMap::new();
         for candidate in &refs {
-            for &(choice, branch) in &candidate.choice_branch {
-                branches_seen.entry(choice).or_default().insert(branch);
-            }
-            for (&(choice, _), &arity) in
-                candidate.choice_branch.iter().zip(&candidate.choice_arity)
+            for (depth, (&(choice, branch), &arity)) in candidate
+                .choice_branch
+                .iter()
+                .zip(&candidate.choice_arity)
+                .enumerate()
             {
                 arity_of_choice.insert(choice, arity);
+                // A choice's depth is where it sits in the ancestry; take the
+                // *shallowest* sighting, since that is its real nesting level
+                // (a deeper ref lists it at the same index, never a lower one).
+                depth_of_choice
+                    .entry(choice)
+                    .and_modify(|existing| *existing = (*existing).min(depth))
+                    .or_insert(depth);
+                ancestry.insert((choice, branch), candidate.choice_branch[..=depth].to_vec());
             }
         }
         for candidate in &refs {
             let max = candidate.cardinality.max?;
+            // Within its own branch a ref contributes its branch-local count; the
+            // `min: 0` that branch membership imposes is not optionality.
             let local = candidate.branch_local_cardinality;
             let exact = (local.min == max && local.max == Some(max)).then_some(max);
             match candidate.choice_branch.last() {
@@ -579,22 +632,58 @@ impl TranslationCtx<'_> {
                 }
             }
         }
-        let mut by_choice: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
-        for ((choice, _), count) in per_branch {
-            by_choice.entry(choice).or_default().push(count?);
-        }
-        for (choice, counts) in by_choice {
-            let expected = arity_of_choice
-                .get(&choice)
-                .copied()
-                .unwrap_or_else(|| branches_seen.get(&choice).map_or(0, BTreeSet::len));
-            let first = counts.first().copied()?;
-            // Every branch must agree *and* be accounted for — `(A A | B)` has
-            // branch counts 2 and 1, so the prefix is not a fixed position.
-            if counts.len() != expected || counts.iter().any(|count| *count != first) {
-                return None;
+        // Deepest choices first, so an inner result rolls up into its parent branch.
+        // The list is rebuilt from `per_branch` each pass, because folding an inner
+        // choice *creates* an entry for its parent that must then fold in turn.
+        let mut processed: BTreeSet<usize> = BTreeSet::new();
+        // Deepest unprocessed choice still holding entries. Folding one creates an
+        // entry for its parent, so the candidate set is re-examined every pass.
+        while let Some(choice) = per_branch
+            .keys()
+            .map(|(choice, _)| *choice)
+            .filter(|choice| !processed.contains(choice))
+            .max_by_key(|choice| depth_of_choice.get(choice).copied().unwrap_or(0))
+        {
+            processed.insert(choice);
+            let counts = per_branch
+                .iter()
+                .filter(|((candidate, _), _)| *candidate == choice)
+                .map(|((_, branch), count)| (*branch, *count))
+                .collect::<Vec<_>>();
+            if counts.is_empty() {
+                continue;
             }
-            total = total.saturating_add(first);
+            let agreed = if restricted_to_one_path {
+                // One path survives, so there is nothing to agree with.
+                counts.iter().try_fold(0_usize, |sum, (_, count)| {
+                    Some(sum.saturating_add((*count)?))
+                })?
+            } else {
+                let expected = arity_of_choice.get(&choice).copied()?;
+                let first = counts.first().and_then(|(_, count)| *count)?;
+                if counts.len() != expected || counts.iter().any(|(_, count)| *count != Some(first))
+                {
+                    return None;
+                }
+                first
+            };
+            let parent = counts.first().and_then(|(branch, _)| {
+                ancestry.get(&(choice, *branch)).and_then(|chain| {
+                    chain
+                        .split_last()
+                        .and_then(|(_, rest)| rest.last().copied())
+                })
+            });
+            for (branch, _) in &counts {
+                per_branch.remove(&(choice, *branch));
+            }
+            match parent {
+                Some(parent_key) => {
+                    let slot = per_branch.entry(parent_key).or_insert(Some(0));
+                    *slot = slot.map(|sum| sum.saturating_add(agreed));
+                }
+                None => total = total.saturating_add(agreed),
+            }
         }
         Some(total)
     }
@@ -656,24 +745,44 @@ impl TranslationCtx<'_> {
         // The choice ancestry the action itself sits in, derived from spans: the
         // action belongs to the innermost branch whose refs bracket its offset.
         // Refs from any *other* branch of those choices cannot have run.
+        // The choice branches that syntactically *enclose* the action. A branch
+        // encloses it only when the branch has a ref before the action AND no
+        // sibling branch of the same choice has a ref after it — a sibling ref
+        // afterwards means the choice is still open, i.e. the action follows the
+        // whole group rather than sitting inside one branch. Nearest-preceding-ref
+        // alone gets `(A | xs+=A) {…}` wrong, marking the action as confined to the
+        // final branch when it actually runs for either.
+        // The choice branches that syntactically enclose the action: those whose
+        // *block* span contains the action's offset. Ref spans alone cannot decide
+        // this — `(A | xs+=A) {…}` and `(A x=A {…} | B)` both put branch refs on
+        // either side of the action — but the block's own extent can: in the first
+        // the action sits after the closing paren, in the second inside it.
         let action_branches = action_offset.map(|offset| {
-            // The *nearest* preceding ref, by source position — not the deepest.
-            // Taking the deepest would keep a closed-over branch's ancestry after
-            // the choice ends: in `(A A | B) x=(C | D) {…}` the second `A` is
-            // deeper than `x`, and treating the action as still inside that branch
-            // would count both `A`s as matched.
-            alt.refs
-                .iter()
-                .filter_map(|candidate| {
-                    candidate
-                        .span
-                        .filter(|(start, _)| *start < offset)
-                        .map(|(start, _)| (start, &candidate.choice_branch))
-                })
-                .max_by_key(|(start, _)| *start)
-                .map(|(_, branches)| branches.clone())
-                .unwrap_or_default()
+            let mut enclosing: Vec<(usize, usize)> = Vec::new();
+            for candidate in &alt.refs {
+                let inside_all = candidate
+                    .choice_spans
+                    .iter()
+                    .all(|&(start, end)| start <= offset && offset < end);
+                if !inside_all || candidate.choice_branch.is_empty() {
+                    continue;
+                }
+                // Only the branch actually containing the action counts, so require
+                // the candidate itself to be positioned around it.
+                let brackets = candidate.span.is_some_and(|(start, _)| start < offset);
+                if brackets {
+                    for &key in &candidate.choice_branch {
+                        if !enclosing.contains(&key) {
+                            enclosing.push(key);
+                        }
+                    }
+                }
+            }
+            enclosing
         });
+        let branch_confined = action_branches
+            .as_ref()
+            .is_some_and(|branches| !branches.is_empty());
         // Whether a ref can have run before the action, given that ancestry. An
         // action after the whole choice (`(x=A | A) {$x}`) has no branch tag, so
         // every branch counts; one written inside a branch excludes its siblings —
@@ -762,9 +871,14 @@ impl TranslationCtx<'_> {
             // terminals matched ahead of the block on this parse path — every
             // terminal counts, not just ones sharing the block's token set, since
             // each is a distinct child of the same context.
-            let terminals_before = Self::exact_terminal_count(before.iter().filter(|candidate| {
-                !candidate.token_types.is_empty() && on_action_path(candidate)
-            }));
+            // `on_action_path` already narrowed these to one parse path (when the
+            // action is inside a branch), so branches that survive simply count.
+            let terminals_before = Self::exact_child_count(
+                before.iter().filter(|candidate| {
+                    !candidate.token_types.is_empty() && on_action_path(candidate)
+                }),
+                branch_confined,
+            );
             // Without a fixed index the read falls back to the most recent
             // terminal, which is only right when nothing has been matched since.
             // A sibling branch that puts a terminal at the same index supplies the
@@ -817,21 +931,27 @@ impl TranslationCtx<'_> {
                 .iter()
                 .any(|token_type| element.token_types.contains(token_type))
         };
-        let occurrence = before
-            .iter()
-            .filter(|candidate| counts_toward_occurrence(candidate))
-            .try_fold(0_usize, |total, candidate| {
-                let max = candidate.cardinality.max?;
-                // A group only *sometimes* yields a matching child, so its count
-                // is exact only when every member is one the read selects.
-                let all_match = candidate
+        // A token *group* only sometimes yields a matching child, so its count is
+        // exact only when every member is one the read selects.
+        if before.iter().any(|candidate| {
+            counts_toward_occurrence(candidate)
+                && !candidate.token_types.is_empty()
+                && !candidate
                     .token_types
                     .iter()
-                    .all(|token_type| element.token_types.contains(token_type));
-                (candidate.cardinality.min == max
-                    && (candidate.token_types.is_empty() || all_match))
-                    .then(|| total.saturating_add(max))
-            })?;
+                    .all(|token_type| element.token_types.contains(token_type))
+        }) {
+            return None;
+        }
+        // Count only children on the label's own parse path, and — when the action
+        // is confined to a branch — count the surviving branch as that path rather
+        // than demanding agreement from branches already filtered out.
+        let occurrence = Self::exact_child_count(
+            before.iter().filter(|candidate| {
+                counts_toward_occurrence(candidate) && candidate.can_coexist_with(element)
+            }),
+            true,
+        )?;
         // An optional label is displaced by a following same-target child that can
         // slide into its position, whether that child is mandatory (`x=A? A`) or
         // optional (`(pred x=A)? A?` — the follower may consume the only token).
@@ -973,6 +1093,7 @@ fn translate_reference(
             stable_accessor: false,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -990,6 +1111,7 @@ fn translate_reference(
             stable_accessor: false,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1343,6 +1465,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1356,6 +1479,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1400,13 +1524,16 @@ mod tests {
     #[test]
     fn inexact_preceding_refs_leave_labels_unresolved_instead_of_misindexing() {
         let mut statement = rule("s");
+        // `r : (e | x=e) {…}`: the two refs are *sequential* here, not branches of
+        // one choice — an unlabeled `e` genuinely precedes the label on the same
+        // path, which is what leaves its position unfixed. (The mutually exclusive
+        // spelling is covered by `sibling_branch_children_do_not_shadow_an_optional_label`.)
         let branch_ref = |label: Option<&str>| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: "e".to_owned(),
             token_types: Vec::new(),
             is_block: false,
             is_list: false,
-            // Sibling branches of a choice are mutually exclusive.
             cardinality: ChildCardinality {
                 min: 0,
                 max: Some(1),
@@ -1414,8 +1541,13 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
-            branch_local_cardinality: ChildCardinality::ONE,
+            // Optional on its own path, so the count ahead of the label floats.
+            branch_local_cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1462,6 +1594,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1506,6 +1639,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality { min, max: Some(1) },
         };
@@ -1551,6 +1685,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1567,6 +1702,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1624,6 +1760,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1637,6 +1774,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -1692,6 +1830,7 @@ mod tests {
                         stable_accessor: true,
                         choice_branch: Vec::new(),
                         choice_arity: Vec::new(),
+                        choice_spans: Vec::new(),
                         span: Some((10, 20)),
                         branch_local_cardinality: ChildCardinality::ONE,
                     },
@@ -1708,6 +1847,7 @@ mod tests {
                         stable_accessor: true,
                         choice_branch: Vec::new(),
                         choice_arity: Vec::new(),
+                        choice_spans: Vec::new(),
                         span: Some((30, 31)),
                         branch_local_cardinality: ChildCardinality::ONE,
                     },
@@ -1759,6 +1899,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1818,6 +1959,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: vec![(5, branch)],
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1878,6 +2020,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1930,6 +2073,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -1989,6 +2133,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2029,6 +2174,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2097,6 +2243,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2113,6 +2260,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2139,6 +2287,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: branches,
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2188,6 +2337,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: vec![(3, branch)],
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2251,6 +2401,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -2268,6 +2419,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -2313,6 +2465,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: vec![(7, branch)],
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2358,6 +2511,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2402,6 +2556,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2418,6 +2573,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2472,6 +2628,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2533,6 +2690,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             choice_arity: Vec::new(),
+            choice_spans: Vec::new(),
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
         };
@@ -2614,6 +2772,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },
@@ -2627,6 +2786,7 @@ mod tests {
                     stable_accessor: true,
                     choice_branch: Vec::new(),
                     choice_arity: Vec::new(),
+                    choice_spans: Vec::new(),
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                 },

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -468,9 +468,8 @@ impl TranslationCtx<'_> {
             // relative to these refs is not recoverable here and the read is
             // accepted as-is. A label read *across* an intervening terminal
             // (`((x=(A | B))) C {$x.text}` reads `C`) is therefore still wrong;
-            // fixing it needs element spans in the model, tracked separately
-            // rather than papered over with a guard that would reject the
-            // conformance shapes above.
+            // fixing it needs element spans in the model (issue #233) rather
+            // than a guard that would reject the conformance shapes above.
             return Some((element.clone(), 0));
         }
 
@@ -1253,7 +1252,8 @@ mod tests {
     /// action runs at its own source position. `ElementRef` carries no span, so
     /// that ordering is not recoverable here and the read is accepted as-is —
     /// this test pins the resulting behaviour, including the known limitation
-    /// that a read across an intervening terminal picks the later token.
+    /// that a read across an intervening terminal picks the later token
+    /// (issue #233).
     #[test]
     fn block_labels_resolve_to_the_most_recent_terminal_read() {
         let mut statement = rule("s");

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -115,6 +115,12 @@ pub(crate) struct ElementRef {
     /// predicates — such a branch emits no `ElementRef` at all, so ref spans alone
     /// would attribute the action to a neighbouring branch.
     pub(crate) branch_spans: Vec<(usize, usize)>,
+    /// Whether no terminal can precede this element on its own parse path. Only
+    /// then do a block read (which indexes every terminal child) and a token read
+    /// (which indexes only same-type children) provably agree, so this is what
+    /// makes a mixed-mode merge sound — occurrence zero alone is not enough, since
+    /// a token-mode zero can still sit at a non-zero terminal position.
+    pub(crate) leading_terminal: bool,
     /// Byte span of the element in the grammar source, when known. A mid-rule
     /// action executes at *its* source position, so only refs that start before
     /// the action's offset have been matched when its body runs.
@@ -522,9 +528,7 @@ impl TranslationCtx<'_> {
                 .filter(|candidate| {
                     !candidate.token_types.is_empty() && candidate.cardinality.max != Some(0)
                 })
-                .any(|candidate| {
-                    Self::exact_terminal_index(alt, candidate).is_none_or(|at| at == occurrence)
-                });
+                .any(|candidate| Self::can_occupy_terminal_index(alt, candidate, occurrence));
         }
         // The read queries by token *type*, so a differently-spelled terminal with
         // the same type is the same child (`A : 'a';` makes `A` and `'a'` one).
@@ -550,6 +554,29 @@ impl TranslationCtx<'_> {
         // A list read selects any same-target child; a positional read needs one
         // at `occurrence`. An unbounded count can always reach either.
         available.is_none_or(|available| available > occurrence)
+    }
+
+    /// Whether `candidate` can occupy terminal index `occurrence` on its own parse
+    /// path. A *repeated* candidate spans a range of positions rather than one, so
+    /// comparing a single index would miss it: in `C x=(A | B) | (D | E)+` the
+    /// repeated group starts at 0 yet also covers 1, where `x` reads.
+    fn can_occupy_terminal_index(
+        alt: &AltModel,
+        candidate: &ElementRef,
+        occurrence: usize,
+    ) -> bool {
+        let Some(start) = Self::exact_terminal_index(alt, candidate) else {
+            // No fixed start: the candidate could be anywhere.
+            return true;
+        };
+        if start > occurrence {
+            return false;
+        }
+        // Unbounded repetition reaches every later index.
+        candidate
+            .cardinality
+            .max
+            .is_none_or(|max| start + max > occurrence)
     }
 
     /// Index among terminal children at which `element` sits on its own parse
@@ -796,15 +823,20 @@ impl TranslationCtx<'_> {
         // different children, and `A x='a' B | A x=A C` has them meaning the same
         // child while reporting 1 and 1 only by coincidence.
         //
-        // Rather than guess, mixed-mode pairs merge only at occurrence zero — the
-        // one index where the two systems provably coincide, since "no terminal
-        // before" and "no same-type token before" agree there. Same-mode pairs
-        // compare directly.
+        // Rather than guess, mixed-mode pairs merge only when *neither* has anything
+        // ahead of it — occurrence zero in both systems *and* no preceding terminal
+        // of any type. Occurrence zero alone is not enough: in `B x=A | x='a'` the
+        // symbolic side reports same-token occurrence 0 while sitting at terminal
+        // position 1, and merging it with the literal's terminal 0 exposed `B`.
+        // Same-mode pairs compare directly.
         if !left.0.token_types.is_empty() && left.0.token_types == right.0.token_types {
             if left.0.is_block == right.0.is_block {
                 return left.1 == right.1;
             }
-            return left.1 == 0 && right.1 == 0;
+            return left.1 == 0
+                && right.1 == 0
+                && left.0.leading_terminal
+                && right.0.leading_terminal;
         }
         if left.0.is_block != right.0.is_block {
             return false;
@@ -1025,6 +1057,20 @@ impl TranslationCtx<'_> {
         // results to agree, so one read demonstrably serves every branch:
         // `(A x=A B | x=A C)` wants occurrence 1 then 0, and `(x=A B | x=A+ C)`
         // wants a first-match read then a last-match one.
+        // An action confined to one branch never sees a sibling branch's declaration,
+        // so requiring agreement with it would reject a read that is unambiguous
+        // where the action actually runs (`(x=A {$x} | x=A+ B)`).
+        let relevant = declarations
+            .iter()
+            .copied()
+            .filter(|candidate| !branch_confined || on_action_path(candidate))
+            .collect::<Vec<_>>();
+        let declarations = if relevant.is_empty() {
+            declarations
+        } else {
+            relevant
+        };
+        let element = *declarations.first()?;
         if declarations.len() > 1 {
             let mut resolutions = Vec::with_capacity(declarations.len());
             for candidate in &declarations {
@@ -1062,6 +1108,13 @@ impl TranslationCtx<'_> {
         // leave a literal label counting same-target children while its read walks
         // every terminal.
         if element.is_block {
+            // A *repeated* block label (`x=(A | B)+`) is overwritten each iteration,
+            // so ANTLR exposes the last match while a positional read pins the first.
+            // The non-block path already declines this; do the same rather than read
+            // the wrong iteration.
+            if element.cardinality.is_repeated() {
+                return None;
+            }
             // A block label has no single target to query, so its read walks the
             // context's terminal children by position. The index is the number of
             // terminals matched ahead of the block on this parse path — every
@@ -1069,12 +1122,31 @@ impl TranslationCtx<'_> {
             // each is a distinct child of the same context.
             // `on_action_path` already narrowed these to one parse path (when the
             // action is inside a branch), so branches that survive simply count.
-            let terminals_before = Self::exact_child_count(
-                before.iter().filter(|candidate| {
-                    !candidate.token_types.is_empty() && on_action_path(candidate)
-                }),
-                branch_confined,
-            );
+            // Confinement to one *outer* branch does not restrict a nested choice
+            // inside it: `((a=A | b=B) x=(C | D) {…} | E)` still has the `A`/`B`
+            // branches to reconcile, and calling the count path-restricted summed
+            // them. Strip the tags of choices the action is genuinely inside, then
+            // let any surviving tag force cross-branch agreement.
+            let counted = before
+                .iter()
+                .filter(|candidate| !candidate.token_types.is_empty() && on_action_path(candidate))
+                .cloned()
+                .map(|mut candidate| {
+                    if let Some(branches) = action_branches.as_ref() {
+                        candidate.choice_branch.retain(|(choice, _)| {
+                            !branches.iter().any(|(taken, _)| taken == choice)
+                        });
+                        let keep = candidate.choice_branch.len();
+                        candidate.choice_arity.truncate(keep);
+                        candidate.choice_spans.truncate(keep);
+                    }
+                    candidate
+                })
+                .collect::<Vec<_>>();
+            let restricted = counted
+                .iter()
+                .all(|candidate| candidate.choice_branch.is_empty());
+            let terminals_before = Self::exact_child_count(counted.iter(), restricted);
             // Without a fixed index the read falls back to the most recent
             // terminal, which is only right when nothing has been matched since.
             // A sibling branch that puts a terminal at the same index supplies the
@@ -1091,8 +1163,7 @@ impl TranslationCtx<'_> {
                         !candidate.can_coexist_with(element)
                             && !candidate.token_types.is_empty()
                             && candidate.cardinality.max != Some(0)
-                            && Self::exact_terminal_index(alt, candidate)
-                                .is_none_or(|at| at == index)
+                            && Self::can_occupy_terminal_index(alt, candidate, index)
                     });
                 if sibling_at_index {
                     return None;
@@ -1169,7 +1240,13 @@ impl TranslationCtx<'_> {
         let counted = before
             .iter()
             .filter(|candidate| {
-                counts_toward_occurrence(candidate) && candidate.can_coexist_with(element)
+                // Only children already matched when the action runs can affect its
+                // read. An inline action *before* the label sees none of them, so a
+                // later unbounded run must not poison the count:
+                // `r : {$x.text} A* x=A EOF;` reads an empty list, whatever follows.
+                counts_toward_occurrence(candidate)
+                    && matched_at_action(candidate)
+                    && candidate.can_coexist_with(element)
             })
             .cloned()
             .map(|mut candidate| {
@@ -1363,6 +1440,7 @@ fn translate_reference(
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -1384,6 +1462,7 @@ fn translate_reference(
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -1741,6 +1820,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -1758,6 +1838,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -1823,6 +1904,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             // Optional on its own path, so the count ahead of the label floats.
             branch_local_cardinality: ChildCardinality {
@@ -1882,6 +1964,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -1930,6 +2013,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality { min, max: Some(1) },
             group_local_cardinality: ChildCardinality { min, max: Some(1) },
@@ -1979,6 +2063,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -1999,6 +2084,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2060,6 +2146,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -2077,6 +2164,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -2136,6 +2224,7 @@ mod tests {
                         choice_spans: Vec::new(),
                         group_spans: Vec::new(),
                         branch_spans: Vec::new(),
+                        leading_terminal: true,
                         span: Some((10, 20)),
                         branch_local_cardinality: ChildCardinality::ONE,
                         group_local_cardinality: ChildCardinality::ONE,
@@ -2156,6 +2245,7 @@ mod tests {
                         choice_spans: Vec::new(),
                         group_spans: Vec::new(),
                         branch_spans: Vec::new(),
+                        leading_terminal: true,
                         span: Some((30, 31)),
                         branch_local_cardinality: ChildCardinality::ONE,
                         group_local_cardinality: ChildCardinality::ONE,
@@ -2211,6 +2301,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2277,6 +2368,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2361,6 +2453,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2417,6 +2510,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2480,6 +2574,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2524,6 +2619,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2596,6 +2692,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2616,6 +2713,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2646,6 +2744,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2699,6 +2798,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2766,6 +2866,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -2787,6 +2888,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -2836,6 +2938,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2885,6 +2988,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: Some(span),
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2933,6 +3037,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -2953,6 +3058,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -3011,6 +3117,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -3076,6 +3183,7 @@ mod tests {
             choice_spans: Vec::new(),
             group_spans: Vec::new(),
             branch_spans: Vec::new(),
+            leading_terminal: true,
             span: None,
             branch_local_cardinality: ChildCardinality::ONE,
             group_local_cardinality: ChildCardinality::ONE,
@@ -3161,6 +3269,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,
@@ -3178,6 +3287,7 @@ mod tests {
                     choice_spans: Vec::new(),
                     group_spans: Vec::new(),
                     branch_spans: Vec::new(),
+                    leading_terminal: true,
                     span: None,
                     branch_local_cardinality: ChildCardinality::ONE,
                     group_local_cardinality: ChildCardinality::ONE,

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -14,7 +14,7 @@
 //! references with labels (for `$label.attr` occurrence resolution), and
 //! `@members` bodies split into struct fields, impl items, and module items.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write as _;
 use std::io;
 
@@ -498,6 +498,64 @@ impl TranslationCtx<'_> {
         available.is_none_or(|available| available > occurrence)
     }
 
+    /// Index among terminal children at which `element` sits on its own parse
+    /// path, or `None` when that index is not fixed.
+    fn exact_terminal_index(alt: &AltModel, element: &ElementRef) -> Option<usize> {
+        let position = alt
+            .refs
+            .iter()
+            .position(|candidate| std::ptr::eq(candidate, element))?;
+        Self::exact_terminal_count(alt.refs[..position].iter().filter(|candidate| {
+            !candidate.token_types.is_empty() && candidate.can_coexist_with(element)
+        }))
+    }
+
+    /// Total terminals contributed by `refs`, or `None` when not fixed. Refs are
+    /// grouped by their innermost choice so an *exhaustive* choice counts once
+    /// rather than per branch; the choice is exact only when every branch it has
+    /// contributes the same number.
+    fn exact_terminal_count<'a>(refs: impl Iterator<Item = &'a ElementRef>) -> Option<usize> {
+        let refs = refs.collect::<Vec<_>>();
+        let mut total = 0_usize;
+        let mut per_branch: BTreeMap<(usize, usize), Option<usize>> = BTreeMap::new();
+        let mut branches_seen: BTreeMap<usize, BTreeSet<usize>> = BTreeMap::new();
+        for candidate in &refs {
+            for &(choice, branch) in &candidate.choice_branch {
+                branches_seen.entry(choice).or_default().insert(branch);
+            }
+        }
+        for candidate in &refs {
+            let max = candidate.cardinality.max?;
+            let local = candidate.branch_local_cardinality;
+            let exact = (local.min == max && local.max == Some(max)).then_some(max);
+            match candidate.choice_branch.last() {
+                None => total = total.saturating_add(exact?),
+                Some(&key) => {
+                    let slot = per_branch.entry(key).or_insert(Some(0));
+                    *slot = match (*slot, exact) {
+                        (Some(sum), Some(next)) => Some(sum.saturating_add(next)),
+                        _ => None,
+                    };
+                }
+            }
+        }
+        let mut by_choice: BTreeMap<usize, Vec<usize>> = BTreeMap::new();
+        for ((choice, _), count) in per_branch {
+            by_choice.entry(choice).or_default().push(count?);
+        }
+        for (choice, counts) in by_choice {
+            let expected = branches_seen.get(&choice).map_or(0, BTreeSet::len);
+            let first = counts.first().copied()?;
+            // Every branch must agree *and* be accounted for — `(A A | B)` has
+            // branch counts 2 and 1, so the prefix is not a fixed position.
+            if counts.len() != expected || counts.iter().any(|count| *count != first) {
+                return None;
+            }
+            total = total.saturating_add(first);
+        }
+        Some(total)
+    }
+
     /// Whether two per-alternative resolutions lower to the same read, so one
     /// translation can stand for both. The fields compared are exactly those
     /// `translate_element_read` consumes to pick a read: list mode, block mode,
@@ -507,8 +565,10 @@ impl TranslationCtx<'_> {
         if left.0.is_list != right.0.is_list || left.0.is_block != right.0.is_block {
             return false;
         }
-        if left.0.is_block && left.0.target.is_empty() && right.0.target.is_empty() {
-            return true;
+        // Block reads are positional now, so two block labels agree only when
+        // their terminal indices do: `x=(A | B) | C x=(A | B)` puts `x` at 0 and 1.
+        if left.0.is_block && right.0.is_block {
+            return left.1 == right.1;
         }
         left.1 == right.1 && left.0.target == right.0.target
     }
@@ -554,19 +614,22 @@ impl TranslationCtx<'_> {
         // action belongs to the innermost branch whose refs bracket its offset.
         // Refs from any *other* branch of those choices cannot have run.
         let action_branches = action_offset.map(|offset| {
-            let mut enclosing: Vec<(usize, usize)> = Vec::new();
-            for candidate in &alt.refs {
-                let Some((start, _)) = candidate.span else {
-                    continue;
-                };
-                // A ref before the action shares its path only if no later ref of
-                // the same branch-set is closer; taking the nearest preceding ref
-                // gives the branch the action was written inside.
-                if start < offset && candidate.choice_branch.len() >= enclosing.len() {
-                    enclosing.clone_from(&candidate.choice_branch);
-                }
-            }
-            enclosing
+            // The *nearest* preceding ref, by source position — not the deepest.
+            // Taking the deepest would keep a closed-over branch's ancestry after
+            // the choice ends: in `(A A | B) x=(C | D) {…}` the second `A` is
+            // deeper than `x`, and treating the action as still inside that branch
+            // would count both `A`s as matched.
+            alt.refs
+                .iter()
+                .filter_map(|candidate| {
+                    candidate
+                        .span
+                        .filter(|(start, _)| *start < offset)
+                        .map(|(start, _)| (start, &candidate.choice_branch))
+                })
+                .max_by_key(|(start, _)| *start)
+                .map(|(_, branches)| branches.clone())
+                .unwrap_or_default()
         });
         // Whether a ref can have run before the action, given that ancestry. An
         // action after the whole choice (`(x=A | A) {$x}`) has no branch tag, so
@@ -656,16 +719,25 @@ impl TranslationCtx<'_> {
             // terminals matched ahead of the block on this parse path — every
             // terminal counts, not just ones sharing the block's token set, since
             // each is a distinct child of the same context.
-            let terminals_before = before
-                .iter()
-                .filter(|candidate| !candidate.token_types.is_empty() && on_action_path(candidate))
-                .try_fold(0_usize, |total, candidate| {
-                    let max = candidate.cardinality.max?;
-                    (candidate.cardinality.min == max || !candidate.choice_branch.is_empty())
-                        .then(|| total.saturating_add(max))
-                });
+            let terminals_before = Self::exact_terminal_count(before.iter().filter(|candidate| {
+                !candidate.token_types.is_empty() && on_action_path(candidate)
+            }));
             // Without a fixed index the read falls back to the most recent
             // terminal, which is only right when nothing has been matched since.
+            // A sibling branch that puts a terminal at the same index supplies the
+            // child this read selects on a parse where the label is unset:
+            // `((x=(A | B)) | C) {$x}` reads `C` on the `C` branch.
+            if let Some(index) = terminals_before {
+                let sibling_at_index = alt.refs.iter().any(|candidate| {
+                    !candidate.can_coexist_with(element)
+                        && !candidate.token_types.is_empty()
+                        && candidate.cardinality.max != Some(0)
+                        && Self::exact_terminal_index(alt, candidate).is_none_or(|at| at == index)
+                });
+                if sibling_at_index {
+                    return None;
+                }
+            }
             return terminals_before.map_or_else(
                 || {
                     let displaced = after.iter().any(|candidate| {
@@ -1373,6 +1445,8 @@ mod tests {
     #[test]
     fn disjoint_token_groups_do_not_poison_a_later_block_label() {
         let mut statement = rule("s");
+        // `branch_local_cardinality` mirrors `cardinality` here: the optionality
+        // comes from the group's own `?`, not from choice membership.
         let group_ref = |label: Option<&str>, token_types: Vec<i32>, min| ElementRef {
             label: label.map(ToOwned::to_owned),
             target: String::new(),
@@ -1383,7 +1457,7 @@ mod tests {
             stable_accessor: true,
             choice_branch: Vec::new(),
             span: None,
-            branch_local_cardinality: ChildCardinality::ONE,
+            branch_local_cardinality: ChildCardinality { min, max: Some(1) },
         };
         statement.alts.push(AltModel {
             label: None,

--- a/src/bin_support/embedded.rs
+++ b/src/bin_support/embedded.rs
@@ -77,23 +77,29 @@ pub(crate) struct ElementRef {
     /// label accessor. Single-alternative EBNF groups preserve it; choices opt
     /// out because their flattened CST children do not retain the chosen path.
     pub(crate) stable_accessor: bool,
-    /// `(choice id, alternative index)` of the innermost enclosing *multi*-
-    /// alternative block, if any. Two refs tagged with the same choice id but
-    /// different alternative indexes are mutually exclusive: no parse contains
-    /// both. `None` means the ref is on the rule's own sequential path.
-    pub(crate) choice_branch: Option<(usize, usize)>,
+    /// `(choice id, alternative index)` for every enclosing *multi*-alternative
+    /// block, outermost first. Two refs that share a choice id but sit in
+    /// different alternatives of it are mutually exclusive: no parse contains
+    /// both. Empty means the ref is on the rule's own sequential path.
+    ///
+    /// The whole ancestry is kept, not just the innermost choice: for
+    /// `((x=e | f) | e)` the labeled `x` and the trailing `e` are separated by
+    /// the *outer* choice, which an innermost-only tag would lose.
+    pub(crate) choice_branch: Vec<(usize, usize)>,
 }
 
 impl ElementRef {
-    /// Whether `self` and `other` can both appear in one parse. Refs from
-    /// different alternatives of the same choice never do.
-    pub(crate) const fn can_coexist_with(&self, other: &Self) -> bool {
-        match (self.choice_branch, other.choice_branch) {
-            (Some((left_choice, left_alt)), Some((right_choice, right_alt))) => {
-                left_choice != right_choice || left_alt == right_alt
-            }
-            _ => true,
-        }
+    /// Whether `self` and `other` can both appear in one parse. They cannot when
+    /// any choice encloses both in *different* alternatives.
+    pub(crate) fn can_coexist_with(&self, other: &Self) -> bool {
+        !self.choice_branch.iter().any(|(choice, branch)| {
+            other
+                .choice_branch
+                .iter()
+                .any(|(other_choice, other_branch)| {
+                    choice == other_choice && branch != other_branch
+                })
+        })
     }
 }
 
@@ -400,7 +406,9 @@ impl TranslationCtx<'_> {
     fn resolve_label(&self, label: &str) -> Option<(ElementRef, usize)> {
         let rule = self.rule();
         if let Some(alt) = self.body_offset.and_then(|offset| rule.alt_at(offset)) {
-            return Self::resolve_label_in_alt(alt, label);
+            // A mid-rule action is confined to the branch it is written in, so a
+            // sibling branch's children can be excluded.
+            return Self::resolve_label_in_alt(alt, label, true);
         }
         // `@after` / `@init` bodies are not scoped to an alternative, so the
         // label may be declared in several. One read has to serve whichever
@@ -417,7 +425,10 @@ impl TranslationCtx<'_> {
                 non_declaring.push(alt);
                 continue;
             }
-            let candidate = Self::resolve_label_in_alt(alt, label)?;
+            // An `@after` / `@init` body runs whichever branch the parse took, so
+            // a sibling branch's match *can* be the child present when the read
+            // executes — sibling exclusion does not apply here.
+            let candidate = Self::resolve_label_in_alt(alt, label, false)?;
             if resolved
                 .as_ref()
                 .is_some_and(|existing| !Self::same_label_read(existing, &candidate))
@@ -475,7 +486,11 @@ impl TranslationCtx<'_> {
         left.1 == right.1 && left.0.target == right.0.target
     }
 
-    fn resolve_label_in_alt(alt: &AltModel, label: &str) -> Option<(ElementRef, usize)> {
+    fn resolve_label_in_alt(
+        alt: &AltModel,
+        label: &str,
+        exclude_sibling_branches: bool,
+    ) -> Option<(ElementRef, usize)> {
         let declarations = alt
             .refs
             .iter()
@@ -483,10 +498,20 @@ impl TranslationCtx<'_> {
             .collect::<Vec<_>>();
         let element = *declarations.first()?;
         let declares_label = |candidate: &ElementRef| candidate.label.as_deref() == Some(label);
+        // The generated read queries by rule index or *token type*, so a
+        // differently-spelled terminal with the same type is the same child as
+        // far as the read is concerned (`A : 'a';` makes `A` and `'a'` aliases).
         let same_target = |candidate: &ElementRef| {
-            !candidate.target.is_empty()
-                && candidate.target == element.target
-                && candidate.cardinality.max != Some(0)
+            if candidate.target.is_empty() || candidate.cardinality.max == Some(0) {
+                return false;
+            }
+            if element.token_types.is_empty() || candidate.token_types.is_empty() {
+                return candidate.target == element.target;
+            }
+            candidate
+                .token_types
+                .iter()
+                .any(|token_type| element.token_types.contains(token_type))
         };
 
         if element.is_list {
@@ -568,9 +593,10 @@ impl TranslationCtx<'_> {
         // cannot, since no parse contains both, so counting it would reject valid
         // mid-rule actions like `r : (x=A {$x.text} B | A C)`.
         let shadowed_when_absent = element.cardinality.min == 0
-            && after
-                .iter()
-                .any(|candidate| same_target(candidate) && candidate.can_coexist_with(element));
+            && after.iter().any(|candidate| {
+                same_target(candidate)
+                    && (!exclude_sibling_branches || candidate.can_coexist_with(element))
+            });
         (!shadowed_when_absent).then_some((element.clone(), occurrence))
     }
 }
@@ -695,7 +721,7 @@ fn translate_reference(
             is_list: false,
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let _ = target_rule;
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
@@ -709,7 +735,7 @@ fn translate_reference(
             is_list: false,
             cardinality: ChildCardinality::ONE,
             stable_accessor: false,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         return translate_element_read(&element, usize::MAX, suffix, ctx, body);
     }
@@ -1050,7 +1076,7 @@ mod tests {
                     is_list: false,
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
                 ElementRef {
                     label: Some("right".to_owned()),
@@ -1060,7 +1086,7 @@ mod tests {
                     is_list: false,
                     cardinality: ChildCardinality::ONE,
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
             ],
             children: BTreeMap::from([(
@@ -1115,7 +1141,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1160,7 +1186,7 @@ mod tests {
             is_list: false,
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1199,7 +1225,7 @@ mod tests {
             is_list: false,
             cardinality: ChildCardinality { min, max: Some(1) },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1241,7 +1267,7 @@ mod tests {
             is_list: true,
             cardinality: ChildCardinality { min: 1, max },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let single_ref = ElementRef {
             label: Some("name".to_owned()),
@@ -1254,7 +1280,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let translate = |max| {
             let mut statement = rule("s");
@@ -1308,7 +1334,7 @@ mod tests {
                         max: Some(1),
                     },
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
                 ElementRef {
                     label: Some("errors".to_owned()),
@@ -1318,7 +1344,7 @@ mod tests {
                     is_list: true,
                     cardinality: ChildCardinality { min: 0, max: None },
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
             ],
             children: BTreeMap::new(),
@@ -1371,7 +1397,7 @@ mod tests {
                         max: Some(1),
                     },
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
                 ElementRef {
                     label: None,
@@ -1384,7 +1410,7 @@ mod tests {
                         max: Some(1),
                     },
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
             ],
             children: BTreeMap::new(),
@@ -1422,7 +1448,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let translate = |second: ElementRef| {
             let mut statement = rule("s");
@@ -1478,7 +1504,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let mut statement = rule("s");
         statement.alts.push(AltModel {
@@ -1515,7 +1541,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let mut choice = rule("s");
         for (index, refs) in [vec![block_ref(vec![1, 2])], vec![block_ref(vec![3, 4])]]
@@ -1580,7 +1606,7 @@ mod tests {
             is_list: true,
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let error = translate(group_list, "$xs").expect_err("no target to iterate");
         assert!(error.contains("cannot translate $xs"), "{error}");
@@ -1593,10 +1619,167 @@ mod tests {
             is_list: false,
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let error = translate(repeated_single, "$x.text").expect_err("no last-occurrence read");
         assert!(error.contains("cannot translate $x"), "{error}");
+    }
+
+    /// Mutual exclusion needs the *whole* choice ancestry, not just the innermost
+    /// choice. In `((x=e | f) | e)` the label and the trailing `e` are separated
+    /// by the outer choice; keeping only the inner tag would make them look
+    /// independent and reject a valid action.
+    #[test]
+    fn nested_choices_keep_their_outer_branch_ancestry() {
+        let rule_ref = |label: Option<&str>, branches: Vec<(usize, usize)>| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "e".to_owned(),
+            token_types: Vec::new(),
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+            choice_branch: branches,
+        };
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![
+                // Outer choice 1 branch 0, then inner choice 2 branch 0.
+                rule_ref(Some("x"), vec![(1, 0), (2, 0)]),
+                // Outer choice 1 branch 1 — excluded by the *outer* choice alone.
+                rule_ref(None, vec![(1, 1)]),
+            ],
+            children: BTreeMap::new(),
+            leading_target: Some("e".to_owned()),
+        });
+        let m = model(vec![statement, rule("e")]);
+        let toks = tokens(&[]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let translated = translate_body("$x.text", &ctx).expect("outer exclusion still applies");
+        assert!(translated.contains(".nth(0)"), "{translated}");
+    }
+
+    /// Sibling exclusion is valid only for a *mid-rule* action, which is confined
+    /// to the branch it is written in. An `@after` body runs whichever branch the
+    /// parse took, so `r @after {$x.text} : (x=A | A) EOF;` must decline — the
+    /// unlabeled branch's `A` is present when the read executes.
+    #[test]
+    fn unscoped_bodies_treat_sibling_matches_as_hazards() {
+        let branch_ref = |label: Option<&str>, branch| ElementRef {
+            label: label.map(ToOwned::to_owned),
+            target: "A".to_owned(),
+            token_types: vec![1],
+            is_block: false,
+            is_list: false,
+            cardinality: ChildCardinality {
+                min: 0,
+                max: Some(1),
+            },
+            stable_accessor: true,
+            choice_branch: vec![(3, branch)],
+        };
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![branch_ref(Some("x"), 0), branch_ref(None, 1)],
+            children: BTreeMap::new(),
+            leading_target: Some("A".to_owned()),
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1)]);
+        let after = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            // `@after`: unscoped, so any branch may have run.
+            body_offset: None,
+            site: ActionSite::After,
+            token_types: &toks,
+        };
+        let error = translate_body("$x.text", &after).expect_err("sibling match is a hazard here");
+        assert!(error.to_string().contains("cannot translate $x"), "{error}");
+
+        // The same refs read from a mid-rule action inside the labeled branch do
+        // resolve, since that action cannot run on the sibling branch.
+        let body = TranslationCtx {
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            ..after
+        };
+        let translated =
+            translate_body("$x.text", &body).expect("mid-rule action excludes sibling");
+        assert!(translated.contains(".nth(0)"), "{translated}");
+    }
+
+    /// A token label's read queries by token *type*, so a differently-spelled
+    /// terminal with the same type is the same child: with `A : 'a';`,
+    /// `r : (xs+=A)? 'a' {$xs}` must decline because the mandatory `'a'` would be
+    /// iterated as an `xs` element.
+    #[test]
+    fn token_labels_compare_types_not_source_spelling() {
+        let mut statement = rule("s");
+        statement.alts.push(AltModel {
+            label: None,
+            span: (10, 20),
+            refs: vec![
+                ElementRef {
+                    label: Some("xs".to_owned()),
+                    target: "A".to_owned(),
+                    token_types: vec![1],
+                    is_block: false,
+                    is_list: true,
+                    cardinality: ChildCardinality {
+                        min: 0,
+                        max: Some(1),
+                    },
+                    stable_accessor: true,
+                    choice_branch: Vec::new(),
+                },
+                ElementRef {
+                    label: None,
+                    // Literal spelling differs; the token type is identical.
+                    target: "'a'".to_owned(),
+                    token_types: vec![1],
+                    is_block: false,
+                    is_list: false,
+                    cardinality: ChildCardinality {
+                        min: 1,
+                        max: Some(1),
+                    },
+                    stable_accessor: true,
+                    choice_branch: Vec::new(),
+                },
+            ],
+            children: BTreeMap::new(),
+            leading_target: None,
+        });
+        let m = model(vec![statement]);
+        let toks = tokens(&[("A", 1)]);
+        let ctx = TranslationCtx {
+            model: &m,
+            rule_index: 0,
+            body_offset: Some(15),
+            site: ActionSite::Body,
+            token_types: &toks,
+        };
+
+        let error = translate_body("$xs", &ctx).expect_err("aliased terminal is the same child");
+        assert!(
+            error.to_string().contains("cannot translate $xs"),
+            "{error}"
+        );
     }
 
     /// A same-target ref in a *sibling* choice branch never coexists with the
@@ -1618,7 +1801,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: Some((7, branch)),
+            choice_branch: vec![(7, branch)],
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1656,7 +1839,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         sequential.alts.push(AltModel {
             label: None,
@@ -1693,7 +1876,7 @@ mod tests {
             is_list: true,
             cardinality: ChildCardinality { min: 1, max: None },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let token_ref = ElementRef {
             label: None,
@@ -1706,7 +1889,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let mut statement = rule("s");
         for (index, refs) in [
@@ -1757,7 +1940,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         let translate = |second: Vec<ElementRef>| {
             let mut statement = rule("s");
@@ -1815,7 +1998,7 @@ mod tests {
                 max: Some(1),
             },
             stable_accessor: true,
-            choice_branch: None,
+            choice_branch: Vec::new(),
         };
         statement.alts.push(AltModel {
             label: None,
@@ -1893,7 +2076,7 @@ mod tests {
                     is_list: true,
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
                 ElementRef {
                     label: Some("ids".to_owned()),
@@ -1903,7 +2086,7 @@ mod tests {
                     is_list: true,
                     cardinality: ChildCardinality { min: 1, max: None },
                     stable_accessor: true,
-                    choice_branch: None,
+                    choice_branch: Vec::new(),
                 },
             ],
             children: BTreeMap::new(),

--- a/src/snapshots/antlr4_runtime__tree__tests__terminal_children_raw_vs_labeled.snap
+++ b/src/snapshots/antlr4_runtime__tree__tests__terminal_children_raw_vs_labeled.snap
@@ -1,0 +1,15 @@
+---
+source: src/tree.rs
+expression: "(raw, labeled)"
+---
+(
+    [
+        "x",
+        "<missing B>",
+        "c",
+    ],
+    [
+        "<missing B>",
+        "c",
+    ],
+)

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1163,6 +1163,35 @@ impl ParserRuleContext {
             })
     }
 
+    /// Terminal children as a *grammar-positional* sequence: deleted input tokens
+    /// are skipped while inserted missing tokens are kept.
+    ///
+    /// A generated label read derives its index from the grammar, which knows
+    /// nothing about error recovery. A deleted token still occupies a child slot, so
+    /// indexing [`Self::terminal_children`] would shift every later position on
+    /// recovered input; an *inserted* token, by contrast, is the value ANTLR assigns
+    /// to the label and must stay. This matches the labeled-token accessors the
+    /// generator emits.
+    pub fn labeled_terminal_children<'a>(
+        &'a self,
+        storage: &'a ParseTreeStorage,
+        tokens: &'a TokenStore,
+    ) -> impl Iterator<Item = TerminalNodeView<'a>> + 'a {
+        self.child_nodes(storage, tokens)
+            .filter_map(|child| match child.kind() {
+                NodeKind::Terminal => child.as_terminal(),
+                NodeKind::Error => {
+                    let terminal = child.as_error().map(ErrorNodeView::terminal)?;
+                    let symbol = terminal.symbol();
+                    // Inserted missing tokens carry ANTLR's synthetic -1:-1 span;
+                    // deleted input tokens retain real source boundaries.
+                    (symbol.start() == usize::MAX && symbol.stop() == usize::MAX)
+                        .then_some(terminal)
+                }
+                NodeKind::Rule => None,
+            })
+    }
+
     #[must_use]
     pub fn text(&self, storage: &ParseTreeStorage, tokens: &TokenStore) -> String {
         self.child_nodes(storage, tokens).map(Node::text).collect()
@@ -1486,6 +1515,7 @@ fn stored_token_id(raw: u32) -> TokenId {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // insta assertion macros unwrap internal I/O.
 mod tests {
     use super::*;
     use crate::token::TokenSpec;
@@ -1518,6 +1548,41 @@ mod tests {
             parsed.tree().to_string_tree_with_names(&["root"]),
             "(root a b)"
         );
+    }
+
+    #[test]
+    fn labeled_terminal_children_keep_inserted_tokens_and_skip_deleted_ones() {
+        let mut tokens = TokenStore::new(None, "");
+        let deleted = token(&mut tokens, 1, "x");
+        let inserted = tokens
+            .push(
+                TokenSpec::explicit(2, "<missing B>")
+                    .with_span(usize::MAX, usize::MAX)
+                    .with_byte_span(0, 0),
+            )
+            .expect("test token should fit");
+        let kept = token(&mut tokens, 3, "c");
+        let mut storage = ParseTreeStorage::new();
+        let deleted = storage.error(deleted);
+        let inserted = storage.error(inserted);
+        let kept = storage.terminal(kept);
+        let mut context = ParserRuleContext::new(0, -1);
+        storage.add_child(&mut context, deleted);
+        storage.add_child(&mut context, inserted);
+        storage.add_child(&mut context, kept);
+
+        // `terminal_children` is the raw CST view: every error node counts, so a
+        // deleted token shifts the positions a grammar-derived index relies on.
+        let raw = context
+            .terminal_children(&storage, &tokens)
+            .map(|terminal| terminal.text().to_owned())
+            .collect::<Vec<_>>();
+        let labeled = context
+            .labeled_terminal_children(&storage, &tokens)
+            .map(|terminal| terminal.text().to_owned())
+            .collect::<Vec<_>>();
+
+        insta::assert_debug_snapshot!("terminal_children_raw_vs_labeled", (raw, labeled));
     }
 
     #[test]

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -914,10 +914,19 @@ mod multi_alternative_label_tests {
     use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
 
     fn parse(input: &str) -> antlr4_runtime::ParsedFile {
+        parse_rule(input, TParser::expr)
+    }
+
+    fn parse_rule(
+        input: &str,
+        entry: impl FnOnce(
+            &mut TParser<TLexer<antlr4_runtime::InputStream>>,
+        ) -> Result<antlr4_runtime::NodeId, antlr4_runtime::AntlrError>,
+    ) -> antlr4_runtime::ParsedFile {
         let lexer = TLexer::new(InputStream::new(input));
         let tokens = CommonTokenStream::new(lexer);
         let mut parser = TParser::new(tokens);
-        let root = parser.expr().expect("input should parse");
+        let root = entry(&mut parser).expect("input should parse");
         assert_eq!(parser.number_of_syntax_errors(), 0);
         parser.into_parsed_file(root)
     }
@@ -950,6 +959,78 @@ mod multi_alternative_label_tests {
 
         let leaf = product.calc_children().next().expect("leaf calc");
         assert!(leaf.op().is_none(), "primary alternative carries no operator");
+    }
+
+    // Issue #201: labels nested inside an unlabeled grouping block reach the
+    // typed surface, and reading them agrees with the parsed text.
+    #[test]
+    fn labels_inside_grouping_blocks_read_their_own_children() {
+        let parsed = parse_rule("doc in a, b 7", TParser::grouped);
+        let grouped = parsed
+            .tree()
+            .as_rule()
+            .expect("grouped rule")
+            .downcast_ref::<GroupedContext>()
+            .expect("typed grouped context");
+        assert_eq!(grouped.doc().expect("doc token").to_string(), "doc");
+        assert!(
+            grouped.oneway().is_none(),
+            "the throws branch carries no oneway token"
+        );
+        assert_eq!(
+            grouped
+                .errors()
+                .map(|error| error.text())
+                .collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+
+        // The other branch of the same block, and both optionals absent.
+        let parsed = parse_rule("* 7", TParser::grouped);
+        let grouped = parsed
+            .tree()
+            .as_rule()
+            .expect("grouped rule")
+            .downcast_ref::<GroupedContext>()
+            .expect("typed grouped context");
+        assert!(grouped.doc().is_none(), "absent optional reads as None");
+        assert_eq!(grouped.oneway().expect("oneway token").to_string(), "*");
+        assert_eq!(grouped.errors().count(), 0);
+    }
+
+    // Issue #201: a single and a list label on the same rule must each resolve
+    // past the other's children rather than by caller-side positional guessing.
+    #[test]
+    fn single_and_list_labels_on_one_rule_stay_disjoint() {
+        let parsed = parse_rule("f ( x y ) in a, b", TParser::mixed);
+        let mixed = parsed
+            .tree()
+            .as_rule()
+            .expect("mixed rule")
+            .downcast_ref::<MixedContext>()
+            .expect("typed mixed context");
+        assert_eq!(mixed.name().expect("name label").text(), "f");
+        assert_eq!(
+            mixed.errors().map(|error| error.text()).collect::<Vec<_>>(),
+            ["a", "b"]
+        );
+        // `name` is the sole unary outside the throws list, so the list accessor
+        // must not include it and the two must partition `unary_children`.
+        assert_eq!(mixed.unary_children().count(), 3);
+
+        let parsed = parse_rule("f ( ) ", TParser::mixed);
+        let mixed = parsed
+            .tree()
+            .as_rule()
+            .expect("mixed rule")
+            .downcast_ref::<MixedContext>()
+            .expect("typed mixed context");
+        assert_eq!(mixed.name().expect("name label").text(), "f");
+        assert_eq!(
+            mixed.errors().count(),
+            0,
+            "the absent throws clause contributes no errors"
+        );
     }
 }
 "#,

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ActionAfterNestedChoice.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ActionAfterNestedChoice.g4
@@ -1,0 +1,3 @@
+grammar ActionAfterNestedChoice;
+r : (A | xs+=A) { let _: Vec<_> = $xs.collect(); } EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ActionInCollapsibleChoice.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ActionInCollapsibleChoice.g4
@@ -1,0 +1,3 @@
+grammar ActionInCollapsibleChoice;
+r : x=A? (A | B { println!("{}", $x.text); }) EOF ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ActionInsideTakenGroup.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ActionInsideTakenGroup.g4
@@ -1,0 +1,3 @@
+grammar ActionInsideTakenGroup;
+r : (A x=A { println!("{}", $x.text); })? EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ActionOnlyBranch.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ActionOnlyBranch.g4
@@ -1,0 +1,3 @@
+grammar ActionOnlyBranch;
+r : x=A? (A | { println!("{}", $x.text); }) EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/AliasDeclarationsInChoice.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/AliasDeclarationsInChoice.g4
@@ -1,0 +1,5 @@
+grammar AliasDeclarationsInChoice;
+r
+@after { println!("{}", $x.text); }
+  : (x=A | x='a') EOF ;
+A : 'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/AliasDifferingOccurrenceInAlt.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/AliasDifferingOccurrenceInAlt.g4
@@ -1,0 +1,5 @@
+grammar AliasDifferingOccurrenceInAlt;
+r
+@after { println!("{}", $x.text); }
+  : A x='a' B | A x=A C ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ChoicePrefixOutsideLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ChoicePrefixOutsideLabel.g4
@@ -1,0 +1,3 @@
+grammar ChoicePrefixOutsideLabel;
+r : (A B | A C) x=A { println!("{}", $x.text); } ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ClosedRepeatedGroupPrefix.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ClosedRepeatedGroupPrefix.g4
@@ -1,0 +1,3 @@
+grammar ClosedRepeatedGroupPrefix;
+r : ((A B)+ x=A { println!("{}", $x.text); })? EOF ;
+A : [ac]; B : 'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/CollapsedBlockIsTerminal.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/CollapsedBlockIsTerminal.g4
@@ -1,0 +1,5 @@
+grammar CollapsedBlockIsTerminal;
+r
+@after { println!("{}", $x.text); }
+  : (B) x=A | x='a' ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ConjuredLiteralLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ConjuredLiteralLabel.g4
@@ -1,0 +1,2 @@
+grammar ConjuredLiteralLabel;
+a : 'a' x='b' { println!("conjured={}", $x); } 'c' ;

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/DeclarationsDifferingOccurrence.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/DeclarationsDifferingOccurrence.g4
@@ -1,0 +1,3 @@
+grammar DeclarationsDifferingOccurrence;
+r : (A x=A B | x=A C) { println!("{}", $x.text); } ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/DeclarationsDifferingRepetition.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/DeclarationsDifferingRepetition.g4
@@ -1,0 +1,3 @@
+grammar DeclarationsDifferingRepetition;
+r : (x=A B | x=A+ C) { println!("{}", $x.text); } ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ExhaustiveChoicePrefix.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ExhaustiveChoicePrefix.g4
@@ -1,0 +1,3 @@
+grammar ExhaustiveChoicePrefix;
+r : (a=A | b=A) x=A EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ExhaustiveInnerChoiceInAction.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ExhaustiveInnerChoiceInAction.g4
@@ -1,0 +1,4 @@
+grammar ExhaustiveInnerChoiceInAction;
+r : (((y=A | z=A) x=A {System.out.println($x.text);}) | C) EOF;
+A : 'a';
+C : 'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ExpandedBlockTerminalState.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ExpandedBlockTerminalState.g4
@@ -1,0 +1,5 @@
+grammar ExpandedBlockTerminalState;
+r @after {System.out.println($x.text);} : (B y=C? | ) x=A | x='a';
+A : 'a';
+B : 'b';
+C : 'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/FallbackReadSiblingAlternative.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/FallbackReadSiblingAlternative.g4
@@ -1,0 +1,5 @@
+grammar FallbackReadSiblingAlternative;
+r
+@after { println!("{}", $x.text); }
+  : A? ((x=(B|C))) | D ;
+A:'a'; B:'b'; C:'c'; D:'d';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ForwardBlockLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ForwardBlockLabel.g4
@@ -1,0 +1,3 @@
+grammar ForwardBlockLabel;
+r : A { println!("{}", $x.text); } B? x=(C|D) EOF ;
+A:'a'; B:'b'; C:'c'; D:'d';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/IdenticalDeclarationsInChoice.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/IdenticalDeclarationsInChoice.g4
@@ -1,0 +1,3 @@
+grammar IdenticalDeclarationsInChoice;
+r : (x=A | x=A) { println!("{}", $x.text); } EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/InitActionBeforeChildren.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/InitActionBeforeChildren.g4
@@ -1,0 +1,5 @@
+grammar InitActionBeforeChildren;
+r
+@init { let _: Vec<_> = $xs.collect(); }
+  : xs+=A A ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/InitScalarRuleLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/InitScalarRuleLabel.g4
@@ -1,0 +1,6 @@
+grammar InitScalarRuleLabel;
+r
+@init { let _ = $x.ctx; }
+  : x=q EOF ;
+q : A ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/InlineActionBeforeLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/InlineActionBeforeLabel.g4
@@ -1,0 +1,3 @@
+grammar InlineActionBeforeLabel;
+r : { println!("{}", $x.text); } A* x=A EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/InnerChoiceArityInAction.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/InnerChoiceArityInAction.g4
@@ -1,0 +1,5 @@
+grammar InnerChoiceArityInAction;
+r : (((y=A | z=A | B) x=A {System.out.println($x.text);}) | C) EOF;
+A : 'a';
+B : 'b';
+C : 'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/InnerGroupClosedBeforeAction.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/InnerGroupClosedBeforeAction.g4
@@ -1,0 +1,4 @@
+grammar InnerGroupClosedBeforeAction;
+r : ((q)? x=q { println!("{}", $x.text); })? EOF ;
+q : A ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ListAliasAcrossModes.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ListAliasAcrossModes.g4
@@ -1,0 +1,3 @@
+grammar ListAliasAcrossModes;
+r @after { let _: Vec<_> = $xs.collect(); } : xs+=A | xs+='a';
+A : 'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ListAliasDeclarations.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ListAliasDeclarations.g4
@@ -1,0 +1,3 @@
+grammar ListAliasDeclarations;
+r : (xs+=A B | xs+='a' C) { let _: Vec<_> = $xs.collect(); } ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ListDeclarationsDifferingStart.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ListDeclarationsDifferingStart.g4
@@ -1,0 +1,3 @@
+grammar ListDeclarationsDifferingStart;
+r : (A xs+=A | xs+=A) EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ListLabelWithoutIterator.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ListLabelWithoutIterator.g4
@@ -1,0 +1,4 @@
+grammar ListLabelWithoutIterator;
+r @after { let _: Vec<_> = $xs.collect(); } : xs+='a' | B xs+='a';
+A : 'a';
+B : 'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ListPrefixRepeatsWithLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ListPrefixRepeatsWithLabel.g4
@@ -1,0 +1,3 @@
+grammar ListPrefixRepeatsWithLabel;
+r : (A xs+=A)+ EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/LiteralAliasDifferingOccurrence.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/LiteralAliasDifferingOccurrence.g4
@@ -1,0 +1,5 @@
+grammar LiteralAliasDifferingOccurrence;
+r
+@after { println!("{}", $x.text); }
+  : B x='a' | C A x=A ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/LiteralAliasSameOccurrence.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/LiteralAliasSameOccurrence.g4
@@ -1,0 +1,5 @@
+grammar LiteralAliasSameOccurrence;
+r
+@after { println!("{}", $x.text); }
+  : x=A | x='a' ;
+A : 'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/MandatoryInnerGroupClosed.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/MandatoryInnerGroupClosed.g4
@@ -1,0 +1,4 @@
+grammar MandatoryInnerGroupClosed;
+r : ((q) x=q { println!("{}", $x.text); })? EOF ;
+q : A ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/MergedDeclarationOptionalFollower.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/MergedDeclarationOptionalFollower.g4
@@ -1,0 +1,3 @@
+grammar MergedDeclarationOptionalFollower;
+r : (x=A? B | x=B) EOF ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/MixedModeLeadingTerminal.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/MixedModeLeadingTerminal.g4
@@ -1,0 +1,5 @@
+grammar MixedModeLeadingTerminal;
+r
+@after { println!("{}", $x.text); }
+  : B x=A | x='a' ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/NestedChoiceInsideConfinedBranch.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/NestedChoiceInsideConfinedBranch.g4
@@ -1,0 +1,3 @@
+grammar NestedChoiceInsideConfinedBranch;
+r : ((a=A | b=B) x=(C | D) { println!("{}", $x.text); } | E) EOF ;
+A:'a'; B:'b'; C:'c'; D:'d'; E:'e';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/NestedChoiceSatisfiability.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/NestedChoiceSatisfiability.g4
@@ -1,0 +1,8 @@
+grammar NestedChoiceSatisfiability;
+r
+@after { println!("{}", $x.text); }
+  : q x=q | ((q|b)|(q|c)) ;
+q : A ;
+b : B ;
+c : C ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/NotSetLabelBeforeTerminal.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/NotSetLabelBeforeTerminal.g4
@@ -1,0 +1,3 @@
+grammar NotSetLabelBeforeTerminal;
+a : t=~'x' 'z' { println!("{}", $t.text); } ;
+X : 'x' ; Z : 'z' ;

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/OptionalBlockFollowedByTerminal.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/OptionalBlockFollowedByTerminal.g4
@@ -1,0 +1,3 @@
+grammar OptionalBlockFollowedByTerminal;
+r : x=(A | B)? C { println!("{}", $x.text); } EOF ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/OptionalGroupSharedWithLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/OptionalGroupSharedWithLabel.g4
@@ -1,0 +1,3 @@
+grammar OptionalGroupSharedWithLabel;
+r : (A x=A)? EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/PrecedingSiblingBranch.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/PrecedingSiblingBranch.g4
@@ -1,0 +1,3 @@
+grammar PrecedingSiblingBranch;
+r : (A | x=A) {System.out.println($x.text);} EOF;
+A : 'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/ReassignedAfterAction.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/ReassignedAfterAction.g4
@@ -1,0 +1,3 @@
+grammar ReassignedAfterAction;
+r : x=A { println!("{}", $x.text); } x=A EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/RecoveredDeletedTokenIndex.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/RecoveredDeletedTokenIndex.g4
@@ -1,0 +1,3 @@
+grammar RecoveredDeletedTokenIndex;
+r : D A x=(B | C) { println!("{}", $x.text); } EOF ;
+A:'a'; B:'b'; C:'c'; D:'d'; X:'x';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedBlockLabel.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedBlockLabel.g4
@@ -1,0 +1,3 @@
+grammar RepeatedBlockLabel;
+r : x=(A | B)+ { println!("{}", $x.text); } EOF ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedMergeFollowedByMatch.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedMergeFollowedByMatch.g4
@@ -1,0 +1,3 @@
+grammar RepeatedMergeFollowedByMatch;
+r : (x=A A B | x=A+ C) EOF ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedScalarMerge.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedScalarMerge.g4
@@ -1,0 +1,3 @@
+grammar RepeatedScalarMerge;
+r : (x=A+ | x=B+) EOF ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedSiblingSpansIndex.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/RepeatedSiblingSpansIndex.g4
@@ -1,0 +1,5 @@
+grammar RepeatedSiblingSpansIndex;
+r
+@after { println!("{}", $x.text); }
+  : C x=(A | B) | (D | E)+ ;
+A:'a'; B:'b'; C:'c'; D:'d'; E:'e';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/SiblingBranchShorterThanOccurrence.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/SiblingBranchShorterThanOccurrence.g4
@@ -1,0 +1,3 @@
+grammar SiblingBranchShorterThanOccurrence;
+r : (A | A A x=A) EOF ;
+A:'a';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/SiblingDeclarationIrrelevant.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/SiblingDeclarationIrrelevant.g4
@@ -1,0 +1,3 @@
+grammar SiblingDeclarationIrrelevant;
+r : (x=A { println!("{}", $x.text); } | x=A+ B) EOF ;
+A:'a'; B:'b';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/SiblingUnlabeledSameTarget.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/SiblingUnlabeledSameTarget.g4
@@ -1,0 +1,3 @@
+grammar SiblingUnlabeledSameTarget;
+r : (B | C x=A? A { println!("{}", $x.text); }) EOF ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/label-resolution/UnrelatedLaterChoiceConfinement.g4
+++ b/tests/fixtures/antlr4-rust-gen/label-resolution/UnrelatedLaterChoiceConfinement.g4
@@ -1,0 +1,3 @@
+grammar UnrelatedLaterChoiceConfinement;
+r : ({false}? x=A | A) (B { println!("{}", $x.text); } | C) EOF ;
+A:'a'; B:'b'; C:'c';

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -72,6 +72,13 @@ exhaustive_prefix
     : (first = unary | second = unary) pick = unary NUM
     ;
 
+// Nested exhaustive choices: every path still yields exactly one `unary` before
+// the label, so the inner choice's agreed count rolls up into the outer branch
+// and the accessor survives.
+nested_exhaustive_prefix
+    : ((one = unary | two = unary) | three = unary) chosen = unary NUM
+    ;
+
 // The same choice made *optional*: it may now contribute no `unary` at all, so
 // the following label has no fixed position and loses its accessor. Only the
 // branch-local cardinality separates this from `exhaustive_prefix` above.

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -120,6 +120,23 @@ nested_group
     : ((deep = IDENT))? NUM
     ;
 
+// The outer `?` is satisfied wherever the label binds, but the *inner* `+` is a
+// closed repeated group: it ran an unknown number of times, so the count of
+// matching children ahead of the label is not fixed and the accessor must go.
+// Only the repeated-group carve-out separates this from `nested_group`'s
+// all-shared-groups case.
+closed_repeat_prefix
+    : ((IDENT STAR)+ tail = IDENT)? NUM
+    ;
+
+// Restricting to the label's path drops the *outer* choice, so the surviving
+// inner choice must be read with its own arity of three. Treating it as an
+// exhaustive two-way choice would fix the prefix count at one and emit
+// `.nth(1)`, which reads nothing on the `param` path.
+inner_choice_arity
+    : ((unary | unary | param) tail = unary | NUM) NUM
+    ;
+
 LESS
     : '<'
     ;

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -27,6 +27,45 @@ unary
     | NUM
     ;
 
+// Issue #201, shape 1: the labels sit *inside* an unlabeled grouping block, so
+// collapsing the block into one token-group ref would swallow them. Mirrors
+// avdl's `(doc=DocComment)?` and `(oneway=Oneway | Throws errors+=...)?`.
+grouped
+    : (doc = IDENT)? (oneway = STAR | IN errors += unary (COMMA errors += unary)*)? NUM
+    ;
+
+// Issue #201, shape 2: `name` and `errors` label the same rule, mixing a single
+// and a list label, so each accessor must resolve past the other's children.
+// Mirrors avdl's `messageDeclaration`; `param` stands in for its
+// `formalParameter`, keeping the `unary` count before `errors` exact.
+mixed
+    : name = unary LPAREN param* RPAREN (IN errors += unary (COMMA errors += unary)*)?
+    ;
+
+// A variable count of the label's own target in front of it leaves no fixed
+// `.skip(N)`, so the list accessor must be declined even though the labels
+// themselves are unambiguous.
+mixed_unbounded
+    : unary* IN errors += unary
+    ;
+
+param
+    : IDENT
+    ;
+
+// Only one branch of the choice supplies `pick`, and its sibling branch matches
+// the same rule unlabeled at the same flattened position — `.nth(0)` could read
+// the sibling's child, so no accessor may be emitted.
+branch_hazard
+    : (pick = unary | STAR unary) NUM
+    ;
+
+// Same target labeled differently per branch: neither label may read the
+// other branch's child.
+branch_rival
+    : (left = unary | right = unary) NUM
+    ;
+
 LESS
     : '<'
     ;
@@ -81,6 +120,20 @@ IDENT
 
 NUM
     : [0-9]+
+    ;
+
+// Declared last so the issue #201 rules above do not renumber the token types
+// the pre-existing context snapshots pin.
+COMMA
+    : ','
+    ;
+
+LPAREN
+    : '('
+    ;
+
+RPAREN
+    : ')'
     ;
 
 WS

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -72,6 +72,12 @@ exhaustive_prefix
     : (first = unary | second = unary) pick = unary NUM
     ;
 
+// A repeated scalar label over mutually exclusive branches: ANTLR overwrites a
+// scalar on every iteration, so the merged read must select the *last* match.
+merged_repeats
+    : (last_pick = IDENT+ | last_pick = NUM+) NUM
+    ;
+
 // One label declared over mutually exclusive branches at the same occurrence: the
 // accessor's unioned token set selects whichever token the parse bound, so a
 // single positional read serves both.

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -72,6 +72,19 @@ exhaustive_prefix
     : (first = unary | second = unary) pick = unary NUM
     ;
 
+// One label declared over mutually exclusive branches at the same occurrence: the
+// accessor's unioned token set selects whichever token the parse bound, so a
+// single positional read serves both.
+merged_rivals
+    : (pick = IDENT | pick = NUM) NUM
+    ;
+
+// A label behind a sibling branch: restricting to the label's own path leaves one
+// preceding `unary`, so the accessor is emitted at that fixed position.
+path_restricted
+    : (unary tail = unary | NUM) NUM
+    ;
+
 // Nested exhaustive choices: every path still yields exactly one `unary` before
 // the label, so the inner choice's agreed count rolls up into the outer branch
 // and the accessor survives.

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -72,6 +72,13 @@ exhaustive_prefix
     : (first = unary | second = unary) pick = unary NUM
     ;
 
+// The same choice made *optional*: it may now contribute no `unary` at all, so
+// the following label has no fixed position and loses its accessor. Only the
+// branch-local cardinality separates this from `exhaustive_prefix` above.
+optional_prefix
+    : (early = unary | late = unary)? tail = unary NUM
+    ;
+
 // A preceding token group overlaps the label's token type, so only some parses
 // put a matching child ahead of it — no fixed occurrence, so no accessor.
 overlapping_group

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -73,9 +73,12 @@ exhaustive_prefix
     ;
 
 // A repeated scalar label over mutually exclusive branches: ANTLR overwrites a
-// scalar on every iteration, so the merged read must select the *last* match.
+// scalar on every iteration, so the merged read must select the *last* match. The
+// trailing `LPAREN` is outside the accessor's token union, so nothing can become
+// the `last()` ahead of the label — with a trailing `NUM` it could, and the merge
+// would have to decline.
 merged_repeats
-    : (last_pick = IDENT+ | last_pick = NUM+) NUM
+    : (last_pick = IDENT+ | last_pick = NUM+) LPAREN
     ;
 
 // One label declared over mutually exclusive branches at the same occurrence: the

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -66,6 +66,12 @@ branch_rival
     : (left = unary | right = unary) NUM
     ;
 
+// Extra grouping levels are syntactically inert, so a label buried under them
+// must still defeat the token-group collapse that would discard it.
+nested_group
+    : ((deep = IDENT))? NUM
+    ;
+
 LESS
     : '<'
     ;

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -66,6 +66,18 @@ branch_rival
     : (left = unary | right = unary) NUM
     ;
 
+// An *exhaustive* choice contributes exactly one `unary` however it branches, so
+// the following label is reliably the second one and keeps its accessor.
+exhaustive_prefix
+    : (first = unary | second = unary) pick = unary NUM
+    ;
+
+// A preceding token group overlaps the label's token type, so only some parses
+// put a matching child ahead of it — no fixed occurrence, so no accessor.
+overlapping_group
+    : (IDENT | NUM) tail = IDENT
+    ;
+
 // Extra grouping levels are syntactically inert, so a label buried under them
 // must still defeat the token-group collapse that would discard it.
 nested_group


### PR DESCRIPTION
Fixes #201. Closes #233.

## What the issue asked for vs. what was actually broken

The issue's two headline examples **already worked** at HEAD — PR #211 landed both
`primitiveType.typeName()` and `messageDeclaration.name()`. Checking the real
`Idl.g4` before writing any code is what found the actual gap: **20 labels across
12 rules** get no accessor, and neither of the issue's proposed fixes addresses
them, because the defects are in the **structural ref model**
(`collect_structural_context_refs_with_cardinality`), not in the accessor
derivation (`context_label_accessor`) the issue points at.

### Cause 1 — group collapse swallowed labels sitting *inside* the block

A token-only block collapses into a single group ref. That collapse is what makes
`x=(A | B)` yield one labeled token child, so it has to stay. But it also fired
when the block was **unlabeled** and the labels sat *inside* it:

```antlr
messageDeclaration: (doc=DocComment)? ... (oneway=Oneway | Throws errors+=identifier ...)? ;
```

Here the collapse produced one ref carrying the *block's* label (`None`) and
`continue`d — never descending, so `doc`, `oneway` and `errors` were simply
dropped. Collapse now requires the label to be on the group itself; otherwise we
descend and let the inner refs carry their own labels.

### Cause 2 — `stable_accessor` was masking a dishonest cardinality

Refs inside a multi-alternative block were blanket-marked `stable_accessor: false`
while still carrying `min: 1` — i.e. the model claimed a child is *always* present
when only the taken branch supplies it. The flag papered over the lie instead of
correcting it.

Branch refs now report `min: 0`. That makes a sibling alternative matching the
same target read as **inexact**, so the pre-existing occurrence-lookup guards
(`exact_target_cardinality`) reject exactly the layouts where positional access
could resolve to another branch's child — no new guard logic needed. This is what
lets `name=identifier` and `errors+=identifier` coexist on one rule:

```rust
pub fn name(&self)   -> Result<IdentifierContext<'a>, MissingChildError> { ... .nth(0) ... }
pub fn errors(&self) -> impl Iterator<Item = IdentifierContext<'a>> + '_  { ... .skip(1) ... }
```

### Follow-ups from review — the same honesty applied to action translation

Making branch refs inexact exposed a latent flaw one layer over, in
`TranslationCtx::resolve_label`. That function derives a positional CST index by
counting same-target refs ahead of a label, and several shapes make that count
meaningless. **~50 reviewer findings across ~25 rounds** (Codex and CodeRabbit),
each verified against the parent commit to separate regressions this PR
introduced from pre-existing gaps it exposed:

| Shape | Before | Regression? | Now |
| --- | --- | --- | --- |
| `r : (B \| x=B) {$x}` | `nth(1)` on a 1-child CST | **yes** | errors loudly |
| `r : ((x=A))? EOF` | no `x()` accessor | no | `x()` emitted |
| `r : (A \| B)? x=(C \| D) {$x}` | `cannot translate $x` | **yes** | generates again |
| `r : ({false}? x=A)? A {$x}` | `nth(0)` reads the mandatory `A` | **yes** | errors loudly |
| `r : errors+=u name=u {$name}` | `nth(0)` reads an `errors` child | **yes** | `nth(1)` |
| `r : errors+=u+ name=u {$name}` | wrong `nth()`, silently | no | errors loudly |
| `r : name=e ... errors+=e {$errors}` | read folds in `name`'s child | no | errors loudly |
| `r : (x=A \| x=B) {$x}` | searches for `A` on the `B` branch | **yes** | errors loudly |
| `r : x=A \| x=B` + `@after {$x}` | `A` lookup, defaults on `B` | no | errors loudly |
| `r : (xs+=(A \| B))+ {$xs}` | `.last()…collect()` — **does not compile** | **yes** | errors loudly |
| `r : (x=A)+ {$x}` | `nth(0)` pins the first, not the latest | **yes** | errors loudly |
| `r : (x=A {$x} B \| A C)` | `cannot translate $x` | **yes** | translates again |
| `r : x=(A \| B) \| x=(C \| D)` + `@after` | `cannot translate $x` | **yes** | translates again |
| `r : x=A \| A` + `@after {$x}` | reads the unlabeled `A` | no | errors loudly |
| `r : xs+=A xs+=B {$xs}` | iterates `A`, drops every `B` | no | errors loudly |
| `r : ({false}? x=A)? A? {$x}` | reads the follower's token as `x` | **yes** | errors loudly |
| `r : ((x=e {$x} \| f) \| e)` | `cannot translate $x` | **yes** | translates again |
| `r @after {$x} : (x=A \| A) EOF` | reads the sibling branch's `A` | **yes** | errors loudly |
| `r : (xs+=A)? 'a' {$xs}` (`A : 'a';`) | iterates the literal as `xs` | **yes** | errors loudly |
| `r : xs+=A {$xs} A;` | `cannot translate $xs` | **yes** | translates again |
| `r : (x=A e {$x} \| x=A f {$x})` | `cannot translate $x` | **yes** | translates again |
| `r @after {$x} : x=A \| x='a';` | `cannot translate $x` | **yes** | translates again |
| `r : (x=A \| A) {$x} EOF;` | reads the sibling branch's `A` | **yes** | errors loudly |
| `r : (a=A \| b=A) x=A EOF;` | `x()` accessor dropped | **yes** | `x()` emitted |
| `r : (A \| B) x=A {$x}` | reads the group's token | no | errors loudly |
| `r : (e \| xs+=e {$xs}) EOF;` | `cannot translate $xs` | **yes** | translates again |
| `r : ((x=(A \| B))) A {$x}` | `last()` reads the trailing `A` | no | reads `nth(0)` |
| `t=~'x' 'z' {$t.text}` on `yz` | `last()` reads `z` | no | reads `y` |
| `r : (A \| xs+=A) {$xs} EOF;` | reports the sibling's token | **yes** | errors loudly |
| `r @init {$xs} : xs+=A A;` | `cannot translate $xs` | **yes** | translates again |
| `((a=A \| b=B) C \| D) x=(E \| F) {$x}` | `nth(2)`, wrong on `D E` | **yes** | falls back to `last()` |
| `r @after {$x} : (x='a') \| B;` | reports `b` as `x` | **yes** | errors loudly |
| `r : (x=A \| x=B) EOF;` | `x()` dropped | **yes** | `x()` emitted (merged read) |
| `r : (A x=A \| B) EOF;` | `x()` dropped | **yes** | `x()` emitted |
| `r : (A x=A {$x} \| B) EOF;` | `cannot translate $x` | **yes** | translates again |
| `r : (a=A \| ) x=A EOF;` | `x()` at `nth(1)`, misses empty branch | **yes** | `x()` dropped |
| `r @after {$x} : A x=A \| (A B? \| A C?);` | `cannot translate $x` | **yes** | translates again |
| `r @after {$x} : (B) x=A \| x='a';` | mixed-mode merge on a false leading flag | **yes** | errors loudly |
| `r : ({false}? x=A \| A) (B {$x} \| C)` | sibling exempted by an unrelated choice | **yes** | errors loudly |
| `r : D A x=(B \| C) {$x}` on `dxab` | recovery shifts the index, reads `x` | **yes** | reads `b` |
| `r : ((A B)+ x=A)? EOF;` | `x()` at `nth(1)`, ignores the closed `+` | **yes** | `x()` dropped |
| `r : ((q \| q \| b) x=q \| c) EOF;` | inner arity read as the outer's | **yes** | `x()` dropped |
| `r : (A \| x=A) {$x}` | reads the *preceding* sibling branch | **yes** | errors loudly |
| `r : (B y=C? \| ) x=A \| x='a';` | expanded block reported no terminal | **yes** | errors loudly |
| `r @after {$xs…collect()} : xs+=A \| xs+='a';` | `.collect()` on a `String` — **does not compile** | **yes** | errors loudly |
| `r @after {$xs…collect()} : xs+='a' \| B xs+='a';` | same broken `.collect()` | no | errors loudly |
| `(((y=A \| z=A \| B) x=A {$x}) \| C)` | `nth(0)`/`nth(1)`, wrong on `ba` | no | errors loudly |

The unifying fix is that `resolve_label` now carries the running occurrence as
`Option<usize>` and stops guessing when the position isn't fixed:

* refs with **inexact cardinality** poison the bucket — that covers both
  mutually-exclusive branch refs and unbounded list runs, without special-casing
  either;
* **empty-target** refs (token groups, wildcards) stay out of the buckets
  entirely, since their reads take the last terminal child and never consult an
  index — sharing one `""` bucket was what made unrelated groups interfere;
* **optional** labels are rejected when a following same-target child *can
  coexist* with them and slide into their position. Cardinality cannot express
  this: a sequential optional follower may consume the label's only token, while a
  sibling-branch ref reports the same `min: 0` yet never coexists. `ElementRef`
  therefore carries `choice_branch: (choice id, branch index)`, so
  `can_coexist_with` answers it structurally instead of by inference. The tag is
  the full choice *ancestry*, and the exclusion applies only to mid-rule bodies —
  an `@after` body runs whichever branch the parse took, so a sibling match really
  can be the child present when its read executes;
* the **action's enclosing branch** comes from `choice_spans` — the byte extent of
  each enclosing choice block — because ref order cannot distinguish an action
  *after* a group from one *inside* its last branch;
* **`@init`** runs before any child exists, so no child-based hazard applies;
* child counting is **one shared routine** (`exact_child_count`) that folds nested
  choices innermost-first and takes an explicit `restricted_to_one_path` flag —
  filtering to a path and demanding cross-branch agreement are contradictory;
* **token-backed** comparisons overlap `token_types` rather than matching source
  spelling, since the read queries by type (`A : 'a';` makes `A` and `'a'` one
  child) — the same rule the typed-accessor path already uses;
* reads the translator **cannot express** (a list over a token group has no target
  to iterate; a repeated single label has no last-occurrence read) stay unresolved
  instead of falling through to a different read — one of them was emitting Rust
  that does not compile.

Roughly a third end up *better than the parent commit* rather than merely
restored — the unbounded-list, list-sharing-a-target, nested-grouping,
inner-choice-arity, and literal-list cases were already wrong before this PR, the
last of which generated Rust that does not compile.

Two further structural changes came out of the later rounds and are worth calling
out, because both replace a per-call-site convention with an enforced one:

* **`ElementRef::retain_choices`** — `choice_branch`, `choice_arity`,
  `choice_spans`, and `branch_spans` are indexed by position, so dropping a choice
  must drop the same position from all four. Three call sites instead `retain`ed
  one and `truncate`d the rest, which is equivalent only when the dropped entries
  form a *suffix* — and since ancestry is outermost-first while the dropped
  choices are the outer ones, it was wrong in the common case. The invariant now
  lives in one method.
* **`ParserRuleContext::labeled_terminal_children`** (new public runtime API) — a
  grammar-derived index knows nothing about error recovery. A *deleted* token
  occupies a child slot but corresponds to no grammar element, so counting it
  shifts every later position; an *inserted* token is the value ANTLR binds to the
  label and must stay. The new iterator keeps inserted and skips deleted,
  discriminating on the synthetic `-1:-1` span — the same rule #235's generated
  `__labeled_token_children` accessors already apply, so the two label surfaces
  now agree.

### Correction: the block-label case is fixed, and #233 is closed

An earlier revision of this description said a block label reading across an
intervening terminal was unfixable here, because deciding it needed element spans
that `ElementRef` did not carry. **That was wrong.**
`grammar::model::Element` has carried `span: SourceSpan` all along — it was simply
never propagated into `embedded::ElementRef`. Once threaded through, the action's
byte offset makes every remaining question in this area decidable, and the guesses
that stood in for it stopped trading one correct case for another.

The block-label read is now **positional**: `terminal_children().nth(i)` where `i`
is the number of terminals matched ahead of the block on the action's parse path.
`last()` survives only as the fallback when that count is not fixed. So
`((x=(A | B))) C {$x}` reads the token the label bound, and
`t=~'x' 'z' {$t.text}` still works — the two are distinguished rather than traded.

Worth noting how invisible the original bug was: the upstream descriptors use
input `zz`, so both tokens are `z` and `last()` passed by luck. I confirmed it
with `a : t=~'x' 'z' {$t.text}` on input **`yz`** — the action printed `z` before
and prints `y` now.

**Closes #233.**

## Design note: I did not take the issue's suggested approach

The issue floated "recording label ids on children in the tree, or deriving from
the alternative's shape at codegen." Recording label ids would grow **every**
node. Making the cardinality honest instead let the existing guards do the work:
both new shapes resolve with **zero runtime cost and zero new tree state**.

## Verification

| Check | Result |
| --- | --- |
| Accessor-set diff vs. parent commit — Avro IDL | **+20 gained, 0 lost** |
| Accessor-set diff vs. parent commit — Kotlin (151 contexts) | **byte-identical** |
| `antlr4-runtime-testsuite` conformance sweep | **357 / 357** |
| Unit tests / CLI integration tests | 780 / 38 pass |
| Kotlin parity (vs. `antlr4-python3-runtime` oracle) | 9 / 9 trees identical |
| JavaScript / TypeScript parity | 6 / 6 and 5 / 5 identical |
| `cargo clippy --locked --all-targets --all-features -- -D warnings` | clean |

The accessor-set diff is the check I'd weight most. I built the generator at the
parent commit in a scratch `git worktree`, generated the same grammars with both
binaries, and diffed the emitted `pub fn` set per context — proving nothing was
**lost** matters more than counting what was gained. Presence alone is not
evidence of correctness. Both figures were re-confirmed after **every** commit — 24 of them.

The 357/357 sweep also does real work for the `resolve_label` guard: it exercises
hundreds of embedded actions, so it demonstrates the guard rejects no *legitimate*
translation.

I also confirmed the new end-to-end tests actually *execute*: the generated-project
tests run under `cargo test` inside a temp crate, so I temporarily broke one
assertion and watched it fail. Without that they could have compiled-but-skipped
and looked green.

## Two things that looked like bugs but are correct

- **`doc` reads `None` on the unmodified `Idl.g4`.** `DocComment` is
  `-> channel(HIDDEN)`, so it never becomes a CST child — `None` is correct ANTLR
  behaviour. Verified against a de-hidden copy of the grammar, where `doc` reads
  `Some("/** hello doc */")`.
- **`mixed_unbounded` (`unary* IN errors+=unary`) still declines.** A variable
  count of the label's own target ahead of it leaves no fixed `.skip(N)`. Pinned
  as an explicit negative test so a future change can't silently start emitting an
  unsound accessor here.

## Tests added

Extended `tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4` with both
issue shapes plus five hazard shapes, and covered them at three levels:

- **Generator snapshots** pin the complete generated surface of all six contexts —
  `grouped` and `mixed` (fixed shapes), `nested_group` (label under redundant
  grouping), and the three declines `mixed_unbounded`, `branch_hazard`, and
  `branch_rival`. The declines are snapshotted whole rather than probed with
  `!contains`, per the AGENTS.md guidance; reviewing the recorded output is how I
  confirmed they drop *only* the label accessor and keep the plain
  `unary_children()` / `num_token()` surface.
- **Runtime tests** (`tests/antlr4_rust_gen_cli.rs`) parse real input through the
  generated parser and assert the label reads agree with the text — including both
  branches of the choice and the all-optionals-absent case.
- **Action-translation unit tests** pin each `resolve_label` hazard separately,
  one per shape in the table above, including
  `list_refs_ahead_of_a_single_label_are_counted_then_poison_when_unbounded`
  (covering *both* the countable and the unbounded ordering).
- **A label-resolution corpus** (`tests/fixtures/antlr4-rust-gen/label-resolution/`,
  47 grammars) pins every outcome *with its reason*, as
  `(fixture, label, resolves, why)` rows in
  `label_resolution_corpus_matches_expected_outcomes`. This is the artefact I'd
  point a future maintainer at: it makes each decline a documented decision rather
  than an absence, and it caught two of my own over-corrections during the later
  rounds. I mutation-tested it by reverting one fix and confirming it named the
  case.

New rules and tokens are appended **after** the existing ones deliberately: adding
them mid-file renumbers rule/token indices and churns every pre-existing context
snapshot. That ordering keeps the snapshot diff to the two genuinely new files.

## Reviewer notes

- `src/bin/antlr4-rust-gen.rs` is the core change: ~15 lines in the block arm of
  `collect_structural_context_refs_with_cardinality`, plus the new
  `structural_block_labels_inside` helper. `src/bin_support/embedded.rs` carries the
  `resolve_label` guard. The rest of the diff is tests, fixture, and snapshots.
- **Copy/Paste Detection reports 2 duplications** — both are pre-existing test code
  at lines 1507/1607 and 2589/2656 of `tests/antlr4_rust_gen_cli.rs`, well outside
  this diff's 653–770 range. The bot scans whole changed files, so they surface here
  without being introduced here.
- C# grammar generation fails at **both** the parent commit and this one —
  pre-existing and unrelated, so I left it out of scope rather than widening the PR.
- **One declined finding**, stated rather than quietly skipped: CodeRabbit asked
  that unlabeled `ElementKind::Range` elements be accounted for in
  `alt_can_satisfy_read`. Its repro (`r : x=(A | B) | 'c'..'d';`) is rejected by
  validation before reaching the resolver (`error[G4S009]`), matching ANTLR's own
  `error(181): token ranges not allowed in parser`. There is no reachable input
  that needs the guard.
- **A process correction I owe the record:** for two rounds I reported "no open
  findings" when there were several. My checker fetched only the first page of
  review comments and filtered to one bot. Both bugs are fixed; the current script
  paginates and covers every bot, and reports 0 unreplied across all 96 threads.

