### PR TITLE
fix(codegen): diagnose left-recursive lexer rules

### DIFF
--- a/src/bin_support/grammar/atn/analysis.rs
+++ b/src/bin_support/grammar/atn/analysis.rs
@@ -80,7 +80,7 @@ pub(crate) fn analyze_parser(
     }
 
     let nullable_rule_indices = nullable_rule_indices(graph);
-    let recursive_components = indirect_left_recursive_components(graph, &nullable_rule_indices);
+    let recursive_components = left_recursive_components(graph, &nullable_rule_indices);
     diagnostics.extend(recursion_diagnostics(grammar, &recursive_components));
     if has_errors(&diagnostics) {
         return Err(CompilationError::new(diagnostics));
@@ -247,7 +247,7 @@ fn epsilon_reaches(
     false
 }
 
-fn indirect_left_recursive_components(
+pub(super) fn left_recursive_components(
     graph: &FinalizedAtnGraph,
     nullable_rules: &BTreeSet<usize>,
 ) -> Vec<Vec<RuleId>> {
@@ -340,7 +340,10 @@ fn collect_left_corners(
     }
 }
 
-fn recursion_diagnostics(grammar: &SemanticGrammar, components: &[Vec<RuleId>]) -> Vec<Diagnostic> {
+pub(super) fn recursion_diagnostics(
+    grammar: &SemanticGrammar,
+    components: &[Vec<RuleId>],
+) -> Vec<Diagnostic> {
     let rules = grammar
         .unit
         .rules

--- a/src/bin_support/grammar/atn/lexer.rs
+++ b/src/bin_support/grammar/atn/lexer.rs
@@ -20,7 +20,7 @@ use super::super::model::{
 };
 use super::super::provenance::{Origin, ProvenanceIndex, SyntheticReason};
 use super::super::unicode::{property_ranges, simple_lowercase, simple_uppercase};
-use super::analysis::LookAnalyzer;
+use super::analysis::{LookAnalyzer, left_recursive_components, recursion_diagnostics};
 use super::build::{
     BuildGraph, BuildTransitionKind, BuildTransitionSpec, FinalizedAtnGraph, FinalizedTransition,
     FinalizedTransitionKind,
@@ -1285,6 +1285,12 @@ fn analyze_lexer(
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Result<LexerAnalysis, CompilationError> {
     let nullable_indices = nullable_rule_indices(graph);
+    let left_recursion = left_recursive_components(graph, &nullable_indices);
+    diagnostics.extend(recursion_diagnostics(grammar, &left_recursion));
+    if has_errors(diagnostics) {
+        return Err(CompilationError::new(std::mem::take(diagnostics)));
+    }
+
     let recursive_components = recursive_rule_components(grammar);
     let analyzer = LookAnalyzer::new(graph);
     for (rule, start, stop) in closure_sites {

--- a/src/bin_support/grammar/left_recursion.rs
+++ b/src/bin_support/grammar/left_recursion.rs
@@ -4,7 +4,7 @@ use super::diagnostic::Diagnostic;
 use super::model::{
     Alternative, AlternativeId, Block, Element, ElementKind, GrammarUnit, LeftRecursionInfo,
     LeftRecursiveAlternativeKind, ModelIdAllocator, ModelNodeId, Quantifier,
-    RemovedLeftRecursiveLabel, Rule, RuleId,
+    RemovedLeftRecursiveLabel, Rule, RuleId, RuleKind,
 };
 use super::provenance::{LeftRecursionRole, Origin, ProvenanceIndex, Tombstone};
 
@@ -17,7 +17,9 @@ pub(crate) fn rewrite_immediate_left_recursion(
     let mut rewritten_names = BTreeSet::new();
     for unit in units.iter_mut() {
         for rule in &mut unit.rules {
-            if matches!(classify_rule(rule), RuleClassification::NotLeftRecursive) {
+            if rule.kind != RuleKind::Parser
+                || matches!(classify_rule(rule), RuleClassification::NotLeftRecursive)
+            {
                 continue;
             }
             match rewrite_rule(rule, ids, provenance) {

--- a/src/bin_support/grammar/mutual_recursion.rs
+++ b/src/bin_support/grammar/mutual_recursion.rs
@@ -1896,8 +1896,8 @@ mod tests {
         // Precedence rewriting is a parser-rule construct. Routing a lexer SCC
         // through it produced an "unsupported embedded lexer action" naming an
         // action the grammar never declared. Left-recursive lexer rules are
-        // invalid in ANTLR regardless (error(119)); diagnosing them properly is
-        // tracked separately as issue #236.
+        // invalid in ANTLR regardless (error(119)); lexer ATN analysis reports
+        // their left-corner cycles as G4A005 (issue #236).
         let mut fixture = parse(
             "lexer grammar L; \
              A : B 'a' | 'x' ; \

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -2209,6 +2209,35 @@ fn invalid_source_emits_diagnostics_without_partial_outputs() {
     );
 }
 
+/// Issue #236: lexer left-corner cycles are grammar errors, not parser
+/// precedence rules. Diagnose direct and mutual cycles before DFA construction;
+/// ordinary recursion after a consuming transition remains covered by the
+/// `lexer-recursion` ATN parity fixture.
+#[allow(clippy::disallowed_methods)] // `insta` assertion macros unwrap internal I/O.
+#[test]
+fn lexer_left_recursion_reports_each_cycle_without_partial_outputs() {
+    let temp = temporary_directory("lexer-left-recursion");
+    let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/lexer-left-recursion/LexerLeftRecursion.g4");
+    let out = temp.path().join("generated");
+
+    let output = run_antlr4_rust_gen(&[
+        grammar.as_os_str(),
+        OsStr::new("--out-dir"),
+        out.as_os_str(),
+    ]);
+    assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stdout), "");
+    let stderr = utf8(&output.stderr).replace(
+        grammar
+            .to_str()
+            .expect("fixture path should be valid Unicode"),
+        "<grammar>",
+    );
+    insta::assert_snapshot!("lexer_left_recursion_diagnostics", stderr);
+    assert!(!out.exists(), "failed compilation emitted output");
+}
+
 #[test]
 fn imported_source_diagnostics_report_the_import_path() {
     let temp = temporary_directory("imported-diagnostic");

--- a/tests/fixtures/antlr4-rust-gen/lexer-left-recursion/LexerLeftRecursion.g4
+++ b/tests/fixtures/antlr4-rust-gen/lexer-left-recursion/LexerLeftRecursion.g4
@@ -1,0 +1,5 @@
+lexer grammar LexerLeftRecursion;
+
+A : A 'a' | 'x' ;
+B : C 'b' | 'y' ;
+C : B 'c' ;

--- a/tests/snapshots/antlr4_rust_gen_cli__lexer_left_recursion_diagnostics.snap
+++ b/tests/snapshots/antlr4_rust_gen_cli__lexer_left_recursion_diagnostics.snap
@@ -1,0 +1,5 @@
+---
+source: tests/antlr4_rust_gen_cli.rs
+expression: stderr
+---
+Error: Custom { kind: InvalidInput, error: "error[G4A005]: <grammar>:3:0: mutually left-recursive rules: [A]\nerror[G4A005]: <grammar>:4:0: mutually left-recursive rules: [B, C]\n" }


### PR DESCRIPTION
## Summary

- keep parser precedence rewriting out of lexer rules
- reject lexer left-corner cycles with the existing `G4A005` analysis diagnostic before lowering or DFA construction
- cover direct and mutual lexer left recursion end to end, including the no-partial-output contract

## Root cause

The mutual-left-recursion pass already skipped lexer grammars, but the immediate-left-recursion pass did not. A direct lexer cycle was therefore rewritten as a parser precedence rule and surfaced as a fabricated embedded-action error.

Unrewritten mutual lexer cycles passed ATN construction because lexer analysis tracked general recursive SCCs without applying the parser's left-corner cycle detector. They then reached compiled DFA construction and overflowed the native stack.

The fix scopes the immediate rewrite by `RuleKind` and shares the ATN left-corner SCC detector and diagnostic renderer with lexer analysis. Ordinary recursive lexer rules that consume input before recursing remain valid and retain their existing Java ATN parity coverage.

## Validation

- `cargo fmt --all -- --check`
- `node tools/grammar-frontend/validate-interp-fixtures.mjs`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-features --workspace`
- `ANTLR4_RUNTIME_TESTSUITE=/tmp/antlr-cleanroom/antlr4-upstream-4.13.2-issue236/runtime-testsuite cargo run --locked --release --quiet --bin antlr4-runtime-testsuite --features codegen` (`357 passed, 0 failed, 0 skipped`)

Fixes #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and reporting of direct and indirect left-recursion cycles in lexer grammars.
  * Lexer generation now stops cleanly when recursion errors are found and avoids producing partial output.
  * Prevented parser-specific left-recursion rewriting from affecting lexer rules.

* **Tests**
  * Added coverage for multiple mutually recursive lexer rules and verified diagnostic output and failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->