### PR TITLE
feat(codegen): per-decision tiers, decisions.json report, opt-in --fixed-lookahead static dispatch (#150)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,13 @@ on `--jobs` parallel workers (default `min(cores, 8)`), each with its own cargo 
 prebuilt once per sweep. Wall-clock ≈ 2 minutes on Apple Silicon. `ANTLR4_RUST_GEN_EXTRA_ARGS="--fixed-lookahead 3"` forwards extra generator flags
 for opt-in-tier sweeps.
 
+Every `antlr4-rust-gen` run also writes a `decisions.json` manifest next to
+`semantics.json`, reporting each parser decision's tier (`ll1` / `fixed` /
+`adaptive` + reason). The opt-in `--fixed-lookahead <k>` flag compiles
+decisions provable within `k` tokens into static dispatch tables; hits commit
+bare only on within-rule (sync-no-op) lookahead and a miss falls through to
+the regular sync + adaptive body (see the README "Decision Tiers" section).
+
 ### The rendered (embedded-actions) pipeline
 
 The harness runs descriptors the way every official ANTLR target does:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,11 @@ The harness reads `antlr4-upstream/runtime-testsuite` and the same ANTLR jar fet
 cargo run --release --quiet --bin antlr4-runtime-testsuite
 ```
 
-Defaults to `ANTLR4_JAR=/tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar` and `ANTLR4_RUNTIME_TESTSUITE=/tmp/antlr-cleanroom/antlr4-upstream/runtime-testsuite`. Override with `--antlr-jar`/`--descriptors` or env vars. Cases run on `--jobs` parallel workers (default `min(cores, 8)`), each with its own cargo target-dir stripe; the render driver and `antlr4-rust-gen` are prebuilt once per sweep. Wall-clock ≈ 2 minutes on Apple Silicon.
+Defaults to `ANTLR4_JAR=/tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar` and
+`ANTLR4_RUNTIME_TESTSUITE=/tmp/antlr-cleanroom/antlr4-upstream/runtime-testsuite`. Override with `--antlr-jar`/`--descriptors` or env vars. Cases run
+on `--jobs` parallel workers (default `min(cores, 8)`), each with its own cargo target-dir stripe; the render driver and `antlr4-rust-gen` are
+prebuilt once per sweep. Wall-clock ≈ 2 minutes on Apple Silicon. `ANTLR4_RUST_GEN_EXTRA_ARGS="--fixed-lookahead 3"` forwards extra generator flags
+for opt-in-tier sweeps.
 
 ### The rendered (embedded-actions) pipeline
 
@@ -106,7 +110,8 @@ cargo run --release --quiet --bin antlr4-runtime-testsuite -- --group LeftRecurs
 cargo run --release --quiet --bin antlr4-runtime-testsuite -- --case ParserErrors/SingleSetInsertion --keep
 ```
 
-Per-case scratch crates land under `target/antlr-runtime-testsuite/<case>/`. Stale dirs from a killed run can fail a re-run with `Os { code: 66, ... DirectoryNotEmpty }` — `rm -rf target/antlr-runtime-testsuite/*` to recover.
+Per-case scratch crates land under `target/antlr-runtime-testsuite/<case>/`. Stale dirs from a killed run can fail a re-run with
+`Os { code: 66, ... DirectoryNotEmpty }` — `rm -rf target/antlr-runtime-testsuite/*` to recover.
 
 ## Code coverage
 
@@ -200,7 +205,8 @@ only for small, stable values. Project specifics:
 
 ## CI parity
 
-CI runs `cargo clippy --locked --all-targets --all-features -- -D warnings`, so reproduce locally with the same flags before pushing — `clippy::excessive-nesting`, `clippy::disallowed_types`, and similar nursery/pedantic lints all promote to errors there.
+CI runs `cargo clippy --locked --all-targets --all-features -- -D warnings`, so reproduce locally with the same flags before pushing —
+`clippy::excessive-nesting`, `clippy::disallowed_types`, and similar nursery/pedantic lints all promote to errors there.
 
 Validate `.github/workflows/*.yml` with `actionlint` (not a generic YAML linter);
 it shellchecks `run:` scripts too.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,6 +92,15 @@ Generated parsers emit SemIR tables, `with_hooks(tokens, hooks)`, and typed
 hook adapters for bare helper predicates; lexer callers can route closure hooks
 through `LexerSemCtx` and the shared `SemanticHooks` trait.
 
+A `decisions.json` manifest is written alongside, reporting each parser
+decision's tier (`ll1` / `fixed` / `adaptive` + reason). The opt-in
+`--fixed-lookahead <k>` flag compiles decisions provable within `k` tokens
+into static dispatch tables; hits commit bare only on within-rule (sync-no-op)
+lookahead and a miss falls through to the regular sync + adaptive body (see
+the README "Decision Tiers" section; research background in issue 150). The
+conformance harness forwards `ANTLR4_RUST_GEN_EXTRA_ARGS="--fixed-lookahead 3"`
+for flag-on sweeps.
+
 ## Kotlin parser parity perf benchmark
 
 Reproduces the timings against the Kotlin grammar from `antlr/grammars-v4`.
@@ -159,7 +168,10 @@ The harness reads `antlr4-upstream/runtime-testsuite` and the same ANTLR jar fet
 cargo run --release --quiet --bin antlr4-runtime-testsuite
 ```
 
-Defaults to `ANTLR4_JAR=/tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar` and `ANTLR4_RUNTIME_TESTSUITE=/tmp/antlr-cleanroom/antlr4-upstream/runtime-testsuite`. Override with `--antlr-jar`/`--descriptors` or env vars. Cases run on `--jobs` parallel workers (default `min(cores, 8)`), each with its own cargo target-dir stripe; the render driver and `antlr4-rust-gen` are prebuilt once per sweep. Wall-clock ≈ 2 minutes on Apple Silicon.
+Defaults to `ANTLR4_JAR=/tmp/antlr-cleanroom/tools/antlr-4.13.2-complete.jar` and
+`ANTLR4_RUNTIME_TESTSUITE=/tmp/antlr-cleanroom/antlr4-upstream/runtime-testsuite`. Override with `--antlr-jar`/`--descriptors` or env vars. Cases run
+on `--jobs` parallel workers (default `min(cores, 8)`), each with its own cargo target-dir stripe; the render driver and `antlr4-rust-gen` are
+prebuilt once per sweep. Wall-clock ≈ 2 minutes on Apple Silicon.
 
 ### The rendered (embedded-actions) pipeline
 
@@ -190,7 +202,8 @@ cargo run --release --quiet --bin antlr4-runtime-testsuite -- --group LeftRecurs
 cargo run --release --quiet --bin antlr4-runtime-testsuite -- --case ParserErrors/SingleSetInsertion --keep
 ```
 
-Per-case scratch crates land under `target/antlr-runtime-testsuite/<case>/`. Stale dirs from a killed run can fail a re-run with `Os { code: 66, ... DirectoryNotEmpty }` — `rm -rf target/antlr-runtime-testsuite/*` to recover.
+Per-case scratch crates land under `target/antlr-runtime-testsuite/<case>/`. Stale dirs from a killed run can fail a re-run with
+`Os { code: 66, ... DirectoryNotEmpty }` — `rm -rf target/antlr-runtime-testsuite/*` to recover.
 
 ## Code coverage
 
@@ -278,7 +291,8 @@ loop.
 
 ## CI parity
 
-CI runs `cargo clippy --locked --all-targets --all-features -- -D warnings`, so reproduce locally with the same flags before pushing — `clippy::excessive-nesting`, `clippy::disallowed_types`, and similar nursery/pedantic lints all promote to errors there.
+CI runs `cargo clippy --locked --all-targets --all-features -- -D warnings`, so reproduce locally with the same flags before pushing —
+`clippy::excessive-nesting`, `clippy::disallowed_types`, and similar nursery/pedantic lints all promote to errors there.
 
 Validate `.github/workflows/*.yml` with `actionlint` (not a generic YAML linter);
 it shellchecks `run:` scripts too.

--- a/README.md
+++ b/README.md
@@ -601,6 +601,44 @@ inline at their ATN action/predicate coordinates. This is the mode the
 conformance harness uses after rendering descriptor grammars through
 `Rust.test.stg` (see below).
 
+### Decision Tiers and `--fixed-lookahead`
+
+ANTLR always generates an adaptive `ALL(*)` recognizer: every decision point
+carries prediction machinery and a learned DFA cache, even when one token of
+lookahead already settles it. Like the Java tool, `antlr4-rust-gen`
+classifies every parser decision and ports Java's tiering: decisions whose
+alternatives' LOOK(1) sets are pairwise disjoint compile to plain token
+switches, and only the rest run adaptive prediction.
+
+Every generation writes a **`decisions.json`** manifest next to
+`semantics.json` reporting the tier of each decision — `ll1`, `fixed`
+(see below), or `adaptive` with the reason it needs the simulator
+(`non-greedy`, `precedence`, `predicate`, `empty-look`, `not-disjoint`,
+`budget-exceeded`) — so you can see exactly which parts of a grammar pay for
+`ALL(*)` and why:
+
+```json
+{"decision": 4, "rule": "namespace_", "state": 113, "tier": "fixed", "lookahead": 2}
+```
+
+The opt-in **`--fixed-lookahead <k>`** flag (off by default) goes one tier
+further than Java: decisions that are not LL(1) but whose lookahead
+languages are pairwise disjoint within `k` tokens compile into a static
+nested `match` over `la(1) .. la(k)` — no simulator, no DFA warming, no
+per-decision cache. In plain (non-embedded) mode the flag also compiles the
+Java-parity LL(1) switches statically. Behavior is preserved by
+construction: error-recovery sync runs before the dispatch table exactly
+where the untiered parser performs it, and any lookahead outside the proven
+language falls through to the decision's regular adaptive body. The
+classification is deterministic and idempotent; predicate-guarded,
+non-greedy, and precedence decisions always stay adaptive.
+
+`grammars-v4` examples: Thrift classifies 53 of 54 decisions LL(1) and the
+last (`namespace_`) fixed-LL(2) — with `--fixed-lookahead 2` the whole
+parser runs prediction-free. Rego adds two fixed-LL(2) tables (`regoElse`,
+and `object_`'s trailing-comma list loop) over 27 LL(1) decisions, with the
+10 genuinely ambiguous decisions staying adaptive.
+
 ### Binary and Byte-Oriented Parsing
 
 ANTLR grammars can parse binary formats, not just text. The convention the

--- a/README.md
+++ b/README.md
@@ -614,8 +614,8 @@ Every generation writes a **`decisions.json`** manifest next to
 `semantics.json` reporting the tier of each decision — `ll1`, `fixed`
 (see below), or `adaptive` with the reason it needs the simulator
 (`non-greedy`, `precedence`, `predicate`, `empty-look`, `not-disjoint`,
-`budget-exceeded`) — so you can see exactly which parts of a grammar pay for
-`ALL(*)` and why:
+`budget-exceeded`, `sync-bound`) — so you can see exactly which parts of a
+grammar pay for `ALL(*)` and why:
 
 ```json
 {"decision": 4, "rule": "namespace_", "state": 113, "tier": "fixed", "lookahead": 2}
@@ -627,11 +627,12 @@ languages are pairwise disjoint within `k` tokens compile into a static
 nested `match` over `la(1) .. la(k)` — no simulator, no DFA warming, no
 per-decision cache. In plain (non-embedded) mode the flag also compiles the
 Java-parity LL(1) switches statically. Behavior is preserved by
-construction: error-recovery sync runs before the dispatch table exactly
-where the untiered parser performs it, and any lookahead outside the proven
-language falls through to the decision's regular adaptive body. The
-classification is deterministic and idempotent; predicate-guarded,
-non-greedy, and precedence decisions always stay adaptive.
+construction: dispatch arms are restricted to lookahead for which the
+decision's recovery sync is a provable no-op, and any other lookahead falls
+through to the decision's regular sync + adaptive body, so error recovery
+happens exactly where the untiered parser performs it. The classification
+is deterministic and idempotent; predicate-guarded, non-greedy, and
+precedence decisions always stay adaptive.
 
 `grammars-v4` examples: Thrift classifies 53 of 54 decisions LL(1) and the
 last (`namespace_`) fixed-LL(2) — with `--fixed-lookahead 2` the whole

--- a/src/bin/antlr4-runtime-testsuite.rs
+++ b/src/bin/antlr4-runtime-testsuite.rs
@@ -888,6 +888,14 @@ fn generate_rust_modules(
         .arg(&rust_dir)
         .arg("--actions")
         .arg("embedded");
+    // Whitespace-split extra generator flags, e.g.
+    // `ANTLR4_RUST_GEN_EXTRA_ARGS="--fixed-lookahead 3"` to sweep the
+    // conformance suite against opt-in codegen tiers.
+    if let Ok(extra_args) = env::var("ANTLR4_RUST_GEN_EXTRA_ARGS") {
+        for extra_arg in extra_args.split_whitespace() {
+            command.arg(extra_arg);
+        }
+    }
     run_checked(&mut command, "Rust metadata generator")?;
     Ok(rust_dir)
 }

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -152,7 +152,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             enforce_sem_unknown(args.sem_unknown, &entries)?;
             enforce_require_full_semantics(args.require_full_semantics, &entries)?;
             let grammar_name = compiled.semantic.recognizer.name.clone();
-            let module = render_parser_with_options(
+            let (module, decision_report_rows) = render_parser_with_decision_report(
                 &grammar_name,
                 &data,
                 ParserRenderOptions {
@@ -166,11 +166,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 },
             )?;
             insert_rendered_module(&mut rendered_modules, &grammar_name, module)?;
-            let classification = classify_decisions(&data, args.fixed_lookahead)?;
             decision_report_grammars.push(DecisionReportGrammar {
                 name: grammar_name.clone(),
                 rule_names: data.rule_names.clone(),
-                rows: classification.report_rows,
+                rows: decision_report_rows,
             });
             manifest_grammars.push(("parser", grammar_name, entries));
         }
@@ -1677,10 +1676,13 @@ fn render_decisions_manifest(
 ) -> String {
     let mut out = String::new();
     out.push_str("{\n  \"version\": 1,\n");
+    // `null` when the flag is unset: flag-off and `--fixed-lookahead 1`
+    // emit different parsers (only the latter compiles static LL(1)
+    // dispatch), so the manifest must not conflate them.
     let _ = writeln!(
         out,
         "  \"fixedLookahead\": {},",
-        fixed_lookahead.unwrap_or(1)
+        json_optional_number(fixed_lookahead)
     );
     out.push_str("  \"grammars\": [");
     for (grammar_position, grammar) in grammars.iter().enumerate() {
@@ -11821,36 +11823,21 @@ const fn render_compile_parse_tree_pattern_method() -> &'static str {
 "#
 }
 
-/// Decision classification for parser rendering: computed whenever a
-/// consumer needs it — embedded mode routes decisions by the tool
-/// classification (Java parity), and `--fixed-lookahead` compiles static
-/// dispatch in either mode.
-fn parser_decision_classification(
-    data: &CodegenData<'_>,
-    options: ParserRenderOptions<'_>,
-) -> io::Result<Option<DecisionClassification>> {
-    if options.embedded || options.fixed_lookahead.is_some() {
-        Ok(Some(classify_decisions(data, options.fixed_lookahead)?))
-    } else {
-        Ok(None)
-    }
-}
-
 /// Step-render view over the opt-in `--fixed-lookahead` routing. Embedded
 /// mode reads its LL(1) switch tables through `EmbeddedStepRender`; the
 /// depth-1 dispatch tables are for plain mode, where static LL(1) switches
 /// are part of the opt-in flag.
 fn decision_routing_render<'a>(
-    classification: Option<&'a DecisionClassification>,
+    classification: &'a DecisionClassification,
     options: ParserRenderOptions<'_>,
 ) -> DecisionRoutingRender<'a> {
     DecisionRoutingRender {
-        ll1_dispatch_tables: classification
-            .filter(|_| !options.embedded && options.fixed_lookahead.is_some())
-            .map(|classification| &classification.ll1_dispatch_tables),
-        fixed_lookahead_tables: classification
-            .filter(|_| options.fixed_lookahead.is_some_and(|depth| depth >= 2))
-            .map(|classification| &classification.fixed_lookahead_tables),
+        ll1_dispatch_tables: (!options.embedded && options.fixed_lookahead.is_some())
+            .then_some(&classification.ll1_dispatch_tables),
+        fixed_lookahead_tables: options
+            .fixed_lookahead
+            .is_some_and(|depth| depth >= 2)
+            .then_some(&classification.fixed_lookahead_tables),
     }
 }
 
@@ -11863,7 +11850,7 @@ fn parser_render_surfaces(
     type_name: &str,
     grammar_name: &str,
     options: ParserRenderOptions<'_>,
-    decision_classification: Option<&DecisionClassification>,
+    decision_classification: &DecisionClassification,
 ) -> io::Result<(Option<EmbeddedParserData>, Option<EmbeddedParserData>)> {
     if options.embedded {
         let embedded = build_embedded_parser_data(
@@ -11871,7 +11858,7 @@ fn parser_render_surfaces(
             type_name,
             grammar_name,
             options,
-            decision_classification.expect("decision classification is computed for embedded mode"),
+            decision_classification,
         )?;
         Ok((Some(embedded), None))
     } else {
@@ -11880,11 +11867,26 @@ fn parser_render_surfaces(
     }
 }
 
+/// Test-facing wrapper over [`render_parser_with_decision_report`] for the
+/// many render assertions that never look at the manifest rows.
+#[cfg(test)]
 fn render_parser_with_options(
     grammar_name: &str,
     data: &CodegenData<'_>,
     options: ParserRenderOptions<'_>,
 ) -> io::Result<String> {
+    Ok(render_parser_with_decision_report(grammar_name, data, options)?.0)
+}
+
+/// [`render_parser_with_options`] plus the per-decision tier rows for the
+/// `decisions.json` manifest, so callers that emit the manifest reuse the
+/// classification the renderer already computed (the bounded LOOK(k)
+/// enumeration is the expensive part under `--fixed-lookahead`).
+fn render_parser_with_decision_report(
+    grammar_name: &str,
+    data: &CodegenData<'_>,
+    options: ParserRenderOptions<'_>,
+) -> io::Result<(String, Vec<DecisionReportRow>)> {
     let empty_patterns = SemPatternFile::default();
     let patterns = options.patterns.unwrap_or(&empty_patterns);
     let type_name = rust_type_name(grammar_name);
@@ -11897,17 +11899,19 @@ fn render_parser_with_options(
     let rule_constants = render_rule_constants(data);
     // Decision routing: embedded mode always follows the tool
     // classification (Java parity); `--fixed-lookahead` additionally
-    // compiles static dispatch for provable decisions in either mode.
-    let decision_classification = parser_decision_classification(data, options)?;
+    // compiles static dispatch for provable decisions in either mode. The
+    // classification also carries the tier rows this function returns for
+    // the `decisions.json` manifest.
+    let decision_classification = classify_decisions(data, options.fixed_lookahead)?;
     let (embedded_data, structural_surface) = parser_render_surfaces(
         data,
         &type_name,
         grammar_name,
         options,
-        decision_classification.as_ref(),
+        &decision_classification,
     )?;
     let embedded_step_render = embedded_data.as_ref().map(embedded_step_render);
-    let decision_routing = decision_routing_render(decision_classification.as_ref(), options);
+    let decision_routing = decision_routing_render(&decision_classification, options);
     let mut portable_local_data = if options.embedded {
         PortableLocalData::default()
     } else {
@@ -12106,7 +12110,7 @@ fn render_parser_with_options(
     } else {
         ""
     };
-    Ok(format!(
+    let module = format!(
         r#"{generated_header}use antlr4_runtime::recognizer::RecognizerData;
 use antlr4_runtime::token::TokenSource;
 use antlr4_runtime::token_stream::CommonTokenStream;
@@ -12468,7 +12472,8 @@ where
     fn remove_parse_listeners(&mut self) -> Vec<Box<dyn antlr4_runtime::ParseListener>> {{ self.base.remove_parse_listeners() }}
 }}
 {generated_footer}"#
-    ))
+    );
+    Ok((module, decision_classification.report_rows))
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -19071,6 +19076,14 @@ lower = "cmp(ne, ctx_rule_text(local_type), str(\"var\"))"
             }],
         );
         insta::assert_snapshot!("fixed_lookahead_decisions_manifest", manifest);
+
+        // Flag-off and `--fixed-lookahead 1` emit different parsers (only
+        // the latter compiles static LL(1) dispatch), so the manifest must
+        // not conflate them: unset renders as null.
+        let flag_off = render_decisions_manifest(None, &[]);
+        assert!(flag_off.contains("\"fixedLookahead\": null"));
+        let depth_one = render_decisions_manifest(Some(1), &[]);
+        assert!(depth_one.contains("\"fixedLookahead\": 1"));
     }
 
     #[test]
@@ -19096,8 +19109,13 @@ lower = "cmp(ne, ctx_rule_text(local_type), str(\"var\"))"
         // are restricted to lookahead where `sync_decision` provably
         // no-ops — so the decision's sync must render only in the miss
         // arm, after the dispatch.
-        let preceding = &rendered[dispatch_start.saturating_sub(400)..dispatch_start];
-        assert!(!preceding.contains("sync_decision"));
+        // Anchor at the enclosing generated method so the checked window is
+        // defined by the generated structure (rule entry .. dispatch), not
+        // an arbitrary byte count that preamble growth could outrun.
+        let method_start = rendered[..dispatch_start]
+            .rfind("fn parse_generated_rule_")
+            .expect("dispatch is inside a generated rule method");
+        assert!(!rendered[method_start..dispatch_start].contains("sync_decision"));
         assert!(rendered[dispatch_start..].contains("sync_decision"));
     }
 

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -4179,9 +4179,6 @@ struct PortableLocalStepRender<'a> {
     required_generated_rules: &'a BTreeSet<usize>,
 }
 
-/// Complete LOOK(1) dispatch intervals per alternative, keyed by decision.
-type Ll1DecisionArms = BTreeMap<usize, Vec<Vec<(i32, i32)>>>;
-
 /// Mode-independent decision routing produced by [`classify_decisions`].
 ///
 /// Embedded mode reads its Java-parity LL(1) tables through
@@ -4191,36 +4188,23 @@ type Ll1DecisionArms = BTreeMap<usize, Vec<Vec<(i32, i32)>>>;
 /// with the flag unset so default rendering is untouched.
 #[derive(Clone, Copy, Default)]
 struct DecisionRoutingRender<'a> {
-    ll1_decision_arms: Option<&'a Ll1DecisionArms>,
+    ll1_dispatch_tables: Option<&'a BTreeMap<usize, FixedLookaheadTable>>,
     fixed_lookahead_tables: Option<&'a BTreeMap<usize, FixedLookaheadTable>>,
 }
 
-impl DecisionRoutingRender<'_> {
+impl<'a> DecisionRoutingRender<'a> {
     /// Static dispatch table for a decision: the fixed-LL(k) trie when the
-    /// probe proved one, else a depth-1 table from the tool's complete
+    /// probe proved one, else the depth-1 table from the tool's complete
     /// LOOK(1) arms (plain mode only; embedded mode renders its Java-parity
-    /// switch through [`EmbeddedStepRender`]). Both render through the same
-    /// sync-first dispatch shape.
-    fn static_dispatch_table(self, decision: usize) -> Option<FixedLookaheadTable> {
-        if let Some(table) = self
-            .fixed_lookahead_tables
+    /// switch through [`EmbeddedStepRender`]). Both are pre-restricted to
+    /// sync-no-op lookahead and render through the same dispatch shape.
+    fn static_dispatch_table(self, decision: usize) -> Option<&'a FixedLookaheadTable> {
+        self.fixed_lookahead_tables
             .and_then(|tables| tables.get(&decision))
-        {
-            return Some(table.clone());
-        }
-        let arms = self.ll1_decision_arms?.get(&decision)?;
-        Some(FixedLookaheadTable {
-            lookahead: 1,
-            root: FixedLookaheadNode::Probe(
-                arms.iter()
-                    .enumerate()
-                    .filter(|(_, intervals)| !intervals.is_empty())
-                    .map(|(index, intervals)| {
-                        (intervals.clone(), FixedLookaheadNode::Alt(index + 1))
-                    })
-                    .collect(),
-            ),
-        })
+            .or_else(|| {
+                self.ll1_dispatch_tables
+                    .and_then(|tables| tables.get(&decision))
+            })
     }
 }
 
@@ -7206,7 +7190,7 @@ fn render_generated_decision(
             &pad,
             state,
             decision,
-            &table,
+            table,
             render_context,
             "false",
         );
@@ -7357,14 +7341,15 @@ fn render_generated_ll1_then_adaptive_prediction(
 /// `--fixed-lookahead`: a static `la(1)..la(k)` dispatch trie whose hits
 /// commit an alternative without touching the simulator.
 ///
-/// The shape mirrors the adaptive body the table replaces, token for token
-/// on the error path: `sync_decision` runs FIRST (its context-aware
-/// single-token deletion must happen exactly where the untiered parser
-/// performs it — a table computed with context-free FOLLOW could otherwise
-/// swallow an invalid token into an exit arm and move the "extraneous
-/// input" report a rule higher), then the trie probes the post-sync
-/// lookahead, and a miss falls through to the decision's regular adaptive
-/// prediction.
+/// A hit skips the decision's recovery synchronization, which is safe
+/// because every first-token arm is pre-restricted to the decision's
+/// within-rule lookahead — exactly the set for which `sync_decision`
+/// early-returns without doing recovery work (the same shape the default
+/// partial fast path ships today). Every other token — including
+/// context-dependent loop exits, where synchronization performs real
+/// single-token deletion — falls through to the decision's regular
+/// sync + adaptive body, so error recovery happens exactly where the
+/// untiered parser performs it.
 #[allow(clippy::too_many_arguments)]
 fn render_generated_fixed_lookahead_prediction(
     out: &mut String,
@@ -7375,10 +7360,9 @@ fn render_generated_fixed_lookahead_prediction(
     render_context: GeneratedStepRenderContext<'_>,
     loop_sync_flag: &str,
 ) {
-    render_generated_sync_decision(out, pad, state, loop_sync_flag);
     writeln!(
         out,
-        "{pad}let __decision_start = antlr4_runtime::IntStream::index(self.base.input());"
+        "{pad}let mut __decision_start = antlr4_runtime::IntStream::index(self.base.input());"
     )
     .expect("writing to a string cannot fail");
     write!(out, "{pad}let __fixed_lookahead_alt: Option<usize> = ")
@@ -7397,6 +7381,12 @@ fn render_generated_fixed_lookahead_prediction(
     .expect("writing to a string cannot fail");
     writeln!(out, "{pad}}} else {{").expect("writing to a string cannot fail");
     let inner_pad = format!("{pad}    ");
+    render_generated_sync_decision(out, &inner_pad, state, loop_sync_flag);
+    writeln!(
+        out,
+        "{inner_pad}__decision_start = antlr4_runtime::IntStream::index(self.base.input());"
+    )
+    .expect("writing to a string cannot fail");
     if render_context
         .embedded
         .is_some_and(|embedded| embedded.adaptive_decision(decision))
@@ -7991,7 +7981,7 @@ fn render_generated_star_loop(
             &inner_pad,
             state,
             decision,
-            &table,
+            table,
             render_context,
             &loop_iter,
         );
@@ -8813,13 +8803,30 @@ fn classify_decisions(
             continue;
         }
         if decision_alt_looks_disjoint(&looks) {
-            classification.ll1_decision_arms.insert(
-                decision,
-                looks
-                    .iter()
-                    .map(|look| symbol_intervals(&look.symbols))
-                    .collect(),
-            );
+            let arms: Vec<Vec<(i32, i32)>> = looks
+                .iter()
+                .map(|look| symbol_intervals(&look.symbols))
+                .collect();
+            // With the opt-in flag, plain mode compiles the switch
+            // statically. Only arms over sync-no-op lookahead commit
+            // without the decision's recovery synchronization.
+            if fixed_lookahead.is_some() {
+                let root = FixedLookaheadNode::Probe(
+                    arms.iter()
+                        .enumerate()
+                        .filter(|(_, intervals)| !intervals.is_empty())
+                        .map(|(index, intervals)| {
+                            (intervals.clone(), FixedLookaheadNode::Alt(index + 1))
+                        })
+                        .collect(),
+                );
+                if let Some(root) = restrict_dispatch_to_sync_noop(atn, state, root) {
+                    classification
+                        .ll1_dispatch_tables
+                        .insert(decision, FixedLookaheadTable { lookahead: 1, root });
+                }
+            }
+            classification.ll1_decision_arms.insert(decision, arms);
             classification
                 .report_rows
                 .push(report(DecisionTierReport::Ll1));
@@ -8832,10 +8839,21 @@ fn classify_decisions(
         for depth in 2..=max_lookahead {
             match fixed_lookahead_table(atn, state, depth) {
                 FixedLookaheadOutcome::Table(table) => {
-                    classification
-                        .fixed_lookahead_tables
-                        .insert(decision, table);
-                    tier = DecisionTierReport::Fixed { lookahead: depth };
+                    match restrict_dispatch_to_sync_noop(atn, state, table.root) {
+                        Some(root) => {
+                            classification.fixed_lookahead_tables.insert(
+                                decision,
+                                FixedLookaheadTable {
+                                    lookahead: table.lookahead,
+                                    root,
+                                },
+                            );
+                            tier = DecisionTierReport::Fixed { lookahead: depth };
+                        }
+                        None => {
+                            tier = DecisionTierReport::adaptive(AdaptiveReason::SyncBound, depth);
+                        }
+                    }
                     break;
                 }
                 FixedLookaheadOutcome::NotDisjoint => {}
@@ -8854,6 +8872,103 @@ fn classify_decisions(
     Ok(classification)
 }
 
+/// Restricts a dispatch trie's first-token arms to the decision's
+/// within-rule lookahead — the exact set for which the runtime's
+/// `sync_decision` early-returns without recovery work — so a table hit can
+/// commit without running the synchronization the untiered parser would
+/// no-op through, while every other token falls through to the full
+/// sync + adaptive body. Returns `None` when no arm survives.
+fn restrict_dispatch_to_sync_noop(
+    atn: &ParserAtn,
+    state: ParserAtnState<'_>,
+    root: FixedLookaheadNode,
+) -> Option<FixedLookaheadNode> {
+    let allowed = sync_noop_symbol_intervals(atn, state);
+    let FixedLookaheadNode::Probe(arms) = root else {
+        // A rootless commit would skip synchronization for every token;
+        // decline (decision states always probe, so this is defensive).
+        return None;
+    };
+    let arms: Vec<(Vec<(i32, i32)>, FixedLookaheadNode)> = arms
+        .into_iter()
+        .filter_map(|(intervals, child)| {
+            let restricted = intersect_interval_sets(&intervals, &allowed);
+            (!restricted.is_empty()).then_some((restricted, child))
+        })
+        .collect();
+    (!arms.is_empty()).then_some(FixedLookaheadNode::Probe(arms))
+}
+
+/// The decision state's within-rule lookahead: the union of every
+/// alternative's FIRST set bounded at the owning rule's stop state,
+/// mirroring the runtime's `transition_first_set`, whose per-transition
+/// sets are exactly `sync_decision`'s early-return condition.
+fn sync_noop_symbol_intervals(atn: &ParserAtn, state: ParserAtnState<'_>) -> Vec<(i32, i32)> {
+    let Some(rule_index) = state.rule_index() else {
+        return Vec::new();
+    };
+    let Some(rule_stop) = atn.rule_to_stop_state().get(rule_index) else {
+        return Vec::new();
+    };
+    let mut ctx = GeneratedFirstSetCtx::default();
+    let mut symbols = BTreeSet::new();
+    for transition in state.transitions() {
+        let direct = generated_transition_symbols(transition, atn.max_token_type());
+        if !direct.is_empty() {
+            symbols.extend(direct);
+            continue;
+        }
+        match transition.data() {
+            ParserTransitionData::Rule {
+                target,
+                rule_index: child_rule,
+                follow_state,
+                ..
+            } => {
+                let Some(child_stop) = atn.rule_to_stop_state().get(child_rule) else {
+                    continue;
+                };
+                let child = generated_rule_first_set(atn, target, child_stop, &mut ctx);
+                symbols.extend(child.symbols.iter().copied());
+                if child.nullable {
+                    let follow = generated_rule_first_set(atn, follow_state, rule_stop, &mut ctx);
+                    symbols.extend(follow.symbols.iter().copied());
+                }
+            }
+            ParserTransitionData::Epsilon { target }
+            | ParserTransitionData::Action { target, .. }
+            | ParserTransitionData::Predicate { target, .. }
+            | ParserTransitionData::Precedence { target, .. } => {
+                let first = generated_rule_first_set(atn, target, rule_stop, &mut ctx);
+                symbols.extend(first.symbols.iter().copied());
+            }
+            _ => {}
+        }
+    }
+    symbol_intervals(&symbols)
+}
+
+/// Intersection of two sorted disjoint interval sets.
+fn intersect_interval_sets(left: &[(i32, i32)], right: &[(i32, i32)]) -> Vec<(i32, i32)> {
+    let mut result = Vec::new();
+    let (mut left_index, mut right_index) = (0, 0);
+    while left_index < left.len() && right_index < right.len() {
+        let (left_start, left_stop) = left[left_index];
+        let (right_start, right_stop) = right[right_index];
+        let start = left_start.max(right_start);
+        let stop = left_stop.min(right_stop);
+        if start <= stop {
+            result.push((start, stop));
+        }
+        if left_stop < right_stop {
+            left_index += 1;
+        } else {
+            right_index += 1;
+        }
+    }
+    result
+}
+
 /// Tool-side decision classification (see [`classify_decisions`]).
 #[derive(Debug, Default)]
 struct DecisionClassification {
@@ -8867,8 +8982,12 @@ struct DecisionClassification {
     /// fast-path/LL(1) analyses, so legit input never falls through to the
     /// simulator (Java's switch never does).
     ll1_decision_arms: BTreeMap<usize, Vec<Vec<(i32, i32)>>>,
+    /// `--fixed-lookahead` in plain mode: depth-1 static dispatch for the
+    /// LL(1) decisions above, restricted to sync-no-op lookahead.
+    ll1_dispatch_tables: BTreeMap<usize, FixedLookaheadTable>,
     /// `--fixed-lookahead`: static dispatch tables for decisions whose
-    /// LOOK(k) languages are pairwise disjoint at some 2 <= k <= flag.
+    /// LOOK(k) languages are pairwise disjoint at some 2 <= k <= flag,
+    /// restricted to sync-no-op lookahead.
     fixed_lookahead_tables: BTreeMap<usize, FixedLookaheadTable>,
     /// Per-decision tier verdicts for the `decisions.json` manifest.
     report_rows: Vec<DecisionReportRow>,
@@ -8925,6 +9044,11 @@ enum AdaptiveReason {
     NotDisjoint,
     /// The fixed-lookahead walk exceeded its rectangle or step budget.
     Budget,
+    /// Disjointness was proven, but every first-token dispatch symbol lies
+    /// outside the decision's within-rule lookahead — the region where
+    /// recovery synchronization is a provable no-op — so no arm survives
+    /// the sync-safety restriction.
+    SyncBound,
 }
 
 impl AdaptiveReason {
@@ -8936,6 +9060,7 @@ impl AdaptiveReason {
             Self::EmptyLook => "empty-look",
             Self::NotDisjoint => "not-disjoint",
             Self::Budget => "budget-exceeded",
+            Self::SyncBound => "sync-bound",
         }
     }
 }
@@ -11713,16 +11838,16 @@ fn parser_decision_classification(
 
 /// Step-render view over the opt-in `--fixed-lookahead` routing. Embedded
 /// mode reads its LL(1) switch tables through `EmbeddedStepRender`; the
-/// routing copy of the arms is for plain mode, where static LL(1) switches
+/// depth-1 dispatch tables are for plain mode, where static LL(1) switches
 /// are part of the opt-in flag.
 fn decision_routing_render<'a>(
     classification: Option<&'a DecisionClassification>,
     options: ParserRenderOptions<'_>,
 ) -> DecisionRoutingRender<'a> {
     DecisionRoutingRender {
-        ll1_decision_arms: classification
+        ll1_dispatch_tables: classification
             .filter(|_| !options.embedded && options.fixed_lookahead.is_some())
-            .map(|classification| &classification.ll1_decision_arms),
+            .map(|classification| &classification.ll1_dispatch_tables),
         fixed_lookahead_tables: classification
             .filter(|_| options.fixed_lookahead.is_some_and(|depth| depth >= 2))
             .map(|classification| &classification.fixed_lookahead_tables),
@@ -18949,7 +19074,7 @@ lower = "cmp(ne, ctx_rule_text(local_type), str(\"var\"))"
     }
 
     #[test]
-    fn fixed_lookahead_dispatch_probes_second_token_after_sync() {
+    fn fixed_lookahead_dispatch_commits_bare_and_syncs_on_miss() {
         let data = parser_fixture_data("fixed-lookahead/T.g4");
         let without_flag = render_parser("T", &data).expect("parser renders");
         assert!(!without_flag.contains("__fixed_lookahead_alt"));
@@ -18967,11 +19092,48 @@ lower = "cmp(ne, ctx_rule_text(local_type), str(\"var\"))"
             .find("let __fixed_lookahead_alt")
             .expect("fixed dispatch rendered");
         assert!(rendered.contains("match self.base.la(2)"));
-        // The context-aware sync must run before the table probes the
-        // lookahead — recovery deletes extraneous tokens exactly where the
-        // untiered parser would.
-        let sync_before_dispatch = rendered[..dispatch_start].rfind("sync_decision");
-        assert!(sync_before_dispatch.is_some());
+        // A table hit commits without recovery synchronization — its arms
+        // are restricted to lookahead where `sync_decision` provably
+        // no-ops — so the decision's sync must render only in the miss
+        // arm, after the dispatch.
+        let preceding = &rendered[dispatch_start.saturating_sub(400)..dispatch_start];
+        assert!(!preceding.contains("sync_decision"));
+        assert!(rendered[dispatch_start..].contains("sync_decision"));
+    }
+
+    #[test]
+    fn fixed_lookahead_arms_stay_inside_sync_noop_lookahead() {
+        // Every emitted dispatch arm must lie inside the decision's
+        // within-rule lookahead: outside it, `sync_decision` performs real
+        // recovery work (context-aware single-token deletion) that a bare
+        // table hit would skip, moving error reports between rules.
+        let data = parser_fixture_data("fixed-lookahead/T.g4");
+        let atn = data.parser_atn().expect("parser atn").clone();
+        let classification = classify_decisions(&data, Some(2)).expect("classification succeeds");
+        assert!(!classification.ll1_dispatch_tables.is_empty());
+        let tables = classification
+            .ll1_dispatch_tables
+            .iter()
+            .chain(classification.fixed_lookahead_tables.iter());
+        for (decision, table) in tables {
+            let state_number = atn
+                .decision_to_state()
+                .iter()
+                .nth(*decision)
+                .expect("decision state number");
+            let state = atn.state(state_number).expect("decision state");
+            let allowed = sync_noop_symbol_intervals(&atn, state);
+            let FixedLookaheadNode::Probe(arms) = &table.root else {
+                panic!("decision tables always probe la(1)");
+            };
+            for (intervals, _) in arms {
+                assert_eq!(
+                    &intersect_interval_sets(intervals, &allowed),
+                    intervals,
+                    "decision {decision}: arm {intervals:?} escapes sync-no-op set {allowed:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -93,6 +93,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut grammar_options = Vec::new();
     let mut manifest_grammars: Vec<(&'static str, String, Vec<SemanticsEntry>)> = Vec::new();
+    let mut decision_report_grammars: Vec<DecisionReportGrammar> = Vec::new();
     let mut rendered_modules = BTreeMap::<PathBuf, String>::new();
     let mut emitted_lexers = BTreeSet::new();
     let mut emitted_parsers = BTreeSet::new();
@@ -161,9 +162,16 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     generate_visitor: args.generate_visitor,
                     sem_unknown: args.sem_unknown,
                     patterns: Some(&args.sem_patterns),
+                    fixed_lookahead: args.fixed_lookahead,
                 },
             )?;
             insert_rendered_module(&mut rendered_modules, &grammar_name, module)?;
+            let classification = classify_decisions(&data, args.fixed_lookahead)?;
+            decision_report_grammars.push(DecisionReportGrammar {
+                name: grammar_name.clone(),
+                rule_names: data.rule_names.clone(),
+                rows: classification.report_rows,
+            });
             manifest_grammars.push(("parser", grammar_name, entries));
         }
     }
@@ -179,6 +187,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         fs::write(args.out_dir.join(path), module)?;
     }
     fs::write(args.out_dir.join("semantics.json"), manifest)?;
+    fs::write(
+        args.out_dir.join("decisions.json"),
+        render_decisions_manifest(args.fixed_lookahead, &decision_report_grammars),
+    )?;
     Ok(())
 }
 
@@ -1646,6 +1658,105 @@ fn render_semantics_manifest(
     out
 }
 
+/// Per-parser-grammar rows for the `decisions.json` manifest.
+struct DecisionReportGrammar {
+    name: String,
+    rule_names: Vec<String>,
+    rows: Vec<DecisionReportRow>,
+}
+
+/// Renders the `decisions.json` manifest: one row per parser decision with
+/// its classifier tier — `ll1` (Java compiles a token switch), `fixed`
+/// (`--fixed-lookahead` proved disjointness at `lookahead` tokens and a
+/// static dispatch table was emitted), or `adaptive` with the reason the
+/// decision keeps `adaptivePredict`. Deterministic: rows are in decision
+/// order, and the classifier itself is pure.
+fn render_decisions_manifest(
+    fixed_lookahead: Option<usize>,
+    grammars: &[DecisionReportGrammar],
+) -> String {
+    let mut out = String::new();
+    out.push_str("{\n  \"version\": 1,\n");
+    let _ = writeln!(
+        out,
+        "  \"fixedLookahead\": {},",
+        fixed_lookahead.unwrap_or(1)
+    );
+    out.push_str("  \"grammars\": [");
+    for (grammar_position, grammar) in grammars.iter().enumerate() {
+        if grammar_position > 0 {
+            out.push(',');
+        }
+        out.push_str("\n    {\n");
+        let _ = writeln!(out, "      \"name\": {},", json_string(&grammar.name));
+        let (mut ll1, mut fixed, mut adaptive) = (0_usize, 0_usize, 0_usize);
+        for row in &grammar.rows {
+            match row.tier {
+                DecisionTierReport::Ll1 => ll1 += 1,
+                DecisionTierReport::Fixed { .. } => fixed += 1,
+                DecisionTierReport::Adaptive { .. } => adaptive += 1,
+            }
+        }
+        let _ = writeln!(
+            out,
+            "      \"summary\": {{\"total\": {}, \"ll1\": {ll1}, \"fixed\": {fixed}, \"adaptive\": {adaptive}}},",
+            grammar.rows.len()
+        );
+        out.push_str("      \"decisions\": [");
+        for (row_position, row) in grammar.rows.iter().enumerate() {
+            if row_position > 0 {
+                out.push(',');
+            }
+            out.push_str("\n        ");
+            write_decision_report_row(&mut out, row, &grammar.rule_names);
+        }
+        if grammar.rows.is_empty() {
+            out.push_str("]\n    }");
+        } else {
+            out.push_str("\n      ]\n    }");
+        }
+    }
+    if grammars.is_empty() {
+        out.push_str("]\n}\n");
+    } else {
+        out.push_str("\n  ]\n}\n");
+    }
+    out
+}
+
+fn write_decision_report_row(out: &mut String, row: &DecisionReportRow, rule_names: &[String]) {
+    let rule_name = row
+        .rule_index
+        .and_then(|rule_index| rule_names.get(rule_index));
+    out.push('{');
+    let _ = write!(out, "\"decision\": {}", row.decision);
+    let _ = write!(
+        out,
+        ", \"rule\": {}",
+        json_optional_string(rule_name.map(String::as_str))
+    );
+    let _ = write!(out, ", \"state\": {}", row.state);
+    match row.tier {
+        DecisionTierReport::Ll1 => {
+            let _ = write!(out, ", \"tier\": \"ll1\"");
+        }
+        DecisionTierReport::Fixed { lookahead } => {
+            let _ = write!(out, ", \"tier\": \"fixed\", \"lookahead\": {lookahead}");
+        }
+        DecisionTierReport::Adaptive {
+            reason,
+            probed_lookahead,
+        } => {
+            let _ = write!(
+                out,
+                ", \"tier\": \"adaptive\", \"reason\": {}, \"probedLookahead\": {probed_lookahead}",
+                json_string(reason.manifest_name())
+            );
+        }
+    }
+    out.push('}');
+}
+
 fn write_grammar_option_entry(out: &mut String, entry: &GrammarOptionEntry) {
     out.push('{');
     let _ = write!(out, "\"name\": {}", json_string(&entry.key));
@@ -2026,6 +2137,11 @@ struct Args {
     /// bodies (rendered through a `.test.stg`); splice them verbatim after
     /// `$`-attribute translation instead of recognizing template markup.
     embedded_actions: bool,
+    /// `--fixed-lookahead <k>`: compile decisions whose alternatives are
+    /// pairwise disjoint within `k` tokens of lookahead into static dispatch
+    /// tables instead of adaptive prediction. `None` keeps the default
+    /// routing (Java parity).
+    fixed_lookahead: Option<usize>,
 }
 
 enum CliCommand {
@@ -2048,6 +2164,7 @@ impl Args {
         let mut option_hooks = BTreeSet::new();
         let mut generate_listener = true;
         let mut generate_visitor = false;
+        let mut fixed_lookahead = None;
         let mut positional_only = false;
 
         let mut iter = env::args().skip(1);
@@ -2094,6 +2211,22 @@ impl Args {
                     sem_unknown =
                         SemUnknownPolicy::parse_flag(&next_arg(&mut iter, "--sem-unknown")?)?;
                 }
+                "--fixed-lookahead" => {
+                    let value = next_arg(&mut iter, "--fixed-lookahead")?;
+                    let depth = value
+                        .parse::<usize>()
+                        .ok()
+                        .filter(|depth| (1..=MAX_FIXED_LOOKAHEAD_FLAG).contains(depth));
+                    match depth {
+                        Some(depth) => fixed_lookahead = Some(depth),
+                        None => {
+                            return Err(format!(
+                                "--fixed-lookahead expects an integer between 1 and {MAX_FIXED_LOOKAHEAD_FLAG}; got {value}\n\n{}",
+                                usage()
+                            ));
+                        }
+                    }
+                }
                 "--help" | "-h" => return Ok(CliCommand::Help),
                 "--version" | "-V" => return Ok(CliCommand::Version),
                 other if other.starts_with("-I") && other.len() > 2 => {
@@ -2126,6 +2259,7 @@ impl Args {
             generate_listener,
             generate_visitor,
             embedded_actions,
+            fixed_lookahead,
         }))
     }
 }
@@ -2155,6 +2289,9 @@ Options:
   --sem-patterns FILE              Load semantic helper patterns
   --option-hook KEY=VALUE          Acknowledge an option implemented by caller hooks
   --require-full-semantics         Fail if any semantic coordinate or option is unsupported
+  --fixed-lookahead K              Compile decisions provable within K tokens of lookahead
+                                   into static dispatch tables (off by default; every
+                                   remaining decision keeps adaptive prediction)
   -V, --version                    Print version
   -h, --help                       Print this help"
         .to_owned()
@@ -4042,6 +4179,48 @@ struct PortableLocalStepRender<'a> {
     required_generated_rules: &'a BTreeSet<usize>,
 }
 
+/// Mode-independent decision routing produced by [`classify_decisions`].
+///
+/// Embedded mode reads its Java-parity LL(1) tables through
+/// [`EmbeddedStepRender`]; these fields carry the opt-in
+/// `--fixed-lookahead` routing: complete LL(1) switch tables for plain
+/// mode, and fixed-LL(k) dispatch tables for both modes. Both stay `None`
+/// with the flag unset so default rendering is untouched.
+#[derive(Clone, Copy, Default)]
+struct DecisionRoutingRender<'a> {
+    ll1_decision_arms: Option<&'a BTreeMap<usize, Vec<Vec<(i32, i32)>>>>,
+    fixed_lookahead_tables: Option<&'a BTreeMap<usize, FixedLookaheadTable>>,
+}
+
+impl DecisionRoutingRender<'_> {
+    /// Static dispatch table for a decision: the fixed-LL(k) trie when the
+    /// probe proved one, else a depth-1 table from the tool's complete
+    /// LOOK(1) arms (plain mode only; embedded mode renders its Java-parity
+    /// switch through [`EmbeddedStepRender`]). Both render through the same
+    /// sync-first dispatch shape.
+    fn static_dispatch_table(&self, decision: usize) -> Option<FixedLookaheadTable> {
+        if let Some(table) = self
+            .fixed_lookahead_tables
+            .and_then(|tables| tables.get(&decision))
+        {
+            return Some(table.clone());
+        }
+        let arms = self.ll1_decision_arms?.get(&decision)?;
+        Some(FixedLookaheadTable {
+            lookahead: 1,
+            root: FixedLookaheadNode::Probe(
+                arms.iter()
+                    .enumerate()
+                    .filter(|(_, intervals)| !intervals.is_empty())
+                    .map(|(index, intervals)| {
+                        (intervals.clone(), FixedLookaheadNode::Alt(index + 1))
+                    })
+                    .collect(),
+            ),
+        })
+    }
+}
+
 #[derive(Clone, Copy)]
 struct GeneratedStepRenderContext<'a> {
     current_rule_index: usize,
@@ -4049,6 +4228,8 @@ struct GeneratedStepRenderContext<'a> {
     embedded: Option<EmbeddedStepRender<'a>>,
     /// Portable raw-grammar boolean locals translated without embedded mode.
     portable_locals: Option<PortableLocalStepRender<'a>>,
+    /// Opt-in `--fixed-lookahead` static dispatch routing (both modes).
+    decision_routing: DecisionRoutingRender<'a>,
     inline_action_statements: &'a BTreeMap<usize, String>,
     track_alt_numbers: bool,
     track_context_alt_numbers: bool,
@@ -4102,6 +4283,9 @@ struct ParserRenderOptions<'a> {
     generate_visitor: bool,
     sem_unknown: SemUnknownPolicy,
     patterns: Option<&'a SemPatternFile>,
+    /// `--fixed-lookahead <k>`: compile decisions provable within `k`
+    /// tokens of lookahead into static dispatch tables.
+    fixed_lookahead: Option<usize>,
 }
 
 impl Default for ParserRenderOptions<'_> {
@@ -4113,6 +4297,7 @@ impl Default for ParserRenderOptions<'_> {
             generate_visitor: false,
             sem_unknown: SemUnknownPolicy::default(),
             patterns: None,
+            fixed_lookahead: None,
         }
     }
 }
@@ -5823,6 +6008,7 @@ fn render_generated_rule_dispatch(
         false,
         None,
         None,
+        DecisionRoutingRender::default(),
     )
 }
 
@@ -5904,6 +6090,7 @@ impl GeneratedRuleError {{
 }
 
 #[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments)]
 fn render_generated_rule_routing(
     rules: &[Option<GeneratedParserRule>],
     rule_names: &[String],
@@ -5912,6 +6099,7 @@ fn render_generated_rule_routing(
     track_context_alt_numbers: bool,
     embedded: Option<EmbeddedStepRender<'_>>,
     portable_locals: Option<PortableLocalStepRender<'_>>,
+    decision_routing: DecisionRoutingRender<'_>,
 ) -> (String, usize) {
     let direct_generated_rule_calls = rules.iter().map(Option::is_some).collect::<Vec<_>>();
     let preferred_rule_count = generated_adaptive_atn_preferred_rule_count(
@@ -5928,6 +6116,7 @@ fn render_generated_rule_routing(
         track_context_alt_numbers,
         embedded,
         portable_locals,
+        decision_routing,
     );
     (dispatch, preferred_rule_count)
 }
@@ -5942,6 +6131,7 @@ fn render_generated_rule_dispatch_with_rule_names(
     track_context_alt_numbers: bool,
     embedded: Option<EmbeddedStepRender<'_>>,
     portable_locals: Option<PortableLocalStepRender<'_>>,
+    decision_routing: DecisionRoutingRender<'_>,
 ) -> String {
     let mut out = String::new();
     let force_generated_rules = generated_force_generated_rules(
@@ -6017,6 +6207,7 @@ fn render_generated_rule_dispatch_with_rule_names(
         current_rule_index: usize::MAX,
         embedded,
         portable_locals,
+        decision_routing,
         inline_action_statements,
         track_alt_numbers,
         track_context_alt_numbers,
@@ -6991,13 +7182,33 @@ fn render_generated_decision(
         alts,
     } = decision_info;
     let pad = "    ".repeat(indent);
+    // Opt-in `--fixed-lookahead` static dispatch replaces the prediction
+    // block entirely; its fall-through arm renders the decision's regular
+    // adaptive body, so unproven lookahead behaves exactly as untiered.
+    let static_table = (!allow_semantic_context && !force_context)
+        .then(|| {
+            render_context
+                .decision_routing
+                .static_dispatch_table(decision)
+        })
+        .flatten();
     // A tool-LL(1) decision dispatches on the tool's complete LOOK table
     // (exit alternatives included), like Java's switch compilation.
     let tool_fast_path = render_context
         .embedded
         .and_then(|embedded| embedded.tool_ll1_fast_path(decision));
     let fast_path = tool_fast_path.as_ref().or(fast_path);
-    if let Some(fast_path) = fast_path.filter(|_| {
+    if let Some(table) = static_table {
+        render_generated_fixed_lookahead_prediction(
+            out,
+            &pad,
+            state,
+            decision,
+            &table,
+            render_context,
+            "false",
+        );
+    } else if let Some(fast_path) = fast_path.filter(|_| {
         !allow_semantic_context
             && !force_context
             && !render_context
@@ -7139,6 +7350,88 @@ fn render_generated_ll1_then_adaptive_prediction(
     writeln!(out, "{pad}}} else {{").expect("writing to a string cannot fail");
     render_generated_sll_then_context_prediction_with_indent(out, pad, decision, 1);
     writeln!(out, "{pad}}}{suffix}").expect("writing to a string cannot fail");
+}
+
+/// `--fixed-lookahead`: a static `la(1)..la(k)` dispatch trie whose hits
+/// commit an alternative without touching the simulator.
+///
+/// The shape mirrors the adaptive body the table replaces, token for token
+/// on the error path: `sync_decision` runs FIRST (its context-aware
+/// single-token deletion must happen exactly where the untiered parser
+/// performs it — a table computed with context-free FOLLOW could otherwise
+/// swallow an invalid token into an exit arm and move the "extraneous
+/// input" report a rule higher), then the trie probes the post-sync
+/// lookahead, and a miss falls through to the decision's regular adaptive
+/// prediction.
+fn render_generated_fixed_lookahead_prediction(
+    out: &mut String,
+    pad: &str,
+    state: usize,
+    decision: usize,
+    table: &FixedLookaheadTable,
+    render_context: GeneratedStepRenderContext<'_>,
+    loop_sync_flag: &str,
+) {
+    render_generated_sync_decision(out, pad, state, loop_sync_flag);
+    writeln!(
+        out,
+        "{pad}let __decision_start = antlr4_runtime::IntStream::index(self.base.input());"
+    )
+    .expect("writing to a string cannot fail");
+    write!(out, "{pad}let __fixed_lookahead_alt: Option<usize> = ")
+        .expect("writing to a string cannot fail");
+    render_fixed_lookahead_node(out, pad, &table.root, 1);
+    writeln!(out, ";").expect("writing to a string cannot fail");
+    writeln!(
+        out,
+        "{pad}let __prediction = if let Some(__fixed_lookahead_alt) = __fixed_lookahead_alt {{"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(
+        out,
+        "{pad}    antlr4_runtime::ParserAtnPrediction {{ alt: __fixed_lookahead_alt, requires_full_context: false, has_semantic_context: false, diagnostic: None }}"
+    )
+    .expect("writing to a string cannot fail");
+    writeln!(out, "{pad}}} else {{").expect("writing to a string cannot fail");
+    let inner_pad = format!("{pad}    ");
+    if render_context
+        .embedded
+        .is_some_and(|embedded| embedded.adaptive_decision(decision))
+    {
+        render_generated_sll_then_context_prediction_with_indent(out, pad, decision, 1);
+    } else {
+        render_generated_ll1_then_adaptive_prediction(out, &inner_pad, state, decision, false);
+    }
+    writeln!(out, "{pad}}};").expect("writing to a string cannot fail");
+}
+
+/// Renders one dispatch-trie node as an expression. `node_pad` is the
+/// indentation of the node's closing brace; `depth` is the 1-based
+/// lookahead position this node probes.
+fn render_fixed_lookahead_node(
+    out: &mut String,
+    node_pad: &str,
+    node: &FixedLookaheadNode,
+    depth: usize,
+) {
+    match node {
+        FixedLookaheadNode::Alt(alt) => {
+            write!(out, "Some({alt})").expect("writing to a string cannot fail");
+        }
+        FixedLookaheadNode::Probe(arms) => {
+            writeln!(out, "match self.base.la({depth}) {{")
+                .expect("writing to a string cannot fail");
+            let arm_pad = format!("{node_pad}    ");
+            for (intervals, child) in arms {
+                let patterns = render_i32_match_patterns(intervals);
+                write!(out, "{arm_pad}{patterns} => ").expect("writing to a string cannot fail");
+                render_fixed_lookahead_node(out, &arm_pad, child, depth + 1);
+                writeln!(out, ",").expect("writing to a string cannot fail");
+            }
+            writeln!(out, "{arm_pad}_ => None,").expect("writing to a string cannot fail");
+            write!(out, "{node_pad}}}").expect("writing to a string cannot fail");
+        }
+    }
 }
 
 fn render_generated_decision_diagnostic_report(
@@ -7663,6 +7956,16 @@ fn render_generated_star_loop(
     } = loop_info;
     let (enter_alt, exit_alt) = alts;
     let pad = "    ".repeat(indent);
+    // Opt-in `--fixed-lookahead` static dispatch (see
+    // `render_generated_decision`); the miss arm renders the loop's regular
+    // adaptive body.
+    let static_table = (!allow_semantic_context && !force_context)
+        .then(|| {
+            render_context
+                .decision_routing
+                .static_dispatch_table(decision)
+        })
+        .flatten();
     // A tool-LL(1) loop decision dispatches on the tool's complete LOOK
     // table (exit alternative included), like Java's switch-driven loops.
     let tool_fast_path = render_context
@@ -7679,7 +7982,17 @@ fn render_generated_star_loop(
         .expect("writing to a string cannot fail");
     writeln!(out, "{pad}loop {{").expect("writing to a string cannot fail");
     let inner_pad = format!("{pad}    ");
-    if let Some(fast_path) = fast_path.filter(|_| {
+    if let Some(table) = static_table {
+        render_generated_fixed_lookahead_prediction(
+            out,
+            &inner_pad,
+            state,
+            decision,
+            &table,
+            render_context,
+            &loop_iter,
+        );
+    } else if let Some(fast_path) = fast_path.filter(|_| {
         !allow_semantic_context
             && !force_context
             && !render_context
@@ -8388,6 +8701,25 @@ struct DecisionAltLook {
     hit_pred: bool,
 }
 
+/// Upper bound accepted by `--fixed-lookahead`. Dispatch-table size and
+/// analysis cost grow with depth; beyond a few tokens the tier stops paying
+/// for itself, so cap the flag rather than let a typo explode generation.
+const MAX_FIXED_LOOKAHEAD_FLAG: usize = 8;
+/// Per-alternative cap on lookahead rectangles gathered by the fixed-LL(k)
+/// walk. This is an *analysis* budget: generous enough that ordinary
+/// decisions get an honest disjoint / not-disjoint verdict (fan-outy
+/// recursive regions need thousands of rectangles at depth 2-3), while the
+/// emitted code size is bounded separately by the table-arm budget.
+const FIXED_LOOKAHEAD_RECTANGLE_BUDGET: usize = 8192;
+/// Per-alternative cap on total walk steps (closure visits), guarding
+/// against pathological ATN regions; deterministic by construction.
+const FIXED_LOOKAHEAD_STEP_BUDGET: usize = 200_000;
+/// Cap on total dispatch-trie arms actually emitted for one decision. A
+/// disjointness proof over a huge rectangle set would compile into an
+/// unreasonably large `match`; past this size the adaptive simulator's
+/// learned DFA is the better engine, so decline the table.
+const FIXED_LOOKAHEAD_TABLE_ARM_BUDGET: usize = 256;
+
 /// Ports the ANTLR tool's `AnalysisPipeline` classification: the decisions
 /// whose alternatives' LOOK(1) sets are not pairwise disjoint (or hit a
 /// predicate, or come up empty). Java compiles LL(1)-disjoint decisions to
@@ -8395,19 +8727,52 @@ struct DecisionAltLook {
 /// other decision through `adaptivePredict`, the only place DFA states are
 /// learned and full-context diagnostics fire. `dumpDFA` and diagnostic
 /// output therefore only match Java when the generated routing agrees.
-fn tool_decision_analysis(data: &CodegenData<'_>) -> io::Result<ToolDecisionAnalysis> {
+///
+/// On top of that Java-parity split, `--fixed-lookahead k` (k >= 2) probes
+/// the residual `adaptivePredict` decisions with a bounded LOOK(k) walk and
+/// compiles the ones whose k-token lookahead languages are pairwise disjoint
+/// into static dispatch tables ([`FixedLookaheadTable`]). Every tier verdict
+/// is recorded in [`DecisionClassification::report_rows`] for the
+/// `decisions.json` manifest.
+fn classify_decisions(
+    data: &CodegenData<'_>,
+    fixed_lookahead: Option<usize>,
+) -> io::Result<DecisionClassification> {
     let atn = data.parser_atn()?;
-    let mut analysis = ToolDecisionAnalysis::default();
+    let max_lookahead = fixed_lookahead.unwrap_or(1);
+    let mut classification = DecisionClassification::default();
     for (decision, state_number) in atn.decision_to_state().iter().enumerate() {
         let Some(state) = atn.state(state_number) else {
             continue;
+        };
+        let report = |tier: DecisionTierReport| DecisionReportRow {
+            decision,
+            state: state_number,
+            rule_index: state.rule_index(),
+            tier,
         };
         // The tool never LL(1)-compiles non-greedy or left-recursion
         // precedence decisions, disjoint LOOK or not — Java always emits
         // `adaptivePredict` for them (a token switch would make a
         // non-greedy loop greedy).
-        if state.non_greedy() || state.precedence_rule_decision() {
-            analysis.adaptive_decisions.insert(decision);
+        if state.non_greedy() {
+            classification.adaptive_decisions.insert(decision);
+            classification
+                .report_rows
+                .push(report(DecisionTierReport::adaptive(
+                    AdaptiveReason::NonGreedy,
+                    0,
+                )));
+            continue;
+        }
+        if state.precedence_rule_decision() {
+            classification.adaptive_decisions.insert(decision);
+            classification
+                .report_rows
+                .push(report(DecisionTierReport::adaptive(
+                    AdaptiveReason::Precedence,
+                    0,
+                )));
             continue;
         }
         let looks: Vec<DecisionAltLook> = state
@@ -8424,31 +8789,517 @@ fn tool_decision_analysis(data: &CodegenData<'_>) -> io::Result<ToolDecisionAnal
                 look
             })
             .collect();
+        if looks.iter().any(|look| look.hit_pred) {
+            classification.adaptive_decisions.insert(decision);
+            classification
+                .report_rows
+                .push(report(DecisionTierReport::adaptive(
+                    AdaptiveReason::Predicate,
+                    1,
+                )));
+            continue;
+        }
+        if looks.iter().any(|look| look.symbols.is_empty()) {
+            classification.adaptive_decisions.insert(decision);
+            classification
+                .report_rows
+                .push(report(DecisionTierReport::adaptive(
+                    AdaptiveReason::EmptyLook,
+                    1,
+                )));
+            continue;
+        }
         if decision_alt_looks_disjoint(&looks) {
-            analysis.ll1_decision_arms.insert(
+            classification.ll1_decision_arms.insert(
                 decision,
                 looks
                     .iter()
                     .map(|look| symbol_intervals(&look.symbols))
                     .collect(),
             );
-        } else {
-            analysis.adaptive_decisions.insert(decision);
+            classification
+                .report_rows
+                .push(report(DecisionTierReport::Ll1));
+            continue;
         }
+        // Not LL(1): Java parity keeps the decision adaptive. With the
+        // opt-in flag, probe increasing fixed depths before giving up.
+        classification.adaptive_decisions.insert(decision);
+        let mut tier = DecisionTierReport::adaptive(AdaptiveReason::NotDisjoint, max_lookahead);
+        for depth in 2..=max_lookahead {
+            match fixed_lookahead_table(atn, state, depth) {
+                FixedLookaheadOutcome::Table(table) => {
+                    classification
+                        .fixed_lookahead_tables
+                        .insert(decision, table);
+                    tier = DecisionTierReport::Fixed { lookahead: depth };
+                    break;
+                }
+                FixedLookaheadOutcome::NotDisjoint => {}
+                FixedLookaheadOutcome::Predicate => {
+                    tier = DecisionTierReport::adaptive(AdaptiveReason::Predicate, depth);
+                    break;
+                }
+                FixedLookaheadOutcome::Budget => {
+                    tier = DecisionTierReport::adaptive(AdaptiveReason::Budget, depth);
+                    break;
+                }
+            }
+        }
+        classification.report_rows.push(report(tier));
     }
-    Ok(analysis)
+    Ok(classification)
 }
 
-/// Tool-side decision classification (see [`tool_decision_analysis`]).
+/// Tool-side decision classification (see [`classify_decisions`]).
 #[derive(Debug, Default)]
-struct ToolDecisionAnalysis {
-    /// Decisions Java compiles to `adaptivePredict` calls.
+struct DecisionClassification {
+    /// Decisions Java compiles to `adaptivePredict` calls. Decisions that
+    /// additionally earned a [`FixedLookaheadTable`] stay in this set: the
+    /// table's fall-through branch must render the same adaptive body the
+    /// decision would get without the table.
     adaptive_decisions: BTreeSet<usize>,
     /// Complete LOOK(1) dispatch intervals per alt for LL(1)-disjoint
     /// decisions — exit alternatives included, unlike the within-rule
     /// fast-path/LL(1) analyses, so legit input never falls through to the
     /// simulator (Java's switch never does).
     ll1_decision_arms: BTreeMap<usize, Vec<Vec<(i32, i32)>>>,
+    /// `--fixed-lookahead`: static dispatch tables for decisions whose
+    /// LOOK(k) languages are pairwise disjoint at some 2 <= k <= flag.
+    fixed_lookahead_tables: BTreeMap<usize, FixedLookaheadTable>,
+    /// Per-decision tier verdicts for the `decisions.json` manifest.
+    report_rows: Vec<DecisionReportRow>,
+}
+
+/// One decision's verdict for the `decisions.json` manifest.
+#[derive(Clone, Debug)]
+struct DecisionReportRow {
+    decision: usize,
+    state: usize,
+    rule_index: Option<usize>,
+    tier: DecisionTierReport,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DecisionTierReport {
+    /// LOOK(1)-disjoint: Java compiles a token switch; no prediction runs.
+    Ll1,
+    /// Disjoint at a fixed `lookahead` >= 2; static dispatch table emitted
+    /// (only reported when `--fixed-lookahead` enabled the probe).
+    Fixed { lookahead: usize },
+    /// Stays on adaptive prediction. `probed_lookahead` is the deepest
+    /// lookahead the classifier examined before settling on the reason.
+    Adaptive {
+        reason: AdaptiveReason,
+        probed_lookahead: usize,
+    },
+}
+
+impl DecisionTierReport {
+    const fn adaptive(reason: AdaptiveReason, probed_lookahead: usize) -> Self {
+        Self::Adaptive {
+            reason,
+            probed_lookahead,
+        }
+    }
+}
+
+/// Why a decision keeps `adaptivePredict` routing.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AdaptiveReason {
+    /// Non-greedy loop entry: a dispatch table would make it greedy.
+    NonGreedy,
+    /// Left-recursion precedence decision: gated on the runtime
+    /// precedence stack, invisible to token lookahead.
+    Precedence,
+    /// A semantic predicate guards lookahead-reachable paths; only the
+    /// simulator evaluates predicates during prediction.
+    Predicate,
+    /// Some alternative's lookahead set came up empty (Java nulls the
+    /// whole decision in `getDecisionLookahead`).
+    EmptyLook,
+    /// Lookahead languages stay overlapping at every probed depth.
+    NotDisjoint,
+    /// The fixed-lookahead walk exceeded its rectangle or step budget.
+    Budget,
+}
+
+impl AdaptiveReason {
+    const fn manifest_name(self) -> &'static str {
+        match self {
+            Self::NonGreedy => "non-greedy",
+            Self::Precedence => "precedence",
+            Self::Predicate => "predicate",
+            Self::EmptyLook => "empty-look",
+            Self::NotDisjoint => "not-disjoint",
+            Self::Budget => "budget-exceeded",
+        }
+    }
+}
+
+/// One k-token lookahead "rectangle": dimension `d` holds the interval set
+/// of tokens an ATN path can match at lookahead position `d + 1`. A
+/// rectangle denotes the cross product of its dimensions, and the union of
+/// an alternative's rectangles is exactly its LOOK(k) language: every path
+/// through the ATN consuming k terminal edges contributes the cross product
+/// of the sets those edges match, and every LOOK(k) word arises from such a
+/// path. Paths that reach end-of-input early pad the remaining dimensions
+/// with `{EOF}`, matching a token stream's behavior of returning EOF for
+/// every position past the end.
+type LookaheadRectangle = Vec<Vec<(i32, i32)>>;
+
+/// Static dispatch table for one fixed-LL(k) decision.
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct FixedLookaheadTable {
+    lookahead: usize,
+    root: FixedLookaheadNode,
+}
+
+/// Dispatch trie over `la(1) .. la(k)`. Arms at each probe level are
+/// pairwise disjoint interval sets; lookahead words outside every arm fall
+/// through to the decision's regular adaptive body.
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum FixedLookaheadNode {
+    /// Every surviving rectangle belongs to this 1-based alternative; no
+    /// further lookahead is read.
+    Alt(usize),
+    /// Probe the next lookahead token and descend.
+    Probe(Vec<(Vec<(i32, i32)>, Self)>),
+}
+
+enum FixedLookaheadOutcome {
+    Table(FixedLookaheadTable),
+    NotDisjoint,
+    Predicate,
+    Budget,
+}
+
+/// Probes one decision at exactly `depth` tokens of lookahead: walks every
+/// alternative's LOOK(depth) rectangles, requires the alternatives'
+/// languages to be pairwise disjoint, and compiles the dispatch trie.
+fn fixed_lookahead_table(
+    atn: &ParserAtn,
+    state: ParserAtnState<'_>,
+    depth: usize,
+) -> FixedLookaheadOutcome {
+    let mut alt_rectangles: Vec<Vec<LookaheadRectangle>> = Vec::new();
+    for transition in state.transitions() {
+        let mut walk = FixedLookaheadWalk {
+            atn,
+            depth_limit: depth,
+            steps: 0,
+        };
+        match walk.alt_rectangles(transition.target()) {
+            Ok(rectangles) if rectangles.is_empty() => {
+                // No k-token word reaches here (only possible through walk
+                // pruning); without a complete language the table would be
+                // unsound, so keep the decision adaptive.
+                return FixedLookaheadOutcome::NotDisjoint;
+            }
+            Ok(rectangles) => alt_rectangles.push(rectangles),
+            Err(FixedWalkBail::Predicate) => return FixedLookaheadOutcome::Predicate,
+            Err(FixedWalkBail::Budget) => return FixedLookaheadOutcome::Budget,
+        }
+    }
+    for (left, left_rectangles) in alt_rectangles.iter().enumerate() {
+        for right_rectangles in alt_rectangles.iter().skip(left + 1) {
+            let overlap = left_rectangles.iter().any(|left_rectangle| {
+                right_rectangles
+                    .iter()
+                    .any(|right_rectangle| rectangles_overlap(left_rectangle, right_rectangle))
+            });
+            if overlap {
+                return FixedLookaheadOutcome::NotDisjoint;
+            }
+        }
+    }
+    let items: Vec<(usize, &LookaheadRectangle)> = alt_rectangles
+        .iter()
+        .enumerate()
+        .flat_map(|(index, rectangles)| {
+            rectangles
+                .iter()
+                .map(move |rectangle| (index + 1, rectangle))
+        })
+        .collect();
+    match build_fixed_lookahead_node(&items, 0, depth) {
+        Some(root) => {
+            // A valid proof can still compile into an unreasonably large
+            // `match`; past the arm budget the simulator's learned DFA is
+            // the better engine.
+            if fixed_lookahead_node_arm_count(&root) > FIXED_LOOKAHEAD_TABLE_ARM_BUDGET {
+                return FixedLookaheadOutcome::Budget;
+            }
+            FixedLookaheadOutcome::Table(FixedLookaheadTable {
+                lookahead: depth,
+                root,
+            })
+        }
+        // Unreachable when disjointness holds; decline defensively rather
+        // than emit a table the proof does not cover.
+        None => FixedLookaheadOutcome::NotDisjoint,
+    }
+}
+
+/// Total dispatch arms across the trie (leaves plus probe arms), the size
+/// proxy for the emitted `match` code.
+fn fixed_lookahead_node_arm_count(node: &FixedLookaheadNode) -> usize {
+    match node {
+        FixedLookaheadNode::Alt(_) => 1,
+        FixedLookaheadNode::Probe(arms) => arms
+            .iter()
+            .map(|(_, child)| 1 + fixed_lookahead_node_arm_count(child))
+            .sum(),
+    }
+}
+
+/// Two k-dimensional rectangles overlap iff every dimension's interval
+/// sets intersect.
+fn rectangles_overlap(left: &LookaheadRectangle, right: &LookaheadRectangle) -> bool {
+    left.iter()
+        .zip(right.iter())
+        .all(|(left_set, right_set)| interval_sets_intersect(left_set, right_set))
+}
+
+/// Whether two sorted disjoint interval sets share any symbol.
+fn interval_sets_intersect(left: &[(i32, i32)], right: &[(i32, i32)]) -> bool {
+    let (mut left_index, mut right_index) = (0, 0);
+    while left_index < left.len() && right_index < right.len() {
+        let (left_start, left_stop) = left[left_index];
+        let (right_start, right_stop) = right[right_index];
+        if left_stop < right_start {
+            left_index += 1;
+        } else if right_stop < left_start {
+            right_index += 1;
+        } else {
+            return true;
+        }
+    }
+    false
+}
+
+/// Builds the dispatch trie for `items` (1-based alt, rectangle) from
+/// dimension `dim`. Returns `None` only if two alternatives still share a
+/// full lookahead word — impossible once pairwise disjointness holds, but
+/// declining beats emitting a table the proof does not cover.
+fn build_fixed_lookahead_node(
+    items: &[(usize, &LookaheadRectangle)],
+    dim: usize,
+    depth: usize,
+) -> Option<FixedLookaheadNode> {
+    let first_alt = items.first().map(|(alt, _)| *alt)?;
+    if items.iter().all(|(alt, _)| *alt == first_alt) {
+        return Some(FixedLookaheadNode::Alt(first_alt));
+    }
+    if dim >= depth {
+        return None;
+    }
+    // Atomize this dimension: split the token space at every interval
+    // boundary so each atom is covered by a fixed subset of rectangles.
+    let mut bounds = BTreeSet::new();
+    for (_, rectangle) in items {
+        for (start, stop) in &rectangle[dim] {
+            bounds.insert(*start);
+            bounds.insert(stop.checked_add(1)?);
+        }
+    }
+    let bounds: Vec<i32> = bounds.into_iter().collect();
+    let mut arms: Vec<(Vec<(i32, i32)>, FixedLookaheadNode)> = Vec::new();
+    for window in bounds.windows(2) {
+        let (atom_start, atom_stop) = (window[0], window[1] - 1);
+        let covering: Vec<(usize, &LookaheadRectangle)> = items
+            .iter()
+            .filter(|(_, rectangle)| {
+                interval_sets_intersect(&rectangle[dim], &[(atom_start, atom_start)])
+            })
+            .copied()
+            .collect();
+        if covering.is_empty() {
+            continue;
+        }
+        let child = build_fixed_lookahead_node(&covering, dim + 1, depth)?;
+        match arms.iter_mut().find(|(_, existing)| *existing == child) {
+            Some((intervals, _)) => push_coalesced_interval(intervals, atom_start, atom_stop),
+            None => arms.push((vec![(atom_start, atom_stop)], child)),
+        }
+    }
+    Some(FixedLookaheadNode::Probe(arms))
+}
+
+/// Appends `[start, stop]` to a sorted interval list, merging with the
+/// previous interval when adjacent (atoms arrive in ascending order).
+fn push_coalesced_interval(intervals: &mut Vec<(i32, i32)>, start: i32, stop: i32) {
+    match intervals.last_mut() {
+        Some((_, last_stop)) if *last_stop + 1 == start => *last_stop = stop,
+        _ => intervals.push((start, stop)),
+    }
+}
+
+enum FixedWalkBail {
+    Predicate,
+    Budget,
+}
+
+/// Bounded LOOK(k) enumeration for one decision alternative.
+///
+/// Follows [`DecisionLookWalk`]'s structure — the same rule-stop return
+/// handling, empty-context FOLLOW fallthrough, and per-closure recursion
+/// guards — but keeps walking through consuming edges until `depth_limit`
+/// tokens accumulate. The busy set and called-rule guard reset at every
+/// consumed token (they cut epsilon cycles inside one closure segment;
+/// re-entering a rule after consuming input is legitimate recursion), while
+/// the simulated call stack carries across segments. Predicate or
+/// precedence edges abort the alternative: only the simulator can evaluate
+/// them during prediction, so any decision they guard stays adaptive.
+struct FixedLookaheadWalk<'a> {
+    atn: &'a ParserAtn,
+    depth_limit: usize,
+    steps: usize,
+}
+
+impl FixedLookaheadWalk<'_> {
+    fn alt_rectangles(&mut self, start: usize) -> Result<Vec<LookaheadRectangle>, FixedWalkBail> {
+        let mut rectangles = Vec::new();
+        let rule_count = self.atn.rule_to_start_state().len();
+        self.segment(
+            start,
+            &mut Vec::new(),
+            &mut BTreeSet::new(),
+            &mut vec![false; rule_count],
+            &[],
+            &mut rectangles,
+        )?;
+        Ok(rectangles)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn segment(
+        &mut self,
+        state_number: usize,
+        ctx: &mut Vec<usize>,
+        busy: &mut BTreeSet<(usize, Vec<usize>)>,
+        called_rules: &mut Vec<bool>,
+        prefix: &[Vec<(i32, i32)>],
+        out: &mut Vec<LookaheadRectangle>,
+    ) -> Result<(), FixedWalkBail> {
+        self.steps += 1;
+        if self.steps > FIXED_LOOKAHEAD_STEP_BUDGET {
+            return Err(FixedWalkBail::Budget);
+        }
+        if !busy.insert((state_number, ctx.clone())) {
+            return Ok(());
+        }
+        let Some(state) = self.atn.state(state_number) else {
+            return Ok(());
+        };
+        if state.kind() == AtnStateKind::RuleStop {
+            if let Some(return_state) = ctx.pop() {
+                let cleared = state
+                    .rule_index()
+                    .map(|rule| std::mem::replace(&mut called_rules[rule], false));
+                let result = self.segment(return_state, ctx, busy, called_rules, prefix, out);
+                if let (Some(rule), Some(flag)) = (state.rule_index(), cleared) {
+                    called_rules[rule] = flag;
+                }
+                ctx.push(return_state);
+                return result;
+            }
+            if state.transitions().is_empty() {
+                // Escaped the start rule's stop state: every remaining
+                // lookahead position reads EOF.
+                self.emit_eof_padded(prefix.to_vec(), out)?;
+                return Ok(());
+            }
+        }
+        for transition in state.transitions() {
+            match transition.data() {
+                ParserTransitionData::Rule {
+                    target,
+                    rule_index,
+                    follow_state,
+                    ..
+                } => {
+                    if called_rules.get(rule_index).copied().unwrap_or(true) {
+                        continue;
+                    }
+                    called_rules[rule_index] = true;
+                    ctx.push(follow_state);
+                    let result = self.segment(target, ctx, busy, called_rules, prefix, out);
+                    ctx.pop();
+                    called_rules[rule_index] = false;
+                    result?;
+                }
+                ParserTransitionData::Predicate { .. }
+                | ParserTransitionData::Precedence { .. } => {
+                    return Err(FixedWalkBail::Predicate);
+                }
+                ParserTransitionData::Epsilon { target }
+                | ParserTransitionData::Action { target, .. } => {
+                    self.segment(target, ctx, busy, called_rules, prefix, out)?;
+                }
+                _ => {
+                    // Terminal edge: enumerate the vocabulary through the
+                    // shared `matches` so atoms, ranges, sets, negations and
+                    // wildcards agree with the simulator exactly.
+                    let mut symbols = BTreeSet::new();
+                    for symbol in TOKEN_EOF..=self.atn.max_token_type() {
+                        if transition.matches(symbol, 1, self.atn.max_token_type()) {
+                            symbols.insert(symbol);
+                        }
+                    }
+                    // A consumed EOF pins every later position to EOF, so
+                    // split it out of the deeper walk.
+                    if symbols.remove(&TOKEN_EOF) {
+                        let mut rectangle = prefix.to_vec();
+                        rectangle.push(vec![(TOKEN_EOF, TOKEN_EOF)]);
+                        self.emit_eof_padded(rectangle, out)?;
+                    }
+                    if symbols.is_empty() {
+                        continue;
+                    }
+                    let mut extended = prefix.to_vec();
+                    extended.push(symbol_intervals(&symbols));
+                    if extended.len() == self.depth_limit {
+                        push_rectangle(out, extended)?;
+                    } else {
+                        // Token consumed: fresh closure guards, same stack.
+                        let rule_count = called_rules.len();
+                        self.segment(
+                            transition.target(),
+                            ctx,
+                            &mut BTreeSet::new(),
+                            &mut vec![false; rule_count],
+                            &extended,
+                            out,
+                        )?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn emit_eof_padded(
+        &self,
+        mut rectangle: LookaheadRectangle,
+        out: &mut Vec<LookaheadRectangle>,
+    ) -> Result<(), FixedWalkBail> {
+        while rectangle.len() < self.depth_limit {
+            rectangle.push(vec![(TOKEN_EOF, TOKEN_EOF)]);
+        }
+        push_rectangle(out, rectangle)
+    }
+}
+
+fn push_rectangle(
+    out: &mut Vec<LookaheadRectangle>,
+    rectangle: LookaheadRectangle,
+) -> Result<(), FixedWalkBail> {
+    if out.len() >= FIXED_LOOKAHEAD_RECTANGLE_BUDGET {
+        return Err(FixedWalkBail::Budget);
+    }
+    out.push(rectangle);
+    Ok(())
 }
 
 /// Collapses a sorted symbol set into inclusive intervals.
@@ -8568,6 +9419,7 @@ fn build_embedded_parser_data(
     type_name: &str,
     grammar_name: &str,
     options: ParserRenderOptions<'_>,
+    decisions: &DecisionClassification,
 ) -> io::Result<EmbeddedParserData> {
     let model = structural_embedded_model(data, true)?;
     let token_types: BTreeMap<String, i32> = data
@@ -8585,15 +9437,14 @@ fn build_embedded_parser_data(
         post_process_embedded(body, translated, type_name)
     };
 
-    let decision_analysis = tool_decision_analysis(data)?;
     let mut out = EmbeddedParserData {
         rule_has_attrs: model
             .rules
             .iter()
             .map(embedded::RuleModel::has_attrs)
             .collect(),
-        adaptive_decisions: decision_analysis.adaptive_decisions,
-        ll1_decision_arms: decision_analysis.ll1_decision_arms,
+        adaptive_decisions: decisions.adaptive_decisions.clone(),
+        ll1_decision_arms: decisions.ll1_decision_arms.clone(),
         ..EmbeddedParserData::default()
     };
 
@@ -10857,6 +11708,14 @@ fn render_parser_with_options(
     let parser_atn_data = render_u32_slice(parser_atn.packed_words());
     let token_constants = render_token_constants(data);
     let rule_constants = render_rule_constants(data);
+    // Decision routing: embedded mode always follows the tool
+    // classification (Java parity); `--fixed-lookahead` additionally
+    // compiles static dispatch for provable decisions in either mode.
+    let decision_classification = if options.embedded || options.fixed_lookahead.is_some() {
+        Some(classify_decisions(data, options.fixed_lookahead)?)
+    } else {
+        None
+    };
     // Embedded mode: the grammar carries real Rust action/predicate bodies
     // (rendered through the target `.test.stg`); translate and splice them
     // instead of recognizing template markup.
@@ -10866,6 +11725,9 @@ fn render_parser_with_options(
             &type_name,
             grammar_name,
             options,
+            decision_classification
+                .as_ref()
+                .expect("decision classification is computed for embedded mode"),
         )?)
     } else {
         None
@@ -10880,6 +11742,19 @@ fn render_parser_with_options(
         )?)
     };
     let embedded_step_render = embedded_data.as_ref().map(embedded_step_render);
+    let decision_routing = DecisionRoutingRender {
+        // Embedded mode reads its LL(1) switch tables through
+        // `EmbeddedStepRender`; the routing copy is for plain mode, where
+        // static LL(1) switches are part of the opt-in flag.
+        ll1_decision_arms: decision_classification
+            .as_ref()
+            .filter(|_| !options.embedded && options.fixed_lookahead.is_some())
+            .map(|classification| &classification.ll1_decision_arms),
+        fixed_lookahead_tables: decision_classification
+            .as_ref()
+            .filter(|_| options.fixed_lookahead.is_some_and(|depth| depth >= 2))
+            .map(|classification| &classification.fixed_lookahead_tables),
+    };
     let mut portable_local_data = if options.embedded {
         PortableLocalData::default()
     } else {
@@ -10996,6 +11871,7 @@ fn render_parser_with_options(
             track_context_alt_numbers,
             embedded_step_render,
             portable_step_render,
+            decision_routing,
         );
     let unknown_policy_literal = parser_unknown_policy_literal(options.sem_unknown);
     let parse_rule_fallback = render_parser_parse_rule_fallback(
@@ -14456,6 +15332,7 @@ mod tests {
             false,
             None,
             None,
+            DecisionRoutingRender::default(),
         );
 
         // ATN-preferred children route through `parse_rule_precedence_from_generated`:
@@ -14494,6 +15371,7 @@ mod tests {
             false,
             None,
             None,
+            DecisionRoutingRender::default(),
         );
 
         // A configured depth cap overrides the ATN preference: only generated
@@ -14629,6 +15507,7 @@ mod tests {
                 rule_arg0: &rule_arg0,
             }),
             None,
+            DecisionRoutingRender::default(),
         );
 
         assert!(!rendered.contains("if self.generated_only()"));
@@ -14963,6 +15842,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -14996,6 +15876,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -15177,9 +16058,15 @@ mod tests {
             structural_embedded_model(&data, false).expect("structural model should resolve");
         insta::assert_debug_snapshot!("left_recursive_label_alternatives", model.rules[1].alts);
 
-        let embedded =
-            build_embedded_parser_data(&data, "TParser", "T", ParserRenderOptions::default())
-                .expect("embedded actions should resolve deleted left-recursive labels");
+        let decisions = classify_decisions(&data, None).expect("decision classification");
+        let embedded = build_embedded_parser_data(
+            &data,
+            "TParser",
+            "T",
+            ParserRenderOptions::default(),
+            &decisions,
+        )
+        .expect("embedded actions should resolve deleted left-recursive labels");
         insta::assert_debug_snapshot!("left_recursive_label_actions", embedded.inline_actions);
     }
 
@@ -16474,6 +17361,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16526,6 +17414,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16591,6 +17480,7 @@ mod tests {
                     predicates: &predicates,
                     required_generated_rules: &required_generated_rules,
                 }),
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &inline_actions,
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16638,6 +17528,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16685,6 +17576,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16732,6 +17624,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16786,6 +17679,7 @@ mod tests {
                     predicates: &predicates,
                     required_generated_rules: &required_generated_rules,
                 }),
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -16843,6 +17737,7 @@ mod tests {
                 current_rule_index: 0,
                 embedded: None,
                 portable_locals: None,
+                decision_routing: DecisionRoutingRender::default(),
                 inline_action_statements: &BTreeMap::new(),
                 track_alt_numbers: false,
                 track_context_alt_numbers: false,
@@ -17959,6 +18854,96 @@ lower = "cmp(ne, ctx_rule_text(local_type), str(\"var\"))"
 
     fn portable_bool_parser_data() -> CodegenData<'static> {
         parser_fixture_data("portable-bool/S.g4")
+    }
+
+    #[test]
+    fn fixed_lookahead_classifier_tiers_thrift_like_decision() {
+        let data = parser_fixture_data("fixed-lookahead/T.g4");
+
+        // Flag off: Java-parity classification only. The `a` decision's
+        // first two alternatives share 'ns', so it stays adaptive.
+        let default_classification =
+            classify_decisions(&data, None).expect("classification succeeds");
+        assert!(default_classification.fixed_lookahead_tables.is_empty());
+        assert_eq!(default_classification.adaptive_decisions.len(), 1);
+        let adaptive_row = default_classification
+            .report_rows
+            .iter()
+            .find(|row| matches!(row.tier, DecisionTierReport::Adaptive { .. }))
+            .expect("one adaptive row");
+        assert_eq!(
+            adaptive_row.tier,
+            DecisionTierReport::Adaptive {
+                reason: AdaptiveReason::NotDisjoint,
+                probed_lookahead: 1,
+            }
+        );
+
+        // Flag on: the same decision is provably LL(2) and earns a table;
+        // it stays in `adaptive_decisions` so its miss arm renders the
+        // adaptive body it would have without the table.
+        let classification = classify_decisions(&data, Some(2)).expect("classification succeeds");
+        assert_eq!(classification.fixed_lookahead_tables.len(), 1);
+        let (decision, table) = classification
+            .fixed_lookahead_tables
+            .iter()
+            .next()
+            .expect("one fixed table");
+        assert!(classification.adaptive_decisions.contains(decision));
+        assert_eq!(table.lookahead, 2);
+        insta::assert_debug_snapshot!("fixed_lookahead_thrift_like_table", table);
+
+        // Deterministic and idempotent: same inputs, same classification.
+        let again = classify_decisions(&data, Some(2)).expect("classification succeeds");
+        assert_eq!(
+            format!("{:?}", classification.fixed_lookahead_tables),
+            format!("{:?}", again.fixed_lookahead_tables)
+        );
+        assert_eq!(
+            format!("{:?}", classification.report_rows),
+            format!("{:?}", again.report_rows)
+        );
+    }
+
+    #[test]
+    fn fixed_lookahead_manifest_reports_tiers() {
+        let data = parser_fixture_data("fixed-lookahead/T.g4");
+        let classification = classify_decisions(&data, Some(2)).expect("classification succeeds");
+        let manifest = render_decisions_manifest(
+            Some(2),
+            &[DecisionReportGrammar {
+                name: "T".to_owned(),
+                rule_names: data.rule_names,
+                rows: classification.report_rows,
+            }],
+        );
+        insta::assert_snapshot!("fixed_lookahead_decisions_manifest", manifest);
+    }
+
+    #[test]
+    fn fixed_lookahead_dispatch_probes_second_token_after_sync() {
+        let data = parser_fixture_data("fixed-lookahead/T.g4");
+        let without_flag = render_parser("T", &data).expect("parser renders");
+        assert!(!without_flag.contains("__fixed_lookahead_alt"));
+
+        let rendered = render_parser_with_options(
+            "T",
+            &data,
+            ParserRenderOptions {
+                fixed_lookahead: Some(2),
+                ..ParserRenderOptions::default()
+            },
+        )
+        .expect("parser renders");
+        let dispatch_start = rendered
+            .find("let __fixed_lookahead_alt")
+            .expect("fixed dispatch rendered");
+        assert!(rendered.contains("match self.base.la(2)"));
+        // The context-aware sync must run before the table probes the
+        // lookahead — recovery deletes extraneous tokens exactly where the
+        // untiered parser would.
+        let sync_before_dispatch = rendered[..dispatch_start].rfind("sync_decision");
+        assert!(sync_before_dispatch.is_some());
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -72,7 +72,7 @@ pub use self::__antlr4_rust_generated::*;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args = match Args::parse()? {
-        CliCommand::Generate(args) => args,
+        CliCommand::Generate(args) => *args,
         CliCommand::Help => {
             let mut stdout = io::stdout().lock();
             writeln!(stdout, "{}", usage())?;
@@ -2145,7 +2145,7 @@ struct Args {
 }
 
 enum CliCommand {
-    Generate(Args),
+    Generate(Box<Args>),
     Help,
     Version,
 }
@@ -2246,7 +2246,7 @@ impl Args {
             ));
         }
 
-        Ok(CliCommand::Generate(Self {
+        Ok(CliCommand::Generate(Box::new(Self {
             roots,
             library_directories,
             out_dir: out_dir.unwrap_or_else(|| PathBuf::from(".")),
@@ -2260,7 +2260,7 @@ impl Args {
             generate_visitor,
             embedded_actions,
             fixed_lookahead,
-        }))
+        })))
     }
 }
 
@@ -4179,6 +4179,9 @@ struct PortableLocalStepRender<'a> {
     required_generated_rules: &'a BTreeSet<usize>,
 }
 
+/// Complete LOOK(1) dispatch intervals per alternative, keyed by decision.
+type Ll1DecisionArms = BTreeMap<usize, Vec<Vec<(i32, i32)>>>;
+
 /// Mode-independent decision routing produced by [`classify_decisions`].
 ///
 /// Embedded mode reads its Java-parity LL(1) tables through
@@ -4188,7 +4191,7 @@ struct PortableLocalStepRender<'a> {
 /// with the flag unset so default rendering is untouched.
 #[derive(Clone, Copy, Default)]
 struct DecisionRoutingRender<'a> {
-    ll1_decision_arms: Option<&'a BTreeMap<usize, Vec<Vec<(i32, i32)>>>>,
+    ll1_decision_arms: Option<&'a Ll1DecisionArms>,
     fixed_lookahead_tables: Option<&'a BTreeMap<usize, FixedLookaheadTable>>,
 }
 
@@ -4198,7 +4201,7 @@ impl DecisionRoutingRender<'_> {
     /// LOOK(1) arms (plain mode only; embedded mode renders its Java-parity
     /// switch through [`EmbeddedStepRender`]). Both render through the same
     /// sync-first dispatch shape.
-    fn static_dispatch_table(&self, decision: usize) -> Option<FixedLookaheadTable> {
+    fn static_dispatch_table(self, decision: usize) -> Option<FixedLookaheadTable> {
         if let Some(table) = self
             .fixed_lookahead_tables
             .and_then(|tables| tables.get(&decision))
@@ -6090,7 +6093,6 @@ impl GeneratedRuleError {{
 }
 
 #[allow(clippy::too_many_arguments)]
-#[allow(clippy::too_many_arguments)]
 fn render_generated_rule_routing(
     rules: &[Option<GeneratedParserRule>],
     rule_names: &[String],
@@ -7363,6 +7365,7 @@ fn render_generated_ll1_then_adaptive_prediction(
 /// input" report a rule higher), then the trie probes the post-sync
 /// lookahead, and a miss falls through to the decision's regular adaptive
 /// prediction.
+#[allow(clippy::too_many_arguments)]
 fn render_generated_fixed_lookahead_prediction(
     out: &mut String,
     pad: &str,
@@ -9172,7 +9175,7 @@ impl FixedLookaheadWalk<'_> {
         Ok(rectangles)
     }
 
-    #[allow(clippy::too_many_lines)]
+    #[allow(clippy::too_many_lines, clippy::too_many_arguments)]
     fn segment(
         &mut self,
         state_number: usize,
@@ -11693,6 +11696,65 @@ const fn render_compile_parse_tree_pattern_method() -> &'static str {
 "#
 }
 
+/// Decision classification for parser rendering: computed whenever a
+/// consumer needs it — embedded mode routes decisions by the tool
+/// classification (Java parity), and `--fixed-lookahead` compiles static
+/// dispatch in either mode.
+fn parser_decision_classification(
+    data: &CodegenData<'_>,
+    options: ParserRenderOptions<'_>,
+) -> io::Result<Option<DecisionClassification>> {
+    if options.embedded || options.fixed_lookahead.is_some() {
+        Ok(Some(classify_decisions(data, options.fixed_lookahead)?))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Step-render view over the opt-in `--fixed-lookahead` routing. Embedded
+/// mode reads its LL(1) switch tables through `EmbeddedStepRender`; the
+/// routing copy of the arms is for plain mode, where static LL(1) switches
+/// are part of the opt-in flag.
+fn decision_routing_render<'a>(
+    classification: Option<&'a DecisionClassification>,
+    options: ParserRenderOptions<'_>,
+) -> DecisionRoutingRender<'a> {
+    DecisionRoutingRender {
+        ll1_decision_arms: classification
+            .filter(|_| !options.embedded && options.fixed_lookahead.is_some())
+            .map(|classification| &classification.ll1_decision_arms),
+        fixed_lookahead_tables: classification
+            .filter(|_| options.fixed_lookahead.is_some_and(|depth| depth >= 2))
+            .map(|classification| &classification.fixed_lookahead_tables),
+    }
+}
+
+/// Builds the mode-specific action/attribute surface: embedded mode
+/// translates and splices the grammar's real Rust action/predicate bodies
+/// (rendered through the target `.test.stg`) instead of recognizing
+/// template markup; plain mode builds the structural surface.
+fn parser_render_surfaces(
+    data: &CodegenData<'_>,
+    type_name: &str,
+    grammar_name: &str,
+    options: ParserRenderOptions<'_>,
+    decision_classification: Option<&DecisionClassification>,
+) -> io::Result<(Option<EmbeddedParserData>, Option<EmbeddedParserData>)> {
+    if options.embedded {
+        let embedded = build_embedded_parser_data(
+            data,
+            type_name,
+            grammar_name,
+            options,
+            decision_classification.expect("decision classification is computed for embedded mode"),
+        )?;
+        Ok((Some(embedded), None))
+    } else {
+        let surface = build_structural_parser_surface(data, grammar_name, options)?;
+        Ok((None, Some(surface)))
+    }
+}
+
 fn render_parser_with_options(
     grammar_name: &str,
     data: &CodegenData<'_>,
@@ -11711,50 +11773,16 @@ fn render_parser_with_options(
     // Decision routing: embedded mode always follows the tool
     // classification (Java parity); `--fixed-lookahead` additionally
     // compiles static dispatch for provable decisions in either mode.
-    let decision_classification = if options.embedded || options.fixed_lookahead.is_some() {
-        Some(classify_decisions(data, options.fixed_lookahead)?)
-    } else {
-        None
-    };
-    // Embedded mode: the grammar carries real Rust action/predicate bodies
-    // (rendered through the target `.test.stg`); translate and splice them
-    // instead of recognizing template markup.
-    let embedded_data = if options.embedded {
-        Some(build_embedded_parser_data(
-            data,
-            &type_name,
-            grammar_name,
-            options,
-            decision_classification
-                .as_ref()
-                .expect("decision classification is computed for embedded mode"),
-        )?)
-    } else {
-        None
-    };
-    let structural_surface = if options.embedded {
-        None
-    } else {
-        Some(build_structural_parser_surface(
-            data,
-            grammar_name,
-            options,
-        )?)
-    };
+    let decision_classification = parser_decision_classification(data, options)?;
+    let (embedded_data, structural_surface) = parser_render_surfaces(
+        data,
+        &type_name,
+        grammar_name,
+        options,
+        decision_classification.as_ref(),
+    )?;
     let embedded_step_render = embedded_data.as_ref().map(embedded_step_render);
-    let decision_routing = DecisionRoutingRender {
-        // Embedded mode reads its LL(1) switch tables through
-        // `EmbeddedStepRender`; the routing copy is for plain mode, where
-        // static LL(1) switches are part of the opt-in flag.
-        ll1_decision_arms: decision_classification
-            .as_ref()
-            .filter(|_| !options.embedded && options.fixed_lookahead.is_some())
-            .map(|classification| &classification.ll1_decision_arms),
-        fixed_lookahead_tables: decision_classification
-            .as_ref()
-            .filter(|_| options.fixed_lookahead.is_some_and(|depth| depth >= 2))
-            .map(|classification| &classification.fixed_lookahead_tables),
-    };
+    let decision_routing = decision_routing_render(decision_classification.as_ref(), options);
     let mut portable_local_data = if options.embedded {
         PortableLocalData::default()
     } else {

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -2186,11 +2186,7 @@ impl<'a> CodegenData<'a> {
             literal_names: recognizer.literal_names.clone(),
             symbolic_names: recognizer.symbolic_names.clone(),
             rule_names: recognizer.rule_names.clone(),
-            channel_names: recognizer
-                .channel_names
-                .iter()
-                .map(|name| name.clone().unwrap_or_default())
-                .collect(),
+            channel_names: runtime_channel_names(&recognizer.channel_numbers),
             channel_numbers: recognizer.channel_numbers.clone(),
             mode_names: recognizer.mode_names.clone(),
             mode_numbers: recognizer.mode_numbers.clone(),
@@ -2211,11 +2207,7 @@ impl<'a> CodegenData<'a> {
             literal_names: recognizer.literal_names.clone(),
             symbolic_names: recognizer.symbolic_names.clone(),
             rule_names: recognizer.rule_names.clone(),
-            channel_names: recognizer
-                .channel_names
-                .iter()
-                .map(|name| name.clone().unwrap_or_default())
-                .collect(),
+            channel_names: runtime_channel_names(&recognizer.channel_numbers),
             channel_numbers: recognizer.channel_numbers.clone(),
             mode_names: recognizer.mode_names.clone(),
             mode_numbers: recognizer.mode_numbers.clone(),
@@ -2247,6 +2239,24 @@ impl<'a> CodegenData<'a> {
             )
         })
     }
+}
+
+/// Dense channel-name table indexed by runtime channel value, matching the
+/// Java target's generated `channelNames` array. The semantic model keeps the
+/// `.interp`-shaped vector (two `null` placeholder rows before user channels,
+/// a tool serialization quirk), so rebuild from the value map instead of
+/// copying it — otherwise a custom channel's display name lands at
+/// `value + 2` and `channel_names[value]` reads as empty.
+fn runtime_channel_names(channel_numbers: &BTreeMap<String, i32>) -> Vec<String> {
+    let mut names = vec![String::new(); channel_numbers.len()];
+    for (name, number) in channel_numbers {
+        let index = usize::try_from(*number).expect("channel value is non-negative");
+        if index >= names.len() {
+            names.resize(index + 1, String::new());
+        }
+        names[index].clone_from(name);
+    }
+    names
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -17949,6 +17959,24 @@ lower = "cmp(ne, ctx_rule_text(local_type), str(\"var\"))"
 
     fn portable_bool_parser_data() -> CodegenData<'static> {
         parser_fixture_data("portable-bool/S.g4")
+    }
+
+    #[test]
+    fn runtime_channel_names_are_dense_by_value() {
+        // The semantic model keeps the `.interp`-shaped table (two `null`
+        // placeholder rows before user channels); the generated runtime
+        // metadata must instead match Java's dense `channelNames` array so
+        // `channel_names[value]` resolves the declared name.
+        let data = lexer_fixture_data("custom-channels/L.g4");
+        assert_eq!(
+            data.channel_names,
+            [
+                "DEFAULT_TOKEN_CHANNEL".to_owned(),
+                "HIDDEN".to_owned(),
+                "COMMENTS_AND_FORMATTING".to_owned(),
+            ]
+        );
+        assert_eq!(data.channel_numbers["COMMENTS_AND_FORMATTING"], 2);
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9366,15 +9366,15 @@ impl FixedLookaheadWalk<'_> {
                     self.segment(target, ctx, busy, called_rules, prefix, out)?;
                 }
                 _ => {
-                    // Terminal edge: enumerate the vocabulary through the
-                    // shared `matches` so atoms, ranges, sets, negations and
-                    // wildcards agree with the simulator exactly.
-                    let mut symbols = BTreeSet::new();
-                    for symbol in TOKEN_EOF..=self.atn.max_token_type() {
-                        if transition.matches(symbol, 1, self.atn.max_token_type()) {
-                            symbols.insert(symbol);
-                        }
-                    }
+                    // Terminal edge: expand the transition's own
+                    // label/range/set data — the same expansion the
+                    // within-rule FIRST walks use, and identical to the
+                    // simulator's `matches` for every terminal kind —
+                    // instead of probing the whole vocabulary per visit
+                    // (this walk revisits edges across segments and
+                    // probed depths, so a vocabulary scan multiplies).
+                    let mut symbols =
+                        generated_transition_symbols(transition, self.atn.max_token_type());
                     // A consumed EOF pins every later position to EOF, so
                     // split it out of the deeper walk.
                     if symbols.remove(&TOKEN_EOF) {

--- a/src/bin/snapshots/antlr4_rust_gen__tests__fixed_lookahead_decisions_manifest.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__fixed_lookahead_decisions_manifest.snap
@@ -1,0 +1,18 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: manifest
+---
+{
+  "version": 1,
+  "fixedLookahead": 2,
+  "grammars": [
+    {
+      "name": "T",
+      "summary": {"total": 2, "ll1": 1, "fixed": 1, "adaptive": 0},
+      "decisions": [
+        {"decision": 0, "rule": "s", "state": 7, "tier": "ll1"},
+        {"decision": 1, "rule": "a", "state": 20, "tier": "fixed", "lookahead": 2}
+      ]
+    }
+  ]
+}

--- a/src/bin/snapshots/antlr4_rust_gen__tests__fixed_lookahead_thrift_like_table.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__fixed_lookahead_thrift_like_table.snap
@@ -1,0 +1,56 @@
+---
+source: src/bin/antlr4-rust-gen.rs
+expression: table
+---
+FixedLookaheadTable {
+    lookahead: 2,
+    root: Probe(
+        [
+            (
+                [
+                    (
+                        1,
+                        1,
+                    ),
+                ],
+                Probe(
+                    [
+                        (
+                            [
+                                (
+                                    2,
+                                    2,
+                                ),
+                            ],
+                            Alt(
+                                1,
+                            ),
+                        ),
+                        (
+                            [
+                                (
+                                    4,
+                                    4,
+                                ),
+                            ],
+                            Alt(
+                                2,
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+            (
+                [
+                    (
+                        3,
+                        3,
+                    ),
+                ],
+                Alt(
+                    3,
+                ),
+            ),
+        ],
+    ),
+}

--- a/tests/fixtures/antlr4-rust-gen/custom-channels/L.g4
+++ b/tests/fixtures/antlr4-rust-gen/custom-channels/L.g4
@@ -1,0 +1,9 @@
+lexer grammar L;
+
+channels {
+    COMMENTS_AND_FORMATTING
+}
+
+A       : 'a';
+Comment : '#' ~[\r\n]* -> Channel(COMMENTS_AND_FORMATTING);
+WS      : [ \t\r\n]+ -> channel(HIDDEN);

--- a/tests/fixtures/antlr4-rust-gen/fixed-lookahead/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/fixed-lookahead/T.g4
@@ -1,0 +1,10 @@
+grammar T;
+
+// The `a` decision mirrors Thrift's `namespace_` shape: alternatives 1 and 2
+// share their first token and separate only at the second, so the decision
+// is fixed-LL(2) but not LL(1). The `a*` loop stays LL(1).
+s: a* EOF;
+a: 'ns' '*' ID | 'ns' ID ID | 'x' ID;
+
+ID: [a-z]+;
+WS: [ \t\r\n]+ -> skip;

--- a/tools/fixed-lookahead-bench/README.md
+++ b/tools/fixed-lookahead-bench/README.md
@@ -1,0 +1,24 @@
+# Fixed-lookahead differential validation + benchmark
+
+Reproduces the issue #150 acceptance evidence for `--fixed-lookahead` on the
+three target grammars from `antlr/grammars-v4` (Thrift, EDN, Rego):
+
+1. generates a **baseline** and a **`--fixed-lookahead`** parser per grammar,
+2. parses each grammar's full example corpus with both — valid **and**
+   invalid inputs (Rego ships 25 exact-`.errors` recovery fixtures) — and
+   fails unless parse trees *and* error output are byte-identical,
+3. runs a same-machine interleaved A/B benchmark (total min-parse time,
+   per-file geomean speedup, cold first-parse time).
+
+```bash
+tools/fixed-lookahead-bench/run.sh                      # clones grammars-v4 (sparse) itself
+tools/fixed-lookahead-bench/run.sh --grammars-v4 DIR    # reuse an existing checkout
+```
+
+Work products land under `target/fixed-lookahead-bench/`; the generated
+`decisions.json` next to each parser lists every decision's tier
+(`ll1` / `fixed` / `adaptive` + reason).
+
+Reference numbers (Apple Silicon, 2026-07): Thrift +12% parse & fastest
+cold-start (0 adaptive decisions at `--fixed-lookahead 2`), EDN +5%, Rego
+parity-neutral with 1955/1955 files byte-identical.

--- a/tools/fixed-lookahead-bench/bench.py
+++ b/tools/fixed-lookahead-bench/bench.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Same-machine interleaved A/B benchmark: baseline vs --fixed-lookahead.
+
+Driven by run.sh (env: GRAMMARS_DIR, DRIVER_BIN). For each corpus file the
+base and fixed drivers run alternately, each reporting the minimum of N
+in-process parses; a second interleaved round keeps the per-file minimum.
+Reports total min-parse time, per-file geomean speedup, and cold (first
+in-process parse) time on the largest file, min over 10 process samples.
+"""
+
+import math
+import os
+import subprocess
+from pathlib import Path
+
+GRAMMARS_DIR = Path(os.environ["GRAMMARS_DIR"])
+DRIVER_BIN = Path(os.environ["DRIVER_BIN"])
+CORPORA = {
+    "thrift": (GRAMMARS_DIR / "thrift/examples", "*.thrift", 25),
+    "edn": (GRAMMARS_DIR / "edn/examples", "*", 25),
+    "rego": (GRAMMARS_DIR / "rego/examples", "*.stmt", 7),
+}
+
+
+def min_us(binary: Path, source: Path, iters: int) -> int:
+    out = subprocess.run(
+        [binary, str(source), "--quiet", "--time", "--iters", str(iters)],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout
+    for line in out.splitlines():
+        if line.startswith("TIME_MIN_US="):
+            return int(line.split("=", 1)[1])
+    raise SystemExit(f"no timing line from {binary} {source}")
+
+
+def main() -> None:
+    for grammar, (root, glob, iters) in CORPORA.items():
+        files = sorted(
+            f
+            for f in root.rglob(glob)
+            if f.is_file() and not f.name.endswith((".errors", ".tree"))
+        )
+        base_total = 0
+        fixed_total = 0
+        ratios = []
+        for source in files:
+            base = min_us(DRIVER_BIN / f"{grammar}_base", source, iters)
+            fixed = min_us(DRIVER_BIN / f"{grammar}_fixed", source, iters)
+            base = min(base, min_us(DRIVER_BIN / f"{grammar}_base", source, iters))
+            fixed = min(fixed, min_us(DRIVER_BIN / f"{grammar}_fixed", source, iters))
+            base_total += base
+            fixed_total += fixed
+            if base > 0 and fixed > 0:
+                ratios.append(base / fixed)
+        geomean = (
+            math.exp(sum(map(math.log, ratios)) / len(ratios)) if ratios else float("nan")
+        )
+        largest = max(files, key=lambda f: f.stat().st_size)
+        cold_base = min(min_us(DRIVER_BIN / f"{grammar}_base", largest, 1) for _ in range(10))
+        cold_fixed = min(
+            min_us(DRIVER_BIN / f"{grammar}_fixed", largest, 1) for _ in range(10)
+        )
+        print(
+            f"{grammar}: files={len(files)} "
+            f"total_min base={base_total / 1000:.2f}ms fixed={fixed_total / 1000:.2f}ms "
+            f"({base_total / max(fixed_total, 1):.3f}x) geomean={geomean:.3f}x "
+            f"cold({largest.name}) base={cold_base / 1000:.2f}ms fixed={cold_fixed / 1000:.2f}ms"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/fixed-lookahead-bench/run.sh
+++ b/tools/fixed-lookahead-bench/run.sh
@@ -1,0 +1,200 @@
+#!/bin/bash
+# Differential validation + A/B benchmark for `--fixed-lookahead` (issue #150).
+#
+# For each target grammar (Thrift, EDN, Rego from antlr/grammars-v4) this
+# script generates a baseline parser and a `--fixed-lookahead` parser,
+# parses the grammar's full example corpus with both (valid AND invalid
+# inputs), and requires byte-identical parse trees and error output. It then
+# reports interleaved min-parse timings.
+#
+# Usage: tools/fixed-lookahead-bench/run.sh [--grammars-v4 DIR]
+# Everything lands under target/fixed-lookahead-bench/.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+WORK="$ROOT/target/fixed-lookahead-bench"
+GRAMMARS=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --grammars-v4) GRAMMARS="$2"; shift 2 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+mkdir -p "$WORK"
+
+# 1. grammars-v4 checkout (sparse: the three target grammars).
+if [ -z "$GRAMMARS" ]; then
+  GRAMMARS="$WORK/grammars-v4"
+  if [ ! -d "$GRAMMARS/.git" ]; then
+    git init -q "$GRAMMARS"
+    git -C "$GRAMMARS" remote add origin https://github.com/antlr/grammars-v4.git
+    git -C "$GRAMMARS" sparse-checkout init --cone
+    git -C "$GRAMMARS" sparse-checkout set thrift edn rego
+    git -C "$GRAMMARS" fetch --depth 1 origin master
+    git -C "$GRAMMARS" checkout -q FETCH_HEAD
+  fi
+fi
+
+# 2. Build the generator and generate base/fixed parser pairs.
+cargo build --release --features codegen --bin antlr4-rust-gen --manifest-path "$ROOT/Cargo.toml"
+GEN="$ROOT/target/release/antlr4-rust-gen"
+
+"$GEN" "$GRAMMARS/thrift/Thrift.g4" --require-generated-parser \
+    --out-dir "$WORK/gen/thrift-base"
+"$GEN" "$GRAMMARS/thrift/Thrift.g4" --require-generated-parser \
+    --fixed-lookahead 2 --out-dir "$WORK/gen/thrift-fixed"
+"$GEN" "$GRAMMARS/edn/edn.g4" --require-generated-parser \
+    --out-dir "$WORK/gen/edn-base"
+"$GEN" "$GRAMMARS/edn/edn.g4" --require-generated-parser \
+    --fixed-lookahead 2 --out-dir "$WORK/gen/edn-fixed"
+"$GEN" "$GRAMMARS/rego/RegoLexer.g4" "$GRAMMARS/rego/RegoParser.g4" \
+    --require-generated-parser --out-dir "$WORK/gen/rego-base"
+"$GEN" "$GRAMMARS/rego/RegoLexer.g4" "$GRAMMARS/rego/RegoParser.g4" \
+    --require-generated-parser --fixed-lookahead 3 --out-dir "$WORK/gen/rego-fixed"
+
+# 3. Scaffold the six-binary driver crate (tree dump + timing per file).
+DRIVER="$WORK/driver"
+mkdir -p "$DRIVER/src/bin"
+cat > "$DRIVER/Cargo.toml" <<EOF
+[package]
+name = "fixed-lookahead-driver"
+version = "0.0.0"
+edition = "2024"
+publish = false
+
+[dependencies]
+antlr4_runtime = { package = "antlr-rust-runtime", path = "$ROOT" }
+
+[workspace]
+EOF
+
+emit_bin() {
+  local bin=$1 gendir=$2 module=$3 lexer=$4 parser=$5 entry=$6
+  cat > "$DRIVER/src/bin/$bin.rs" <<EOF
+#[path = "$WORK/gen/$gendir/${module}_lexer.rs"]
+mod glexer;
+#[path = "$WORK/gen/$gendir/${module}_parser.rs"]
+mod gparser;
+
+use antlr4_runtime::{Node, NodeKind, Parser};
+use std::io::Write;
+use std::time::Instant;
+
+fn dump(out: &mut impl Write, tree: Node<'_>, rule_names: &[&str], depth: usize) {
+    let pad = "  ".repeat(depth);
+    match tree.kind() {
+        NodeKind::Rule => {
+            let rule = tree.as_rule().expect("rule node");
+            let name = rule_names.get(rule.rule_index()).copied().unwrap_or("<?>");
+            writeln!(out, "{pad}Rule({name}, children={})", rule.child_count()).expect("write");
+            for child in rule.children() {
+                dump(out, child, rule_names, depth + 1);
+            }
+        }
+        NodeKind::Terminal => {
+            writeln!(out, "{pad}Term({:?})", tree.as_terminal().expect("terminal").text())
+                .expect("write");
+        }
+        NodeKind::Error => {
+            writeln!(out, "{pad}Err({:?})", tree.as_error().expect("error").text())
+                .expect("write");
+        }
+    }
+}
+
+fn main() {
+    let mut file = None;
+    let mut iters = 1usize;
+    let mut report_time = false;
+    let mut quiet = false;
+    let mut args = std::env::args().skip(1);
+    while let Some(arg) = args.next() {
+        match arg.as_str() {
+            "--iters" => iters = args.next().expect("--iters value").parse().expect("usize"),
+            "--time" => report_time = true,
+            "--quiet" => quiet = true,
+            other => file = Some(other.to_owned()),
+        }
+    }
+    let file = file.expect("usage: $bin FILE [--iters N] [--time] [--quiet]");
+    let text = std::fs::read_to_string(&file).expect("readable input");
+    let stdout = std::io::stdout();
+    let mut out = std::io::BufWriter::new(stdout.lock());
+    let mut min_us = u128::MAX;
+    let mut result = None;
+    for _ in 0..iters {
+        let started = Instant::now();
+        let outcome = gparser::parse_with_parser(&text, glexer::$lexer::new, |parser| {
+            parser.$entry()
+        });
+        min_us = min_us.min(started.elapsed().as_micros());
+        result = Some(outcome);
+    }
+    if report_time {
+        writeln!(out, "TIME_MIN_US={min_us}").expect("write");
+    }
+    match result.expect("at least one iteration") {
+        Ok(output) => {
+            writeln!(out, "SYNTAX_ERRORS={}", output.parser.number_of_syntax_errors())
+                .expect("write");
+            if !quiet {
+                let parsed = output.parser.into_parsed_file(output.result);
+                dump(&mut out, parsed.tree(), gparser::rule_names(), 0);
+            }
+        }
+        Err(error) => {
+            writeln!(out, "ABORT={error}").expect("write");
+        }
+    }
+    out.flush().expect("flush");
+}
+EOF
+  cat >> "$DRIVER/Cargo.toml" <<EOF
+
+[[bin]]
+name = "$bin"
+path = "src/bin/$bin.rs"
+EOF
+}
+
+emit_bin thrift_base thrift-base thrift ThriftLexer ThriftParser document
+emit_bin thrift_fixed thrift-fixed thrift ThriftLexer ThriftParser document
+emit_bin edn_base edn-base edn EdnLexer EdnParser program
+emit_bin edn_fixed edn-fixed edn EdnLexer EdnParser program
+emit_bin rego_base rego-base rego RegoLexer RegoParser root
+emit_bin rego_fixed rego-fixed rego RegoLexer RegoParser root
+
+cargo build --release --quiet --manifest-path "$DRIVER/Cargo.toml"
+BIN="$DRIVER/target/release"
+
+# 4. Differential: every corpus file, trees + error output must match.
+run_corpus() {
+  local grammar=$1
+  local out_base="$WORK/$grammar-base.txt" out_fixed="$WORK/$grammar-fixed.txt"
+  : > "$out_base"; : > "$out_fixed"
+  local count=0
+  while IFS= read -r file; do
+    count=$((count + 1))
+    for cfg in base fixed; do
+      local sink="$WORK/$grammar-$cfg.txt"
+      printf '=== %s\n' "$file" >> "$sink"
+      "$BIN/${grammar}_${cfg}" "$file" > "$WORK/.out" 2> "$WORK/.err"
+      cat "$WORK/.out" "$WORK/.err" >> "$sink"
+    done
+  done
+  echo "$grammar: $count files"
+  if diff -q "$out_base" "$out_fixed" > /dev/null; then
+    echo "$grammar: IDENTICAL"
+  else
+    echo "$grammar: DIVERGED"
+    diff "$out_base" "$out_fixed" | head -20
+    exit 1
+  fi
+}
+find "$GRAMMARS/thrift/examples" -type f -name '*.thrift' | sort | run_corpus thrift
+find "$GRAMMARS/edn/examples" -type f ! -name '*.errors' ! -name '*.tree' | sort | run_corpus edn
+find "$GRAMMARS/rego/examples" -type f ! -name '*.errors' ! -name '*.tree' | sort | run_corpus rego
+
+# 5. Interleaved A/B benchmark.
+GRAMMARS_DIR="$GRAMMARS" DRIVER_BIN="$BIN" python3 "$(dirname "$0")/bench.py"


### PR DESCRIPTION
# Decision tiers: `decisions.json` classifier report + opt-in `--fixed-lookahead` static dispatch (issue #150)

Implements the research direction of #150 — *detect decisions that need strictly less than `ALL(*)` and emit a cheaper recognizer* — as three deliverables, plus a Rego metadata fix found while re-validating the issue's premises.

## What's here

### 1. Per-decision classifier + `decisions.json` manifest (always on)

`classify_decisions` extends the existing Java-parity `AnalysisPipeline` port with per-decision tier verdicts, emitted as a deterministic `decisions.json` next to `semantics.json`:

```json
{"decision": 4, "rule": "namespace_", "state": 113, "tier": "fixed", "lookahead": 2}
{"decision": 6, "rule": "ruleHead", "state": 124, "tier": "adaptive", "reason": "not-disjoint", "probedLookahead": 3}
```

Tiers: `ll1` (Java compiles a token switch), `fixed` (flag proved disjointness at `k ≥ 2`), `adaptive` with the reason (`non-greedy`, `precedence`, `predicate`, `empty-look`, `not-disjoint`, `budget-exceeded`, `sync-bound`).

### 2. Opt-in `--fixed-lookahead <k>` (off by default)

A bounded LOOK(k) rectangle walk probes the residual adaptive decisions: each alternative's k-token lookahead language is enumerated exactly as a union of interval-vector "rectangles" (EOF-padded tails, predicate/precedence edges bail, budgeted). Pairwise-disjoint decisions compile into nested `la(1)..la(k)` match tries; plain mode also gains the tool's complete LL(1) switches through the same shape.

**Error parity by construction.** A table hit skips the decision's recovery sync only where `sync_decision` provably no-ops: first-token arms are restricted to the decision's within-rule lookahead (the runtime's own `transition_first_set` early-return set, mirrored by `generated_rule_first_set`). Context-dependent lookahead — e.g. loop exits decided by caller FOLLOW, where sync performs real single-token deletion — falls through to the decision's regular sync + adaptive body, byte-for-byte the code the decision renders without a table.

The analysis budget (8,192 rectangles/alt) is deliberately separate from the emission budget (256 trie arms): a small analysis budget mislabels genuinely ambiguous decisions as `budget-exceeded` instead of `not-disjoint`.

### 3. Rego channel-names metadata fix

The issue thread's "Rego blocked on uppercase `Channel(...)`" premise was stale (fixed by e0f032b5). The real defect: generated runtime `METADATA` copied the `.interp`-shaped channel-name table (two placeholder rows before user channels — ANTLR's own `.interp` quirk, kept in the semantic model deliberately), so `channel_names[2]` was empty while the `CHANNEL_*` constant said 2. Java's runtime `channelNames` array is dense; the generated table now is too (verified against antlr-4.13.2 Java output for `RegoLexer`).

### 4. Harness: `ANTLR4_RUST_GEN_EXTRA_ARGS`

The conformance harness forwards whitespace-split extra generator flags, enabling flag-on sweeps: `ANTLR4_RUST_GEN_EXTRA_ARGS="--fixed-lookahead 3" cargo run --bin antlr4-runtime-testsuite`.

## Results on the issue's target grammars (grammars-v4)

| Grammar | Classification | Corpus differential (base vs flag-on) | Parse time |
|---|---|---|---|
| Thrift | 53 `ll1` + 1 `fixed@2` (`namespace_`) = **0 adaptive** | 26/26 files byte-identical | **+12% total, +12% geomean, cold −18%** |
| EDN | 6/6 `ll1`, all statically dispatched | 28/28 byte-identical | **+5% total/geomean** |
| Rego | 27 `ll1` + 2 `fixed@2` (`regoElse`, `object_` trailing-comma loop) + 10 adaptive (8 `not-disjoint`, 2 `budget`) | **1955/1955 byte-identical, incl. all 25 exact-`.errors` recovery fixtures** | neutral (+1.8% geomean) |

Differential = trees AND error output compared between baseline and `--fixed-lookahead` parsers over the full corpus, valid and invalid inputs.

## Validation

- `cargo test --locked` — 1,203 tests green; CI clippy flags clean
- Conformance: **357 passed, 0 failed, 0 skipped** in the default configuration **and** with `--fixed-lookahead 3` forced on every descriptor
- Classifier is deterministic and idempotent (pinned by unit test); dispatch tables snapshot-tested
- No runtime (`src/*.rs` non-bin) changes — flag-off generation is byte-identical, so the protected parse-bench matrix is structurally unaffected

## Sync-placement note for reviewers

The dispatch shape went through three iterations, and the final one is load-bearing: bare hits with unrestricted arms moved two Rego recovery errors one rule up (a context-free FOLLOW exit arm swallowed a token `sync_decision` would delete); unconditional sync-before-table fixed parity but cost EDN −4% steady-state (sync per loop iteration). The final shape — bare hits restricted to the sync-no-op set — is the same contract today's partial fast paths ship, extended to complete tables.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added opt-in fixed-lookahead parser generation for faster static decision routing, with safe fallback behavior.
  * Added `decisions.json` reports describing parser decision tiers and lookahead details.
  * Added benchmark tooling to compare correctness and performance across representative grammars.
  * Added support for passing extra generator options through the runtime test suite.

* **Documentation**
  * Documented fixed-lookahead behavior, decision reports, benchmarks, and test-suite workflows.
  * Added grammar fixtures covering fixed lookahead and custom lexer channels.

* **Tests**
  * Expanded coverage for decision classification, dispatch fallback, recovery behavior, reporting, and channel handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->