### PR TITLE
perf(codegen): route costly left-recursive parses through the ATN

### DIFF
--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -34,6 +34,9 @@ pub struct ParserAtnSimulator<'a> {
     deferred_accept_states: FxHashSet<(usize, DfaStateId)>,
     shared_cache_key: Option<usize>,
     shared_cache_generation: u64,
+    shared_cache_trained: bool,
+    adaptive_calls: usize,
+    adaptive_closure_work: usize,
     /// Java's `LL_EXACT_AMBIG_DETECTION`: the full-context loop keeps
     /// consuming past "resolves to one viable alt" conflicts until every
     /// `(state, context)` subset conflicts over the same alt set.
@@ -155,6 +158,7 @@ impl PredictionStore {
 struct SharedPredictionStore {
     generation: u64,
     store: Option<PredictionStore>,
+    trained: bool,
 }
 
 thread_local! {
@@ -168,8 +172,22 @@ fn clear_shared_prediction_store(key: usize) -> u64 {
         let shared = cache.entry(key).or_default();
         shared.generation = shared.generation.wrapping_add(1);
         shared.store = None;
+        shared.trained = false;
         shared.generation
     })
+}
+
+const ADAPTIVE_ATN_PREFERENCE_MIN_CALLS: usize = 32;
+const ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL: usize = 256;
+const ADAPTIVE_ATN_PREFERENCE_DECISIVE_CLOSURE_WORK_PER_CALL: usize = 512;
+
+const fn adaptive_prediction_has_work_density(
+    calls: usize,
+    closure_work: usize,
+    minimum_closure_work_per_call: usize,
+) -> bool {
+    calls >= ADAPTIVE_ATN_PREFERENCE_MIN_CALLS
+        && closure_work >= calls.saturating_mul(minimum_closure_work_per_call)
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -488,6 +506,7 @@ impl Drop for ParserAtnSimulator<'_> {
             .iter()
             .map(ParserDfa::state_count)
             .sum();
+        let trained = self.shared_cache_trained || self.adaptive_calls != 0;
         // Check the DFAs back IN by move. The slot is normally vacant because
         // `new_shared` checked them out; it is occupied only when another
         // simulator for the same ATN was created while this one was alive
@@ -500,6 +519,7 @@ impl Drop for ParserAtnSimulator<'_> {
             if shared.generation != self.shared_cache_generation {
                 return false;
             }
+            shared.trained |= trained;
             if let Some(shared_store) = shared.store.as_mut() {
                 union_prediction_stores(shared_store, store, &mut self.workspace);
             } else {
@@ -531,6 +551,9 @@ impl<'a> ParserAtnSimulator<'a> {
             deferred_accept_states: FxHashSet::default(),
             shared_cache_key: None,
             shared_cache_generation: 0,
+            shared_cache_trained: false,
+            adaptive_calls: 0,
+            adaptive_closure_work: 0,
             exact_ambig_detection: false,
             full_context_memo: HashMap::default(),
             full_context_memo_len: 0,
@@ -540,6 +563,9 @@ impl<'a> ParserAtnSimulator<'a> {
 
     /// Resets transient simulator state while retaining learned decision DFAs.
     pub fn reset(&mut self) {
+        self.shared_cache_trained |= self.adaptive_calls != 0;
+        self.adaptive_calls = 0;
+        self.adaptive_closure_work = 0;
         self.outer_context_cache = None;
         self.deferred_accept_states.clear();
         self.workspace.reset();
@@ -556,6 +582,7 @@ impl<'a> ParserAtnSimulator<'a> {
         self.full_context_memo.clear();
         self.full_context_memo_len = 0;
         self.reset();
+        self.shared_cache_trained = false;
         if let Some(key) = self.shared_cache_key {
             self.shared_cache_generation = clear_shared_prediction_store(key);
         }
@@ -631,15 +658,17 @@ impl<'a> ParserAtnSimulator<'a> {
         let key = ptr as usize;
         #[cfg(feature = "perf-counters")]
         let import_started = std::time::Instant::now();
-        let (store, generation) = SHARED_PREDICTION_STORES.with(|cache| {
+        let (store, generation, trained) = SHARED_PREDICTION_STORES.with(|cache| {
             let mut cache = cache.borrow_mut();
             let shared = cache.entry(key).or_default();
+            let trained = shared.trained && shared.store.is_some();
             (
                 shared
                     .store
                     .take()
                     .unwrap_or_else(|| PredictionStore::new(atn)),
                 shared.generation,
+                trained,
             )
         });
         #[cfg(feature = "perf-counters")]
@@ -661,6 +690,9 @@ impl<'a> ParserAtnSimulator<'a> {
             deferred_accept_states: FxHashSet::default(),
             shared_cache_key: Some(key),
             shared_cache_generation: generation,
+            shared_cache_trained: trained,
+            adaptive_calls: 0,
+            adaptive_closure_work: 0,
             exact_ambig_detection: false,
             full_context_memo: HashMap::default(),
             full_context_memo_len: 0,
@@ -670,6 +702,45 @@ impl<'a> ParserAtnSimulator<'a> {
 
     pub fn decision_dfas(&self) -> &[ParserDfa] {
         &self.store.decision_to_dfa
+    }
+
+    /// Returns the warmed adaptive-call and closure-work counters.
+    #[doc(hidden)]
+    pub const fn adaptive_prediction_work(&self) -> Option<(usize, usize)> {
+        if self.shared_cache_trained {
+            Some((self.adaptive_calls, self.adaptive_closure_work))
+        } else {
+            None
+        }
+    }
+
+    /// Reports whether the adaptive-prediction work between two snapshots is
+    /// expensive enough to justify trying an ATN-recognizer route.
+    #[doc(hidden)]
+    pub const fn adaptive_prediction_delta_is_expensive(
+        before: (usize, usize),
+        after: (usize, usize),
+    ) -> bool {
+        adaptive_prediction_has_work_density(
+            after.0.saturating_sub(before.0),
+            after.1.saturating_sub(before.1),
+            ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL,
+        )
+    }
+
+    /// Reports whether a partial adaptive-prediction window has enough work
+    /// density to justify abandoning generated parsing before the enclosing
+    /// rule invocation completes.
+    #[doc(hidden)]
+    pub const fn adaptive_prediction_delta_is_decisive(
+        before: (usize, usize),
+        after: (usize, usize),
+    ) -> bool {
+        adaptive_prediction_has_work_density(
+            after.0.saturating_sub(before.0),
+            after.1.saturating_sub(before.1),
+            ADAPTIVE_ATN_PREFERENCE_DECISIVE_CLOSURE_WORK_PER_CALL,
+        )
     }
 
     /// Returns aggregate learned parser-DFA storage and interning measurements.
@@ -871,6 +942,7 @@ impl<'a> ParserAtnSimulator<'a> {
             force_full_context_retry,
             sll_probe_only,
         } = request;
+        self.adaptive_calls = self.adaptive_calls.saturating_add(1);
         self.deferred_accept_states
             .retain(|(stored_decision, _)| *stored_decision != decision);
         #[cfg(feature = "perf-counters")]
@@ -1840,8 +1912,10 @@ impl<'a> ParserAtnSimulator<'a> {
                 }
             }
         }
+        let closure_work = scratch.visited.len();
+        self.adaptive_closure_work = self.adaptive_closure_work.saturating_add(closure_work);
         #[cfg(feature = "perf-counters")]
-        crate::perf::record_closure(scratch.visited.len());
+        crate::perf::record_closure(closure_work);
     }
 
     fn closure_at_rule_stop(
@@ -2225,6 +2299,86 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_atn_preference_requires_expensive_prediction_delta() {
+        let atn = two_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+        assert_eq!(simulator.adaptive_prediction_work(), None);
+        simulator.shared_cache_trained = true;
+        assert_eq!(simulator.adaptive_prediction_work(), Some((0, 0)));
+        assert!(!ParserAtnSimulator::adaptive_prediction_delta_is_expensive(
+            (0, 0),
+            (ADAPTIVE_ATN_PREFERENCE_MIN_CALLS - 1, usize::MAX),
+        ));
+        assert!(!ParserAtnSimulator::adaptive_prediction_delta_is_expensive(
+            (5, 7),
+            (
+                5 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS,
+                7 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS
+                    * ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL
+                    - 1,
+            ),
+        ));
+        assert!(ParserAtnSimulator::adaptive_prediction_delta_is_expensive(
+            (5, 7),
+            (
+                5 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS,
+                7 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS
+                    * ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL,
+            ),
+        ));
+        assert!(!ParserAtnSimulator::adaptive_prediction_delta_is_decisive(
+            (5, 7),
+            (
+                5 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS,
+                7 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS
+                    * ADAPTIVE_ATN_PREFERENCE_DECISIVE_CLOSURE_WORK_PER_CALL
+                    - 1,
+            ),
+        ));
+        assert!(ParserAtnSimulator::adaptive_prediction_delta_is_decisive(
+            (5, 7),
+            (
+                5 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS,
+                7 + ADAPTIVE_ATN_PREFERENCE_MIN_CALLS
+                    * ADAPTIVE_ATN_PREFERENCE_DECISIVE_CLOSURE_WORK_PER_CALL,
+            ),
+        ));
+
+        simulator.shared_cache_trained = false;
+        assert_eq!(simulator.adaptive_prediction_work(), None);
+    }
+
+    #[test]
+    fn reset_warms_adaptive_atn_preference_and_clear_dfa_cools_it() {
+        let atn = two_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+        simulator.adaptive_calls = ADAPTIVE_ATN_PREFERENCE_MIN_CALLS;
+        simulator.adaptive_closure_work =
+            ADAPTIVE_ATN_PREFERENCE_MIN_CALLS * ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL;
+
+        simulator.reset();
+        assert!(simulator.shared_cache_trained);
+        assert_eq!(simulator.adaptive_calls, 0);
+        assert_eq!(simulator.adaptive_closure_work, 0);
+        assert_eq!(simulator.adaptive_prediction_work(), Some((0, 0)));
+
+        simulator.adaptive_calls = ADAPTIVE_ATN_PREFERENCE_MIN_CALLS;
+        simulator.adaptive_closure_work =
+            ADAPTIVE_ATN_PREFERENCE_MIN_CALLS * ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL;
+        assert!(ParserAtnSimulator::adaptive_prediction_delta_is_expensive(
+            (0, 0),
+            simulator
+                .adaptive_prediction_work()
+                .expect("warmed counters"),
+        ));
+
+        simulator.clear_dfa();
+        assert!(!simulator.shared_cache_trained);
+        assert_eq!(simulator.adaptive_calls, 0);
+        assert_eq!(simulator.adaptive_closure_work, 0);
+    }
+
+    #[test]
     fn adaptive_predict_reuses_dense_dfa_edges() {
         let atn = two_token_decision_atn();
         let mut simulator = ParserAtnSimulator::new(&atn);
@@ -2249,6 +2403,38 @@ mod tests {
 
         let simulator = ParserAtnSimulator::new_shared(atn);
         assert_eq!(simulator.decision_dfas()[0].states().len(), learned_states);
+    }
+
+    #[test]
+    fn shared_simulator_preserves_and_clears_prediction_training_state() {
+        let atn = Box::leak(Box::new(two_token_decision_atn()));
+        {
+            let mut simulator = ParserAtnSimulator::new_shared(atn);
+            simulator.adaptive_calls = 1;
+        }
+
+        {
+            let simulator = ParserAtnSimulator::new_shared(atn);
+            assert!(simulator.shared_cache_trained);
+        }
+
+        ParserAtnSimulator::clear_shared_dfa(atn);
+        let simulator = ParserAtnSimulator::new_shared(atn);
+        assert!(!simulator.shared_cache_trained);
+    }
+
+    #[test]
+    fn overlapping_shared_simulator_treats_an_empty_store_as_cold() {
+        let atn = Box::leak(Box::new(two_token_decision_atn()));
+        {
+            let mut simulator = ParserAtnSimulator::new_shared(atn);
+            simulator.adaptive_calls = 1;
+        }
+
+        let warmed = ParserAtnSimulator::new_shared(atn);
+        assert!(warmed.shared_cache_trained);
+        let overlapping = ParserAtnSimulator::new_shared(atn);
+        assert!(!overlapping.shared_cache_trained);
     }
 
     #[test]

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -34,7 +34,8 @@ pub struct ParserAtnSimulator<'a> {
     deferred_accept_states: FxHashSet<(usize, DfaStateId)>,
     shared_cache_key: Option<usize>,
     shared_cache_generation: u64,
-    shared_cache_trained: bool,
+    has_trained_decision: bool,
+    measure_adaptive_work: bool,
     adaptive_calls: usize,
     adaptive_closure_work: usize,
     /// Java's `LL_EXACT_AMBIG_DETECTION`: the full-context loop keeps
@@ -158,7 +159,6 @@ impl PredictionStore {
 struct SharedPredictionStore {
     generation: u64,
     store: Option<PredictionStore>,
-    trained: bool,
 }
 
 thread_local! {
@@ -172,7 +172,6 @@ fn clear_shared_prediction_store(key: usize) -> u64 {
         let shared = cache.entry(key).or_default();
         shared.generation = shared.generation.wrapping_add(1);
         shared.store = None;
-        shared.trained = false;
         shared.generation
     })
 }
@@ -506,7 +505,6 @@ impl Drop for ParserAtnSimulator<'_> {
             .iter()
             .map(ParserDfa::state_count)
             .sum();
-        let trained = self.shared_cache_trained || self.adaptive_calls != 0;
         // Check the DFAs back IN by move. The slot is normally vacant because
         // `new_shared` checked them out; it is occupied only when another
         // simulator for the same ATN was created while this one was alive
@@ -519,7 +517,6 @@ impl Drop for ParserAtnSimulator<'_> {
             if shared.generation != self.shared_cache_generation {
                 return false;
             }
-            shared.trained |= trained;
             if let Some(shared_store) = shared.store.as_mut() {
                 union_prediction_stores(shared_store, store, &mut self.workspace);
             } else {
@@ -551,7 +548,8 @@ impl<'a> ParserAtnSimulator<'a> {
             deferred_accept_states: FxHashSet::default(),
             shared_cache_key: None,
             shared_cache_generation: 0,
-            shared_cache_trained: false,
+            has_trained_decision: false,
+            measure_adaptive_work: false,
             adaptive_calls: 0,
             adaptive_closure_work: 0,
             exact_ambig_detection: false,
@@ -563,7 +561,7 @@ impl<'a> ParserAtnSimulator<'a> {
 
     /// Resets transient simulator state while retaining learned decision DFAs.
     pub fn reset(&mut self) {
-        self.shared_cache_trained |= self.adaptive_calls != 0;
+        self.measure_adaptive_work = false;
         self.adaptive_calls = 0;
         self.adaptive_closure_work = 0;
         self.outer_context_cache = None;
@@ -582,7 +580,7 @@ impl<'a> ParserAtnSimulator<'a> {
         self.full_context_memo.clear();
         self.full_context_memo_len = 0;
         self.reset();
-        self.shared_cache_trained = false;
+        self.has_trained_decision = false;
         if let Some(key) = self.shared_cache_key {
             self.shared_cache_generation = clear_shared_prediction_store(key);
         }
@@ -658,19 +656,18 @@ impl<'a> ParserAtnSimulator<'a> {
         let key = ptr as usize;
         #[cfg(feature = "perf-counters")]
         let import_started = std::time::Instant::now();
-        let (store, generation, trained) = SHARED_PREDICTION_STORES.with(|cache| {
+        let (store, generation) = SHARED_PREDICTION_STORES.with(|cache| {
             let mut cache = cache.borrow_mut();
             let shared = cache.entry(key).or_default();
-            let trained = shared.trained && shared.store.is_some();
             (
                 shared
                     .store
                     .take()
                     .unwrap_or_else(|| PredictionStore::new(atn)),
                 shared.generation,
-                trained,
             )
         });
+        let has_trained_decision = store.decision_to_dfa.iter().any(|dfa| !dfa.is_empty());
         #[cfg(feature = "perf-counters")]
         crate::perf::record_dfa_cache_import(
             import_started.elapsed().as_nanos(),
@@ -690,7 +687,8 @@ impl<'a> ParserAtnSimulator<'a> {
             deferred_accept_states: FxHashSet::default(),
             shared_cache_key: Some(key),
             shared_cache_generation: generation,
-            shared_cache_trained: trained,
+            has_trained_decision,
+            measure_adaptive_work: false,
             adaptive_calls: 0,
             adaptive_closure_work: 0,
             exact_ambig_detection: false,
@@ -704,10 +702,14 @@ impl<'a> ParserAtnSimulator<'a> {
         &self.store.decision_to_dfa
     }
 
-    /// Returns the warmed adaptive-call and closure-work counters.
+    /// Returns adaptive-call and closure-work counters for trained decisions.
+    ///
+    /// A call contributes only when its decision DFA was already non-empty at
+    /// call entry, so first-population work cannot make an unrelated candidate
+    /// look expensive.
     #[doc(hidden)]
     pub const fn adaptive_prediction_work(&self) -> Option<(usize, usize)> {
-        if self.shared_cache_trained {
+        if self.has_trained_decision {
             Some((self.adaptive_calls, self.adaptive_closure_work))
         } else {
             None
@@ -935,6 +937,31 @@ impl<'a> ParserAtnSimulator<'a> {
         input: &mut T,
         merge_cache: &mut PredictionWorkspace,
     ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
+        let decision = request.decision;
+        self.measure_adaptive_work = self
+            .store
+            .decision_to_dfa
+            .get(decision)
+            .is_some_and(|dfa| !dfa.is_empty());
+        if self.measure_adaptive_work {
+            self.adaptive_calls = self.adaptive_calls.saturating_add(1);
+        }
+        let result = self.adaptive_predict_stream_inner_impl(request, input, merge_cache);
+        self.measure_adaptive_work = false;
+        self.has_trained_decision |= self
+            .store
+            .decision_to_dfa
+            .get(decision)
+            .is_some_and(|dfa| !dfa.is_empty());
+        result
+    }
+
+    fn adaptive_predict_stream_inner_impl<T: IntStream>(
+        &mut self,
+        request: AdaptivePredictRequest,
+        input: &mut T,
+        merge_cache: &mut PredictionWorkspace,
+    ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
         let AdaptivePredictRequest {
             decision,
             precedence,
@@ -942,7 +969,6 @@ impl<'a> ParserAtnSimulator<'a> {
             force_full_context_retry,
             sll_probe_only,
         } = request;
-        self.adaptive_calls = self.adaptive_calls.saturating_add(1);
         self.deferred_accept_states
             .retain(|(stored_decision, _)| *stored_decision != decision);
         #[cfg(feature = "perf-counters")]
@@ -1913,7 +1939,9 @@ impl<'a> ParserAtnSimulator<'a> {
             }
         }
         let closure_work = scratch.visited.len();
-        self.adaptive_closure_work = self.adaptive_closure_work.saturating_add(closure_work);
+        if self.measure_adaptive_work {
+            self.adaptive_closure_work = self.adaptive_closure_work.saturating_add(closure_work);
+        }
         #[cfg(feature = "perf-counters")]
         crate::perf::record_closure(closure_work);
     }
@@ -2300,11 +2328,6 @@ mod tests {
 
     #[test]
     fn adaptive_atn_preference_requires_expensive_prediction_delta() {
-        let atn = two_token_decision_atn();
-        let mut simulator = ParserAtnSimulator::new(&atn);
-        assert_eq!(simulator.adaptive_prediction_work(), None);
-        simulator.shared_cache_trained = true;
-        assert_eq!(simulator.adaptive_prediction_work(), Some((0, 0)));
         assert!(!ParserAtnSimulator::adaptive_prediction_delta_is_expensive(
             (0, 0),
             (ADAPTIVE_ATN_PREFERENCE_MIN_CALLS - 1, usize::MAX),
@@ -2343,39 +2366,60 @@ mod tests {
                     * ADAPTIVE_ATN_PREFERENCE_DECISIVE_CLOSURE_WORK_PER_CALL,
             ),
         ));
-
-        simulator.shared_cache_trained = false;
-        assert_eq!(simulator.adaptive_prediction_work(), None);
     }
 
     #[test]
-    fn reset_warms_adaptive_atn_preference_and_clear_dfa_cools_it() {
+    fn adaptive_atn_preference_excludes_first_population_per_decision() {
+        let atn = two_independent_decisions_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+
+        assert_eq!(simulator.adaptive_prediction_work(), None);
+        assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
+        let after_first_decision = simulator
+            .adaptive_prediction_work()
+            .expect("one decision is trained");
+        assert_eq!(after_first_decision, (0, 0));
+
+        assert_eq!(simulator.adaptive_predict(1, [1, 2]), Ok(1));
+        assert_eq!(
+            simulator.adaptive_prediction_work(),
+            Some(after_first_decision),
+            "cold work for another decision must not enter the routing counters"
+        );
+
+        assert_eq!(simulator.adaptive_predict(1, [1, 2]), Ok(1));
+        let after_warm_decision = simulator
+            .adaptive_prediction_work()
+            .expect("trained decision work is measurable");
+        assert_eq!(after_warm_decision.0, after_first_decision.0 + 1);
+    }
+
+    #[test]
+    fn reset_retains_adaptive_training_and_clear_dfa_cools_it() {
         let atn = two_token_decision_atn();
         let mut simulator = ParserAtnSimulator::new(&atn);
-        simulator.adaptive_calls = ADAPTIVE_ATN_PREFERENCE_MIN_CALLS;
-        simulator.adaptive_closure_work =
-            ADAPTIVE_ATN_PREFERENCE_MIN_CALLS * ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL;
+        assert_eq!(simulator.adaptive_prediction_work(), None);
+        assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
+        assert_eq!(simulator.adaptive_prediction_work(), Some((0, 0)));
 
         simulator.reset();
-        assert!(simulator.shared_cache_trained);
         assert_eq!(simulator.adaptive_calls, 0);
         assert_eq!(simulator.adaptive_closure_work, 0);
         assert_eq!(simulator.adaptive_prediction_work(), Some((0, 0)));
 
-        simulator.adaptive_calls = ADAPTIVE_ATN_PREFERENCE_MIN_CALLS;
-        simulator.adaptive_closure_work =
-            ADAPTIVE_ATN_PREFERENCE_MIN_CALLS * ADAPTIVE_ATN_PREFERENCE_MIN_CLOSURE_WORK_PER_CALL;
-        assert!(ParserAtnSimulator::adaptive_prediction_delta_is_expensive(
-            (0, 0),
+        assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
+        assert_eq!(
             simulator
                 .adaptive_prediction_work()
-                .expect("warmed counters"),
-        ));
+                .expect("warmed counters")
+                .0,
+            1
+        );
 
         simulator.clear_dfa();
-        assert!(!simulator.shared_cache_trained);
         assert_eq!(simulator.adaptive_calls, 0);
         assert_eq!(simulator.adaptive_closure_work, 0);
+        assert_eq!(simulator.adaptive_prediction_work(), None);
     }
 
     #[test]
@@ -2410,17 +2454,17 @@ mod tests {
         let atn = Box::leak(Box::new(two_token_decision_atn()));
         {
             let mut simulator = ParserAtnSimulator::new_shared(atn);
-            simulator.adaptive_calls = 1;
+            assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
         }
 
         {
             let simulator = ParserAtnSimulator::new_shared(atn);
-            assert!(simulator.shared_cache_trained);
+            assert_eq!(simulator.adaptive_prediction_work(), Some((0, 0)));
         }
 
         ParserAtnSimulator::clear_shared_dfa(atn);
         let simulator = ParserAtnSimulator::new_shared(atn);
-        assert!(!simulator.shared_cache_trained);
+        assert_eq!(simulator.adaptive_prediction_work(), None);
     }
 
     #[test]
@@ -2428,13 +2472,13 @@ mod tests {
         let atn = Box::leak(Box::new(two_token_decision_atn()));
         {
             let mut simulator = ParserAtnSimulator::new_shared(atn);
-            simulator.adaptive_calls = 1;
+            assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
         }
 
         let warmed = ParserAtnSimulator::new_shared(atn);
-        assert!(warmed.shared_cache_trained);
+        assert_eq!(warmed.adaptive_prediction_work(), Some((0, 0)));
         let overlapping = ParserAtnSimulator::new_shared(atn);
-        assert!(!overlapping.shared_cache_trained);
+        assert_eq!(overlapping.adaptive_prediction_work(), None);
     }
 
     #[test]
@@ -3146,66 +3190,101 @@ mod tests {
         two_token_decision_atn_with_precedence(false)
     }
 
+    fn two_independent_decisions_atn() -> Atn {
+        let mut atn = ParserAtnBuilder::new(3);
+        add_two_token_decision_rule(&mut atn, 0, 0);
+        add_two_token_decision_rule(&mut atn, 8, 1);
+        atn.set_rule_to_start_state(vec![0, 8])
+            .expect("rule start states");
+        atn.set_rule_to_stop_state(vec![7, 15])
+            .expect("rule stop states");
+        finish_atn(atn)
+    }
+
     fn two_token_decision_atn_with_precedence(precedence: bool) -> Atn {
         let mut atn = ParserAtnBuilder::new(3);
-        add_state(&mut atn, 0, AtnStateKind::RuleStart);
-        add_state(&mut atn, 1, AtnStateKind::BlockStart);
-        add_state(&mut atn, 2, AtnStateKind::Basic);
-        add_state(&mut atn, 3, AtnStateKind::Basic);
-        add_state(&mut atn, 4, AtnStateKind::Basic);
-        add_state(&mut atn, 5, AtnStateKind::Basic);
-        add_state(&mut atn, 6, AtnStateKind::BlockEnd);
-        add_state(&mut atn, 7, AtnStateKind::RuleStop);
+        add_two_token_decision_rule(&mut atn, 0, 0);
         atn.set_rule_to_start_state(vec![0])
             .expect("rule start states");
         atn.set_rule_to_stop_state(vec![7])
             .expect("rule stop states");
-        atn.add_decision_state(1).expect("decision state");
         if precedence {
             atn.set_precedence_rule_decision(1)
                 .expect("precedence decision state");
         }
-        atn.add_transition(0, ParserTransitionSpec::Epsilon { target: 1 })
-            .expect("transition");
-        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 2 })
-            .expect("transition");
-        atn.add_transition(1, ParserTransitionSpec::Epsilon { target: 4 })
+        finish_atn(atn)
+    }
+
+    fn add_two_token_decision_rule(atn: &mut ParserAtnBuilder, offset: usize, rule_index: usize) {
+        assert_eq!(atn.state_count(), offset);
+        for kind in [
+            AtnStateKind::RuleStart,
+            AtnStateKind::BlockStart,
+            AtnStateKind::Basic,
+            AtnStateKind::Basic,
+            AtnStateKind::Basic,
+            AtnStateKind::Basic,
+            AtnStateKind::BlockEnd,
+            AtnStateKind::RuleStop,
+        ] {
+            let expected = atn.state_count();
+            assert_eq!(
+                atn.add_state(kind, Some(rule_index))
+                    .expect("state")
+                    .index(),
+                expected
+            );
+        }
+        atn.add_decision_state(offset + 1).expect("decision state");
+        atn.add_transition(offset, ParserTransitionSpec::Epsilon { target: offset + 1 })
             .expect("transition");
         atn.add_transition(
-            2,
+            offset + 1,
+            ParserTransitionSpec::Epsilon { target: offset + 2 },
+        )
+        .expect("transition");
+        atn.add_transition(
+            offset + 1,
+            ParserTransitionSpec::Epsilon { target: offset + 4 },
+        )
+        .expect("transition");
+        atn.add_transition(
+            offset + 2,
             ParserTransitionSpec::Atom {
-                target: 3,
+                target: offset + 3,
                 label: 1,
             },
         )
         .expect("transition");
         atn.add_transition(
-            3,
+            offset + 3,
             ParserTransitionSpec::Atom {
-                target: 6,
+                target: offset + 6,
                 label: 2,
             },
         )
         .expect("transition");
         atn.add_transition(
-            4,
+            offset + 4,
             ParserTransitionSpec::Atom {
-                target: 5,
+                target: offset + 5,
                 label: 1,
             },
         )
         .expect("transition");
         atn.add_transition(
-            5,
+            offset + 5,
             ParserTransitionSpec::Atom {
-                target: 6,
+                target: offset + 6,
                 label: 3,
             },
         )
         .expect("transition");
-        atn.add_transition(6, ParserTransitionSpec::Epsilon { target: 7 })
-            .expect("transition");
-        finish_atn(atn)
+        atn.add_transition(
+            offset + 6,
+            ParserTransitionSpec::Epsilon { target: offset + 7 },
+        )
+        .expect("transition");
     }
 
     fn optional_token_decision_atn() -> Atn {

--- a/src/atn/parser.rs
+++ b/src/atn/parser.rs
@@ -702,11 +702,11 @@ impl<'a> ParserAtnSimulator<'a> {
         &self.store.decision_to_dfa
     }
 
-    /// Returns adaptive-call and closure-work counters for trained decisions.
+    /// Returns adaptive-call and closure-work counters for stable decisions.
     ///
-    /// A call contributes only when its decision DFA was already non-empty at
-    /// call entry, so first-population work cannot make an unrelated candidate
-    /// look expensive.
+    /// A call contributes only when its decision DFA was already non-empty and
+    /// did not learn states, edges, or start mappings during the call. This
+    /// excludes both first and incremental population from steady-state work.
     #[doc(hidden)]
     pub const fn adaptive_prediction_work(&self) -> Option<(usize, usize)> {
         if self.has_trained_decision {
@@ -938,16 +938,29 @@ impl<'a> ParserAtnSimulator<'a> {
         merge_cache: &mut PredictionWorkspace,
     ) -> Result<ParserAtnPrediction, ParserAtnSimulatorError> {
         let decision = request.decision;
-        self.measure_adaptive_work = self
+        let learning_revision = self
             .store
             .decision_to_dfa
             .get(decision)
-            .is_some_and(|dfa| !dfa.is_empty());
+            .filter(|dfa| !dfa.is_empty())
+            .map(ParserDfa::learning_revision);
+        let work_start = (self.adaptive_calls, self.adaptive_closure_work);
+        self.measure_adaptive_work = learning_revision.is_some();
         if self.measure_adaptive_work {
             self.adaptive_calls = self.adaptive_calls.saturating_add(1);
         }
         let result = self.adaptive_predict_stream_inner_impl(request, input, merge_cache);
         self.measure_adaptive_work = false;
+        if let Some(learning_revision) = learning_revision
+            && self
+                .store
+                .decision_to_dfa
+                .get(decision)
+                .map(ParserDfa::learning_revision)
+                != Some(learning_revision)
+        {
+            (self.adaptive_calls, self.adaptive_closure_work) = work_start;
+        }
         self.has_trained_decision |= self
             .store
             .decision_to_dfa
@@ -2392,6 +2405,38 @@ mod tests {
             .adaptive_prediction_work()
             .expect("trained decision work is measurable");
         assert_eq!(after_warm_decision.0, after_first_decision.0 + 1);
+    }
+
+    #[test]
+    fn adaptive_atn_preference_excludes_incremental_population_per_decision() {
+        let atn = two_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+
+        assert_eq!(simulator.adaptive_predict(0, [1, 2]), Ok(1));
+        let after_first_path = simulator
+            .adaptive_prediction_work()
+            .expect("the decision is partially trained");
+        let transitions_after_first_path = simulator.decision_dfas()[0].stats().transitions;
+
+        assert_eq!(simulator.adaptive_predict(0, [1, 3]), Ok(2));
+        assert!(
+            simulator.decision_dfas()[0].stats().transitions > transitions_after_first_path,
+            "the second input must extend the partially populated DFA"
+        );
+        assert_eq!(
+            simulator.adaptive_prediction_work(),
+            Some(after_first_path),
+            "incremental DFA construction must not enter the routing counters"
+        );
+
+        assert_eq!(simulator.adaptive_predict(0, [1, 3]), Ok(2));
+        assert_eq!(
+            simulator
+                .adaptive_prediction_work()
+                .expect("the repeated path is stable")
+                .0,
+            after_first_path.0 + 1
+        );
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -5666,11 +5666,12 @@ fn render_generated_rule_dispatch_with_rule_names(
         {
             // Expensive left-recursive regions start generated and switch only
             // after warmed adaptive-prediction work identifies a costly input.
-            // Features implemented solely by generated bodies still override
-            // the adaptive ATN preference.
+            // Features implemented solely by generated bodies, and hooks whose
+            // decision overrides differ between generated and interpreted
+            // parsing, still override the adaptive ATN preference.
             writeln!(
                 out,
-                "            {index} if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() => Some(self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback)),"
+                "            {index} if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() || self.base.observes_parser_decisions() => Some(self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback)),"
             )
             .expect("writing to a string cannot fail");
             writeln!(
@@ -5757,7 +5758,7 @@ fn render_generated_rule_dispatch_with_rule_names(
             .expect("writing to a string cannot fail");
             writeln!(
                 out,
-                "        if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() {{\n            \
+                "        if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() || self.base.observes_parser_decisions() {{\n            \
                  return self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback);\n        \
                  }}\n        \
                  let __adaptive_outermost = self.adaptive_atn_preference_depths[{slot}] == 0;\n        \
@@ -5791,7 +5792,7 @@ fn render_generated_rule_dispatch_with_rule_names(
                          && self.base.number_of_syntax_errors() == self.adaptive_atn_syntax_error_starts[{slot}]\n                        \
                          && antlr4_runtime::ParserAtnSimulator::adaptive_prediction_delta_is_expensive(self.adaptive_atn_preference_starts[{slot}], __adaptive_after);\n                \
                      self.adaptive_atn_preferred_rules[{slot}] = __adaptive_expensive;\n                \
-                     if __adaptive_expensive && !__adaptive_outermost {{\n                    \
+                     if __adaptive_expensive {{\n                    \
                          self.adaptive_atn_retry_slot = Some({slot});\n                    \
                          __result = Err(GeneratedRuleError::AdaptiveRetry);\n                \
                      }}\n            \
@@ -13739,7 +13740,7 @@ mod tests {
         );
 
         assert!(rendered.contains(
-            "0 if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
+            "0 if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() || self.base.observes_parser_decisions() => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
         ));
         assert!(rendered.contains(
             "0 if !self.adaptive_atn_preferred_rules[0] => Some(self.parse_generated_rule_0_adaptive_dispatch(precedence, allow_fallback, None))"
@@ -13758,6 +13759,38 @@ mod tests {
         assert!(rendered.contains(
             "ParserAtnSimulator::adaptive_prediction_delta_is_decisive(self.adaptive_atn_preference_starts[0], __adaptive_after)"
         ));
+        assert!(
+            rendered.contains("if __adaptive_expensive {")
+                && rendered.contains("self.adaptive_atn_retry_slot = Some(0);"),
+            "an expensive outermost candidate must retry on the same invocation"
+        );
+        assert!(
+            !rendered.contains("if __adaptive_expensive && !__adaptive_outermost"),
+            "outermost candidates must not defer routing to parser reuse"
+        );
+    }
+
+    #[test]
+    fn renders_bare_left_recursive_seed_retry_on_same_invocation() {
+        let rules = vec![Some(left_recursive_rule(
+            0,
+            ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST,
+            ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS,
+        ))];
+
+        let rendered = render_generated_rule_dispatch(&rules, &[true], &BTreeMap::new(), false);
+
+        assert!(rendered.contains(
+            "0 if !self.adaptive_atn_preferred_rules[0] => Some(self.parse_generated_rule_0_adaptive_dispatch(precedence, allow_fallback, None))"
+        ));
+        assert!(
+            rendered.contains("if __adaptive_expensive {")
+                && rendered.contains("self.adaptive_atn_retry_slot = Some(0);")
+                && rendered.contains("__result = Err(GeneratedRuleError::AdaptiveRetry);"),
+            "a bare seed must replay through the interpreter as soon as measured work is expensive"
+        );
+        assert!(!rendered.contains("_adaptive_probe_dispatch"));
+        assert!(!rendered.contains("if __adaptive_expensive && !__adaptive_outermost"));
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -3740,6 +3740,7 @@ struct PortableLocalStepRender<'a> {
 
 #[derive(Clone, Copy)]
 struct GeneratedStepRenderContext<'a> {
+    current_rule_index: usize,
     /// `Some` in embedded mode: actions/predicates are verbatim Rust.
     embedded: Option<EmbeddedStepRender<'a>>,
     /// Portable raw-grammar boolean locals translated without embedded mode.
@@ -3749,6 +3750,8 @@ struct GeneratedStepRenderContext<'a> {
     track_context_alt_numbers: bool,
     direct_generated_rule_calls: &'a [bool],
     atn_preferred_rule_calls: &'a [bool],
+    adaptive_atn_preferred_rule_slots: &'a [Option<usize>],
+    adaptive_atn_probe_rule_slots: &'a [Vec<usize>],
 }
 
 struct GeneratedParserCompileContext<'a> {
@@ -3806,6 +3809,23 @@ impl Default for ParserRenderOptions<'_> {
             generate_visitor: false,
             sem_unknown: SemUnknownPolicy::default(),
             patterns: None,
+        }
+    }
+}
+
+/// A non-default policy must reach the interpreter through the emitted runtime
+/// options, so its literal forces the options-carrying call shape.
+///
+/// A `hook`-disposed coordinate falls through to the configured policy when its
+/// hook is unimplemented. It does not escalate the global policy, because that
+/// would flip unrelated `assume-true` coordinates in the same grammar to
+/// fail-loud.
+const fn parser_unknown_policy_literal(policy: SemUnknownPolicy) -> Option<&'static str> {
+    match policy {
+        SemUnknownPolicy::AssumeTrue => None,
+        SemUnknownPolicy::AssumeFalse => Some("antlr4_runtime::UnknownSemanticPolicy::AssumeFalse"),
+        SemUnknownPolicy::Hook | SemUnknownPolicy::Error => {
+            Some("antlr4_runtime::UnknownSemanticPolicy::Error")
         }
     }
 }
@@ -3896,18 +3916,25 @@ fn drop_rules_calling_disabled_rules(rules: &mut [Option<GeneratedParserRule>]) 
 
 const ATN_PREFERRED_LEADING_CALL_CHAIN_MIN: usize = 8;
 const ATN_PREFERRED_CHAIN_MIN_DECISION_DENSITY_NUMERATOR: usize = 2;
+const ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST: usize = 8;
+const ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS: usize = 8;
+const ATN_PREFERRED_LEFT_RECURSIVE_WRAPPER_MIN_DECISION_COST: usize = 8;
 const ATN_PREFERRED_WRAPPER_MIN_DECISION_COST: usize = 2;
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 struct GeneratedRuleShape {
     decision_cost: usize,
     action_or_predicate_count: usize,
+    left_recursive_operator_alts: usize,
 }
 
 impl AddAssign for GeneratedRuleShape {
     fn add_assign(&mut self, rhs: Self) {
         self.decision_cost += rhs.decision_cost;
         self.action_or_predicate_count += rhs.action_or_predicate_count;
+        self.left_recursive_operator_alts = self
+            .left_recursive_operator_alts
+            .max(rhs.left_recursive_operator_alts);
     }
 }
 
@@ -3917,6 +3944,16 @@ fn generated_atn_preferred_rule_calls(
     rule_names: &[String],
 ) -> Vec<bool> {
     generated_atn_preferred_rule_calls_excluding(rules, rule_names, &BTreeSet::new())
+}
+
+#[cfg(test)]
+fn generated_adaptive_atn_preferred_rule_calls(rules: &[Option<GeneratedParserRule>]) -> Vec<bool> {
+    generated_adaptive_atn_preferred_rule_calls_excluding(rules, &BTreeSet::new())
+}
+
+struct GeneratedAdaptiveAtnRouting {
+    candidates: Vec<bool>,
+    probe_candidate_rules: Vec<Vec<usize>>,
 }
 
 fn generated_atn_preferred_rule_calls_excluding(
@@ -3931,13 +3968,7 @@ fn generated_atn_preferred_rule_calls_excluding(
                 .and_then(|rule| generated_steps_leading_mandatory_rule_call(&rule.steps))
         })
         .collect::<Vec<_>>();
-    let shapes = rules
-        .iter()
-        .map(|rule| {
-            rule.as_ref()
-                .map_or_else(GeneratedRuleShape::default, generated_rule_shape)
-        })
-        .collect::<Vec<_>>();
+    let shapes = generated_rule_shapes(rules);
     let mut preferred = vec![false; rules.len()];
 
     for start in 0..rules.len() {
@@ -3969,13 +4000,138 @@ fn generated_atn_preferred_rule_calls_excluding(
         }
     }
     propagate_atn_preferred_wrappers(rules, &shapes, &mut preferred);
+    exclude_forced_generated_rules(&mut preferred, force_generated);
+
+    preferred
+}
+
+fn generated_adaptive_atn_preferred_rule_calls_excluding(
+    rules: &[Option<GeneratedParserRule>],
+    force_generated: &BTreeSet<usize>,
+) -> Vec<bool> {
+    generated_adaptive_atn_routing_excluding(rules, force_generated).candidates
+}
+
+fn generated_adaptive_atn_routing_excluding(
+    rules: &[Option<GeneratedParserRule>],
+    force_generated: &BTreeSet<usize>,
+) -> GeneratedAdaptiveAtnRouting {
+    let shapes = generated_rule_shapes(rules);
+    let seeds = rules
+        .iter()
+        .flatten()
+        .filter(|rule| {
+            generated_rule_is_expensive_left_recursive(
+                rule,
+                shapes.get(rule.rule_index).copied().unwrap_or_default(),
+            )
+        })
+        .map(|rule| rule.rule_index)
+        .collect::<Vec<_>>();
+    let mut candidates = vec![false; rules.len()];
+    let mut probe_candidate_rules = vec![BTreeSet::new(); rules.len()];
+
+    for seed in seeds {
+        let mut region = vec![false; rules.len()];
+        region[seed] = true;
+        let wrappers = rules
+            .iter()
+            .enumerate()
+            .filter_map(|(rule_index, rule)| {
+                rule.as_ref()
+                    .filter(|rule| {
+                        generated_rule_is_atn_preferred_wrapper(
+                            rule,
+                            &shapes,
+                            &region,
+                            ATN_PREFERRED_LEFT_RECURSIVE_WRAPPER_MIN_DECISION_COST,
+                        )
+                    })
+                    .map(|_| rule_index)
+            })
+            .collect::<Vec<_>>();
+        if wrappers.is_empty() {
+            candidates[seed] = true;
+        } else {
+            for wrapper in wrappers {
+                candidates[wrapper] = true;
+                probe_candidate_rules[seed].insert(wrapper);
+            }
+        }
+    }
+    exclude_forced_generated_rules(&mut candidates, force_generated);
+    let probe_candidate_rules = probe_candidate_rules
+        .into_iter()
+        .map(|candidates_for_probe| {
+            candidates_for_probe
+                .into_iter()
+                .filter(|candidate| candidates.get(*candidate).copied().unwrap_or_default())
+                .collect()
+        })
+        .collect();
+
+    GeneratedAdaptiveAtnRouting {
+        candidates,
+        probe_candidate_rules,
+    }
+}
+
+fn indexed_rule_slots(selected: &[bool]) -> Vec<Option<usize>> {
+    let mut next_slot = 0;
+    selected
+        .iter()
+        .map(|selected| {
+            if *selected {
+                let slot = next_slot;
+                next_slot += 1;
+                Some(slot)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn indexed_probe_slots(
+    probe_candidate_rules: &[Vec<usize>],
+    candidate_slots: &[Option<usize>],
+) -> Vec<Vec<usize>> {
+    probe_candidate_rules
+        .iter()
+        .map(|candidate_rules| {
+            candidate_rules
+                .iter()
+                .filter_map(|candidate| candidate_slots.get(*candidate).copied().flatten())
+                .collect()
+        })
+        .collect()
+}
+
+fn generated_rule_shapes(rules: &[Option<GeneratedParserRule>]) -> Vec<GeneratedRuleShape> {
+    rules
+        .iter()
+        .map(|rule| {
+            rule.as_ref()
+                .map_or_else(GeneratedRuleShape::default, generated_rule_shape)
+        })
+        .collect()
+}
+
+fn exclude_forced_generated_rules(preferred: &mut [bool], force_generated: &BTreeSet<usize>) {
     for rule_index in force_generated {
         if let Some(entry) = preferred.get_mut(*rule_index) {
             *entry = false;
         }
     }
+}
 
-    preferred
+const fn generated_rule_is_expensive_left_recursive(
+    rule: &GeneratedParserRule,
+    shape: GeneratedRuleShape,
+) -> bool {
+    rule.left_recursive
+        && shape.decision_cost >= ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST
+        && shape.left_recursive_operator_alts >= ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS
 }
 
 fn generated_rule_callers_reaching(
@@ -4121,6 +4277,20 @@ fn propagate_atn_preferred_wrappers(
     shapes: &[GeneratedRuleShape],
     preferred: &mut [bool],
 ) {
+    propagate_atn_preferred_wrappers_with_min_decision_cost(
+        rules,
+        shapes,
+        preferred,
+        ATN_PREFERRED_WRAPPER_MIN_DECISION_COST,
+    );
+}
+
+fn propagate_atn_preferred_wrappers_with_min_decision_cost(
+    rules: &[Option<GeneratedParserRule>],
+    shapes: &[GeneratedRuleShape],
+    preferred: &mut [bool],
+    min_decision_cost: usize,
+) {
     loop {
         let mut changed = false;
         for (rule_index, rule) in rules.iter().enumerate() {
@@ -4130,7 +4300,8 @@ fn propagate_atn_preferred_wrappers(
             let Some(rule) = rule else {
                 continue;
             };
-            if !generated_rule_is_atn_preferred_wrapper(rule, shapes, preferred) {
+            if !generated_rule_is_atn_preferred_wrapper(rule, shapes, preferred, min_decision_cost)
+            {
                 continue;
             }
             preferred[rule_index] = true;
@@ -4146,13 +4317,14 @@ fn generated_rule_is_atn_preferred_wrapper(
     rule: &GeneratedParserRule,
     shapes: &[GeneratedRuleShape],
     preferred: &[bool],
+    min_decision_cost: usize,
 ) -> bool {
     if rule.left_recursive {
         return false;
     }
     let shape = shapes.get(rule.rule_index).copied().unwrap_or_default();
     shape.action_or_predicate_count == 0
-        && shape.decision_cost >= ATN_PREFERRED_WRAPPER_MIN_DECISION_COST
+        && shape.decision_cost >= min_decision_cost
         && generated_steps_call_atn_preferred_rule(&rule.steps, preferred)
 }
 
@@ -4182,6 +4354,7 @@ fn generated_step_shape(step: &GeneratedParserStep) -> GeneratedRuleShape {
                     fast_path.is_none() || *allow_semantic_context || *force_context,
                 ),
                 action_or_predicate_count: 0,
+                left_recursive_operator_alts: 0,
             };
             for alt in alts {
                 shape += generated_steps_shape(alt);
@@ -4200,6 +4373,7 @@ fn generated_step_shape(step: &GeneratedParserStep) -> GeneratedRuleShape {
                     fast_path.is_none() || *allow_semantic_context || *force_context,
                 ),
                 action_or_predicate_count: 0,
+                left_recursive_operator_alts: 0,
             };
             shape += generated_steps_shape(body);
             shape
@@ -4208,6 +4382,7 @@ fn generated_step_shape(step: &GeneratedParserStep) -> GeneratedRuleShape {
             let mut shape = GeneratedRuleShape {
                 decision_cost: 1,
                 action_or_predicate_count: 0,
+                left_recursive_operator_alts: generated_steps_direct_max_alt_count(body),
             };
             shape += generated_steps_shape(body);
             shape
@@ -4216,6 +4391,7 @@ fn generated_step_shape(step: &GeneratedParserStep) -> GeneratedRuleShape {
             GeneratedRuleShape {
                 decision_cost: 0,
                 action_or_predicate_count: 1,
+                left_recursive_operator_alts: 0,
             }
         }
         GeneratedParserStep::MatchToken { .. }
@@ -4225,6 +4401,26 @@ fn generated_step_shape(step: &GeneratedParserStep) -> GeneratedRuleShape {
         | GeneratedParserStep::Precedence(_)
         | GeneratedParserStep::CallRule { .. } => GeneratedRuleShape::default(),
     }
+}
+
+fn generated_steps_direct_max_alt_count(steps: &[GeneratedParserStep]) -> usize {
+    steps
+        .iter()
+        .filter_map(|step| match step {
+            GeneratedParserStep::Decision { alts, .. } => Some(alts.len()),
+            GeneratedParserStep::MatchToken { .. }
+            | GeneratedParserStep::MatchSet { .. }
+            | GeneratedParserStep::MatchNotSet { .. }
+            | GeneratedParserStep::MatchWildcard { .. }
+            | GeneratedParserStep::Precedence(_)
+            | GeneratedParserStep::Predicate { .. }
+            | GeneratedParserStep::Action { .. }
+            | GeneratedParserStep::CallRule { .. }
+            | GeneratedParserStep::StarLoop { .. }
+            | GeneratedParserStep::LeftRecursiveLoop { .. } => None,
+        })
+        .max()
+        .unwrap_or_default()
 }
 
 fn generated_steps_call_atn_preferred_rule(
@@ -5326,6 +5522,93 @@ fn render_generated_rule_dispatch(
     )
 }
 
+fn generated_force_generated_rules(
+    rules: &[Option<GeneratedParserRule>],
+    embedded: bool,
+    portable_required_generated_rules: Option<&BTreeSet<usize>>,
+) -> BTreeSet<usize> {
+    if embedded {
+        rules.iter().flatten().map(|rule| rule.rule_index).collect()
+    } else {
+        portable_required_generated_rules.map_or_else(BTreeSet::new, |required| {
+            generated_rule_callers_reaching(rules, required)
+        })
+    }
+}
+
+fn generated_adaptive_atn_preferred_rule_count(
+    rules: &[Option<GeneratedParserRule>],
+    embedded: bool,
+    portable_required_generated_rules: Option<&BTreeSet<usize>>,
+) -> usize {
+    let force_generated_rules =
+        generated_force_generated_rules(rules, embedded, portable_required_generated_rules);
+    generated_adaptive_atn_preferred_rule_calls_excluding(rules, &force_generated_rules)
+        .into_iter()
+        .filter(|preferred| *preferred)
+        .count()
+}
+
+struct AdaptiveAtnParserRenderSlots {
+    struct_field: String,
+    field_init: String,
+    reset: &'static str,
+    retry_variant: &'static str,
+    retry_into_error: &'static str,
+}
+
+fn adaptive_atn_parser_render_slots(preferred_rule_count: usize) -> AdaptiveAtnParserRenderSlots {
+    if preferred_rule_count == 0 {
+        return AdaptiveAtnParserRenderSlots {
+            struct_field: String::new(),
+            field_init: String::new(),
+            reset: "",
+            retry_variant: "",
+            retry_into_error: "",
+        };
+    }
+    AdaptiveAtnParserRenderSlots {
+        struct_field: format!(
+            "    adaptive_atn_preferred_rules: [bool; {preferred_rule_count}],\n    adaptive_atn_preference_depths: [usize; {preferred_rule_count}],\n    adaptive_atn_preference_starts: [(usize, usize); {preferred_rule_count}],\n    adaptive_atn_syntax_error_starts: [usize; {preferred_rule_count}],\n    adaptive_atn_retry_slot: Option<usize>,\n"
+        ),
+        field_init: format!(
+            "            adaptive_atn_preferred_rules: [false; {preferred_rule_count}],\n            adaptive_atn_preference_depths: [0; {preferred_rule_count}],\n            adaptive_atn_preference_starts: [(0, 0); {preferred_rule_count}],\n            adaptive_atn_syntax_error_starts: [0; {preferred_rule_count}],\n            adaptive_atn_retry_slot: None,\n"
+        ),
+        reset: "        self.adaptive_atn_preferred_rules.fill(false);\n        self.adaptive_atn_preference_depths.fill(0);\n        self.adaptive_atn_preference_starts.fill((0, 0));\n        self.adaptive_atn_syntax_error_starts.fill(0);\n        self.adaptive_atn_retry_slot = None;\n",
+        retry_variant: "    AdaptiveRetry,\n",
+        retry_into_error: "            Self::AdaptiveRetry => antlr4_runtime::AntlrError::Unsupported(\"internal adaptive ATN retry escaped its routing boundary\".to_owned()),\n",
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_generated_rule_routing(
+    rules: &[Option<GeneratedParserRule>],
+    rule_names: &[String],
+    inline_action_statements: &BTreeMap<usize, String>,
+    track_alt_numbers: bool,
+    track_context_alt_numbers: bool,
+    embedded: Option<EmbeddedStepRender<'_>>,
+    portable_locals: Option<PortableLocalStepRender<'_>>,
+) -> (String, usize) {
+    let direct_generated_rule_calls = rules.iter().map(Option::is_some).collect::<Vec<_>>();
+    let preferred_rule_count = generated_adaptive_atn_preferred_rule_count(
+        rules,
+        embedded.is_some(),
+        portable_locals.map(|portable| portable.required_generated_rules),
+    );
+    let dispatch = render_generated_rule_dispatch_with_rule_names(
+        rules,
+        &direct_generated_rule_calls,
+        rule_names,
+        inline_action_statements,
+        track_alt_numbers,
+        track_context_alt_numbers,
+        embedded,
+        portable_locals,
+    );
+    (dispatch, preferred_rule_count)
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_generated_rule_dispatch_with_rule_names(
     rules: &[Option<GeneratedParserRule>],
@@ -5338,15 +5621,20 @@ fn render_generated_rule_dispatch_with_rule_names(
     portable_locals: Option<PortableLocalStepRender<'_>>,
 ) -> String {
     let mut out = String::new();
-    let force_generated_rules = if embedded.is_some() {
-        rules.iter().flatten().map(|rule| rule.rule_index).collect()
-    } else {
-        portable_locals.map_or_else(BTreeSet::new, |portable| {
-            generated_rule_callers_reaching(rules, portable.required_generated_rules)
-        })
-    };
+    let force_generated_rules = generated_force_generated_rules(
+        rules,
+        embedded.is_some(),
+        portable_locals.map(|portable| portable.required_generated_rules),
+    );
     let atn_preferred_rule_calls =
         generated_atn_preferred_rule_calls_excluding(rules, rule_names, &force_generated_rules);
+    let adaptive_atn_routing =
+        generated_adaptive_atn_routing_excluding(rules, &force_generated_rules);
+    let adaptive_atn_preferred_rule_slots = indexed_rule_slots(&adaptive_atn_routing.candidates);
+    let adaptive_atn_probe_rule_slots = indexed_probe_slots(
+        &adaptive_atn_routing.probe_candidate_rules,
+        &adaptive_atn_preferred_rule_slots,
+    );
     writeln!(
         out,
         "    #[allow(dead_code)]\n    fn parse_generated_rule(&mut self, rule_index: usize, precedence: i32, allow_fallback: bool) -> Option<Result<antlr4_runtime::ParseTree, GeneratedRuleError>> {{"
@@ -5371,6 +5659,25 @@ fn render_generated_rule_dispatch_with_rule_names(
                 "            {index} if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() => Some(self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback)),"
             )
             .expect("writing to a string cannot fail");
+        } else if let Some(slot) = adaptive_atn_preferred_rule_slots
+            .get(index)
+            .copied()
+            .flatten()
+        {
+            // Expensive left-recursive regions start generated and switch only
+            // after warmed adaptive-prediction work identifies a costly input.
+            // Features implemented solely by generated bodies still override
+            // the adaptive ATN preference.
+            writeln!(
+                out,
+                "            {index} if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() => Some(self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback)),"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "            {index} if !self.adaptive_atn_preferred_rules[{slot}] => Some(self.parse_generated_rule_{index}_adaptive_dispatch(precedence, allow_fallback, None)),"
+            )
+            .expect("writing to a string cannot fail");
         } else {
             writeln!(
                 out,
@@ -5383,6 +5690,7 @@ fn render_generated_rule_dispatch_with_rule_names(
     writeln!(out, "        }}").expect("writing to a string cannot fail");
     writeln!(out, "    }}").expect("writing to a string cannot fail");
     let step_render_context = GeneratedStepRenderContext {
+        current_rule_index: usize::MAX,
         embedded,
         portable_locals,
         inline_action_statements,
@@ -5390,9 +5698,123 @@ fn render_generated_rule_dispatch_with_rule_names(
         track_context_alt_numbers,
         direct_generated_rule_calls,
         atn_preferred_rule_calls: &atn_preferred_rule_calls,
+        adaptive_atn_preferred_rule_slots: &adaptive_atn_preferred_rule_slots,
+        adaptive_atn_probe_rule_slots: &adaptive_atn_probe_rule_slots,
     };
     for rule in rules.iter().flatten() {
         let index = rule.rule_index;
+        if let Some(probe_slots) = adaptive_atn_probe_rule_slots
+            .get(index)
+            .filter(|slots| !slots.is_empty())
+        {
+            writeln!(
+                out,
+                "\n    #[allow(dead_code)]\n    fn parse_generated_rule_{index}_adaptive_probe_dispatch(&mut self, precedence: i32, allow_fallback: bool) -> Result<antlr4_runtime::ParseTree, GeneratedRuleError> {{"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "        let __result = self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback);"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "        if __result.is_ok() && self.adaptive_atn_retry_slot.is_none() {{\n            \
+                 if let Some(__adaptive_after) = self.simulator\n                \
+                     .as_ref()\n                \
+                     .and_then(antlr4_runtime::ParserAtnSimulator::adaptive_prediction_work)\n            \
+                 {{"
+            )
+            .expect("writing to a string cannot fail");
+            for slot in probe_slots {
+                writeln!(
+                out,
+                "                if self.adaptive_atn_preference_depths[{slot}] != 0\n                    \
+                     && !self.adaptive_atn_preferred_rules[{slot}]\n                    \
+                     && self.base.number_of_syntax_errors() == self.adaptive_atn_syntax_error_starts[{slot}]\n                    \
+                     && antlr4_runtime::ParserAtnSimulator::adaptive_prediction_delta_is_decisive(self.adaptive_atn_preference_starts[{slot}], __adaptive_after)\n                \
+                     {{\n                    \
+                         self.adaptive_atn_preferred_rules[{slot}] = true;\n                    \
+                         self.adaptive_atn_retry_slot = Some({slot});\n                    \
+                         return Err(GeneratedRuleError::AdaptiveRetry);\n                \
+                     }}"
+                )
+                .expect("writing to a string cannot fail");
+            }
+            writeln!(out, "            }}\n        }}\n        __result")
+                .expect("writing to a string cannot fail");
+            writeln!(out, "    }}").expect("writing to a string cannot fail");
+        }
+        if let Some(slot) = adaptive_atn_preferred_rule_slots
+            .get(index)
+            .copied()
+            .flatten()
+        {
+            writeln!(
+                out,
+                "\n    #[allow(dead_code)]\n    fn parse_generated_rule_{index}_adaptive_dispatch(&mut self, precedence: i32, allow_fallback: bool, invoking_state: Option<isize>) -> Result<antlr4_runtime::ParseTree, GeneratedRuleError> {{"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "        if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() {{\n            \
+                 return self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback);\n        \
+                 }}\n        \
+                 let __adaptive_outermost = self.adaptive_atn_preference_depths[{slot}] == 0;\n        \
+                 let __adaptive_rule_start = antlr4_runtime::IntStream::index(self.base.input());\n        \
+                 let __adaptive_parser_state = self.base.state();\n        \
+                 let __adaptive_diagnostic_marker = self.base.generated_diagnostics_checkpoint();"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "        if __adaptive_outermost {{\n            \
+                 self.adaptive_atn_preference_starts[{slot}] = self.simulator\n                \
+                     .as_ref()\n                \
+                     .and_then(antlr4_runtime::ParserAtnSimulator::adaptive_prediction_work)\n                \
+                     .unwrap_or((0, 0));\n        \
+                 self.adaptive_atn_syntax_error_starts[{slot}] = self.base.number_of_syntax_errors();\n        \
+                 }}\n        \
+                 self.adaptive_atn_preference_depths[{slot}] += 1;\n        \
+                 let mut __result = self.parse_generated_rule_{index}_dispatch(precedence, allow_fallback);\n        \
+                 self.adaptive_atn_preference_depths[{slot}] -= 1;"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(
+                out,
+                "        if !self.adaptive_atn_preferred_rules[{slot}] {{\n            \
+                 if let Some(__adaptive_after) = self.simulator\n                \
+                     .as_ref()\n                \
+                     .and_then(antlr4_runtime::ParserAtnSimulator::adaptive_prediction_work)\n            \
+                 {{\n                \
+                     let __adaptive_expensive = __result.is_ok()\n                        \
+                         && self.base.number_of_syntax_errors() == self.adaptive_atn_syntax_error_starts[{slot}]\n                        \
+                         && antlr4_runtime::ParserAtnSimulator::adaptive_prediction_delta_is_expensive(self.adaptive_atn_preference_starts[{slot}], __adaptive_after);\n                \
+                     self.adaptive_atn_preferred_rules[{slot}] = __adaptive_expensive;\n                \
+                     if __adaptive_expensive && !__adaptive_outermost {{\n                    \
+                         self.adaptive_atn_retry_slot = Some({slot});\n                    \
+                         __result = Err(GeneratedRuleError::AdaptiveRetry);\n                \
+                     }}\n            \
+                 }}\n        \
+                 }}\n        \
+                 if __adaptive_outermost\n            \
+                     && self.adaptive_atn_retry_slot == Some({slot})\n            \
+                     && matches!(&__result, Err(GeneratedRuleError::AdaptiveRetry))\n        \
+                 {{\n            \
+                     self.adaptive_atn_retry_slot = None;\n            \
+                     self.base.restore_generated_diagnostics(__adaptive_diagnostic_marker);\n            \
+                     antlr4_runtime::IntStream::seek(self.base.input(), __adaptive_rule_start);\n            \
+                     self.base.set_state(__adaptive_parser_state);\n            \
+                     if let Some(invoking_state) = invoking_state {{\n                \
+                         self.base.push_invoking_state(invoking_state);\n            \
+                     }}\n            \
+                     return self.parse_rule_precedence_from_generated({index}, precedence).map_err(GeneratedRuleError::Fatal);\n        \
+                 }}"
+            )
+            .expect("writing to a string cannot fail");
+            writeln!(out, "        __result").expect("writing to a string cannot fail");
+            writeln!(out, "    }}").expect("writing to a string cannot fail");
+        }
         writeln!(
             out,
             "\n    #[allow(dead_code)]\n    fn parse_generated_rule_{index}_dispatch(&mut self, precedence: i32, allow_fallback: bool) -> Result<antlr4_runtime::ParseTree, GeneratedRuleError> {{"
@@ -5431,7 +5853,14 @@ fn render_generated_rule_dispatch_with_rule_names(
         )
         .expect("writing to a string cannot fail");
         writeln!(out, "    }}").expect("writing to a string cannot fail");
-        render_generated_rule_method(&mut out, rule, step_render_context);
+        render_generated_rule_method(
+            &mut out,
+            rule,
+            GeneratedStepRenderContext {
+                current_rule_index: index,
+                ..step_render_context
+            },
+        );
     }
     out
 }
@@ -5534,6 +5963,34 @@ fn render_embedded_after_and_seal(
     }
 }
 
+fn render_generated_adaptive_retry_unwind(
+    out: &mut String,
+    step_render_context: GeneratedStepRenderContext<'_>,
+    left_recursive: bool,
+) {
+    if !step_render_context
+        .adaptive_atn_preferred_rule_slots
+        .iter()
+        .any(Option::is_some)
+    {
+        return;
+    }
+    let exit_rule = if left_recursive {
+        "self.base.unroll_recursion_context();"
+    } else {
+        "self.base.exit_rule();"
+    };
+    writeln!(
+        out,
+        "                if self.adaptive_atn_retry_slot.is_some() {{\n                    \
+         {exit_rule}\n                    \
+         self.base.restore_generated_diagnostics(__generated_diagnostic_marker);\n                    \
+         return Err(GeneratedRuleError::AdaptiveRetry);\n                \
+         }}"
+    )
+    .expect("writing to a string cannot fail");
+}
+
 fn render_generated_rule_method(
     out: &mut String,
     rule: &GeneratedParserRule,
@@ -5600,6 +6057,7 @@ fn render_generated_rule_method(
     writeln!(out, "                Ok(__tree)").expect("writing to a string cannot fail");
     writeln!(out, "            }}").expect("writing to a string cannot fail");
     writeln!(out, "            Err(__error) => {{").expect("writing to a string cannot fail");
+    render_generated_adaptive_retry_unwind(out, step_render_context, false);
     // A rule's own `sync_decision` failure (`__sync_error`) is fatal ONLY at the
     // top-level public entry (`allow_fallback`). When this rule is a nested child
     // (`!allow_fallback`), ANTLR recovers the mismatch INSIDE the child and returns
@@ -5736,6 +6194,7 @@ fn render_generated_left_recursive_rule_method(
     writeln!(out, "                Ok(__tree)").expect("writing to a string cannot fail");
     writeln!(out, "            }}").expect("writing to a string cannot fail");
     writeln!(out, "            Err(__error) => {{").expect("writing to a string cannot fail");
+    render_generated_adaptive_retry_unwind(out, step_render_context, true);
     // Same as the non-left-recursive case: a nested child (`!allow_fallback`)
     // recovers its own sync failure internally and returns a partial subtree; only
     // the top-level entry propagates `Fatal`. Use `finish_recursion_rule` (which
@@ -6020,8 +6479,24 @@ fn render_generated_step(
                 .copied()
                 .unwrap_or_default()
             {
+                let probe_slots = render_context
+                    .adaptive_atn_probe_rule_slots
+                    .get(*rule_index)
+                    .map(Vec::as_slice)
+                    .unwrap_or_default();
+                let caller_candidate_slot = render_context
+                    .adaptive_atn_preferred_rule_slots
+                    .get(render_context.current_rule_index)
+                    .copied()
+                    .flatten();
+                let dispatch =
+                    if caller_candidate_slot.is_some_and(|slot| probe_slots.contains(&slot)) {
+                        "adaptive_probe_dispatch"
+                    } else {
+                        "dispatch"
+                    };
                 format!(
-                    "self.parse_generated_rule_{rule_index}_dispatch({precedence}, false).map_err(GeneratedRuleError::into_error)"
+                    "self.parse_generated_rule_{rule_index}_{dispatch}({precedence}, false).map_err(GeneratedRuleError::into_error)"
                 )
             } else {
                 from_generated_call.clone()
@@ -6041,6 +6516,19 @@ fn render_generated_step(
                 // cap or a registered parse listener flips it to the generated
                 // body, the only path that enforces the cap and fires events.
                 from_generated_call
+            } else if let Some(slot) = render_context
+                .adaptive_atn_preferred_rule_slots
+                .get(*rule_index)
+                .copied()
+                .flatten()
+            {
+                // Keep the direct generated call while prediction remains
+                // cheap. Once the warmed simulator crosses the cost threshold,
+                // enter through the wrapper so its guarded dispatch can select
+                // the interpreted rule without reordering buffered actions.
+                format!(
+                    "if self.adaptive_atn_preferred_rules[{slot}] {{ {from_generated_call} }} else {{ self.parse_generated_rule_{rule_index}_adaptive_dispatch({precedence}, false, Some({source_state}isize)).map_err(GeneratedRuleError::into_error) }}"
+                )
             } else {
                 generated_child_call
             };
@@ -9748,37 +10236,18 @@ fn render_parser_with_options(
         // compile; an interpreted fallback would silently skip them.
         require_all_parser_rules_generated(&generated_rules, data)?;
     }
-    let direct_generated_rule_calls = generated_rules
-        .iter()
-        .map(Option::is_some)
-        .collect::<Vec<_>>();
-    let generated_rule_dispatch = render_generated_rule_dispatch_with_rule_names(
-        &generated_rules,
-        &direct_generated_rule_calls,
-        &data.rule_names,
-        &inline_action_statements,
-        track_alt_numbers,
-        track_context_alt_numbers,
-        embedded_step_render,
-        portable_local_data.step_render(),
-    );
-    // A non-default policy must reach the interpreter through the emitted
-    // runtime options, so its literal forces the options-carrying call shape.
-    //
-    // A `hook`-disposed coordinate falls through to the configured policy when
-    // its hook is unimplemented (the documented `SemIR → hook → policy` chain),
-    // so it does NOT escalate the global policy: doing so would flip unrelated
-    // `assume-true` coordinates in the same grammar to fail-loud. Users select
-    // fail-loud for missing hooks with `--sem-unknown=error` /
-    // `--require-full-semantics`; under the default policy a declined hook keeps
-    // historical pass-through, per coordinate.
-    let unknown_policy_literal = match options.sem_unknown {
-        SemUnknownPolicy::AssumeTrue => None,
-        SemUnknownPolicy::AssumeFalse => Some("antlr4_runtime::UnknownSemanticPolicy::AssumeFalse"),
-        SemUnknownPolicy::Hook | SemUnknownPolicy::Error => {
-            Some("antlr4_runtime::UnknownSemanticPolicy::Error")
-        }
-    };
+    let portable_step_render = portable_local_data.step_render();
+    let (generated_rule_dispatch, adaptive_atn_preferred_rule_count) =
+        render_generated_rule_routing(
+            &generated_rules,
+            &data.rule_names,
+            &inline_action_statements,
+            track_alt_numbers,
+            track_context_alt_numbers,
+            embedded_step_render,
+            portable_step_render,
+        );
+    let unknown_policy_literal = parser_unknown_policy_literal(options.sem_unknown);
     let parse_rule_fallback = render_parser_parse_rule_fallback(
         track_alt_numbers,
         track_context_alt_numbers,
@@ -9843,6 +10312,13 @@ fn render_parser_with_options(
     ) = embedded_render_slots(embedded_data.as_ref().or(structural_surface.as_ref()));
     let generated_header = GENERATED_MODULE_HEADER;
     let generated_footer = GENERATED_MODULE_FOOTER;
+    let AdaptiveAtnParserRenderSlots {
+        struct_field: adaptive_atn_preference_struct_field,
+        field_init: adaptive_atn_preference_field_init,
+        reset: adaptive_atn_preference_reset,
+        retry_variant: adaptive_atn_retry_variant,
+        retry_into_error: adaptive_atn_retry_into_error,
+    } = adaptive_atn_parser_render_slots(adaptive_atn_preferred_rule_count);
 
     let embedded_imports = if embedded_data.is_some() || structural_surface.is_some() {
         "#[allow(unused_imports)]\nuse std::io::Write as _;\n#[allow(unused_imports)]\nuse antlr4_runtime::{java_style_list, PredictionMode, BailErrorStrategy, TerminalNodeView as RuntimeTerminalNode, ErrorNodeView as RuntimeErrorNode, RuleNodeView, AsRuleNode, FromRuleNode, MissingChildError, Token as _};\n"
@@ -9893,19 +10369,19 @@ where
     base: BaseParser<L, H>,
     simulator: Option<antlr4_runtime::ParserAtnSimulator<'static>>,
     generated_only: bool,
-{embedded_struct_fields}}}
+{adaptive_atn_preference_struct_field}{embedded_struct_fields}}}
 
 #[allow(dead_code)]
 #[derive(Debug)]
 enum GeneratedRuleError {{
     Fatal(antlr4_runtime::AntlrError),
-}}
+{adaptive_atn_retry_variant}}}
 
 impl GeneratedRuleError {{
     fn into_error(self) -> antlr4_runtime::AntlrError {{
         match self {{
             Self::Fatal(error) => error,
-        }}
+{adaptive_atn_retry_into_error}        }}
     }}
 }}
 
@@ -9931,7 +10407,7 @@ where
             base,
             simulator: None,
             generated_only: std::env::var_os("ANTLR4_RUST_GENERATED_ONLY").is_some(),
-{embedded_field_inits}        }}
+{adaptive_atn_preference_field_init}{embedded_field_inits}        }}
     }}
 
     pub fn metadata() -> &'static GrammarMetadata {{
@@ -9958,7 +10434,7 @@ where
         if let Some(simulator) = self.simulator.as_mut() {{
             simulator.reset();
         }}
-    }}
+{adaptive_atn_preference_reset}    }}
 
     /// Replaces the token stream and fully resets parser-owned state.
     pub fn set_token_stream(&mut self, input: CommonTokenStream<L>) {{
@@ -9966,7 +10442,7 @@ where
         if let Some(simulator) = self.simulator.as_mut() {{
             simulator.reset();
         }}
-    }}
+{adaptive_atn_preference_reset}    }}
 
     #[must_use]
     pub const fn token_stream(&self) -> &CommonTokenStream<L> {{
@@ -10011,7 +10487,7 @@ where
         }} else {{
             antlr4_runtime::ParserAtnSimulator::clear_shared_dfa(atn());
         }}
-    }}
+{adaptive_atn_preference_reset}    }}
 
     #[must_use]
     pub fn node(&self, id: antlr4_runtime::NodeId) -> antlr4_runtime::Node<'_> {{
@@ -12728,6 +13204,41 @@ mod tests {
         }
     }
 
+    fn adaptive_decision(decision: usize, alt_count: usize) -> GeneratedParserStep {
+        GeneratedParserStep::Decision {
+            state: 2_000 + decision,
+            decision,
+            track_alt_number: false,
+            allow_semantic_context: false,
+            force_context: false,
+            fast_path: None,
+            alts: (0..alt_count).map(|_| vec![mt(2, 0)]).collect(),
+        }
+    }
+
+    fn left_recursive_rule(
+        rule_index: usize,
+        decision_cost: usize,
+        operator_alt_count: usize,
+    ) -> GeneratedParserRule {
+        let mut steps = (2..decision_cost).map(adaptive_loop).collect::<Vec<_>>();
+        steps.push(GeneratedParserStep::LeftRecursiveLoop {
+            state: 3_000 + rule_index,
+            decision: 0,
+            enter_alt: 1,
+            exit_alt: 2,
+            rule_index,
+            entry_state: rule_index * 2,
+            body: vec![adaptive_decision(1, operator_alt_count)],
+        });
+        GeneratedParserRule {
+            rule_index,
+            entry_state: rule_index * 2,
+            left_recursive: true,
+            steps,
+        }
+    }
+
     fn expensive_ladder_rule(rule_index: usize, next: Option<usize>) -> GeneratedParserRule {
         let mut steps = Vec::new();
         if let Some(next) = next {
@@ -13035,6 +13546,74 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_atn_preferred_rule_calls_select_expensive_wrapper_boundaries() {
+        let rules = vec![
+            Some(test_rule(0, {
+                let mut steps = (100..108).map(adaptive_loop).collect::<Vec<_>>();
+                steps.push(cr(1));
+                steps
+            })),
+            Some(left_recursive_rule(
+                1,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS,
+            )),
+            Some(left_recursive_rule(
+                2,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST - 1,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS,
+            )),
+            Some(left_recursive_rule(
+                3,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS - 1,
+            )),
+            Some(left_recursive_rule(
+                4,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS,
+            )),
+        ];
+
+        assert_eq!(
+            generated_atn_preferred_rule_calls(&rules, &[]),
+            vec![false; rules.len()],
+            "left-recursive routing must remain separate from unconditional cascade routing"
+        );
+        let preferred = generated_adaptive_atn_preferred_rule_calls(&rules);
+        let routing = generated_adaptive_atn_routing_excluding(&rules, &BTreeSet::new());
+
+        assert!(
+            preferred[0],
+            "an expensive wrapper should become the candidate boundary"
+        );
+        assert!(
+            !preferred[1],
+            "an expensive LR leaf should not overlap its eligible wrapper"
+        );
+        assert!(
+            !preferred[2],
+            "decision cost below the threshold should stay generated"
+        );
+        assert!(
+            !preferred[3],
+            "operator fan-out below the threshold should stay generated"
+        );
+        assert!(
+            preferred[4],
+            "an expensive LR rule without a wrapper should remain a candidate"
+        );
+        assert_eq!(routing.probe_candidate_rules[1], vec![0]);
+        assert!(routing.probe_candidate_rules[4].is_empty());
+
+        let force_generated = generated_rule_callers_reaching(&rules, &BTreeSet::from([1]));
+        assert_eq!(
+            generated_adaptive_atn_preferred_rule_calls_excluding(&rules, &force_generated),
+            vec![false, false, false, false, true]
+        );
+    }
+
+    #[test]
     fn atn_preferred_rule_calls_propagate_through_expensive_wrappers() {
         let mut rules = Vec::new();
         rules.push(Some(test_rule(
@@ -13135,6 +13714,50 @@ mod tests {
         // The ATN-preferred child call routes through the buffering wrapper.
         assert!(rendered.contains("self.parse_rule_precedence_from_generated(2, 0)"));
         assert!(!rendered.contains("self.parse_interpreted_rule_precedence(2, 0)"));
+    }
+
+    #[test]
+    fn renders_adaptive_atn_preference_after_prediction_becomes_expensive() {
+        let rules = vec![
+            Some(test_rule(0, {
+                let mut steps = (100..108).map(adaptive_loop).collect::<Vec<_>>();
+                steps.push(cr(1));
+                steps
+            })),
+            Some(left_recursive_rule(
+                1,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_DECISION_COST,
+                ATN_PREFERRED_LEFT_RECURSIVE_MIN_OPERATOR_ALTS,
+            )),
+        ];
+
+        let rendered = render_generated_rule_dispatch(
+            &rules,
+            &vec![true; rules.len()],
+            &BTreeMap::new(),
+            false,
+        );
+
+        assert!(rendered.contains(
+            "0 if self.generated_only() || self.base.has_rule_depth_cap() || self.base.has_parse_listeners() => Some(self.parse_generated_rule_0_dispatch(precedence, allow_fallback))"
+        ));
+        assert!(rendered.contains(
+            "0 if !self.adaptive_atn_preferred_rules[0] => Some(self.parse_generated_rule_0_adaptive_dispatch(precedence, allow_fallback, None))"
+        ));
+        assert!(rendered.contains(
+            "ParserAtnSimulator::adaptive_prediction_delta_is_expensive(self.adaptive_atn_preference_starts[0], __adaptive_after)"
+        ));
+        assert!(rendered.contains(
+            "self.base.number_of_syntax_errors() == self.adaptive_atn_syntax_error_starts[0]"
+        ));
+        assert!(rendered.contains("return Err(GeneratedRuleError::AdaptiveRetry);"));
+        assert!(rendered.contains(
+            "return self.parse_rule_precedence_from_generated(0, precedence).map_err(GeneratedRuleError::Fatal);"
+        ));
+        assert!(rendered.contains("self.parse_generated_rule_1_adaptive_probe_dispatch(0, false)"));
+        assert!(rendered.contains(
+            "ParserAtnSimulator::adaptive_prediction_delta_is_decisive(self.adaptive_atn_preference_starts[0], __adaptive_after)"
+        ));
     }
 
     #[test]
@@ -13509,6 +14132,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -13516,6 +14140,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -13527,6 +14153,7 @@ mod tests {
     fn render_call_rule_step(
         direct_generated_rule_calls: &[bool],
         atn_preferred_rule_calls: &[bool],
+        adaptive_atn_preferred_rule_slots: &[Option<usize>],
     ) -> String {
         let mut rendered = String::new();
         render_generated_step(
@@ -13538,6 +14165,7 @@ mod tests {
             },
             2,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -13545,6 +14173,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls,
                 atn_preferred_rule_calls,
+                adaptive_atn_preferred_rule_slots,
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
         rendered
@@ -13557,7 +14187,7 @@ mod tests {
         // `parse_rule_precedence_from_generated`, which preserves interpreted routing
         // (the rule's generated dispatch arm is guarded by `generated_only()`) while
         // BUFFERING the child's body actions and `@after` in position.
-        let rendered = render_call_rule_step(&[true, false], &[true, true]);
+        let rendered = render_call_rule_step(&[true, false], &[true, true], &[]);
 
         assert!(rendered.contains("self.parse_rule_precedence_from_generated(1, 0)"));
         assert!(!rendered.contains("self.parse_interpreted_rule_precedence(1, 0)"));
@@ -13572,10 +14202,19 @@ mod tests {
         // parent's buffered actions. The wrapper buffers them in position instead while
         // still parsing the child interpreted (the dispatch arm is `generated_only()`
         // guarded).
-        let rendered = render_call_rule_step(&[true, true], &[true, true]);
+        let rendered = render_call_rule_step(&[true, true], &[true, true], &[]);
 
         assert!(rendered.contains("self.parse_rule_precedence_from_generated(1, 0)"));
         assert!(!rendered.contains("self.parse_interpreted_rule_precedence(1, 0)"));
+    }
+
+    #[test]
+    fn adaptive_atn_preferred_child_starts_with_direct_generated_dispatch() {
+        let rendered = render_call_rule_step(&[true, true], &[], &[None, Some(0)]);
+
+        assert!(rendered.contains(
+            "if self.adaptive_atn_preferred_rules[0] { self.parse_rule_precedence_from_generated(1, 0) } else { self.parse_generated_rule_1_adaptive_dispatch(0, false, Some(4isize)).map_err(GeneratedRuleError::into_error) }"
+        ));
     }
 
     #[test]
@@ -14305,7 +14944,7 @@ mod tests {
 
     #[test]
     fn call_rule_step_skips_child_action_scaffolding_without_parser_actions() {
-        let rendered = render_call_rule_step(&[true, true], &[false, false]);
+        let rendered = render_call_rule_step(&[true, true], &[false, false], &[]);
 
         assert!(rendered.contains("let __child = self.parse_generated_rule_1_dispatch(0, false).map_err(GeneratedRuleError::into_error);"));
         assert!(rendered.contains("self.base.discard_invoking_state(__invoking_marker);"));
@@ -14410,6 +15049,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -14417,6 +15057,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14459,6 +15101,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -14466,6 +15109,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14516,6 +15161,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: Some(PortableLocalStepRender {
                     declarations: &declarations,
@@ -14528,6 +15174,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14565,6 +15213,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -14572,6 +15221,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14609,6 +15260,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -14616,6 +15268,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14653,6 +15307,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -14660,6 +15315,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14699,6 +15356,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: Some(PortableLocalStepRender {
                     declarations: &declarations,
@@ -14711,6 +15369,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 
@@ -14758,6 +15418,7 @@ mod tests {
             },
             0,
             GeneratedStepRenderContext {
+                current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
                 inline_action_statements: &BTreeMap::new(),
@@ -14765,6 +15426,8 @@ mod tests {
                 track_context_alt_numbers: false,
                 direct_generated_rule_calls: &[],
                 atn_preferred_rule_calls: &[],
+                adaptive_atn_preferred_rule_slots: &[],
+                adaptive_atn_probe_rule_slots: &[],
             },
         );
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -4032,6 +4032,10 @@ fn generated_adaptive_atn_routing_excluding(
     let mut probe_candidate_rules = vec![BTreeSet::new(); rules.len()];
 
     for seed in seeds {
+        // Keep the seed eligible when it is entered directly or through a
+        // cheaper caller. Calls from an eligible wrapper use the probe mapping
+        // below instead, so the wrapper remains the retry boundary there.
+        candidates[seed] = true;
         let mut region = vec![false; rules.len()];
         region[seed] = true;
         let wrappers = rules
@@ -4050,13 +4054,9 @@ fn generated_adaptive_atn_routing_excluding(
                     .map(|_| rule_index)
             })
             .collect::<Vec<_>>();
-        if wrappers.is_empty() {
-            candidates[seed] = true;
-        } else {
-            for wrapper in wrappers {
-                candidates[wrapper] = true;
-                probe_candidate_rules[seed].insert(wrapper);
-            }
+        for wrapper in wrappers {
+            candidates[wrapper] = true;
+            probe_candidate_rules[seed].insert(wrapper);
         }
     }
     exclude_forced_generated_rules(&mut candidates, force_generated);
@@ -6474,6 +6474,7 @@ fn render_generated_step(
             };
             let from_generated_call =
                 format!("self.parse_rule_precedence_from_generated({rule_index}, {precedence})");
+            let mut probes_enclosing_candidate = false;
             let generated_child_call = if render_context
                 .direct_generated_rule_calls
                 .get(*rule_index)
@@ -6490,12 +6491,13 @@ fn render_generated_step(
                     .get(render_context.current_rule_index)
                     .copied()
                     .flatten();
-                let dispatch =
-                    if caller_candidate_slot.is_some_and(|slot| probe_slots.contains(&slot)) {
-                        "adaptive_probe_dispatch"
-                    } else {
-                        "dispatch"
-                    };
+                probes_enclosing_candidate =
+                    caller_candidate_slot.is_some_and(|slot| probe_slots.contains(&slot));
+                let dispatch = if probes_enclosing_candidate {
+                    "adaptive_probe_dispatch"
+                } else {
+                    "dispatch"
+                };
                 format!(
                     "self.parse_generated_rule_{rule_index}_{dispatch}({precedence}, false).map_err(GeneratedRuleError::into_error)"
                 )
@@ -6517,6 +6519,11 @@ fn render_generated_step(
                 // cap or a registered parse listener flips it to the generated
                 // body, the only path that enforces the cap and fires events.
                 from_generated_call
+            } else if probes_enclosing_candidate {
+                // The child is also a candidate for direct entry paths, but
+                // this call belongs to an enclosing wrapper candidate. Probe
+                // that wrapper and keep it as the sole retry boundary.
+                generated_child_call
             } else if let Some(slot) = render_context
                 .adaptive_atn_preferred_rule_slots
                 .get(*rule_index)
@@ -13589,8 +13596,8 @@ mod tests {
             "an expensive wrapper should become the candidate boundary"
         );
         assert!(
-            !preferred[1],
-            "an expensive LR leaf should not overlap its eligible wrapper"
+            preferred[1],
+            "an expensive LR seed must remain eligible for direct entry paths"
         );
         assert!(
             !preferred[2],
@@ -13756,6 +13763,9 @@ mod tests {
             "return self.parse_rule_precedence_from_generated(0, precedence).map_err(GeneratedRuleError::Fatal);"
         ));
         assert!(rendered.contains("self.parse_generated_rule_1_adaptive_probe_dispatch(0, false)"));
+        assert!(rendered.contains(
+            "1 if !self.adaptive_atn_preferred_rules[1] => Some(self.parse_generated_rule_1_adaptive_dispatch(precedence, allow_fallback, None))"
+        ));
         assert!(rendered.contains(
             "ParserAtnSimulator::adaptive_prediction_delta_is_decisive(self.adaptive_atn_preference_starts[0], __adaptive_after)"
         ));

--- a/src/dfa.rs
+++ b/src/dfa.rs
@@ -137,6 +137,7 @@ pub struct ParserDfa {
     start_state: DfaStateId,
     precedence_start_states: Vec<DfaStateId>,
     precedence_mode: bool,
+    learning_revision: u64,
     learning: DfaLearningCounters,
 }
 
@@ -160,6 +161,7 @@ impl ParserDfa {
             start_state: NO_DFA_STATE,
             precedence_start_states: Vec::new(),
             precedence_mode: false,
+            learning_revision: 0,
             learning: DfaLearningCounters::default(),
         }
     }
@@ -205,7 +207,11 @@ impl ParserDfa {
 
     pub(crate) fn set_start_state(&mut self, state: DfaStateId) {
         self.assert_valid_state(state);
+        if self.start_state == state {
+            return;
+        }
         self.start_state = state;
+        self.bump_learning_revision();
     }
 
     pub const fn is_precedence_dfa(&self) -> bool {
@@ -222,6 +228,7 @@ impl ParserDfa {
         self.start_state = NO_DFA_STATE;
         self.precedence_start_states.clear();
         self.precedence_mode = precedence_dfa;
+        self.bump_learning_revision();
         if precedence_dfa {
             let state = self.add_state(DfaStateBuilder::new(AtnConfigSet::new()));
             self.start_state = state;
@@ -241,11 +248,19 @@ impl ParserDfa {
 
     pub(crate) fn set_precedence_start_state(&mut self, precedence: usize, state: DfaStateId) {
         self.assert_valid_state(state);
+        if self.precedence_start_state(precedence) == Some(state) {
+            return;
+        }
         if precedence >= self.precedence_start_states.len() {
             self.precedence_start_states
                 .resize(precedence + 1, NO_DFA_STATE);
         }
         self.precedence_start_states[precedence] = state;
+        self.bump_learning_revision();
+    }
+
+    pub(crate) const fn learning_revision(&self) -> u64 {
+        self.learning_revision
     }
 
     pub fn stats(&self) -> ParserDfaStats {
@@ -311,6 +326,7 @@ impl ParserDfa {
         self.cold.push(configs, conflicting_alts);
         self.interner.insert(fingerprint, id);
         self.learning.states_created = self.learning.states_created.saturating_add(1);
+        self.bump_learning_revision();
         #[cfg(feature = "perf-counters")]
         crate::perf::record_dfa_state_created();
         id
@@ -352,7 +368,11 @@ impl ParserDfa {
     pub(crate) fn add_edge(&mut self, source: DfaStateId, symbol: i32, target: DfaStateId) {
         self.assert_valid_state(source);
         self.assert_valid_state(target);
+        let previous = self.edge(source, symbol);
         self.hot.edges.add(source, symbol, target);
+        if self.edge(source, symbol) != previous {
+            self.bump_learning_revision();
+        }
     }
 
     pub(crate) fn configs(&self, state: DfaStateId) -> &AtnConfigSet {
@@ -387,6 +407,10 @@ impl ParserDfa {
             state.index() < self.state_count(),
             "DFA state ID must index aligned hot/cold storage"
         );
+    }
+
+    const fn bump_learning_revision(&mut self) {
+        self.learning_revision = self.learning_revision.wrapping_add(1);
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6084,6 +6084,16 @@ where
         !self.parse_listeners.is_empty()
     }
 
+    /// Reports whether semantic hooks may override interpreted decisions.
+    ///
+    /// Generated parsers use this to keep adaptive performance routing from
+    /// changing parse semantics after a decision DFA becomes warm.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn observes_parser_decisions(&self) -> bool {
+        self.semantic_hooks.observes_parser_decisions()
+    }
+
     /// Fires `enter_every_rule` on registered parse listeners, returning the
     /// abort error if any listener requested one.
     ///

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -272,6 +272,41 @@ fn positional_lexer_root_emits_rust_and_manifest() {
     assert!(manifest.contains("\"kind\": \"lexer\""), "{manifest}");
 }
 
+#[test]
+fn adaptive_atn_routing_generated_path_compiles() {
+    let temp = temporary_directory("adaptive-atn-routing");
+    let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/adaptive-atn-routing/AdaptiveRouting.g4");
+    let out = temp.path().join("generated");
+
+    let output = run_antlr4_rust_gen(&[
+        grammar.as_os_str(),
+        OsStr::new("--out-dir"),
+        out.as_os_str(),
+    ]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+
+    let parser = fs::read_to_string(out.join("adaptive_routing_parser.rs"))
+        .expect("parser should be emitted");
+    assert!(
+        parser.contains("adaptive_atn_preferred_rules"),
+        "structural candidate should emit adaptive ATN routing"
+    );
+    assert!(
+        parser.contains("_adaptive_probe_dispatch"),
+        "left-recursive seed should probe its enclosing candidate"
+    );
+    assert_generated_modules_compile(
+        temp.path(),
+        &["adaptive_routing_lexer.rs", "adaptive_routing_parser.rs"],
+    );
+}
+
 /// Editors on Windows commonly save `.g4` sources with a UTF-8 byte order mark
 /// and CRLF line endings. Both must generate exactly like the plain spelling.
 #[test]

--- a/tests/fixtures/antlr4-rust-gen/adaptive-atn-routing/AdaptiveRouting.g4
+++ b/tests/fixtures/antlr4-rust-gen/adaptive-atn-routing/AdaptiveRouting.g4
@@ -1,0 +1,76 @@
+grammar AdaptiveRouting;
+
+start
+    : wrapper EOF
+    ;
+
+wrapper
+    : (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      expression
+    ;
+
+expression
+    : (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      (ID | ID ID)?
+      ID
+    | expression STAR expression
+    | expression SLASH expression
+    | expression PLUS expression
+    | expression MINUS expression
+    | expression AMP expression
+    | expression CARET expression
+    | expression PIPE expression
+    | expression QUESTION expression
+    ;
+
+STAR
+    : '*'
+    ;
+
+SLASH
+    : '/'
+    ;
+
+PLUS
+    : '+'
+    ;
+
+MINUS
+    : '-'
+    ;
+
+AMP
+    : '&'
+    ;
+
+CARET
+    : '^'
+    ;
+
+PIPE
+    : '|'
+    ;
+
+QUESTION
+    : '?'
+    ;
+
+ID
+    : [a-z]+
+    ;
+
+WS
+    : [ \t\r\n]+ -> skip
+    ;


### PR DESCRIPTION
Fixes #222.

## Root cause

ATN-preferred generated-parser routing only recognized long chains of mandatory
rule calls. A grammar that represents an operator hierarchy as one
left-recursive rule never forms that chain, so the selector abstained even when
repeated adaptive prediction made the generated walker slower than the ATN
recognizer.

## What changed

- Detect candidate regions from grammar-agnostic ATN structure: left recursion,
  decision cost, and operator-alternative fanout.
- Measure adaptive-prediction calls and closure work only when the decision DFA
  remains unchanged during the call, so first or incremental cache population
  cannot trigger interpreter replay.
- Prefer an eligible enclosing wrapper as the retry boundary on wrapper paths.
  Keep the left-recursive seed eligible for direct and cheaper-caller paths,
  retrying it through the interpreter in the same invocation.
- Unwind generated contexts and roll back diagnostics, parse-tree storage,
  parser state, and input before replaying through the interpreter.
- Keep adaptive replay disabled for cold decision DFAs, syntax recovery, parse
  listeners, rule-depth caps, decision-observing semantic hooks, embedded
  semantics, and forced-generated mode.
- Preserve prediction-training state with shared DFA stores while ensuring an
  overlapping simulator that receives an empty store remains cold.
- Add structural unit coverage and a synthetic generated-code compile fixture.

The runtime and generator contain no grammar, language, rule, or file-specific
special cases.

## Validation

- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features`
  - 338 runtime tests
  - 759 generator tests
  - 36 CLI integration tests
- `tools/grammar-frontend/update-stage0.sh --check`
  - Stage 1 and Stage 2 byte-identical
  - checked-in frontend remains the tested fixed point
- `cargo run --release --quiet --bin antlr4-runtime-testsuite`
  - 357 passed, 0 failed
- Kotlin Python-oracle parity: all snippets passed
- Rust/Go AST parity: all 18 Kotlin, C#, Java, and Trino fixtures passed
- Parse-bench Python tests: 17 passed

### Java parse benchmark

Same-machine averages with 1,000 in-process parses per fixture:

| Fixture | `main` | This PR | Ratio |
|---|---:|---:|---:|
| issue-174 return expression | 0.015 ms | 0.014 ms | 0.93x |
| Mojang DataResult | 2.850 ms | 2.876 ms | 1.01x |
| Bazel SkyValueRetriever | 8.574 ms | 5.804 ms | **0.68x** |
| Closure Property | 0.780 ms | 0.791 ms | 1.01x |
| Trino FilterEvaluator | 4.475 ms | 4.513 ms | 1.01x |

`tools/parse-bench/compare.py` passes all five matching results at the `1.15x`
regression threshold.
