### PR TITLE
fix(codegen): retain safe shared-label accessors

### DIFF
--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9177,6 +9177,23 @@ struct ContextLabelSelection {
     compatible_last_after: Option<usize>,
 }
 
+fn reconcile_context_label_selections(
+    selections: &[ContextLabelSelection],
+) -> Option<ContextLabelSelector> {
+    let first = selections.first()?;
+    if selections
+        .iter()
+        .all(|selection| selection.preferred == first.preferred)
+    {
+        return Some(first.preferred);
+    }
+    let skip = first.compatible_last_after?;
+    selections
+        .iter()
+        .all(|selection| selection.compatible_last_after == Some(skip))
+        .then_some(ContextLabelSelector::LastAfter(skip))
+}
+
 fn context_label_accessors(
     rule: &embedded::RuleModel,
     alternative_label: Option<&str>,
@@ -9286,19 +9303,7 @@ fn context_label_accessor(
         });
     }
 
-    let first_selection = selections.first()?;
-    let selector = if selections
-        .iter()
-        .all(|selection| selection.preferred == first_selection.preferred)
-    {
-        first_selection.preferred
-    } else {
-        let skip = first_selection.compatible_last_after?;
-        selections
-            .iter()
-            .all(|selection| selection.compatible_last_after == Some(skip))
-            .then_some(ContextLabelSelector::LastAfter(skip))?
-    };
+    let selector = reconcile_context_label_selections(&selections)?;
     let mut cardinality = choice_cardinality(&cardinalities);
     if !is_list {
         cardinality = embedded::ChildCardinality {
@@ -13598,6 +13603,16 @@ mod tests {
     use super::*;
     use antlr4_runtime::atn::parser_atn::{ParserAtnBuilder, ParserTransitionSpec};
 
+    fn rendered_context_impl<'a>(rendered: &'a str, name: &str) -> &'a str {
+        rendered
+            .split_once(&format!("impl<'a, State> {name}<'a, State> {{"))
+            .unwrap_or_else(|| panic!("{name} impl"))
+            .1
+            .split_once(&format!("impl<State> std::fmt::Display for {name}"))
+            .unwrap_or_else(|| panic!("{name} display impl"))
+            .0
+    }
+
     #[test]
     fn renders_module_level_metadata_helpers() {
         let rendered = render_metadata("TParser", &minimal_parser_data());
@@ -15430,41 +15445,101 @@ mod tests {
         );
         insta::assert_snapshot!("multi_alternative_label_shadowed_context", shadowed_context);
 
-        let context = |name: &str| {
-            rendered
-                .split_once(&format!("impl<'a, State> {name}<'a, State> {{"))
-                .unwrap_or_else(|| panic!("{name} impl"))
-                .1
-                .split_once(&format!("impl<State> std::fmt::Display for {name}"))
-                .unwrap_or_else(|| panic!("{name} display impl"))
-                .0
-                .to_owned()
-        };
-
         // A following union member under the same optional block cannot outlive
         // the label, so the ordinary positional read remains faithful.
         insta::assert_snapshot!(
             "multi_alternative_label_shared_optional_block_context",
-            context("SharedOptionalBlockContext")
+            rendered_context_impl(&rendered, "SharedOptionalBlockContext")
         );
         // A direct `?` on the label breaks that coupling and must still decline.
         insta::assert_snapshot!(
             "multi_alternative_label_direct_optional_in_shared_block_context",
-            context("DirectOptionalInSharedBlockContext")
+            rendered_context_impl(&rendered, "DirectOptionalInSharedBlockContext")
         );
         // A repeated and a non-repeated declaration can share a last-match read
         // only when neither alternative has a later union member.
         insta::assert_snapshot!(
             "multi_alternative_label_mixed_repetition_context",
-            context("MixedRepetitionContext")
+            rendered_context_impl(&rendered, "MixedRepetitionContext")
         );
         insta::assert_snapshot!(
             "multi_alternative_label_prefixed_mixed_repetition_context",
-            context("PrefixedMixedRepetitionContext")
+            rendered_context_impl(&rendered, "PrefixedMixedRepetitionContext")
         );
         insta::assert_snapshot!(
             "multi_alternative_label_mixed_repetition_followed_context",
-            context("MixedRepetitionFollowedContext")
+            rendered_context_impl(&rendered, "MixedRepetitionFollowedContext")
+        );
+    }
+
+    #[test]
+    fn context_label_selection_reconciliation_covers_each_compatibility_path() {
+        let selection = |preferred, compatible_last_after| ContextLabelSelection {
+            preferred,
+            compatible_last_after,
+        };
+        let unanimous_nth = [
+            selection(ContextLabelSelector::Nth(2), None),
+            selection(ContextLabelSelector::Nth(2), Some(2)),
+        ];
+        let unanimous_list = [
+            selection(ContextLabelSelector::AllAfter(1), None),
+            selection(ContextLabelSelector::AllAfter(1), None),
+        ];
+        let promote_zero = [
+            selection(ContextLabelSelector::Nth(0), Some(0)),
+            selection(ContextLabelSelector::LastAfter(0), Some(0)),
+        ];
+        let promote_one = [
+            selection(ContextLabelSelector::LastAfter(1), Some(1)),
+            selection(ContextLabelSelector::Nth(1), Some(1)),
+        ];
+        let different_skips = [
+            selection(ContextLabelSelector::Nth(0), Some(0)),
+            selection(ContextLabelSelector::LastAfter(1), Some(1)),
+        ];
+        let unsafe_nth = [
+            selection(ContextLabelSelector::Nth(0), None),
+            selection(ContextLabelSelector::LastAfter(0), Some(0)),
+        ];
+        let incompatible_modes = [
+            selection(ContextLabelSelector::Nth(0), Some(0)),
+            selection(ContextLabelSelector::AllAfter(0), None),
+        ];
+
+        insta::assert_debug_snapshot!(
+            "context_label_selection_reconciliation",
+            [
+                ("empty", reconcile_context_label_selections(&[])),
+                (
+                    "unanimous nth",
+                    reconcile_context_label_selections(&unanimous_nth),
+                ),
+                (
+                    "unanimous list",
+                    reconcile_context_label_selections(&unanimous_list),
+                ),
+                (
+                    "promote zero",
+                    reconcile_context_label_selections(&promote_zero),
+                ),
+                (
+                    "promote one",
+                    reconcile_context_label_selections(&promote_one),
+                ),
+                (
+                    "different skips",
+                    reconcile_context_label_selections(&different_skips),
+                ),
+                (
+                    "unsafe nth",
+                    reconcile_context_label_selections(&unsafe_nth),
+                ),
+                (
+                    "incompatible modes",
+                    reconcile_context_label_selections(&incompatible_modes),
+                ),
+            ]
         );
     }
 
@@ -15477,37 +15552,26 @@ mod tests {
         let data = parser_fixture_data("multi-alternative-label/T.g4");
         let rendered = render_parser("TParser", &data).expect("parser should render");
 
-        let context = |name: &str| {
-            rendered
-                .split_once(&format!("impl<'a, State> {name}<'a, State> {{"))
-                .unwrap_or_else(|| panic!("{name} impl"))
-                .1
-                .split_once(&format!("impl<State> std::fmt::Display for {name}"))
-                .unwrap_or_else(|| panic!("{name} display impl"))
-                .0
-                .to_owned()
-        };
-
         // `(doc = IDENT)? (oneway = STAR | IN errors += unary ...)?`: the labels
         // sit inside unlabeled grouping blocks, so collapsing each block into
         // one token-group ref would swallow them.
         insta::assert_snapshot!(
             "multi_alternative_label_grouped_context",
-            context("GroupedContext")
+            rendered_context_impl(&rendered, "GroupedContext")
         );
 
         // `name = unary ... errors += unary`: a single and a list label on the
         // same rule must each resolve past the other's children.
         insta::assert_snapshot!(
             "multi_alternative_label_mixed_context",
-            context("MixedContext")
+            rendered_context_impl(&rendered, "MixedContext")
         );
 
         // A label buried under redundant grouping levels still reaches the
         // surface — the collapse check descends nested blocks.
         insta::assert_snapshot!(
             "multi_alternative_label_nested_group_context",
-            context("NestedGroupContext")
+            rendered_context_impl(&rendered, "NestedGroupContext")
         );
 
         // The three declining shapes are snapshotted whole rather than probed
@@ -15527,35 +15591,35 @@ mod tests {
         // child ahead of the label).
         insta::assert_snapshot!(
             "multi_alternative_label_exhaustive_prefix_context",
-            context("ExhaustivePrefixContext")
+            rendered_context_impl(&rendered, "ExhaustivePrefixContext")
         );
         insta::assert_snapshot!(
             "multi_alternative_label_overlapping_group_context",
-            context("OverlappingGroupContext")
+            rendered_context_impl(&rendered, "OverlappingGroupContext")
         );
         // Making that same choice optional removes the fixed position, so the
         // following label loses its accessor — the branch-local cardinality is
         // what distinguishes the two.
         insta::assert_snapshot!(
             "multi_alternative_label_optional_prefix_context",
-            context("OptionalPrefixContext")
+            rendered_context_impl(&rendered, "OptionalPrefixContext")
         );
         // One label over mutually exclusive branches merges into a single read; and
         // restricting to the label's own path lets a sibling branch be ignored
         // rather than demanded.
         insta::assert_snapshot!(
             "multi_alternative_label_merged_rivals_context",
-            context("MergedRivalsContext")
+            rendered_context_impl(&rendered, "MergedRivalsContext")
         );
         // Repeated scalar declarations merge as a *last*-match read, since ANTLR
         // overwrites a scalar label on every iteration.
         insta::assert_snapshot!(
             "multi_alternative_label_merged_repeats_context",
-            context("MergedRepeatsContext")
+            rendered_context_impl(&rendered, "MergedRepeatsContext")
         );
         insta::assert_snapshot!(
             "multi_alternative_label_path_restricted_context",
-            context("PathRestrictedContext")
+            rendered_context_impl(&rendered, "PathRestrictedContext")
         );
         // Two ways the on-path restriction can overstate what it knows, both
         // declining as a result:
@@ -15568,17 +15632,17 @@ mod tests {
         //   exhaustive two-way one and the prefix count is wrongly fixed at 1.
         insta::assert_snapshot!(
             "multi_alternative_label_closed_repeat_prefix_context",
-            context("ClosedRepeatPrefixContext")
+            rendered_context_impl(&rendered, "ClosedRepeatPrefixContext")
         );
         insta::assert_snapshot!(
             "multi_alternative_label_inner_choice_arity_context",
-            context("InnerChoiceArityContext")
+            rendered_context_impl(&rendered, "InnerChoiceArityContext")
         );
         // Nesting the exhaustive choice keeps the count fixed: the inner choice's
         // agreed contribution rolls up into the outer branch.
         insta::assert_snapshot!(
             "multi_alternative_label_nested_exhaustive_prefix_context",
-            context("NestedExhaustivePrefixContext")
+            rendered_context_impl(&rendered, "NestedExhaustivePrefixContext")
         );
 
         for (name, snapshot) in [
@@ -15595,7 +15659,7 @@ mod tests {
                 "multi_alternative_label_branch_rival_context",
             ),
         ] {
-            insta::assert_snapshot!(snapshot, context(name));
+            insta::assert_snapshot!(snapshot, rendered_context_impl(&rendered, name));
         }
     }
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9170,6 +9170,13 @@ enum ContextLabelSelector {
     AllAfter(usize),
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct ContextLabelSelection {
+    preferred: ContextLabelSelector,
+    /// A last-match selector that is equivalent to `preferred`, when one exists.
+    compatible_last_after: Option<usize>,
+}
+
 fn context_label_accessors(
     rule: &embedded::RuleModel,
     alternative_label: Option<&str>,
@@ -9245,7 +9252,7 @@ fn context_label_accessor(
         branch_local_cardinality: embedded::ChildCardinality::ONE,
         group_local_cardinality: embedded::ChildCardinality::ONE,
     };
-    let mut selector = None;
+    let mut selections = Vec::with_capacity(alternatives.len());
     let mut cardinalities = Vec::with_capacity(alternatives.len());
     for alternative in alternatives {
         let matching = alternative
@@ -9269,12 +9276,9 @@ fn context_label_accessor(
             continue;
         }
 
-        let alternative_selector =
+        let alternative_selection =
             context_label_selector(alternative, &matching, &label, &reference, is_list)?;
-        if selector.is_some_and(|existing| existing != alternative_selector) {
-            return None;
-        }
-        selector = Some(alternative_selector);
+        selections.push(alternative_selection);
         cardinalities.push(if is_list {
             sum_child_cardinalities(matching.iter().map(|(_, element)| element.cardinality))
         } else {
@@ -9282,6 +9286,19 @@ fn context_label_accessor(
         });
     }
 
+    let first_selection = selections.first()?;
+    let selector = if selections
+        .iter()
+        .all(|selection| selection.preferred == first_selection.preferred)
+    {
+        first_selection.preferred
+    } else {
+        let skip = first_selection.compatible_last_after?;
+        selections
+            .iter()
+            .all(|selection| selection.compatible_last_after == Some(skip))
+            .then_some(ContextLabelSelector::LastAfter(skip))?
+    };
     let mut cardinality = choice_cardinality(&cardinalities);
     if !is_list {
         cardinality = embedded::ChildCardinality {
@@ -9294,7 +9311,7 @@ fn context_label_accessor(
         target: reference.target,
         token_types: reference.token_types,
         cardinality,
-        selector: selector?,
+        selector,
     })
 }
 
@@ -9304,7 +9321,7 @@ fn context_label_selector(
     label: &str,
     target: &embedded::ElementRef,
     is_list: bool,
-) -> Option<ContextLabelSelector> {
+) -> Option<ContextLabelSelection> {
     let first_position = matching[0].0;
     let labeled = matching[0].1;
     // A sibling branch that matches the same target supplies a child at the very
@@ -9382,8 +9399,10 @@ fn context_label_selector(
             exact_target_cardinality_on_path(&alternative.refs[..*position], target, declaration)
                 == Some(start)
         });
-        return (!has_unlabeled_target && starts_agree)
-            .then_some(ContextLabelSelector::AllAfter(start));
+        return (!has_unlabeled_target && starts_agree).then_some(ContextLabelSelection {
+            preferred: ContextLabelSelector::AllAfter(start),
+            compatible_last_after: None,
+        });
     }
     // Several declarations can share one positional read when they are mutually
     // exclusive and each sits at the same occurrence — `(x=A | x=B)` binds exactly
@@ -9427,24 +9446,30 @@ fn context_label_selector(
         // applies to every branch, so it is only sound when no branch has a matching
         // child *after* its declaration: in `(x=A A B | x=A+ C)` the first branch's
         // trailing unlabeled `A` would become the `last()`.
+        let followed = matching.iter().any(|(position, declaration)| {
+            alternative.refs[position + 1..].iter().any(|following| {
+                following.label.as_deref() != Some(label)
+                    && context_ref_can_match_target(following, target)
+                    && following.cardinality.max != Some(0)
+                    && following.can_coexist_with(declaration)
+            })
+        });
         if matching
             .iter()
             .any(|(_, element)| element.cardinality.is_repeated())
         {
-            let followed = matching.iter().any(|(position, declaration)| {
-                alternative.refs[position + 1..].iter().any(|following| {
-                    following.label.as_deref() != Some(label)
-                        && context_ref_can_match_target(following, target)
-                        && following.cardinality.max != Some(0)
-                        && following.can_coexist_with(declaration)
-                })
-            });
             if followed {
                 return None;
             }
-            return Some(ContextLabelSelector::LastAfter(agreed));
+            return Some(ContextLabelSelection {
+                preferred: ContextLabelSelector::LastAfter(agreed),
+                compatible_last_after: Some(agreed),
+            });
         }
-        return Some(ContextLabelSelector::Nth(agreed));
+        return Some(ContextLabelSelection {
+            preferred: ContextLabelSelector::Nth(agreed),
+            compatible_last_after: (!followed).then_some(agreed),
+        });
     }
     let element = matching[0].1;
     if !element.cardinality.is_repeated() {
@@ -9457,15 +9482,56 @@ fn context_label_selector(
                 .any(|following| {
                     context_ref_can_match_target(following, target)
                         && following.cardinality.max != Some(0)
+                        && following_can_shadow_absent_label(element, following)
                 });
-        return (!shadowed_when_absent).then_some(ContextLabelSelector::Nth(start));
-    }
-    let has_following_target = alternative.refs[first_position + 1..]
-        .iter()
-        .any(|following| {
-            context_ref_can_match_target(following, target) && following.cardinality.max != Some(0)
+        if shadowed_when_absent {
+            return None;
+        }
+        let followed = has_following_context_target(alternative, first_position, target);
+        return Some(ContextLabelSelection {
+            preferred: ContextLabelSelector::Nth(start),
+            compatible_last_after: (!followed).then_some(start),
         });
-    (!has_following_target).then_some(ContextLabelSelector::LastAfter(start))
+    }
+    let has_following_target = has_following_context_target(alternative, first_position, target);
+    (!has_following_target).then_some(ContextLabelSelection {
+        preferred: ContextLabelSelector::LastAfter(start),
+        compatible_last_after: Some(start),
+    })
+}
+
+fn has_following_context_target(
+    alternative: &embedded::AltModel,
+    position: usize,
+    target: &embedded::ElementRef,
+) -> bool {
+    alternative.refs[position + 1..].iter().any(|following| {
+        context_ref_can_match_target(following, target) && following.cardinality.max != Some(0)
+    })
+}
+
+fn following_can_shadow_absent_label(
+    label: &embedded::ElementRef,
+    following: &embedded::ElementRef,
+) -> bool {
+    // A direct suffix can omit the label while every enclosing block remains
+    // present, so no following ref is coupled to that absence.
+    if label.group_local_cardinality.min == 0 {
+        return true;
+    }
+    // Otherwise the label is optional only because an enclosing group can be
+    // absent or an enclosing choice can take another branch. A following ref
+    // under every such group and branch disappears with the label and cannot
+    // slide into its occurrence.
+    label
+        .group_spans
+        .iter()
+        .filter(|group| group.optional)
+        .any(|group| !following.group_spans.contains(group))
+        || label
+            .choice_branch
+            .iter()
+            .any(|branch| !following.choice_branch.contains(branch))
 }
 
 fn same_context_ref_target(left: &embedded::ElementRef, right: &embedded::ElementRef) -> bool {
@@ -15363,6 +15429,43 @@ mod tests {
             "optional labeled token shadowed by a following union match must drop its accessor\n{shadowed_context}"
         );
         insta::assert_snapshot!("multi_alternative_label_shadowed_context", shadowed_context);
+
+        let context = |name: &str| {
+            rendered
+                .split_once(&format!("impl<'a, State> {name}<'a, State> {{"))
+                .unwrap_or_else(|| panic!("{name} impl"))
+                .1
+                .split_once(&format!("impl<State> std::fmt::Display for {name}"))
+                .unwrap_or_else(|| panic!("{name} display impl"))
+                .0
+                .to_owned()
+        };
+
+        // A following union member under the same optional block cannot outlive
+        // the label, so the ordinary positional read remains faithful.
+        insta::assert_snapshot!(
+            "multi_alternative_label_shared_optional_block_context",
+            context("SharedOptionalBlockContext")
+        );
+        // A direct `?` on the label breaks that coupling and must still decline.
+        insta::assert_snapshot!(
+            "multi_alternative_label_direct_optional_in_shared_block_context",
+            context("DirectOptionalInSharedBlockContext")
+        );
+        // A repeated and a non-repeated declaration can share a last-match read
+        // only when neither alternative has a later union member.
+        insta::assert_snapshot!(
+            "multi_alternative_label_mixed_repetition_context",
+            context("MixedRepetitionContext")
+        );
+        insta::assert_snapshot!(
+            "multi_alternative_label_prefixed_mixed_repetition_context",
+            context("PrefixedMixedRepetitionContext")
+        );
+        insta::assert_snapshot!(
+            "multi_alternative_label_mixed_repetition_followed_context",
+            context("MixedRepetitionFollowedContext")
+        );
     }
 
     /// Issue #201: labels nested inside an unlabeled grouping block, and a

--- a/src/bin/snapshots/antlr4_rust_gen__tests__context_label_selection_reconciliation.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__context_label_selection_reconciliation.snap
@@ -1,0 +1,54 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "[(\"empty\", reconcile_context_label_selections(&[])),\n(\"unanimous nth\", reconcile_context_label_selections(&unanimous_nth),),\n(\"unanimous list\", reconcile_context_label_selections(&unanimous_list),),\n(\"promote zero\", reconcile_context_label_selections(&promote_zero),),\n(\"promote one\", reconcile_context_label_selections(&promote_one),),\n(\"different skips\", reconcile_context_label_selections(&different_skips),),\n(\"unsafe nth\", reconcile_context_label_selections(&unsafe_nth),),\n(\"incompatible modes\",\nreconcile_context_label_selections(&incompatible_modes),),]"
+---
+[
+    (
+        "empty",
+        None,
+    ),
+    (
+        "unanimous nth",
+        Some(
+            Nth(
+                2,
+            ),
+        ),
+    ),
+    (
+        "unanimous list",
+        Some(
+            AllAfter(
+                1,
+            ),
+        ),
+    ),
+    (
+        "promote zero",
+        Some(
+            LastAfter(
+                0,
+            ),
+        ),
+    ),
+    (
+        "promote one",
+        Some(
+            LastAfter(
+                1,
+            ),
+        ),
+    ),
+    (
+        "different skips",
+        None,
+    ),
+    (
+        "unsafe nth",
+        None,
+    ),
+    (
+        "incompatible modes",
+        None,
+    ),
+]

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_direct_optional_in_shared_block_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_direct_optional_in_shared_block_context.snap
@@ -1,0 +1,52 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"DirectOptionalInSharedBlockContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 11)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn minus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 12)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_context.snap
@@ -1,0 +1,55 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"MixedRepetitionContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+    pub fn minus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 12).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MixedRepetitionContext", "NUM"))
+    }
+    pub fn latest(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __labeled_token_children_matching(self.__node, &[8, 9, 11, 12])
+            .skip(0).last()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MixedRepetitionContext", "latest"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_followed_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_followed_context.snap
@@ -1,0 +1,47 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"MixedRepetitionFollowedContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 8).map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+    pub fn minus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 12).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("MixedRepetitionFollowedContext", "NUM"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_prefixed_mixed_repetition_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_prefixed_mixed_repetition_context.snap
@@ -1,0 +1,53 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"PrefixedMixedRepetitionContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 8).map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+    pub fn minus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 12).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("PrefixedMixedRepetitionContext", "NUM"))
+    }
+    pub fn latest(&self) -> Result<TerminalNode<'a>, MissingChildError> {
+        __labeled_token_children_matching(self.__node, &[8, 9, 11, 12])
+            .skip(1).last()
+            .map(TerminalNode::new)
+            .ok_or_else(|| MissingChildError::new("PrefixedMixedRepetitionContext", "latest"))
+    }
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_shared_optional_block_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_shared_optional_block_context.snap
@@ -1,0 +1,57 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: "context(\"SharedOptionalBlockContext\")"
+---
+
+    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 11)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn minus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 12)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn shared(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children_matching(self.__node, &[8, 9, 11, 12])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1032,6 +1032,75 @@ mod multi_alternative_label_tests {
             "the absent throws clause contributes no errors"
         );
     }
+
+    #[test]
+    fn shared_optional_block_keeps_its_label_accessor() {
+        let parsed = parse_rule("+*7", TParser::shared_optional_block);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("sharedOptionalBlock rule")
+            .downcast_ref::<SharedOptionalBlockContext>()
+            .expect("typed sharedOptionalBlock context");
+        assert_eq!(context.shared().expect("first alternative label").to_string(), "+");
+
+        let parsed = parse_rule("", TParser::shared_optional_block);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("sharedOptionalBlock rule")
+            .downcast_ref::<SharedOptionalBlockContext>()
+            .expect("typed sharedOptionalBlock context");
+        assert!(context.shared().is_none(), "skipped block leaves the label unset");
+
+        let parsed = parse_rule("*7", TParser::shared_optional_block);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("sharedOptionalBlock rule")
+            .downcast_ref::<SharedOptionalBlockContext>()
+            .expect("typed sharedOptionalBlock context");
+        assert_eq!(context.shared().expect("second alternative label").to_string(), "*");
+    }
+
+    #[test]
+    fn mixed_repetition_uses_the_last_assignment_on_both_alternatives() {
+        let parsed = parse_rule("+-7", TParser::mixed_repetition);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("mixedRepetition rule")
+            .downcast_ref::<MixedRepetitionContext>()
+            .expect("typed mixedRepetition context");
+        assert_eq!(context.latest().expect("repeated label").to_string(), "-");
+
+        let parsed = parse_rule("/7", TParser::mixed_repetition);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("mixedRepetition rule")
+            .downcast_ref::<MixedRepetitionContext>()
+            .expect("typed mixedRepetition context");
+        assert_eq!(context.latest().expect("single label").to_string(), "/");
+
+        let parsed = parse_rule("++-7", TParser::prefixed_mixed_repetition);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("prefixedMixedRepetition rule")
+            .downcast_ref::<PrefixedMixedRepetitionContext>()
+            .expect("typed prefixedMixedRepetition context");
+        assert_eq!(context.latest().expect("prefixed repeated label").to_string(), "-");
+
+        let parsed = parse_rule("*/7", TParser::prefixed_mixed_repetition);
+        let context = parsed
+            .tree()
+            .as_rule()
+            .expect("prefixedMixedRepetition rule")
+            .downcast_ref::<PrefixedMixedRepetitionContext>()
+            .expect("typed prefixedMixedRepetition context");
+        assert_eq!(context.latest().expect("prefixed single label").to_string(), "/");
+    }
 }
 "#,
     );

--- a/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/multi-alternative-label/T.g4
@@ -137,6 +137,42 @@ inner_choice_arity
     : ((unary | unary | param) tail = unary | NUM) NUM
     ;
 
+// Issue #214, shape 1: the labeled group and the following union member are
+// inside the same optional block. If the label is absent because the block was
+// skipped, the follower is absent too, so it cannot slide into the label's slot.
+shared_optional_block
+    : (shared = (PLUS | MINUS) STAR NUM)?
+    | shared = (STAR | SLASH) NUM
+    ;
+
+// Sharing an enclosing optional block is not enough when the labeled element
+// has its own `?`: the block may run, omit the label, and still emit `STAR`.
+direct_optional_in_shared_block
+    : (shared = (PLUS | MINUS)? STAR NUM)?
+    | shared = (STAR | SLASH) NUM
+    ;
+
+// Issue #214, shape 2: the first alternative needs last-assignment-wins while
+// the second has one occurrence. With no later union member, `last()` serves both.
+mixed_repetition
+    : latest = (PLUS | MINUS)+ NUM
+    | latest = (STAR | SLASH) NUM
+    ;
+
+// The same merge after one union-matching prefix proves the shared occurrence
+// is preserved rather than assuming every compatible selector starts at zero.
+prefixed_mixed_repetition
+    : PLUS latest = (PLUS | MINUS)+ NUM
+    | STAR latest = (STAR | SLASH) NUM
+    ;
+
+// The non-repeated alternative cannot be promoted to `last()` when a later
+// union member would replace the token it bound.
+mixed_repetition_followed
+    : latest = (PLUS | MINUS)+ NUM
+    | latest = (STAR | SLASH) STAR NUM
+    ;
+
 LESS
     : '<'
     ;


### PR DESCRIPTION
## Summary

- retain a shared token-label accessor when a following union member is coupled to the label by the same optional group and choice path
- promote compatible `Nth(k)` and `LastAfter(k)` selectors to one last-match read only when every declaring alternative supports the same skip
- cover both fixes, a nonzero skip, and the unsafe direct-optional and later-match neighbors with named snapshots and generated-project runtime tests

## Root cause

The accessor analysis treated every later union match as able to shadow an optional label, even when both disappeared together with the same enclosing block. It also required selectors from separate alternatives to be identical, although a non-repeated `Nth(k)` read with no later match is equivalently served by `LastAfter(k)`.

The fix reuses the existing structural group and choice ancestry, and records a selector's compatible last-match form without changing its preferred read. Promotion occurs only when all alternatives agree on the same `LastAfter(k)`.

## Validation

- `cargo test --locked --all-features --workspace`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo fmt --check`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite -- --descriptors /tmp/antlr-cleanroom/antlr4-upstream-214/runtime-testsuite` (`357 passed, 0 failed, 0 skipped`)

Fixes #214


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved generated parser accessors for labeled tokens used across multiple grammar alternatives.
  - Preserved reliable label access when optional sections are present or absent.
  - Improved handling of repeated labels so accessors consistently reference the correct final assignment.
  - Added support for more complex combinations of optional, repeated, and follow-on grammar contexts.
- **Tests**
  - Expanded coverage for multi-alternative label scenarios and generated typed parsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->