### PR TITLE
feat(codegen): add validated parse tree surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,41 @@ repeated children are lazy iterators. Rule labels keep their grammar names
 (`left()`), while token accessors use snake_case names such as `int_token()` and
 `comma_tokens()`.
 
+Call `parse_validated` when the application rejects recovered parses. It checks
+lexer and parser syntax-error counts, recovered error nodes, and every generated
+required-child invariant before returning a `<Grammar>ValidatedTree`:
+
+```rust
+use generated::json_lexer::JsonLexer;
+use generated::json_parser::{
+    self, JsonContext, JsonParser, ValidatedTreeContext,
+};
+
+fn main() -> Result<(), json_parser::JsonValidationError> {
+    let validated = json_parser::parse_validated(
+        r#"{"a":1}"#,
+        JsonLexer::new,
+        JsonParser::json,
+    )?;
+    let json = validated
+        .tree()
+        .downcast_ref::<JsonContext<'_, ValidatedTreeContext>>()
+        .expect("the selected entry rule is json");
+
+    // `value` and `EOF` are required by `json : value EOF`.
+    println!("{}{}", json.value().text(), json.eof_token());
+    Ok(())
+}
+```
+
+Required accessors on contexts carrying `ValidatedTreeContext` return the child
+directly. Optional children remain `Option<T>`, and repeated children remain
+iterators. `parse_with_parser(...).validate()` provides the same boundary when
+the caller needs the parser first. Generated `<Grammar>ValidatedListener` and,
+with `--visitor`, `<Grammar>ValidatedVisitor` traits traverse this surface
+without `MissingChildError` plumbing. The original listener, visitor, and
+`ParsedFile` context APIs remain recovery-oriented and fallible.
+
 `--no-visitor` disables visitor generation. The generator also accepts ANTLR's
 single-dash spellings (`-listener`, `-no-listener`, `-visitor`,
 `-no-visitor`).

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -9917,7 +9917,10 @@ impl ContextSurfaceNames {
 /// always use a `Label`/`_label` suffix so their generated surfaces cannot be
 /// confused with rule surfaces.
 fn context_surface_names(model: &embedded::EmbeddedModel) -> ContextSurfaceNames {
-    let mut used_context_types = BTreeSet::from(["StoredTreeContext".to_owned()]);
+    let mut used_context_types = BTreeSet::from([
+        "StoredTreeContext".to_owned(),
+        "ValidatedTreeContext".to_owned(),
+    ]);
     let mut used_listener_methods = BTreeSet::from(["every_rule".to_owned()]);
     let mut used_visitor_methods = BTreeSet::from([
         "children".to_owned(),
@@ -10861,18 +10864,79 @@ fn accessor_stem(name: &str) -> String {
     rust_function_name(name).trim_start_matches("r#").to_owned()
 }
 
-fn render_rule_label_accessor(
+#[derive(Debug, Default, Eq, PartialEq)]
+struct RenderedContextAccessors {
+    recovered: String,
+    validated: String,
+    validation: String,
+}
+
+fn render_required_accessor_validation(
+    out: &mut String,
+    method: &str,
+    validation_error_name: &str,
+) {
+    let _ = writeln!(
+        out,
+        "        let _ = context.{method}().map_err({validation_error_name}::MissingChild)?;"
+    );
+}
+
+fn render_repeated_accessor_validation(
     out: &mut String,
     method: &str,
     view_name: &str,
-    child_view: &str,
-    child_index: usize,
-    label: &ContextLabelAccessor,
+    child_name: &str,
+    minimum: usize,
+    validation_error_name: &str,
 ) {
+    if minimum == 0 {
+        return;
+    }
+    let _ = writeln!(
+        out,
+        "        {{\n            let actual = context.{method}().count();\n            if actual < {minimum} {{\n                return Err({validation_error_name}::InvalidChildCount {{\n                    context: \"{view_name}\",\n                    child: \"{child_name}\",\n                    minimum: {minimum},\n                    actual,\n                }});\n            }}\n        }}"
+    );
+}
+
+#[derive(Clone, Copy)]
+struct RuleLabelAccessorRender<'a> {
+    method: &'a str,
+    view_name: &'a str,
+    child_view: &'a str,
+    child_index: usize,
+    label: &'a ContextLabelAccessor,
+    validation_error_name: &'a str,
+}
+
+fn render_rule_label_accessor(
+    rendered: &mut RenderedContextAccessors,
+    context: RuleLabelAccessorRender<'_>,
+) {
+    let RuleLabelAccessorRender {
+        method,
+        view_name,
+        child_view,
+        child_index,
+        label,
+        validation_error_name,
+    } = context;
     if let ContextLabelSelector::AllAfter(skip) = label.selector {
         let _ = writeln!(
-            out,
+            rendered.recovered,
             "    pub fn {method}(&self) -> impl Iterator<Item = {child_view}<'a>> + '_ {{\n        __rule_children(self.__node, {child_index})\n            .skip({skip})\n            .map(move |node| {child_view}::__from_child_node(node, self.__invocation_states.as_deref()))\n    }}"
+        );
+        let _ = writeln!(
+            rendered.validated,
+            "    pub fn {method}(&self) -> impl Iterator<Item = {child_view}<'a, ValidatedTreeContext>> + '_ {{\n        __rule_children(self.__node, {child_index})\n            .skip({skip})\n            .map(move |node| {child_view}::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))\n    }}"
+        );
+        render_repeated_accessor_validation(
+            &mut rendered.validation,
+            method,
+            view_name,
+            &label.source_name,
+            label.cardinality.min,
+            validation_error_name,
         );
         return;
     }
@@ -10883,23 +10947,38 @@ fn render_rule_label_accessor(
     };
     if label.cardinality.is_required_single() {
         let _ = writeln!(
-            out,
+            rendered.recovered,
             "    pub fn {method}(&self) -> Result<{child_view}<'a>, MissingChildError> {{\n        __rule_children(self.__node, {child_index})\n            {lookup}\n            .map(|node| {child_view}::__from_child_node(node, self.__invocation_states.as_deref()))\n            .ok_or_else(|| MissingChildError::new(\"{view_name}\", \"{}\"))\n    }}",
             label.source_name
         );
+        let _ = writeln!(
+            rendered.validated,
+            "    pub fn {method}(&self) -> {child_view}<'a, ValidatedTreeContext> {{\n        let Some(node) = __rule_children(self.__node, {child_index})\n            {lookup}\n        else {{\n            unreachable!(\"validated {view_name} is missing required child {}\")\n        }};\n        {child_view}::<ValidatedTreeContext>::__from_validated_child_node(\n            node,\n            self.__invocation_states.as_deref(),\n        )\n    }}",
+            label.source_name
+        );
+        render_required_accessor_validation(
+            &mut rendered.validation,
+            method,
+            validation_error_name,
+        );
     } else {
         let _ = writeln!(
-            out,
+            rendered.recovered,
             "    pub fn {method}(&self) -> Option<{child_view}<'a>> {{\n        __rule_children(self.__node, {child_index})\n            {lookup}\n            .map(|node| {child_view}::__from_child_node(node, self.__invocation_states.as_deref()))\n    }}"
+        );
+        let _ = writeln!(
+            rendered.validated,
+            "    pub fn {method}(&self) -> Option<{child_view}<'a, ValidatedTreeContext>> {{\n        __rule_children(self.__node, {child_index})\n            {lookup}\n            .map(|node| {child_view}::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))\n    }}"
         );
     }
 }
 
 fn render_token_label_accessor(
-    out: &mut String,
+    rendered: &mut RenderedContextAccessors,
     method: &str,
     view_name: &str,
     label: &ContextLabelAccessor,
+    validation_error_name: &str,
 ) {
     let token_types = label
         .token_types
@@ -10914,8 +10993,20 @@ fn render_token_label_accessor(
     };
     if let ContextLabelSelector::AllAfter(skip) = label.selector {
         let _ = writeln!(
-            out,
+            rendered.recovered,
             "    pub fn {method}(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {{\n        {children}\n            .skip({skip})\n            .map(TerminalNode::new)\n    }}"
+        );
+        let _ = writeln!(
+            rendered.validated,
+            "    pub fn {method}(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {{\n        {children}\n            .skip({skip})\n            .map(TerminalNode::new)\n    }}"
+        );
+        render_repeated_accessor_validation(
+            &mut rendered.validation,
+            method,
+            view_name,
+            &label.source_name,
+            label.cardinality.min,
+            validation_error_name,
         );
         return;
     }
@@ -10926,31 +11017,77 @@ fn render_token_label_accessor(
     };
     if label.cardinality.is_required_single() {
         let _ = writeln!(
-            out,
+            rendered.recovered,
             "    pub fn {method}(&self) -> Result<TerminalNode<'a>, MissingChildError> {{\n        {children}\n            {lookup}\n            .map(TerminalNode::new)\n            .ok_or_else(|| MissingChildError::new(\"{view_name}\", \"{}\"))\n    }}",
             label.source_name
         );
+        let _ = writeln!(
+            rendered.validated,
+            "    pub fn {method}(&self) -> TerminalNode<'a> {{\n        let Some(node) = {children}\n            {lookup}\n        else {{\n            unreachable!(\"validated {view_name} is missing required child {}\")\n        }};\n        TerminalNode::new(node)\n    }}",
+            label.source_name
+        );
+        render_required_accessor_validation(
+            &mut rendered.validation,
+            method,
+            validation_error_name,
+        );
     } else {
         let _ = writeln!(
-            out,
+            rendered.recovered,
+            "    pub fn {method}(&self) -> Option<TerminalNode<'a>> {{\n        {children}\n            {lookup}\n            .map(TerminalNode::new)\n    }}"
+        );
+        let _ = writeln!(
+            rendered.validated,
             "    pub fn {method}(&self) -> Option<TerminalNode<'a>> {{\n        {children}\n            {lookup}\n            .map(TerminalNode::new)\n    }}"
         );
     }
 }
 
-fn render_context_child_accessors(
-    view_name: &str,
-    model: &embedded::EmbeddedModel,
-    context_names: &ContextSurfaceNames,
-    token_accessors: &[(String, i32)],
-    child_cardinalities: &BTreeMap<String, embedded::ChildCardinality>,
-    label_accessors: &[ContextLabelAccessor],
-) -> String {
-    let mut out = String::new();
-    let _ = writeln!(
-        out,
-        "    pub fn child_count(&self) -> usize {{\n        match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.child_count(),\n            __GeneratedRuleContext::Active {{ context, .. }} => context.child_count(),\n        }}\n    }}\n\n    pub fn start(&self) -> __GeneratedTokenView {{\n        let token = match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.start(),\n            __GeneratedRuleContext::Active {{ context, tokens, .. }} => context.start(tokens),\n        }};\n        __GeneratedTokenView {{ text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }}\n    }}\n\n    pub fn text(&self) -> String {{\n        match &self.__node {{\n            __GeneratedRuleContext::Stored(node) => node.text(),\n            __GeneratedRuleContext::Active {{ context, storage, tokens }} => context.text(storage, tokens),\n        }}\n    }}"
-    );
+const CONTEXT_COMMON_ACCESSORS: &str = r#"    pub fn child_count(&self) -> usize {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.child_count(),
+            __GeneratedRuleContext::Active { context, .. } => context.child_count(),
+        }
+    }
+
+    pub fn start(&self) -> __GeneratedTokenView {
+        let token = match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.start(),
+            __GeneratedRuleContext::Active { context, tokens, .. } => context.start(tokens),
+        };
+        __GeneratedTokenView { text: token.map(|token| token.text_or_empty().to_owned()).unwrap_or_default() }
+    }
+
+    pub fn text(&self) -> String {
+        match &self.__node {
+            __GeneratedRuleContext::Stored(node) => node.text(),
+            __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
+        }
+    }
+"#;
+
+#[derive(Clone, Copy)]
+struct ContextAccessorsRender<'a> {
+    view_name: &'a str,
+    model: &'a embedded::EmbeddedModel,
+    context_names: &'a ContextSurfaceNames,
+    token_accessors: &'a [(String, i32)],
+    child_cardinalities: &'a BTreeMap<String, embedded::ChildCardinality>,
+    label_accessors: &'a [ContextLabelAccessor],
+    validation_error_name: &'a str,
+}
+
+fn render_context_child_accessors(context: ContextAccessorsRender<'_>) -> RenderedContextAccessors {
+    let ContextAccessorsRender {
+        view_name,
+        model,
+        context_names,
+        token_accessors,
+        child_cardinalities,
+        label_accessors,
+        validation_error_name,
+    } = context;
+    let mut rendered = RenderedContextAccessors::default();
     let mut used_methods = BTreeSet::from([
         "child_count".to_owned(),
         "rule_node".to_owned(),
@@ -10975,19 +11112,45 @@ fn render_context_child_accessors(
         let child_view = &context_names.rules[child_index].context_type;
         if cardinality.is_repeated() {
             let _ = writeln!(
-                out,
+                rendered.recovered,
                 "    pub fn {method}(&self) -> impl Iterator<Item = {child_view}<'a>> + '_ {{\n        __rule_children(self.__node, {child_index})\n            .map(move |node| {child_view}::__from_child_node(node, self.__invocation_states.as_deref()))\n    }}"
+            );
+            let _ = writeln!(
+                rendered.validated,
+                "    pub fn {method}(&self) -> impl Iterator<Item = {child_view}<'a, ValidatedTreeContext>> + '_ {{\n        __rule_children(self.__node, {child_index})\n            .map(move |node| {child_view}::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))\n    }}"
+            );
+            render_repeated_accessor_validation(
+                &mut rendered.validation,
+                &method,
+                view_name,
+                &child.name,
+                cardinality.min,
+                validation_error_name,
             );
         } else if cardinality.is_required_single() {
             let _ = writeln!(
-                out,
+                rendered.recovered,
                 "    pub fn {method}(&self) -> Result<{child_view}<'a>, MissingChildError> {{\n        __rule_children(self.__node, {child_index})\n            .next()\n            .map(|node| {child_view}::__from_child_node(node, self.__invocation_states.as_deref()))\n            .ok_or_else(|| MissingChildError::new(\"{view_name}\", \"{}\"))\n    }}",
                 child.name
             );
+            let _ = writeln!(
+                rendered.validated,
+                "    pub fn {method}(&self) -> {child_view}<'a, ValidatedTreeContext> {{\n        let Some(node) = __rule_children(self.__node, {child_index}).next() else {{\n            unreachable!(\"validated {view_name} is missing required child {}\")\n        }};\n        {child_view}::<ValidatedTreeContext>::__from_validated_child_node(\n            node,\n            self.__invocation_states.as_deref(),\n        )\n    }}",
+                child.name
+            );
+            render_required_accessor_validation(
+                &mut rendered.validation,
+                &method,
+                validation_error_name,
+            );
         } else {
             let _ = writeln!(
-                out,
+                rendered.recovered,
                 "    pub fn {method}(&self) -> Option<{child_view}<'a>> {{\n        __rule_children(self.__node, {child_index})\n            .next()\n            .map(|node| {child_view}::__from_child_node(node, self.__invocation_states.as_deref()))\n    }}"
+            );
+            let _ = writeln!(
+                rendered.validated,
+                "    pub fn {method}(&self) -> Option<{child_view}<'a, ValidatedTreeContext>> {{\n        __rule_children(self.__node, {child_index})\n            .next()\n            .map(|node| {child_view}::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))\n    }}"
             );
         }
     }
@@ -11009,17 +11172,42 @@ fn render_context_child_accessors(
         );
         if cardinality.is_repeated() {
             let _ = writeln!(
-                out,
+                rendered.recovered,
                 "    pub fn {method}(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {{\n        __token_children(self.__node, {token_type}).map(TerminalNode::new)\n    }}"
+            );
+            let _ = writeln!(
+                rendered.validated,
+                "    pub fn {method}(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {{\n        __token_children(self.__node, {token_type}).map(TerminalNode::new)\n    }}"
+            );
+            render_repeated_accessor_validation(
+                &mut rendered.validation,
+                &method,
+                view_name,
+                token_name,
+                cardinality.min,
+                validation_error_name,
             );
         } else if cardinality.is_required_single() {
             let _ = writeln!(
-                out,
+                rendered.recovered,
                 "    pub fn {method}(&self) -> Result<TerminalNode<'a>, MissingChildError> {{\n        __token_children(self.__node, {token_type})\n            .next()\n            .map(TerminalNode::new)\n            .ok_or_else(|| MissingChildError::new(\"{view_name}\", \"{token_name}\"))\n    }}"
+            );
+            let _ = writeln!(
+                rendered.validated,
+                "    pub fn {method}(&self) -> TerminalNode<'a> {{\n        let Some(node) = __token_children(self.__node, {token_type}).next() else {{\n            unreachable!(\"validated {view_name} is missing required child {token_name}\")\n        }};\n        TerminalNode::new(node)\n    }}"
+            );
+            render_required_accessor_validation(
+                &mut rendered.validation,
+                &method,
+                validation_error_name,
             );
         } else {
             let _ = writeln!(
-                out,
+                rendered.recovered,
+                "    pub fn {method}(&self) -> Option<TerminalNode<'a>> {{\n        __token_children(self.__node, {token_type})\n            .next()\n            .map(TerminalNode::new)\n    }}"
+            );
+            let _ = writeln!(
+                rendered.validated,
                 "    pub fn {method}(&self) -> Option<TerminalNode<'a>> {{\n        __token_children(self.__node, {token_type})\n            .next()\n            .map(TerminalNode::new)\n    }}"
             );
         }
@@ -11039,21 +11227,30 @@ fn render_context_child_accessors(
         {
             let child_view = &context_names.rules[child_index].context_type;
             render_rule_label_accessor(
-                &mut out,
-                &method,
-                view_name,
-                child_view,
-                child_index,
-                label,
+                &mut rendered,
+                RuleLabelAccessorRender {
+                    method: &method,
+                    view_name,
+                    child_view,
+                    child_index,
+                    label,
+                    validation_error_name,
+                },
             );
             continue;
         }
         if label.token_types.is_empty() {
             continue;
         }
-        render_token_label_accessor(&mut out, &method, view_name, label);
+        render_token_label_accessor(
+            &mut rendered,
+            &method,
+            view_name,
+            label,
+            validation_error_name,
+        );
     }
-    out
+    rendered
 }
 
 const LABELED_TOKEN_CHILD_HELPERS: &str = r#"#[allow(dead_code)]
@@ -11101,6 +11298,625 @@ fn __labeled_token_children_matching<'a>(
 
 "#;
 
+fn render_validated_tree_support(surface_name: &str) -> String {
+    let validated_tree = format!("{surface_name}ValidatedTree");
+    let validation_error = format!("{surface_name}ValidationError");
+    format!(
+        r#"/// Marker carried by generated contexts whose required-child
+/// invariants were checked after a syntax-clean parse.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ValidatedTreeContext {{
+    __private: (),
+}}
+
+#[allow(dead_code)]
+trait __RecoveryContextState {{}}
+
+impl __RecoveryContextState for StoredTreeContext {{}}
+impl __RecoveryContextState for __ActiveParserContext {{}}
+
+/// A completed, syntax-clean parse tree whose generated child cardinalities
+/// have been structurally validated.
+#[derive(Debug)]
+pub struct {validated_tree} {{
+    parsed: antlr4_runtime::ParsedFile,
+}}
+
+impl {validated_tree} {{
+    fn __new(parsed: antlr4_runtime::ParsedFile) -> Self {{
+        Self {{ parsed }}
+    }}
+
+    /// Returns the validated entry-rule root.
+    pub fn tree(&self) -> ValidatedRuleNode<'_> {{
+        let Some(rule) = self.parsed.tree().as_rule() else {{
+            unreachable!("validated parse root was checked as a rule node")
+        }};
+        ValidatedRuleNode {{ __node: rule }}
+    }}
+
+    /// Borrows the underlying recovery-oriented parsed file.
+    pub const fn parsed_file(&self) -> &antlr4_runtime::ParsedFile {{
+        &self.parsed
+    }}
+
+    /// Drops the validation type boundary and returns the underlying parsed file.
+    pub fn into_parsed_file(self) -> antlr4_runtime::ParsedFile {{
+        self.parsed
+    }}
+}}
+
+/// A rule node borrowed from a [`{validated_tree}`].
+#[derive(Clone, Copy, Debug)]
+pub struct ValidatedRuleNode<'a> {{
+    __node: RuleNodeView<'a>,
+}}
+
+impl<'a> ValidatedRuleNode<'a> {{
+    pub const fn rule_node(self) -> RuleNodeView<'a> {{
+        self.__node
+    }}
+
+    pub const fn node(self) -> antlr4_runtime::Node<'a> {{
+        self.__node.node()
+    }}
+
+    pub fn rule_index(self) -> usize {{
+        self.__node.rule_index()
+    }}
+
+    pub fn text(self) -> String {{
+        self.__node.text()
+    }}
+
+    pub fn downcast_ref<T: FromValidatedRuleNode<'a>>(self) -> Option<T> {{
+        T::from_validated_rule_node(self)
+    }}
+}}
+
+/// Constructs a generated validated context from a validated rule node.
+pub trait FromValidatedRuleNode<'a>: Sized {{
+    fn from_validated_rule_node(node: ValidatedRuleNode<'a>) -> Option<Self>;
+}}
+
+/// Failure to recognize or validate a strict generated parse.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum {validation_error} {{
+    Recognition(antlr4_runtime::AntlrError),
+    SyntaxErrors {{
+        lexer: usize,
+        parser: usize,
+    }},
+    MissingChild(MissingChildError),
+    InvalidChildCount {{
+        context: &'static str,
+        child: &'static str,
+        minimum: usize,
+        actual: usize,
+    }},
+    RecoveredErrorNode {{
+        line: usize,
+        column: usize,
+        text: String,
+    }},
+    InvalidRoot,
+    UnknownRule {{
+        rule_index: usize,
+    }},
+}}
+
+impl std::fmt::Display for {validation_error} {{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {{
+        match self {{
+            Self::Recognition(error) => write!(f, "parse failed: {{error}}"),
+            Self::SyntaxErrors {{ lexer, parser }} => write!(
+                f,
+                "parse produced {{lexer}} lexer and {{parser}} parser syntax errors"
+            ),
+            Self::MissingChild(error) => error.fmt(f),
+            Self::InvalidChildCount {{
+                context,
+                child,
+                minimum,
+                actual,
+            }} => write!(
+                f,
+                "required child {{child}} occurs {{actual}} times in {{context}}; expected at least {{minimum}}"
+            ),
+            Self::RecoveredErrorNode {{
+                line,
+                column,
+                text,
+            }} => write!(
+                f,
+                "recovered error node at {{line}}:{{column}}: {{text}}"
+            ),
+            Self::InvalidRoot => f.write_str("validated parse root is not a rule node"),
+            Self::UnknownRule {{ rule_index }} => write!(
+                f,
+                "parse tree contains unknown rule index {{rule_index}}"
+            ),
+        }}
+    }}
+}}
+
+impl std::error::Error for {validation_error} {{
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {{
+        match self {{
+            Self::Recognition(error) => Some(error),
+            Self::MissingChild(error) => Some(error),
+            _ => None,
+        }}
+    }}
+}}
+
+impl From<antlr4_runtime::AntlrError> for {validation_error} {{
+    fn from(error: antlr4_runtime::AntlrError) -> Self {{
+        Self::Recognition(error)
+    }}
+}}
+
+impl From<MissingChildError> for {validation_error} {{
+    fn from(error: MissingChildError) -> Self {{
+        Self::MissingChild(error)
+    }}
+}}
+
+"#
+    )
+}
+
+fn render_context_listener_surface(
+    context_names: &ContextSurfaceNames,
+    listener_trait: &str,
+    tree_walker: &str,
+    validated_listener_trait: &str,
+    validated_tree_walker: &str,
+) -> String {
+    let mut out = String::new();
+    let mut trait_methods = String::new();
+    let mut enter_arms = String::new();
+    let mut exit_arms = String::new();
+    let mut validated_trait_methods = String::new();
+    let mut validated_enter_arms = String::new();
+    let mut validated_exit_arms = String::new();
+    for (kind_id, view) in context_names.views.iter().enumerate() {
+        let ContextSurfaceName {
+            context_type,
+            listener_method,
+            ..
+        } = &view.surface;
+        let _ = writeln!(
+            trait_methods,
+            "    fn enter_{listener_method}(&mut self, _ctx: &{context_type}) -> Result<(), E> {{ Ok(()) }}\n    fn exit_{listener_method}(&mut self, _ctx: &{context_type}) -> Result<(), E> {{ Ok(()) }}"
+        );
+        let _ = writeln!(
+            enter_arms,
+            "                        {kind_id} => listener.enter_{listener_method}(&{context_type}::__from_listener_node(context, invocation_states.as_deref()))?,"
+        );
+        let _ = writeln!(
+            exit_arms,
+            "                    {kind_id} => listener.exit_{listener_method}(&{context_type}::__from_listener_node(context, invocation_states.as_deref()))?,"
+        );
+        let _ = writeln!(
+            validated_trait_methods,
+            "    fn enter_{listener_method}(&mut self, _ctx: &{context_type}<ValidatedTreeContext>) -> Result<(), E> {{ Ok(()) }}\n    fn exit_{listener_method}(&mut self, _ctx: &{context_type}<ValidatedTreeContext>) -> Result<(), E> {{ Ok(()) }}"
+        );
+        let _ = writeln!(
+            validated_enter_arms,
+            "                        {kind_id} => listener.enter_{listener_method}(&{context_type}::<ValidatedTreeContext>::__from_validated_listener_node(context, invocation_states.as_deref()))?,"
+        );
+        let _ = writeln!(
+            validated_exit_arms,
+            "                    {kind_id} => listener.exit_{listener_method}(&{context_type}::<ValidatedTreeContext>::__from_validated_listener_node(context, invocation_states.as_deref()))?,"
+        );
+    }
+    let _ = writeln!(
+        out,
+        "#[allow(dead_code, unused_variables)]\npub trait {listener_trait}<E = std::convert::Infallible> {{\n    fn walk(&mut self, tree: antlr4_runtime::Node<'_>) -> Result<(), E>\n    where\n        Self: Sized,\n    {{\n        {tree_walker}::walk(self, tree)\n    }}\n\n    fn enter_every_rule(&mut self, _ctx: RuleNodeView<'_>) -> Result<(), E> {{ Ok(()) }}\n    fn exit_every_rule(&mut self, _ctx: RuleNodeView<'_>) -> Result<(), E> {{ Ok(()) }}\n\n{trait_methods}    fn visit_terminal(&mut self, _node: &TerminalNode) -> Result<(), E> {{ Ok(()) }}\n    fn visit_error_node(&mut self, _node: &ErrorNode) -> Result<(), E> {{ Ok(()) }}\n    fn output(&mut self) -> std::io::Stdout {{ std::io::stdout() }}\n}}\n"
+    );
+
+    let _ = writeln!(
+        out,
+        r#"#[allow(dead_code)]
+pub struct {tree_walker};
+
+#[allow(dead_code)]
+impl {tree_walker} {{
+    pub fn walk<E, T: {listener_trait}<E>>(
+        listener: &mut T,
+        tree: antlr4_runtime::Node<'_>,
+    ) -> Result<(), E> {{
+        Self::__walk(listener, tree, None)
+    }}
+
+    pub fn walk_with_invocation_states<E, T: {listener_trait}<E>>(
+        listener: &mut T,
+        tree: antlr4_runtime::Node<'_>,
+        parent_invocation_states: Vec<isize>,
+    ) -> Result<(), E> {{
+        Self::__walk(listener, tree, Some(parent_invocation_states))
+    }}
+
+    fn __walk<E, T: {listener_trait}<E>>(
+        listener: &mut T,
+        tree: antlr4_runtime::Node<'_>,
+        mut invocation_states: Option<Vec<isize>>,
+    ) -> Result<(), E> {{
+        enum Event<'tree> {{
+            Enter(antlr4_runtime::Node<'tree>),
+            Exit(RuleNodeView<'tree>),
+        }}
+
+        let mut stack = vec![Event::Enter(tree)];
+        while let Some(event) = stack.pop() {{
+            match event {{
+                Event::Enter(node) => match node.kind() {{
+                    antlr4_runtime::NodeKind::Rule => {{
+                        let context = node.as_rule().expect("rule node kind checked");
+                        if let Some(states) = &mut invocation_states {{
+                            states.insert(0, context.invoking_state());
+                        }}
+                        listener.enter_every_rule(context)?;
+                        match __context_kind(context) {{
+{enter_arms}                            _ => {{}}
+                        }}
+                        stack.push(Event::Exit(context));
+                        stack.extend(context.children().rev().map(Event::Enter));
+                    }}
+                    antlr4_runtime::NodeKind::Terminal => {{
+                        listener.visit_terminal(&TerminalNode::new(
+                            node.as_terminal().expect("terminal node kind checked"),
+                        ))?;
+                    }}
+                    antlr4_runtime::NodeKind::Error => {{
+                        listener.visit_error_node(&ErrorNode::new(
+                            node.as_error().expect("error node kind checked"),
+                        ))?;
+                    }}
+                }},
+                Event::Exit(context) => {{
+                    match __context_kind(context) {{
+{exit_arms}                        _ => {{}}
+                    }}
+                    listener.exit_every_rule(context)?;
+                    if let Some(states) = &mut invocation_states {{
+                        states.remove(0);
+                    }}
+                }}
+            }}
+        }}
+        Ok(())
+    }}
+}}
+
+pub type ParseTreeWalker = {tree_walker};
+"#
+    );
+    let _ = writeln!(
+        out,
+        r#"#[allow(dead_code, unused_variables)]
+pub trait {validated_listener_trait}<E = std::convert::Infallible> {{
+    fn walk(&mut self, tree: ValidatedRuleNode<'_>) -> Result<(), E>
+    where
+        Self: Sized,
+    {{
+        {validated_tree_walker}::walk(self, tree)
+    }}
+
+    fn enter_every_rule(&mut self, _ctx: ValidatedRuleNode<'_>) -> Result<(), E> {{ Ok(()) }}
+    fn exit_every_rule(&mut self, _ctx: ValidatedRuleNode<'_>) -> Result<(), E> {{ Ok(()) }}
+
+{validated_trait_methods}    fn visit_terminal(&mut self, _node: &TerminalNode) -> Result<(), E> {{ Ok(()) }}
+    fn output(&mut self) -> std::io::Stdout {{ std::io::stdout() }}
+}}
+
+#[allow(dead_code)]
+pub struct {validated_tree_walker};
+
+#[allow(dead_code)]
+impl {validated_tree_walker} {{
+    pub fn walk<E, T: {validated_listener_trait}<E>>(
+        listener: &mut T,
+        tree: ValidatedRuleNode<'_>,
+    ) -> Result<(), E> {{
+        Self::__walk(listener, tree.node(), None)
+    }}
+
+    pub fn walk_with_invocation_states<E, T: {validated_listener_trait}<E>>(
+        listener: &mut T,
+        tree: ValidatedRuleNode<'_>,
+        parent_invocation_states: Vec<isize>,
+    ) -> Result<(), E> {{
+        Self::__walk(listener, tree.node(), Some(parent_invocation_states))
+    }}
+
+    fn __walk<E, T: {validated_listener_trait}<E>>(
+        listener: &mut T,
+        tree: antlr4_runtime::Node<'_>,
+        mut invocation_states: Option<Vec<isize>>,
+    ) -> Result<(), E> {{
+        enum Event<'tree> {{
+            Enter(antlr4_runtime::Node<'tree>),
+            Exit(RuleNodeView<'tree>),
+        }}
+
+        let mut stack = vec![Event::Enter(tree)];
+        while let Some(event) = stack.pop() {{
+            match event {{
+                Event::Enter(node) => match node.kind() {{
+                    antlr4_runtime::NodeKind::Rule => {{
+                        let context = node.as_rule().expect("rule node kind checked");
+                        if let Some(states) = &mut invocation_states {{
+                            states.insert(0, context.invoking_state());
+                        }}
+                        listener.enter_every_rule(ValidatedRuleNode {{ __node: context }})?;
+                        match __context_kind(context) {{
+{validated_enter_arms}                            _ => {{}}
+                        }}
+                        stack.push(Event::Exit(context));
+                        stack.extend(context.children().rev().map(Event::Enter));
+                    }}
+                    antlr4_runtime::NodeKind::Terminal => {{
+                        listener.visit_terminal(&TerminalNode::new(
+                            node.as_terminal().expect("terminal node kind checked"),
+                        ))?;
+                    }}
+                    antlr4_runtime::NodeKind::Error => {{
+                        unreachable!("validated parse tree contains an error node")
+                    }}
+                }},
+                Event::Exit(context) => {{
+                    match __context_kind(context) {{
+{validated_exit_arms}                        _ => {{}}
+                    }}
+                    listener.exit_every_rule(ValidatedRuleNode {{ __node: context }})?;
+                    if let Some(states) = &mut invocation_states {{
+                        states.remove(0);
+                    }}
+                }}
+            }}
+        }}
+        Ok(())
+    }}
+}}
+
+pub type ValidatedParseTreeWalker = {validated_tree_walker};
+"#
+    );
+    out
+}
+
+fn render_context_visitor_surface(
+    context_names: &ContextSurfaceNames,
+    visitor_trait: &str,
+    visitable_trait: &str,
+    validated_visitor_trait: &str,
+    validated_visitable_trait: &str,
+) -> String {
+    let mut out = String::new();
+    let mut visitor_methods = String::new();
+    let mut visitor_arms = String::new();
+    let mut validated_visitor_methods = String::new();
+    let mut validated_visitor_arms = String::new();
+    for (kind_id, view) in context_names.views.iter().enumerate() {
+        let ContextSurfaceName {
+            context_type,
+            visitor_method,
+            ..
+        } = &view.surface;
+        let _ = writeln!(
+            visitor_methods,
+            "    fn visit_{visitor_method}(&mut self, ctx: &{context_type}) -> Self::Result {{\n        self.visit_children(ctx)\n    }}"
+        );
+        let _ = writeln!(
+            visitor_arms,
+            "            {kind_id} => {visitor_trait}::visit_{visitor_method}(self.0, &{context_type}::__from_listener_node(context, None)),"
+        );
+        let _ = writeln!(
+            validated_visitor_methods,
+            "    fn visit_{visitor_method}(&mut self, ctx: &{context_type}<ValidatedTreeContext>) -> Self::Result {{\n        self.visit_children(ctx)\n    }}"
+        );
+        let _ = writeln!(
+            validated_visitor_arms,
+            "            {kind_id} => {validated_visitor_trait}::visit_{visitor_method}(self.0, &{context_type}::<ValidatedTreeContext>::__from_validated_listener_node(context, None)),"
+        );
+    }
+    let _ = writeln!(
+        out,
+        r#"#[allow(dead_code, unused_variables)]
+pub trait {visitor_trait}: Sized {{
+    type Result;
+
+    fn default_result(&mut self) -> Self::Result;
+
+    fn visit<'tree, T>(&mut self, tree: T) -> Self::Result
+    where
+        T: {visitable_trait}<'tree>,
+    {{
+        let tree = {visitable_trait}::into_parse_tree_node(tree);
+        let mut bridge = __VisitorBridge(self);
+        antlr4_runtime::ParseTreeVisitor::visit(&mut bridge, tree)
+    }}
+
+    fn visit_children<'tree, T>(&mut self, context: T) -> Self::Result
+    where
+        T: {visitable_trait}<'tree>,
+    {{
+        let tree = {visitable_trait}::into_parse_tree_node(context);
+        let context = tree.as_rule().expect("visit_children requires a rule context");
+        let mut bridge = __VisitorBridge(self);
+        antlr4_runtime::ParseTreeVisitor::visit_children(&mut bridge, context)
+    }}
+
+    fn aggregate_result(
+        &mut self,
+        _aggregate: Self::Result,
+        next_result: Self::Result,
+    ) -> Self::Result {{
+        next_result
+    }}
+
+    fn should_visit_next_child(
+        &mut self,
+        _context: RuleNodeView<'_>,
+        _current_result: &Self::Result,
+    ) -> bool {{
+        true
+    }}
+
+    fn visit_terminal(&mut self, _node: &TerminalNode) -> Self::Result {{
+        self.default_result()
+    }}
+
+    fn visit_error_node(&mut self, _node: &ErrorNode) -> Self::Result {{
+        self.default_result()
+    }}
+
+{visitor_methods}}}
+
+#[allow(dead_code)]
+struct __VisitorBridge<'a, T: {visitor_trait}>(&'a mut T);
+
+impl<T: {visitor_trait}> antlr4_runtime::ParseTreeVisitor for __VisitorBridge<'_, T> {{
+    type Result = T::Result;
+
+    fn visit_rule(&mut self, context: RuleNodeView<'_>) -> Self::Result {{
+        match __context_kind(context) {{
+{visitor_arms}            _ => {visitor_trait}::default_result(self.0),
+        }}
+    }}
+
+    fn visit_terminal(&mut self, node: RuntimeTerminalNode<'_>) -> Self::Result {{
+        {visitor_trait}::visit_terminal(self.0, &TerminalNode::new(node))
+    }}
+
+    fn visit_error_node(&mut self, node: RuntimeErrorNode<'_>) -> Self::Result {{
+        {visitor_trait}::visit_error_node(self.0, &ErrorNode::new(node))
+    }}
+
+    fn default_result(&mut self) -> Self::Result {{
+        {visitor_trait}::default_result(self.0)
+    }}
+
+    fn aggregate_result(
+        &mut self,
+        aggregate: Self::Result,
+        next_result: Self::Result,
+    ) -> Self::Result {{
+        {visitor_trait}::aggregate_result(self.0, aggregate, next_result)
+    }}
+
+    fn should_visit_next_child(
+        &mut self,
+        context: RuleNodeView<'_>,
+        current_result: &Self::Result,
+    ) -> bool {{
+        {visitor_trait}::should_visit_next_child(self.0, context, current_result)
+    }}
+}}
+"#
+    );
+    let _ = writeln!(
+        out,
+        r#"#[allow(dead_code, unused_variables)]
+pub trait {validated_visitor_trait}: Sized {{
+    type Result;
+
+    fn default_result(&mut self) -> Self::Result;
+
+    fn visit<'tree, T>(&mut self, tree: T) -> Self::Result
+    where
+        T: {validated_visitable_trait}<'tree>,
+    {{
+        let tree = {validated_visitable_trait}::into_validated_parse_tree_node(tree);
+        let mut bridge = __ValidatedVisitorBridge(self);
+        antlr4_runtime::ParseTreeVisitor::visit(&mut bridge, tree)
+    }}
+
+    fn visit_children<'tree, T>(&mut self, context: T) -> Self::Result
+    where
+        T: {validated_visitable_trait}<'tree>,
+    {{
+        let tree = {validated_visitable_trait}::into_validated_parse_tree_node(context);
+        let context = tree.as_rule().expect("visit_children requires a rule context");
+        let mut bridge = __ValidatedVisitorBridge(self);
+        antlr4_runtime::ParseTreeVisitor::visit_children(&mut bridge, context)
+    }}
+
+    fn aggregate_result(
+        &mut self,
+        _aggregate: Self::Result,
+        next_result: Self::Result,
+    ) -> Self::Result {{
+        next_result
+    }}
+
+    fn should_visit_next_child(
+        &mut self,
+        _context: ValidatedRuleNode<'_>,
+        _current_result: &Self::Result,
+    ) -> bool {{
+        true
+    }}
+
+    fn visit_terminal(&mut self, _node: &TerminalNode) -> Self::Result {{
+        self.default_result()
+    }}
+
+{validated_visitor_methods}}}
+
+#[allow(dead_code)]
+struct __ValidatedVisitorBridge<'a, T: {validated_visitor_trait}>(&'a mut T);
+
+impl<T: {validated_visitor_trait}> antlr4_runtime::ParseTreeVisitor
+    for __ValidatedVisitorBridge<'_, T>
+{{
+    type Result = T::Result;
+
+    fn visit_rule(&mut self, context: RuleNodeView<'_>) -> Self::Result {{
+        match __context_kind(context) {{
+{validated_visitor_arms}            _ => {validated_visitor_trait}::default_result(self.0),
+        }}
+    }}
+
+    fn visit_terminal(&mut self, node: RuntimeTerminalNode<'_>) -> Self::Result {{
+        {validated_visitor_trait}::visit_terminal(self.0, &TerminalNode::new(node))
+    }}
+
+    fn visit_error_node(&mut self, _node: RuntimeErrorNode<'_>) -> Self::Result {{
+        unreachable!("validated parse tree contains an error node")
+    }}
+
+    fn default_result(&mut self) -> Self::Result {{
+        {validated_visitor_trait}::default_result(self.0)
+    }}
+
+    fn aggregate_result(
+        &mut self,
+        aggregate: Self::Result,
+        next_result: Self::Result,
+    ) -> Self::Result {{
+        {validated_visitor_trait}::aggregate_result(self.0, aggregate, next_result)
+    }}
+
+    fn should_visit_next_child(
+        &mut self,
+        context: RuleNodeView<'_>,
+        current_result: &Self::Result,
+    ) -> bool {{
+        {validated_visitor_trait}::should_visit_next_child(
+            self.0,
+            ValidatedRuleNode {{ __node: context }},
+            current_result,
+        )
+    }}
+}}
+"#
+    );
+    out
+}
+
 /// Generates the typed context views, listener trait, and walker for the
 /// embedded `.test.stg` surface:
 ///
@@ -11113,6 +11929,10 @@ fn __labeled_token_children_matching<'a>(
 /// * a module-local `ParseTreeWalker` whose bridge dispatches the runtime
 ///   walker onto the typed listener callbacks, threading the invoking-state
 ///   chain Java's `RuleContext.toString` renders (`[13 6]`).
+fn parser_surface_name(grammar_name: &str) -> &str {
+    grammar_name.strip_suffix("Parser").unwrap_or(grammar_name)
+}
+
 fn render_embedded_context_types(
     grammar_name: &str,
     data: &CodegenData<'_>,
@@ -11121,11 +11941,16 @@ fn render_embedded_context_types(
 ) -> String {
     let mut out = String::new();
     let context_names = context_surface_names(model);
-    let surface_name = grammar_name.strip_suffix("Parser").unwrap_or(grammar_name);
+    let surface_name = parser_surface_name(grammar_name);
     let listener_trait = format!("{surface_name}Listener");
     let visitor_trait = format!("{surface_name}Visitor");
     let visitable_trait = format!("{surface_name}Visitable");
     let tree_walker = format!("{surface_name}TreeWalker");
+    let validation_error = format!("{surface_name}ValidationError");
+    let validated_listener_trait = format!("{surface_name}ValidatedListener");
+    let validated_visitor_trait = format!("{surface_name}ValidatedVisitor");
+    let validated_visitable_trait = format!("{surface_name}ValidatedVisitable");
+    let validated_tree_walker = format!("{surface_name}ValidatedTreeWalker");
     let token_accessors = std::iter::once(("EOF".to_owned(), TOKEN_EOF))
         .chain(
             data.symbolic_names
@@ -11141,7 +11966,7 @@ fn render_embedded_context_types(
     if options.generate_visitor {
         let _ = writeln!(
             out,
-            "#[allow(dead_code)]\npub trait {visitable_trait}<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a>;\n}}\n\nimpl<'a> {visitable_trait}<'a> for antlr4_runtime::Node<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for RuleNodeView<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.node() }}\n}}\n"
+            "#[allow(dead_code)]\npub trait {visitable_trait}<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a>;\n}}\n\nimpl<'a> {visitable_trait}<'a> for antlr4_runtime::Node<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for RuleNodeView<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.node() }}\n}}\n\n#[allow(dead_code)]\npub trait {validated_visitable_trait}<'a> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a>;\n}}\n\nimpl<'a> {validated_visitable_trait}<'a> for ValidatedRuleNode<'a> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.node() }}\n}}\n\nimpl<'a> {validated_visitable_trait}<'a> for &ValidatedRuleNode<'a> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.node() }}\n}}\n"
         );
     }
 
@@ -11321,13 +12146,15 @@ fn __write_invocation_states(
 
 "#,
     );
+    out.push_str(&render_validated_tree_support(surface_name));
     if options.generate_visitor {
         let _ = writeln!(
             out,
-            "impl<'a> {visitable_trait}<'a> for TerminalNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for &TerminalNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for ErrorNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for &ErrorNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n"
+            "impl<'a> {visitable_trait}<'a> for TerminalNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for &TerminalNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for ErrorNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for &ErrorNode<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {validated_visitable_trait}<'a> for TerminalNode<'a> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n\nimpl<'a> {validated_visitable_trait}<'a> for &TerminalNode<'a> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.__node.node() }}\n}}\n"
         );
     }
     out.push_str(&render_context_kind_functions(model, &context_names));
+    let mut validation_arms = String::new();
 
     for ContextViewName {
         surface,
@@ -11373,27 +12200,48 @@ fn __write_invocation_states(
             out,
             "impl<'a> FromRuleNode<'a> for {view_name}<'a> {{\n    fn from_rule_node(node: RuleNodeView<'a>) -> Option<Self> {{\n        if node.rule_index() != {rule_index}{stored_kind_guard} {{ return None; }}\n        Some(Self::__from_node(node))\n    }}\n}}\n\nimpl<'a> AsRuleNode<'a> for {view_name}<'a> {{\n    fn as_rule_node(&self) -> RuleNodeView<'a> {{ self.rule_node() }}\n}}\n\nimpl<'a> {view_name}<'a> {{\n    pub fn rule_node(&self) -> RuleNodeView<'a> {{\n        match self.__node {{\n            __GeneratedRuleContext::Stored(node) => node,\n            __GeneratedRuleContext::Active {{ .. }} => unreachable!(\"stored context type contains an active parser context\"),\n        }}\n    }}\n}}\n\nimpl<'a> __FromActiveRuleContext<'a> for {view_name}<'a, __ActiveParserContext> {{\n    fn __from_active(\n        context: &'a antlr4_runtime::ParserRuleContext,\n        invocation_states: Vec<isize>,\n        storage: &'a antlr4_runtime::ParseTreeStorage,\n        tokens: &'a antlr4_runtime::TokenStore,\n    ) -> Option<Self> {{\n        if context.rule_index() != {rule_index}{active_kind_guard} {{ return None; }}\n{active_attrs_bindings}        Some(Self {{\n            __node: __GeneratedRuleContext::Active {{ context, storage, tokens }},\n            __invocation_states: Some(invocation_states),\n            __state: std::marker::PhantomData,\n{field_inits}        }})\n    }}\n}}\n"
         );
+        let _ = writeln!(
+            out,
+            "impl<'a> FromValidatedRuleNode<'a> for {view_name}<'a, ValidatedTreeContext> {{\n    fn from_validated_rule_node(node: ValidatedRuleNode<'a>) -> Option<Self> {{\n        let node = node.rule_node();\n        if node.rule_index() != {rule_index}{stored_kind_guard} {{ return None; }}\n        Some(Self::__from_validated_node(node))\n    }}\n}}\n\nimpl<'a> AsRuleNode<'a> for {view_name}<'a, ValidatedTreeContext> {{\n    fn as_rule_node(&self) -> RuleNodeView<'a> {{ self.rule_node() }}\n}}\n"
+        );
         let mut accessors = String::new();
         let _ = writeln!(
             accessors,
             "    fn __from_node(node: RuleNodeView<'a>) -> Self {{\n        Self::__from_node_with_invocation_states(node, None)\n    }}\n\n    fn __from_child_node(\n        node: RuleNodeView<'a>,\n        parent_invocation_states: Option<&[isize]>,\n    ) -> Self {{\n        let invocation_states = parent_invocation_states.map(|states| {{\n            let mut invocation_states = Vec::with_capacity(states.len() + 1);\n            invocation_states.push(node.invoking_state());\n            invocation_states.extend_from_slice(states);\n            invocation_states\n        }});\n        Self::__from_node_with_invocation_states(node, invocation_states)\n    }}\n\n    fn __from_listener_node(node: RuleNodeView<'a>, invocation_states: Option<&[isize]>) -> Self {{\n        Self::__from_node_with_invocation_states(\n            node,\n            invocation_states.map(|states| states.to_vec()),\n        )\n    }}\n\n    fn __from_node_with_invocation_states(\n        node: RuleNodeView<'a>,\n        invocation_states: Option<Vec<isize>>,\n    ) -> Self {{\n{stored_attrs_bindings}        Self {{\n            __node: __GeneratedRuleContext::Stored(node),\n            __invocation_states: invocation_states,\n            __state: std::marker::PhantomData,\n{field_inits}        }}\n    }}\n"
         );
-        let common_accessors = render_context_child_accessors(
+        let mut validated_constructors = String::new();
+        let _ = writeln!(
+            validated_constructors,
+            "    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {{\n        Self::__from_validated_node_with_invocation_states(node, None)\n    }}\n\n    fn __from_validated_child_node(\n        node: RuleNodeView<'a>,\n        parent_invocation_states: Option<&[isize]>,\n    ) -> Self {{\n        let invocation_states = parent_invocation_states.map(|states| {{\n            let mut invocation_states = Vec::with_capacity(states.len() + 1);\n            invocation_states.push(node.invoking_state());\n            invocation_states.extend_from_slice(states);\n            invocation_states\n        }});\n        Self::__from_validated_node_with_invocation_states(node, invocation_states)\n    }}\n\n    fn __from_validated_listener_node(\n        node: RuleNodeView<'a>,\n        invocation_states: Option<&[isize]>,\n    ) -> Self {{\n        Self::__from_validated_node_with_invocation_states(\n            node,\n            invocation_states.map(|states| states.to_vec()),\n        )\n    }}\n\n    fn __from_validated_node_with_invocation_states(\n        node: RuleNodeView<'a>,\n        invocation_states: Option<Vec<isize>>,\n    ) -> Self {{\n{stored_attrs_bindings}        Self {{\n            __node: __GeneratedRuleContext::Stored(node),\n            __invocation_states: invocation_states,\n            __state: std::marker::PhantomData,\n{field_inits}        }}\n    }}\n\n    pub fn rule_node(&self) -> RuleNodeView<'a> {{\n        match self.__node {{\n            __GeneratedRuleContext::Stored(node) => node,\n            __GeneratedRuleContext::Active {{ .. }} => unreachable!(\"validated context contains an active parser context\"),\n        }}\n    }}\n"
+        );
+        let rendered_accessors = render_context_child_accessors(ContextAccessorsRender {
             view_name,
             model,
-            &context_names,
-            &token_accessors,
-            &child_cardinalities,
-            &label_accessors,
-        );
+            context_names: &context_names,
+            token_accessors: &token_accessors,
+            child_cardinalities: &child_cardinalities,
+            label_accessors: &label_accessors,
+            validation_error_name: &validation_error,
+        });
         let _ = writeln!(
             out,
-            "#[allow(dead_code, clippy::all)]\nimpl<'a> {view_name}<'a> {{\n{accessors}}}\n\n#[allow(dead_code, clippy::all)]\nimpl<'a, State> {view_name}<'a, State> {{\n{common_accessors}}}\n"
+            "#[allow(dead_code, clippy::all)]\nimpl<'a> {view_name}<'a> {{\n{accessors}}}\n\n#[allow(dead_code, clippy::all)]\nimpl<'a, State> {view_name}<'a, State> {{\n{CONTEXT_COMMON_ACCESSORS}}}\n\n#[allow(dead_code, private_bounds, clippy::all)]\nimpl<'a, State: __RecoveryContextState> {view_name}<'a, State> {{\n{recovered}}}\n\n#[allow(dead_code, clippy::all)]\nimpl<'a> {view_name}<'a, ValidatedTreeContext> {{\n{validated_constructors}{validated}}}\n",
+            recovered = rendered_accessors.recovered,
+            validated = rendered_accessors.validated,
+        );
+        let _ = writeln!(
+            validation_arms,
+            "                {context_kind} => {{\n                    let context = {view_name}::__from_listener_node(context, None);\n{validation}                }},",
+            validation = rendered_accessors.validation,
         );
         if options.generate_visitor {
             let _ = writeln!(
                 out,
                 "impl<'a> {visitable_trait}<'a> for {view_name}<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.rule_node().node() }}\n}}\n\nimpl<'a> {visitable_trait}<'a> for &{view_name}<'a> {{\n    fn into_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.rule_node().node() }}\n}}\n"
+            );
+            let _ = writeln!(
+                out,
+                "impl<'a> {validated_visitable_trait}<'a> for {view_name}<'a, ValidatedTreeContext> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.rule_node().node() }}\n}}\n\nimpl<'a> {validated_visitable_trait}<'a> for &{view_name}<'a, ValidatedTreeContext> {{\n    fn into_validated_parse_tree_node(self) -> antlr4_runtime::Node<'a> {{ self.rule_node().node() }}\n}}\n"
             );
         }
         // Java's RuleContext.toString(): bracketed invoking-state chain from
@@ -11404,226 +12252,70 @@ fn __write_invocation_states(
         );
     }
 
-    if options.generate_listener {
-        let mut trait_methods = String::new();
-        let mut enter_arms = String::new();
-        let mut exit_arms = String::new();
-        for (kind_id, view) in context_names.views.iter().enumerate() {
-            let ContextSurfaceName {
-                context_type,
-                listener_method,
-                ..
-            } = &view.surface;
-            let _ = writeln!(
-                trait_methods,
-                "    fn enter_{listener_method}(&mut self, _ctx: &{context_type}) -> Result<(), E> {{ Ok(()) }}\n    fn exit_{listener_method}(&mut self, _ctx: &{context_type}) -> Result<(), E> {{ Ok(()) }}"
-            );
-            let _ = writeln!(
-                enter_arms,
-                "                        {kind_id} => listener.enter_{listener_method}(&{context_type}::__from_listener_node(context, invocation_states.as_deref()))?,"
-            );
-            let _ = writeln!(
-                exit_arms,
-                "                    {kind_id} => listener.exit_{listener_method}(&{context_type}::__from_listener_node(context, invocation_states.as_deref()))?,"
-            );
-        }
-        let _ = writeln!(
-            out,
-            "#[allow(dead_code, unused_variables)]\npub trait {listener_trait}<E = std::convert::Infallible> {{\n    fn walk(&mut self, tree: antlr4_runtime::Node<'_>) -> Result<(), E>\n    where\n        Self: Sized,\n    {{\n        {tree_walker}::walk(self, tree)\n    }}\n\n    fn enter_every_rule(&mut self, _ctx: RuleNodeView<'_>) -> Result<(), E> {{ Ok(()) }}\n    fn exit_every_rule(&mut self, _ctx: RuleNodeView<'_>) -> Result<(), E> {{ Ok(()) }}\n\n{trait_methods}    fn visit_terminal(&mut self, _node: &TerminalNode) -> Result<(), E> {{ Ok(()) }}\n    fn visit_error_node(&mut self, _node: &ErrorNode) -> Result<(), E> {{ Ok(()) }}\n    fn output(&mut self) -> std::io::Stdout {{ std::io::stdout() }}\n}}\n"
-        );
-
-        let _ = writeln!(
-            out,
-            r#"#[allow(dead_code)]
-pub struct {tree_walker};
-
-#[allow(dead_code)]
-impl {tree_walker} {{
-    pub fn walk<E, T: {listener_trait}<E>>(
-        listener: &mut T,
-        tree: antlr4_runtime::Node<'_>,
-    ) -> Result<(), E> {{
-        Self::__walk(listener, tree, None)
+    let _ = writeln!(
+        out,
+        r#"/// Checks generated required-child invariants without changing the
+/// recovery-oriented tree's type.
+///
+/// Strict parsing calls this after proving that lexer and parser syntax-error
+/// counts are both zero. It is public so structural runtime/codegen invariant
+/// failures can be diagnosed independently.
+pub fn validate_tree_structure(
+    parsed: &antlr4_runtime::ParsedFile,
+) -> Result<(), {validation_error}> {{
+    let tree = parsed.tree();
+    if tree.as_rule().is_none() {{
+        return Err({validation_error}::InvalidRoot);
     }}
-
-    pub fn walk_with_invocation_states<E, T: {listener_trait}<E>>(
-        listener: &mut T,
-        tree: antlr4_runtime::Node<'_>,
-        parent_invocation_states: Vec<isize>,
-    ) -> Result<(), E> {{
-        Self::__walk(listener, tree, Some(parent_invocation_states))
-    }}
-
-    fn __walk<E, T: {listener_trait}<E>>(
-        listener: &mut T,
-        tree: antlr4_runtime::Node<'_>,
-        mut invocation_states: Option<Vec<isize>>,
-    ) -> Result<(), E> {{
-        enum Event<'tree> {{
-            Enter(antlr4_runtime::Node<'tree>),
-            Exit(RuleNodeView<'tree>),
-        }}
-
-        let mut stack = vec![Event::Enter(tree)];
-        while let Some(event) = stack.pop() {{
-            match event {{
-                Event::Enter(node) => match node.kind() {{
-                    antlr4_runtime::NodeKind::Rule => {{
-                        let context = node.as_rule().expect("rule node kind checked");
-                        if let Some(states) = &mut invocation_states {{
-                            states.insert(0, context.invoking_state());
-                        }}
-                        listener.enter_every_rule(context)?;
-                        match __context_kind(context) {{
-{enter_arms}                            _ => {{}}
-                        }}
-                        stack.push(Event::Exit(context));
-                        stack.extend(context.children().rev().map(Event::Enter));
-                    }}
-                    antlr4_runtime::NodeKind::Terminal => {{
-                        listener.visit_terminal(&TerminalNode::new(
-                            node.as_terminal().expect("terminal node kind checked"),
-                        ))?;
-                    }}
-                    antlr4_runtime::NodeKind::Error => {{
-                        listener.visit_error_node(&ErrorNode::new(
-                            node.as_error().expect("error node kind checked"),
-                        ))?;
-                    }}
-                }},
-                Event::Exit(context) => {{
-                    match __context_kind(context) {{
-{exit_arms}                        _ => {{}}
-                    }}
-                    listener.exit_every_rule(context)?;
-                    if let Some(states) = &mut invocation_states {{
-                        states.remove(0);
+    for node in tree.descendants() {{
+        match node.kind() {{
+            antlr4_runtime::NodeKind::Terminal => {{}}
+            antlr4_runtime::NodeKind::Error => {{
+                let symbol = node
+                    .as_error()
+                    .expect("error node kind checked")
+                    .symbol();
+                return Err({validation_error}::RecoveredErrorNode {{
+                    line: symbol.line(),
+                    column: symbol.column(),
+                    text: symbol.text_or_empty().to_owned(),
+                }});
+            }}
+            antlr4_runtime::NodeKind::Rule => {{
+                let context = node.as_rule().expect("rule node kind checked");
+                match __context_kind(context) {{
+{validation_arms}                    _ => {{
+                        return Err({validation_error}::UnknownRule {{
+                            rule_index: context.rule_index(),
+                        }});
                     }}
                 }}
             }}
         }}
-        Ok(())
     }}
+    Ok(())
 }}
-
-pub type ParseTreeWalker = {tree_walker};
 "#
-        );
+    );
+
+    if options.generate_listener {
+        out.push_str(&render_context_listener_surface(
+            &context_names,
+            &listener_trait,
+            &tree_walker,
+            &validated_listener_trait,
+            &validated_tree_walker,
+        ));
     }
 
     if options.generate_visitor {
-        let mut visitor_methods = String::new();
-        let mut visitor_arms = String::new();
-        for (kind_id, view) in context_names.views.iter().enumerate() {
-            let ContextSurfaceName {
-                context_type,
-                visitor_method,
-                ..
-            } = &view.surface;
-            let _ = writeln!(
-                visitor_methods,
-                "    fn visit_{visitor_method}(&mut self, ctx: &{context_type}) -> Self::Result {{\n        self.visit_children(ctx)\n    }}"
-            );
-            let _ = writeln!(
-                visitor_arms,
-                "            {kind_id} => {visitor_trait}::visit_{visitor_method}(self.0, &{context_type}::__from_listener_node(context, None)),"
-            );
-        }
-        let _ = writeln!(
-            out,
-            r#"#[allow(dead_code, unused_variables)]
-pub trait {visitor_trait}: Sized {{
-    type Result;
-
-    fn default_result(&mut self) -> Self::Result;
-
-    fn visit<'tree, T>(&mut self, tree: T) -> Self::Result
-    where
-        T: {visitable_trait}<'tree>,
-    {{
-        let tree = {visitable_trait}::into_parse_tree_node(tree);
-        let mut bridge = __VisitorBridge(self);
-        antlr4_runtime::ParseTreeVisitor::visit(&mut bridge, tree)
-    }}
-
-    fn visit_children<'tree, T>(&mut self, context: T) -> Self::Result
-    where
-        T: {visitable_trait}<'tree>,
-    {{
-        let tree = {visitable_trait}::into_parse_tree_node(context);
-        let context = tree.as_rule().expect("visit_children requires a rule context");
-        let mut bridge = __VisitorBridge(self);
-        antlr4_runtime::ParseTreeVisitor::visit_children(&mut bridge, context)
-    }}
-
-    fn aggregate_result(
-        &mut self,
-        _aggregate: Self::Result,
-        next_result: Self::Result,
-    ) -> Self::Result {{
-        next_result
-    }}
-
-    fn should_visit_next_child(
-        &mut self,
-        _context: RuleNodeView<'_>,
-        _current_result: &Self::Result,
-    ) -> bool {{
-        true
-    }}
-
-    fn visit_terminal(&mut self, _node: &TerminalNode) -> Self::Result {{
-        self.default_result()
-    }}
-
-    fn visit_error_node(&mut self, _node: &ErrorNode) -> Self::Result {{
-        self.default_result()
-    }}
-
-{visitor_methods}}}
-
-#[allow(dead_code)]
-struct __VisitorBridge<'a, T: {visitor_trait}>(&'a mut T);
-
-impl<T: {visitor_trait}> antlr4_runtime::ParseTreeVisitor for __VisitorBridge<'_, T> {{
-    type Result = T::Result;
-
-    fn visit_rule(&mut self, context: RuleNodeView<'_>) -> Self::Result {{
-        match __context_kind(context) {{
-{visitor_arms}            _ => {visitor_trait}::default_result(self.0),
-        }}
-    }}
-
-    fn visit_terminal(&mut self, node: RuntimeTerminalNode<'_>) -> Self::Result {{
-        {visitor_trait}::visit_terminal(self.0, &TerminalNode::new(node))
-    }}
-
-    fn visit_error_node(&mut self, node: RuntimeErrorNode<'_>) -> Self::Result {{
-        {visitor_trait}::visit_error_node(self.0, &ErrorNode::new(node))
-    }}
-
-    fn default_result(&mut self) -> Self::Result {{
-        {visitor_trait}::default_result(self.0)
-    }}
-
-    fn aggregate_result(
-        &mut self,
-        aggregate: Self::Result,
-        next_result: Self::Result,
-    ) -> Self::Result {{
-        {visitor_trait}::aggregate_result(self.0, aggregate, next_result)
-    }}
-
-    fn should_visit_next_child(
-        &mut self,
-        context: RuleNodeView<'_>,
-        current_result: &Self::Result,
-    ) -> bool {{
-        {visitor_trait}::should_visit_next_child(self.0, context, current_result)
-    }}
-}}
-"#
-        );
+        out.push_str(&render_context_visitor_surface(
+            &context_names,
+            &visitor_trait,
+            &visitable_trait,
+            &validated_visitor_trait,
+            &validated_visitable_trait,
+        ));
     }
     out
 }
@@ -12151,7 +12843,8 @@ fn render_parser_with_decision_report(
             &noop_action_states
         },
     );
-    let parse_convenience = render_parser_parse_convenience(&type_name);
+    let parse_convenience =
+        render_parser_parse_convenience(&type_name, parser_surface_name(grammar_name));
     // A grammar-declared `@members` initializer must seed the parser too, or a
     // predicate reading the slot would observe 0 and reject input the source
     // grammar accepts (issue #206 review).
@@ -14641,8 +15334,10 @@ fn render_parser_base_initialization(
 
 /// Renders parser-module conveniences that wire text or a caller-provided
 /// character stream through the lexer, token stream, parser, and entry rule.
-fn render_parser_parse_convenience(type_name: &str) -> String {
+fn render_parser_parse_convenience(type_name: &str, surface_name: &str) -> String {
     let output_type_name = format!("{type_name}ParseOutput");
+    let validated_tree_name = format!("{surface_name}ValidatedTree");
+    let validation_error_name = format!("{surface_name}ValidationError");
     format!(
         r#"/// Result from [`parse_with_parser`] or [`parse_stream_with_parser`].
 ///
@@ -14655,6 +15350,24 @@ where
 {{
     pub result: R,
     pub parser: {type_name}<L>,
+}}
+
+impl<L: TokenSource> {output_type_name}<antlr4_runtime::NodeId, L> {{
+    /// Validates a completed parse and changes its generated context surface.
+    ///
+    /// Validation rejects lexer diagnostics, parser recovery, recovered error
+    /// nodes, and missing generated required children before constructing the
+    /// validated-tree type boundary.
+    pub fn validate(self) -> Result<{validated_tree_name}, {validation_error_name}> {{
+        let lexer = self.parser.token_stream().number_of_source_errors();
+        let parser = self.parser.number_of_syntax_errors();
+        if lexer != 0 || parser != 0 {{
+            return Err({validation_error_name}::SyntaxErrors {{ lexer, parser }});
+        }}
+        let parsed = self.parser.into_parsed_file(self.result);
+        validate_tree_structure(&parsed)?;
+        Ok({validated_tree_name}::__new(parsed))
+    }}
 }}
 
 /// Parses UTF-8 text by constructing the lexer, token stream, parser, and
@@ -14674,6 +15387,21 @@ pub fn parse<L: TokenSource>(
 ) -> Result<antlr4_runtime::ParsedFile, antlr4_runtime::AntlrError>
 {{
     parse_stream(antlr4_runtime::InputStream::new(input.as_ref()), lexer, entry)
+}}
+
+/// Parses UTF-8 text and returns a typed tree whose required generated child
+/// accessors are infallible.
+pub fn parse_validated<L: TokenSource>(
+    input: impl AsRef<str>,
+    lexer: impl FnOnce(antlr4_runtime::InputStream) -> L,
+    entry: impl FnOnce(&mut {type_name}<L>) -> Result<antlr4_runtime::NodeId, antlr4_runtime::AntlrError>,
+) -> Result<{validated_tree_name}, {validation_error_name}>
+{{
+    parse_stream_validated(
+        antlr4_runtime::InputStream::new(input.as_ref()),
+        lexer,
+        entry,
+    )
 }}
 
 /// Parses UTF-8 text like [`parse`] while returning the parser after the entry
@@ -14709,6 +15437,18 @@ pub fn parse_stream<I: antlr4_runtime::CharStream, L: TokenSource>(
     let {output_type_name} {{ result, parser }} =
         parse_stream_with_parser(input, lexer, entry)?;
     Ok(parser.into_parsed_file(result))
+}}
+
+/// Parses a caller-provided character stream and validates the completed tree.
+pub fn parse_stream_validated<I: antlr4_runtime::CharStream, L: TokenSource>(
+    input: I,
+    lexer: impl FnOnce(I) -> L,
+    entry: impl FnOnce(&mut {type_name}<L>) -> Result<antlr4_runtime::NodeId, antlr4_runtime::AntlrError>,
+) -> Result<{validated_tree_name}, {validation_error_name}>
+{{
+    let output = parse_stream_with_parser(input, lexer, entry)
+        .map_err({validation_error_name}::Recognition)?;
+    output.validate()
 }}
 
 /// Parses a caller-provided character stream like [`parse_stream`] while
@@ -16405,6 +17145,15 @@ mod tests {
             .position(|rule| rule.name == "storedTree")
             .expect("storedTree fixture rule");
         assert_ne!(names.rules[stored_tree].context_type, "StoredTreeContext");
+        let validated_tree = model
+            .rules
+            .iter()
+            .position(|rule| rule.name == "validatedTree")
+            .expect("validatedTree fixture rule");
+        assert_ne!(
+            names.rules[validated_tree].context_type,
+            "ValidatedTreeContext"
+        );
 
         insta::assert_debug_snapshot!("context_surface_name_collision", names);
     }
@@ -17327,7 +18076,7 @@ mod tests {
 
         insta::assert_snapshot!(
             "parser_parse_convenience",
-            render_parser_parse_convenience("TParser")
+            render_parser_parse_convenience("TParser", "T")
         );
         assert!(rendered.contains("pub struct TParserParseOutput<R, L>"));
         assert!(rendered.contains("pub result: R,"));
@@ -17364,6 +18113,19 @@ mod tests {
         assert!(
             rendered.contains("pub fn with_hooks(input: CommonTokenStream<L>, hooks: H) -> Self")
         );
+    }
+
+    #[test]
+    fn validated_parse_names_match_lowercase_grammar_surface() {
+        let rendered = render_parser("u", &minimal_parser_data()).expect("parser should render");
+
+        assert!(rendered.contains("pub struct uValidatedTree"));
+        assert!(rendered.contains("pub enum uValidationError"));
+        assert!(
+            rendered.contains("pub fn validate(self) -> Result<uValidatedTree, uValidationError>")
+        );
+        assert!(!rendered.contains("UValidatedTree"));
+        assert!(!rendered.contains("UValidationError"));
     }
 
     #[test]

--- a/src/bin/antlr4-rust-gen.rs
+++ b/src/bin/antlr4-rust-gen.rs
@@ -12229,10 +12229,17 @@ fn __write_invocation_states(
             recovered = rendered_accessors.recovered,
             validated = rendered_accessors.validated,
         );
+        let validation_body = if rendered_accessors.validation.is_empty() {
+            String::new()
+        } else {
+            format!(
+                "                    let context = {view_name}::__from_listener_node(context, None);\n{}",
+                rendered_accessors.validation
+            )
+        };
         let _ = writeln!(
             validation_arms,
-            "                {context_kind} => {{\n                    let context = {view_name}::__from_listener_node(context, None);\n{validation}                }},",
-            validation = rendered_accessors.validation,
+            "                {context_kind} => {{\n{validation_body}                }},"
         );
         if options.generate_visitor {
             let _ = writeln!(

--- a/src/bin/snapshots/antlr4_rust_gen__tests__context_surface_name_collision.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__context_surface_name_collision.snap
@@ -24,6 +24,11 @@ ContextSurfaceNames {
             listener_method: "stored_tree",
             visitor_method: "stored_tree",
         },
+        ContextSurfaceName {
+            context_type: "ValidatedTreeRuleContext",
+            listener_method: "validated_tree",
+            visitor_method: "validated_tree",
+        },
     ],
     views: [
         ContextViewName {
@@ -82,6 +87,15 @@ ContextSurfaceNames {
                 visitor_method: "stored_tree",
             },
             rule_index: 3,
+            alternative_label: None,
+        },
+        ContextViewName {
+            surface: ContextSurfaceName {
+                context_type: "ValidatedTreeRuleContext",
+                listener_method: "validated_tree",
+                visitor_method: "validated_tree",
+            },
+            rule_index: 4,
             alternative_label: None,
         },
     ],

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_hazard_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_hazard_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: context(name)
+expression: "rendered_context_impl(&rendered, name)"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: context(name)
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> BranchHazardContext<'a, State> {
     pub fn unary(&self) -> Result<UnaryContext<'a>, MissingChildError> {
         __rule_children(self.__node, 4)
             .next()
@@ -40,5 +44,74 @@ expression: context(name)
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("BranchHazardContext", "NUM"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> BranchHazardContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary(&self) -> UnaryContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 4).next() else {
+            unreachable!("validated BranchHazardContext is missing required child unary")
+        };
+        UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated BranchHazardContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_rival_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_branch_rival_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: context(name)
+expression: "rendered_context_impl(&rendered, name)"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: context(name)
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> BranchRivalContext<'a, State> {
     pub fn unary(&self) -> Result<UnaryContext<'a>, MissingChildError> {
         __rule_children(self.__node, 4)
             .next()
@@ -35,5 +39,69 @@ expression: context(name)
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("BranchRivalContext", "NUM"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> BranchRivalContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary(&self) -> UnaryContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 4).next() else {
+            unreachable!("validated BranchRivalContext is missing required child unary")
+        };
+        UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated BranchRivalContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_calc_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_calc_context.snap
@@ -24,6 +24,10 @@ expression: calc_context
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> CalcContext<'a, State> {
     pub fn calc_children(&self) -> impl Iterator<Item = CalcContext<'a>> + '_ {
         __rule_children(self.__node, 2)
             .map(move |node| CalcContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -32,6 +36,94 @@ expression: calc_context
         __rule_children(self.__node, 4)
             .next()
             .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn percent_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 10)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 11)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn minus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 12)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn op(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children_matching(self.__node, &[8, 9, 10, 11, 12])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> CalcContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn calc_children(&self) -> impl Iterator<Item = CalcContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 2)
+            .map(move |node| CalcContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn unary(&self) -> Option<UnaryContext<'a, ValidatedTreeContext>> {
+        __rule_children(self.__node, 4)
+            .next()
+            .map(|node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
     pub fn star_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 8)

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_closed_repeat_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_closed_repeat_prefix_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"ClosedRepeatPrefixContext\")"
+expression: "rendered_context_impl(&rendered, \"ClosedRepeatPrefixContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"ClosedRepeatPrefixContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> ClosedRepeatPrefixContext<'a, State> {
     pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 8).map(TerminalNode::new)
     }
@@ -35,5 +39,66 @@ expression: "context(\"ClosedRepeatPrefixContext\")"
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("ClosedRepeatPrefixContext", "NUM"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> ClosedRepeatPrefixContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 8).map(TerminalNode::new)
+    }
+    pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 13).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated ClosedRepeatPrefixContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_direct_optional_in_shared_block_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_direct_optional_in_shared_block_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"DirectOptionalInSharedBlockContext\")"
+expression: "rendered_context_impl(&rendered, \"DirectOptionalInSharedBlockContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,84 @@ expression: "context(\"DirectOptionalInSharedBlockContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> DirectOptionalInSharedBlockContext<'a, State> {
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 11)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn minus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 12)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> DirectOptionalInSharedBlockContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
     pub fn star_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 8)
             .next()

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_exhaustive_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_exhaustive_prefix_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"ExhaustivePrefixContext\")"
+expression: "rendered_context_impl(&rendered, \"ExhaustivePrefixContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"ExhaustivePrefixContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> ExhaustivePrefixContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -39,5 +43,75 @@ expression: "context(\"ExhaustivePrefixContext\")"
             .nth(1)
             .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
             .ok_or_else(|| MissingChildError::new("ExhaustivePrefixContext", "pick"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> ExhaustivePrefixContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated ExhaustivePrefixContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn pick(&self) -> UnaryContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 4)
+            .nth(1)
+        else {
+            unreachable!("validated ExhaustivePrefixContext is missing required child pick")
+        };
+        UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_grouped_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_grouped_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"GroupedContext\")"
+expression: "rendered_context_impl(&rendered, \"GroupedContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"GroupedContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> GroupedContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -61,6 +65,98 @@ expression: "context(\"GroupedContext\")"
         __rule_children(self.__node, 4)
             .skip(0)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn oneway(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children(self.__node, 8)
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> GroupedContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn in_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 7)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated GroupedContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn comma_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 15).map(TerminalNode::new)
+    }
+    pub fn doc(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children(self.__node, 13)
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+    pub fn errors(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .skip(0)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
     pub fn oneway(&self) -> Option<TerminalNode<'a>> {
         __labeled_token_children(self.__node, 8)

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_inner_choice_arity_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_inner_choice_arity_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"InnerChoiceArityContext\")"
+expression: "rendered_context_impl(&rendered, \"InnerChoiceArityContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"InnerChoiceArityContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> InnerChoiceArityContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -32,6 +36,67 @@ expression: "context(\"InnerChoiceArityContext\")"
         __rule_children(self.__node, 8)
             .next()
             .map(|node| ParamContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> InnerChoiceArityContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn param(&self) -> Option<ParamContext<'a, ValidatedTreeContext>> {
+        __rule_children(self.__node, 8)
+            .next()
+            .map(|node| ParamContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
     pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 14).map(TerminalNode::new)

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_repeats_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"MergedRepeatsContext\")"
+expression: "rendered_context_impl(&rendered, \"MergedRepeatsContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"MergedRepeatsContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> MergedRepeatsContext<'a, State> {
     pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 13).map(TerminalNode::new)
     }
@@ -35,6 +39,72 @@ expression: "context(\"MergedRepeatsContext\")"
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("MergedRepeatsContext", "LPAREN"))
+    }
+    pub fn last_pick(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children_matching(self.__node, &[13, 14])
+            .skip(0).last()
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> MergedRepeatsContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 13).map(TerminalNode::new)
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+    pub fn lparen_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 16).next() else {
+            unreachable!("validated MergedRepeatsContext is missing required child LPAREN")
+        };
+        TerminalNode::new(node)
     }
     pub fn last_pick(&self) -> Option<TerminalNode<'a>> {
         __labeled_token_children_matching(self.__node, &[13, 14])

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_rivals_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_merged_rivals_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"MergedRivalsContext\")"
+expression: "rendered_context_impl(&rendered, \"MergedRivalsContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,72 @@ expression: "context(\"MergedRivalsContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> MergedRivalsContext<'a, State> {
+    pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+    pub fn pick(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children_matching(self.__node, &[13, 14])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> MergedRivalsContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
     pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 13)
             .next()

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"MixedContext\")"
+expression: "rendered_context_impl(&rendered, \"MixedContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"MixedContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> MixedContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -62,5 +66,98 @@ expression: "context(\"MixedContext\")"
             .nth(0)
             .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
             .ok_or_else(|| MissingChildError::new("MixedContext", "name"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> MixedContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn param_children(&self) -> impl Iterator<Item = ParamContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 8)
+            .map(move |node| ParamContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn in_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 7)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn comma_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 15).map(TerminalNode::new)
+    }
+    pub fn lparen_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 16).next() else {
+            unreachable!("validated MixedContext is missing required child LPAREN")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn rparen_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 17).next() else {
+            unreachable!("validated MixedContext is missing required child RPAREN")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn errors(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .skip(1)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn name(&self) -> UnaryContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 4)
+            .nth(0)
+        else {
+            unreachable!("validated MixedContext is missing required child name")
+        };
+        UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"MixedRepetitionContext\")"
+expression: "rendered_context_impl(&rendered, \"MixedRepetitionContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"MixedRepetitionContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> MixedRepetitionContext<'a, State> {
     pub fn star_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 8)
             .next()
@@ -51,5 +55,84 @@ expression: "context(\"MixedRepetitionContext\")"
             .skip(0).last()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("MixedRepetitionContext", "latest"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> MixedRepetitionContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+    pub fn minus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 12).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated MixedRepetitionContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn latest(&self) -> TerminalNode<'a> {
+        let Some(node) = __labeled_token_children_matching(self.__node, &[8, 9, 11, 12])
+            .skip(0).last()
+        else {
+            unreachable!("validated MixedRepetitionContext is missing required child latest")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_followed_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_repetition_followed_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"MixedRepetitionFollowedContext\")"
+expression: "rendered_context_impl(&rendered, \"MixedRepetitionFollowedContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"MixedRepetitionFollowedContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> MixedRepetitionFollowedContext<'a, State> {
     pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 8).map(TerminalNode::new)
     }
@@ -43,5 +47,74 @@ expression: "context(\"MixedRepetitionFollowedContext\")"
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("MixedRepetitionFollowedContext", "NUM"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> MixedRepetitionFollowedContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 8).map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+    pub fn minus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 12).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated MixedRepetitionFollowedContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_unbounded_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_mixed_unbounded_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: context(name)
+expression: "rendered_context_impl(&rendered, name)"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: context(name)
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> MixedUnboundedContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -33,5 +37,64 @@ expression: context(name)
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("MixedUnboundedContext", "IN"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> MixedUnboundedContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn in_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 7).next() else {
+            unreachable!("validated MixedUnboundedContext is missing required child IN")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_exhaustive_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_exhaustive_prefix_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"NestedExhaustivePrefixContext\")"
+expression: "rendered_context_impl(&rendered, \"NestedExhaustivePrefixContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"NestedExhaustivePrefixContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> NestedExhaustivePrefixContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -39,5 +43,75 @@ expression: "context(\"NestedExhaustivePrefixContext\")"
             .nth(1)
             .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
             .ok_or_else(|| MissingChildError::new("NestedExhaustivePrefixContext", "chosen"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> NestedExhaustivePrefixContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated NestedExhaustivePrefixContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn chosen(&self) -> UnaryContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 4)
+            .nth(1)
+        else {
+            unreachable!("validated NestedExhaustivePrefixContext is missing required child chosen")
+        };
+        UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_group_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_nested_group_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"NestedGroupContext\")"
+expression: "rendered_context_impl(&rendered, \"NestedGroupContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"NestedGroupContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> NestedGroupContext<'a, State> {
     pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 13)
             .next()
@@ -34,6 +38,71 @@ expression: "context(\"NestedGroupContext\")"
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("NestedGroupContext", "NUM"))
+    }
+    pub fn deep(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children(self.__node, 13)
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> NestedGroupContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn ident_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 13)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated NestedGroupContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
     }
     pub fn deep(&self) -> Option<TerminalNode<'a>> {
         __labeled_token_children(self.__node, 13)

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_optional_prefix_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_optional_prefix_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"OptionalPrefixContext\")"
+expression: "rendered_context_impl(&rendered, \"OptionalPrefixContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"OptionalPrefixContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> OptionalPrefixContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -33,5 +37,64 @@ expression: "context(\"OptionalPrefixContext\")"
             .next()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("OptionalPrefixContext", "NUM"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> OptionalPrefixContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated OptionalPrefixContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_overlapping_group_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_overlapping_group_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"OverlappingGroupContext\")"
+expression: "rendered_context_impl(&rendered, \"OverlappingGroupContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,67 @@ expression: "context(\"OverlappingGroupContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> OverlappingGroupContext<'a, State> {
+    pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 13).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> OverlappingGroupContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
     pub fn ident_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 13).map(TerminalNode::new)
     }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_path_restricted_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_path_restricted_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"PathRestrictedContext\")"
+expression: "rendered_context_impl(&rendered, \"PathRestrictedContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"PathRestrictedContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> PathRestrictedContext<'a, State> {
     pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a>> + '_ {
         __rule_children(self.__node, 4)
             .map(move |node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -35,5 +39,66 @@ expression: "context(\"PathRestrictedContext\")"
         __rule_children(self.__node, 4)
             .nth(1)
             .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> PathRestrictedContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary_children(&self) -> impl Iterator<Item = UnaryContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 4)
+            .map(move |node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn num_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 14).map(TerminalNode::new)
+    }
+    pub fn tail(&self) -> Option<UnaryContext<'a, ValidatedTreeContext>> {
+        __rule_children(self.__node, 4)
+            .nth(1)
+            .map(|node| UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_prefixed_mixed_repetition_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_prefixed_mixed_repetition_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"PrefixedMixedRepetitionContext\")"
+expression: "rendered_context_impl(&rendered, \"PrefixedMixedRepetitionContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,10 @@ expression: "context(\"PrefixedMixedRepetitionContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> PrefixedMixedRepetitionContext<'a, State> {
     pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 8).map(TerminalNode::new)
     }
@@ -49,5 +53,82 @@ expression: "context(\"PrefixedMixedRepetitionContext\")"
             .skip(1).last()
             .map(TerminalNode::new)
             .ok_or_else(|| MissingChildError::new("PrefixedMixedRepetitionContext", "latest"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> PrefixedMixedRepetitionContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn star_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 8).map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+    pub fn minus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 12).map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> TerminalNode<'a> {
+        let Some(node) = __token_children(self.__node, 14).next() else {
+            unreachable!("validated PrefixedMixedRepetitionContext is missing required child NUM")
+        };
+        TerminalNode::new(node)
+    }
+    pub fn latest(&self) -> TerminalNode<'a> {
+        let Some(node) = __labeled_token_children_matching(self.__node, &[8, 9, 11, 12])
+            .skip(1).last()
+        else {
+            unreachable!("validated PrefixedMixedRepetitionContext is missing required child latest")
+        };
+        TerminalNode::new(node)
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_shadowed_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_shadowed_context.snap
@@ -24,11 +24,76 @@ expression: shadowed_context
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> ShadowedContext<'a, State> {
     pub fn unary(&self) -> Result<UnaryContext<'a>, MissingChildError> {
         __rule_children(self.__node, 4)
             .next()
             .map(|node| UnaryContext::__from_child_node(node, self.__invocation_states.as_deref()))
             .ok_or_else(|| MissingChildError::new("ShadowedContext", "unary"))
+    }
+    pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 11).map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> ShadowedContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn unary(&self) -> UnaryContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 4).next() else {
+            unreachable!("validated ShadowedContext is missing required child unary")
+        };
+        UnaryContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
     }
     pub fn plus_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 11).map(TerminalNode::new)

--- a/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_shared_optional_block_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__multi_alternative_label_shared_optional_block_context.snap
@@ -1,6 +1,6 @@
 ---
 source: src/bin/antlr4-rust-gen.rs
-expression: "context(\"SharedOptionalBlockContext\")"
+expression: "rendered_context_impl(&rendered, \"SharedOptionalBlockContext\")"
 ---
 
     pub fn child_count(&self) -> usize {
@@ -24,6 +24,89 @@ expression: "context(\"SharedOptionalBlockContext\")"
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> SharedOptionalBlockContext<'a, State> {
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 8)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn slash_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 9)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 11)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn minus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 12)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn num_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 14)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn shared(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children_matching(self.__node, &[8, 9, 11, 12])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> SharedOptionalBlockContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
     pub fn star_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 8)
             .next()

--- a/src/bin/snapshots/antlr4_rust_gen__tests__parser_parse_convenience.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__parser_parse_convenience.snap
@@ -15,6 +15,24 @@ where
     pub parser: TParser<L>,
 }
 
+impl<L: TokenSource> TParserParseOutput<antlr4_runtime::NodeId, L> {
+    /// Validates a completed parse and changes its generated context surface.
+    ///
+    /// Validation rejects lexer diagnostics, parser recovery, recovered error
+    /// nodes, and missing generated required children before constructing the
+    /// validated-tree type boundary.
+    pub fn validate(self) -> Result<TValidatedTree, TValidationError> {
+        let lexer = self.parser.token_stream().number_of_source_errors();
+        let parser = self.parser.number_of_syntax_errors();
+        if lexer != 0 || parser != 0 {
+            return Err(TValidationError::SyntaxErrors { lexer, parser });
+        }
+        let parsed = self.parser.into_parsed_file(self.result);
+        validate_tree_structure(&parsed)?;
+        Ok(TValidatedTree::__new(parsed))
+    }
+}
+
 /// Parses UTF-8 text by constructing the lexer, token stream, parser, and
 /// caller-selected entry rule in one call.
 ///
@@ -32,6 +50,21 @@ pub fn parse<L: TokenSource>(
 ) -> Result<antlr4_runtime::ParsedFile, antlr4_runtime::AntlrError>
 {
     parse_stream(antlr4_runtime::InputStream::new(input.as_ref()), lexer, entry)
+}
+
+/// Parses UTF-8 text and returns a typed tree whose required generated child
+/// accessors are infallible.
+pub fn parse_validated<L: TokenSource>(
+    input: impl AsRef<str>,
+    lexer: impl FnOnce(antlr4_runtime::InputStream) -> L,
+    entry: impl FnOnce(&mut TParser<L>) -> Result<antlr4_runtime::NodeId, antlr4_runtime::AntlrError>,
+) -> Result<TValidatedTree, TValidationError>
+{
+    parse_stream_validated(
+        antlr4_runtime::InputStream::new(input.as_ref()),
+        lexer,
+        entry,
+    )
 }
 
 /// Parses UTF-8 text like [`parse`] while returning the parser after the entry
@@ -67,6 +100,18 @@ pub fn parse_stream<I: antlr4_runtime::CharStream, L: TokenSource>(
     let TParserParseOutput { result, parser } =
         parse_stream_with_parser(input, lexer, entry)?;
     Ok(parser.into_parsed_file(result))
+}
+
+/// Parses a caller-provided character stream and validates the completed tree.
+pub fn parse_stream_validated<I: antlr4_runtime::CharStream, L: TokenSource>(
+    input: I,
+    lexer: impl FnOnce(I) -> L,
+    entry: impl FnOnce(&mut TParser<L>) -> Result<antlr4_runtime::NodeId, antlr4_runtime::AntlrError>,
+) -> Result<TValidatedTree, TValidationError>
+{
+    let output = parse_stream_with_parser(input, lexer, entry)
+        .map_err(TValidationError::Recognition)?;
+    output.validate()
 }
 
 /// Parses a caller-provided character stream like [`parse_stream`] while

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_e_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_e_context.snap
@@ -24,6 +24,10 @@ expression: e_context
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> EContext<'a, State> {
     pub fn e_children(&self) -> impl Iterator<Item = EContext<'a>> + '_ {
         __rule_children(self.__node, 1)
             .map(move |node| EContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -52,5 +56,86 @@ expression: e_context
         __rule_children(self.__node, 1)
             .nth(1)
             .map(|node| EContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> EContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        let __default = __RuleAttrs1::default();
+        let __attrs = node.generated_attrs::<__RuleAttrs1>().unwrap_or(&__default);
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+            v: __attrs.v.clone(),
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn e_children(&self) -> impl Iterator<Item = EContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 1)
+            .map(move |node| EContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn int_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 1)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn star_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 2)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn plus_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 3)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn left(&self) -> Option<EContext<'a, ValidatedTreeContext>> {
+        __rule_children(self.__node, 1)
+            .nth(0)
+            .map(|node| EContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn right(&self) -> Option<EContext<'a, ValidatedTreeContext>> {
+        __rule_children(self.__node, 1)
+            .nth(1)
+            .map(|node| EContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_grouped_tokens.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_grouped_tokens.snap
@@ -25,6 +25,10 @@ ExpressionContext
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> ExpressionContext<'a, State> {
     pub fn expression_children(&self) -> impl Iterator<Item = ExpressionContext<'a>> + '_ {
         __rule_children(self.__node, 1)
             .map(move |node| ExpressionContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -33,6 +37,99 @@ ExpressionContext
         __rule_children(self.__node, 4)
             .next()
             .map(|node| IdentifierContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn le_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 1)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn ge_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 2)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn equal_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 3)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn notequal_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 4)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn assign_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 5)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn add_assign_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 6)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn bop(&self) -> Option<TerminalNode<'a>> {
+        __labeled_token_children_matching(self.__node, &[1, 2, 3, 4, 5, 6])
+            .nth(0)
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> ExpressionContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn expression_children(&self) -> impl Iterator<Item = ExpressionContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 1)
+            .map(move |node| ExpressionContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn identifier(&self) -> Option<IdentifierContext<'a, ValidatedTreeContext>> {
+        __rule_children(self.__node, 4)
+            .next()
+            .map(|node| IdentifierContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
     pub fn le_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, 1)
@@ -94,6 +191,77 @@ OperatorSequenceContext
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> OperatorSequenceContext<'a, State> {
+    pub fn le_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 1).map(TerminalNode::new)
+    }
+    pub fn ge_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 2).map(TerminalNode::new)
+    }
+    pub fn equal_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 3).map(TerminalNode::new)
+    }
+    pub fn notequal_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 4).map(TerminalNode::new)
+    }
+    pub fn assign_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 5).map(TerminalNode::new)
+    }
+    pub fn add_assign_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 6).map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> OperatorSequenceContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
     pub fn le_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
         __token_children(self.__node, 1).map(TerminalNode::new)
     }
@@ -137,6 +305,69 @@ EofChoiceContext
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> EofChoiceContext<'a, State> {
+    pub fn eof_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, -1)
+            .next()
+            .map(TerminalNode::new)
+    }
+    pub fn le_token(&self) -> Option<TerminalNode<'a>> {
+        __token_children(self.__node, 1)
+            .next()
+            .map(TerminalNode::new)
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> EofChoiceContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
     pub fn eof_token(&self) -> Option<TerminalNode<'a>> {
         __token_children(self.__node, -1)
             .next()

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_latest_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_latest_context.snap
@@ -24,6 +24,10 @@ expression: latest_context
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> LatestContext<'a, State> {
     pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a>> + '_ {
         __rule_children(self.__node, 2)
             .map(move |node| AtomContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -33,5 +37,69 @@ expression: latest_context
             .skip(0).last()
             .map(|node| AtomContext::__from_child_node(node, self.__invocation_states.as_deref()))
             .ok_or_else(|| MissingChildError::new("LatestContext", "value"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> LatestContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 2)
+            .map(move |node| AtomContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn value(&self) -> AtomContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 2)
+            .skip(0).last()
+        else {
+            unreachable!("validated LatestContext is missing required child value")
+        };
+        AtomContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_many_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_many_context.snap
@@ -24,6 +24,10 @@ expression: many_context
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> ManyLabelContext<'a, State> {
     pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a>> + '_ {
         __rule_children(self.__node, 2)
             .map(move |node| AtomContext::__from_child_node(node, self.__invocation_states.as_deref()))
@@ -35,5 +39,66 @@ expression: many_context
         __rule_children(self.__node, 2)
             .skip(0)
             .map(move |node| AtomContext::__from_child_node(node, self.__invocation_states.as_deref()))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> ManyLabelContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 2)
+            .map(move |node| AtomContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
+    }
+    pub fn comma_tokens(&self) -> impl Iterator<Item = TerminalNode<'a>> + '_ {
+        __token_children(self.__node, 1).map(TerminalNode::new)
+    }
+    pub fn rest(&self) -> impl Iterator<Item = AtomContext<'a, ValidatedTreeContext>> + '_ {
+        __rule_children(self.__node, 2)
+            .skip(0)
+            .map(move |node| AtomContext::<ValidatedTreeContext>::__from_validated_child_node(node, self.__invocation_states.as_deref()))
     }
 }

--- a/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_s_context.snap
+++ b/src/bin/snapshots/antlr4_rust_gen__tests__typed_context_accessors_s_context.snap
@@ -24,6 +24,10 @@ expression: s_context
             __GeneratedRuleContext::Active { context, storage, tokens } => context.text(storage, tokens),
         }
     }
+}
+
+#[allow(dead_code, private_bounds, clippy::all)]
+impl<'a, State: __RecoveryContextState> SContext<'a, State> {
     pub fn e(&self) -> Result<EContext<'a>, MissingChildError> {
         __rule_children(self.__node, 1)
             .next()
@@ -35,5 +39,74 @@ expression: s_context
             .nth(0)
             .map(|node| EContext::__from_child_node(node, self.__invocation_states.as_deref()))
             .ok_or_else(|| MissingChildError::new("SContext", "value"))
+    }
+}
+
+#[allow(dead_code, clippy::all)]
+impl<'a> SContext<'a, ValidatedTreeContext> {
+    fn __from_validated_node(node: RuleNodeView<'a>) -> Self {
+        Self::__from_validated_node_with_invocation_states(node, None)
+    }
+
+    fn __from_validated_child_node(
+        node: RuleNodeView<'a>,
+        parent_invocation_states: Option<&[isize]>,
+    ) -> Self {
+        let invocation_states = parent_invocation_states.map(|states| {
+            let mut invocation_states = Vec::with_capacity(states.len() + 1);
+            invocation_states.push(node.invoking_state());
+            invocation_states.extend_from_slice(states);
+            invocation_states
+        });
+        Self::__from_validated_node_with_invocation_states(node, invocation_states)
+    }
+
+    fn __from_validated_listener_node(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<&[isize]>,
+    ) -> Self {
+        Self::__from_validated_node_with_invocation_states(
+            node,
+            invocation_states.map(|states| states.to_vec()),
+        )
+    }
+
+    fn __from_validated_node_with_invocation_states(
+        node: RuleNodeView<'a>,
+        invocation_states: Option<Vec<isize>>,
+    ) -> Self {
+        Self {
+            __node: __GeneratedRuleContext::Stored(node),
+            __invocation_states: invocation_states,
+            __state: std::marker::PhantomData,
+        }
+    }
+
+    pub fn rule_node(&self) -> RuleNodeView<'a> {
+        match self.__node {
+            __GeneratedRuleContext::Stored(node) => node,
+            __GeneratedRuleContext::Active { .. } => unreachable!("validated context contains an active parser context"),
+        }
+    }
+
+    pub fn e(&self) -> EContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 1).next() else {
+            unreachable!("validated SContext is missing required child e")
+        };
+        EContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
+    }
+    pub fn value(&self) -> EContext<'a, ValidatedTreeContext> {
+        let Some(node) = __rule_children(self.__node, 1)
+            .nth(0)
+        else {
+            unreachable!("validated SContext is missing required child value")
+        };
+        EContext::<ValidatedTreeContext>::__from_validated_child_node(
+            node,
+            self.__invocation_states.as_deref(),
+        )
     }
 }

--- a/src/token_stream.rs
+++ b/src/token_stream.rs
@@ -18,6 +18,7 @@ pub struct CommonTokenStream<S> {
     source: S,
     store: TokenStore,
     source_token_count: usize,
+    source_error_count: usize,
     next_visible_after: Vec<usize>,
     cursor: usize,
     channel: i32,
@@ -94,10 +95,12 @@ where
     pub fn try_with_channel(mut source: S, channel: i32) -> Result<Self, TokenStoreError> {
         let (store, source_errors) = buffer_token_source(&mut source)?;
         let source_token_count = store.len();
+        let source_error_count = source_errors.len();
         let mut stream = Self {
             source,
             store,
             source_token_count,
+            source_error_count,
             next_visible_after: vec![UNKNOWN_NEXT_VISIBLE; source_token_count],
             cursor: 0,
             channel,
@@ -140,6 +143,7 @@ where
         let (store, source_errors) = buffer_token_source(&mut self.source)?;
         self.store = store;
         self.source_token_count = self.store.len();
+        self.source_error_count = source_errors.len();
         self.next_visible_after = vec![UNKNOWN_NEXT_VISIBLE; self.source_token_count];
         self.cursor = self.adjust_seek_index(0);
         self.requested_token_count.set(0);
@@ -228,6 +232,13 @@ where
 
     pub const fn token_count(&self) -> usize {
         self.source_token_count
+    }
+
+    /// Returns the total number of diagnostics emitted while buffering the
+    /// current token source, including diagnostics already delivered through
+    /// [`Self::drain_source_errors`].
+    pub const fn number_of_source_errors(&self) -> usize {
+        self.source_error_count
     }
 
     /// Returns the canonical token store owned by this stream.
@@ -592,12 +603,17 @@ mod tests {
             index: 0,
         });
 
+        assert_eq!(stream.number_of_source_errors(), 1);
         assert!(stream.drain_source_errors().is_empty());
         assert_eq!(stream.token_type_at_index(1), 2);
         assert!(stream.drain_source_errors().is_empty());
 
         assert_eq!(stream.token_type_at_index(2), TOKEN_EOF);
         assert_eq!(stream.drain_source_errors(), vec![suffix_error]);
+        assert_eq!(stream.number_of_source_errors(), 1);
+
+        stream.refill();
+        assert_eq!(stream.number_of_source_errors(), 0);
     }
 
     #[test]
@@ -657,6 +673,7 @@ mod tests {
 
         assert_eq!(stream.channel(), 2);
         assert_eq!(stream.index(), 0);
+        assert_eq!(stream.number_of_source_errors(), 0);
         assert_eq!(stream.la_token(1), 2);
         assert_eq!(stream.text_all(), "new");
     }
@@ -674,6 +691,7 @@ mod tests {
         stream.refill();
 
         assert_eq!(stream.index(), 0);
+        assert_eq!(stream.number_of_source_errors(), 0);
         assert_eq!(stream.la_token(1), 2);
         assert_eq!(stream.text_all(), "new");
     }

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -1815,6 +1815,311 @@ mod token_label_recovery_tests {
 }
 
 #[test]
+fn validated_tree_makes_required_children_infallible_after_full_validation() {
+    let temp = temporary_directory("validated-tree");
+    let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/validated-tree/T.g4");
+    let out = temp.path().join("generated");
+
+    let output = run_antlr4_rust_gen(&[
+        grammar.as_os_str(),
+        OsStr::new("--visitor"),
+        OsStr::new("--out-dir"),
+        out.as_os_str(),
+    ]);
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    let parser = fs::read_to_string(out.join("t_parser.rs")).expect("parser should be emitted");
+    for expected in [
+        "pub struct TValidatedTree",
+        "pub enum TValidationError",
+        "pub fn parse_validated<L: TokenSource>",
+        "pub fn parse_stream_validated<I: antlr4_runtime::CharStream, L: TokenSource>",
+        "pub fn validate(self) -> Result<TValidatedTree, TValidationError>",
+        "pub trait TValidatedListener",
+        "pub trait TValidatedVisitor",
+        "impl<'a> StartContext<'a, ValidatedTreeContext>",
+        "pub fn required_rule(&self) -> RequiredRuleContext<'a, ValidatedTreeContext>",
+        "pub fn bang_token(&self) -> TerminalNode<'a>",
+        "pub fn optional_rule(&self) -> Option<OptionalRuleContext<'a, ValidatedTreeContext>>",
+        "pub fn atom_children(&self) -> impl Iterator<Item = AtomContext<'a, ValidatedTreeContext>>",
+        "let _ = context.required_rule().map_err(TValidationError::MissingChild)?;",
+        "TValidationError::InvalidChildCount",
+    ] {
+        assert!(parser.contains(expected), "missing {expected:?}\n{parser}");
+    }
+
+    assert_generated_project(
+        temp.path(),
+        &["t_lexer.rs", "t_parser.rs"],
+        r#"
+#[cfg(test)]
+mod validated_tree_tests {
+    use std::convert::Infallible;
+
+    use super::t_lexer::TLexer;
+    use super::t_parser::*;
+    use antlr4_runtime::{
+        BaseParser, CommonTokenStream, InputStream, MissingChildError, ParserRuleContext,
+    };
+
+    fn strict(input: &str) -> Result<TValidatedTree, TValidationError> {
+        parse_validated(input, TLexer::new, TParser::start)
+    }
+
+    fn start_context(tree: &TValidatedTree) -> StartContext<'_, ValidatedTreeContext> {
+        tree.tree()
+            .downcast_ref()
+            .expect("validated start context")
+    }
+
+    #[derive(Default)]
+    struct ValidatedTrace {
+        starts: usize,
+        wrapped: usize,
+        bare: usize,
+        atoms: usize,
+    }
+
+    impl TValidatedListener for ValidatedTrace {
+        fn enter_start(
+            &mut self,
+            ctx: &StartContext<ValidatedTreeContext>,
+        ) -> Result<(), Infallible> {
+            self.starts += 1;
+            assert_eq!(ctx.bang_token().to_string(), "!");
+            assert_eq!(ctx.required().text(), "(head)");
+            Ok(())
+        }
+
+        fn enter_wrapped_label(
+            &mut self,
+            ctx: &WrappedLabelContext<ValidatedTreeContext>,
+        ) -> Result<(), Infallible> {
+            self.wrapped += 1;
+            assert_eq!(ctx.id_token().to_string(), "head");
+            Ok(())
+        }
+
+        fn enter_bare_label(
+            &mut self,
+            _ctx: &BareLabelContext<ValidatedTreeContext>,
+        ) -> Result<(), Infallible> {
+            self.bare += 1;
+            Ok(())
+        }
+
+        fn enter_atom(
+            &mut self,
+            ctx: &AtomContext<ValidatedTreeContext>,
+        ) -> Result<(), Infallible> {
+            self.atoms += 1;
+            let _required_token = ctx.id_token();
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct ValidatedVisitor {
+        wrapped: usize,
+        bare: usize,
+        atoms: usize,
+    }
+
+    impl TValidatedVisitor for ValidatedVisitor {
+        type Result = ();
+
+        fn default_result(&mut self) -> Self::Result {}
+
+        fn visit_wrapped_label(
+            &mut self,
+            ctx: &WrappedLabelContext<ValidatedTreeContext>,
+        ) -> Self::Result {
+            self.wrapped += 1;
+            let _required_token = ctx.id_token();
+            self.visit_children(ctx)
+        }
+
+        fn visit_bare_label(
+            &mut self,
+            ctx: &BareLabelContext<ValidatedTreeContext>,
+        ) -> Self::Result {
+            self.bare += 1;
+            let _required_token = ctx.id_token();
+            self.visit_children(ctx)
+        }
+
+        fn visit_atom(
+            &mut self,
+            ctx: &AtomContext<ValidatedTreeContext>,
+        ) -> Self::Result {
+            self.atoms += 1;
+            let _required_token = ctx.id_token();
+        }
+    }
+
+    #[test]
+    fn clean_tree_exposes_direct_required_children_and_typed_traversal() {
+        let validated = strict("(head) [maybe] ! : ? one two").expect("clean parse validates");
+        let start = start_context(&validated);
+
+        assert_eq!(start.required_rule().text(), "(head)");
+        assert_eq!(start.required().text(), "(head)");
+        assert_eq!(
+            start.optional_rule().expect("optional rule").text(),
+            "[maybe]"
+        );
+        assert_eq!(start.optional().expect("optional label").text(), "[maybe]");
+        assert_eq!(start.bang_token().to_string(), "!");
+        assert_eq!(start.bang().to_string(), "!");
+        assert_eq!(start.colon_token().to_string(), ":");
+        assert_eq!(
+            start.question_token().expect("optional token").to_string(),
+            "?"
+        );
+        assert_eq!(start.question().expect("optional label").to_string(), "?");
+        assert_eq!(
+            start
+                .atom_children()
+                .map(|atom| atom.id_token().to_string())
+                .collect::<Vec<_>>(),
+            ["one", "two"]
+        );
+        assert_eq!(
+            start
+                .items()
+                .map(|atom| atom.id_token().to_string())
+                .collect::<Vec<_>>(),
+            ["one", "two"]
+        );
+        assert_eq!(start.eof_token().to_string(), "<EOF>");
+
+        let mut listener = ValidatedTrace::default();
+        listener.walk(validated.tree()).expect("validated walk");
+        assert_eq!(listener.starts, 1);
+        assert_eq!(listener.wrapped, 1);
+        assert_eq!(listener.bare, 0);
+        assert_eq!(listener.atoms, 2);
+
+        let mut visitor = ValidatedVisitor::default();
+        visitor.visit(validated.tree());
+        assert_eq!(visitor.wrapped, 1);
+        assert_eq!(visitor.bare, 0);
+        assert_eq!(visitor.atoms, 2);
+    }
+
+    #[test]
+    fn optional_absence_and_the_other_labeled_alternative_stay_typed() {
+        let validated = strict("head ! : one").expect("clean bare parse validates");
+        let start = start_context(&validated);
+
+        assert!(start.optional_rule().is_none());
+        assert!(start.optional().is_none());
+        assert!(start.question_token().is_none());
+        assert!(start.question().is_none());
+        assert_eq!(start.items().count(), 1);
+
+        let mut visitor = ValidatedVisitor::default();
+        visitor.visit(validated.tree());
+        assert_eq!(visitor.wrapped, 0);
+        assert_eq!(visitor.bare, 1);
+        assert_eq!(visitor.atoms, 1);
+    }
+
+    #[test]
+    fn recovery_and_lexer_errors_cannot_cross_the_type_boundary() {
+        // The first input inserts a missing COLON; the second deletes COMMA.
+        for input in ["head ! one", "head , ! : one"] {
+            let error = parse_with_parser(input, TLexer::new, TParser::start)
+                .expect("ANTLR recovery returns a tree")
+                .validate()
+                .expect_err("recovered parse must not validate");
+            assert!(
+                matches!(
+                    error,
+                    TValidationError::SyntaxErrors {
+                        lexer: 0,
+                        parser: 1..
+                    }
+                ),
+                "{input:?}: {error:?}"
+            );
+
+            let output = parse_with_parser(input, TLexer::new, TParser::start)
+                .expect("ANTLR recovery returns a tree");
+            let TParserParseOutput { result, parser } = output;
+            let recovered = parser.into_parsed_file(result);
+            assert!(
+                matches!(
+                    validate_tree_structure(&recovered),
+                    Err(TValidationError::RecoveredErrorNode { .. })
+                ),
+                "{input:?}"
+            );
+        }
+
+        assert_eq!(
+            strict("head @ ! : one").expect_err("lexer diagnostics must reject validation"),
+            TValidationError::SyntaxErrors {
+                lexer: 1,
+                parser: 0,
+            }
+        );
+
+        assert!(matches!(
+            strict("head : one"),
+            Err(TValidationError::Recognition(_))
+        ));
+    }
+
+    #[test]
+    fn structural_validation_reports_missing_required_children() {
+        let lexer = TLexer::new(InputStream::new(""));
+        let tokens = CommonTokenStream::new(lexer);
+        let data = TParser::<TLexer<InputStream>>::metadata().recognizer_data();
+        let mut parser = BaseParser::new(tokens, data);
+        let root = parser.rule_node(ParserRuleContext::new(0, -1));
+        let malformed = parser.into_parsed_file(root);
+
+        let error =
+            validate_tree_structure(&malformed).expect_err("empty start context must be invalid");
+        assert_eq!(
+            error,
+            TValidationError::MissingChild(MissingChildError::new(
+                "StartContext",
+                "requiredRule",
+            ))
+        );
+        assert_eq!(
+            error.to_string(),
+            "required child requiredRule is missing from StartContext"
+        );
+    }
+
+    #[test]
+    fn recovery_oriented_contexts_keep_fallible_required_accessors() {
+        let parsed = parse("head ! : one", TLexer::new, TParser::start)
+            .expect("clean recovery-oriented parse");
+        let start = parsed
+            .tree()
+            .as_rule()
+            .expect("start rule")
+            .downcast_ref::<StartContext>()
+            .expect("stored start context");
+        let required: Result<RequiredRuleContext<'_>, MissingChildError> =
+            start.required_rule();
+        assert_eq!(required.expect("required child").text(), "head");
+    }
+}
+"#,
+    );
+}
+
+#[test]
 fn compile_parse_tree_pattern_matches_and_binds_against_generated_parser() {
     let temp = temporary_directory("tree-pattern-compile");
     let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/tests/antlr4_rust_gen_cli.rs
+++ b/tests/antlr4_rust_gen_cli.rs
@@ -2101,6 +2101,34 @@ mod validated_tree_tests {
     }
 
     #[test]
+    fn structural_validation_reports_underfilled_repetitions() {
+        let lexer = TLexer::new(InputStream::new("! :"));
+        let tokens = CommonTokenStream::new(lexer);
+        let data = TParser::<TLexer<InputStream>>::metadata().recognizer_data();
+        let mut parser = BaseParser::new(tokens, data);
+        let required_rule = parser.rule_node(ParserRuleContext::new(RULE_REQUIRED_RULE, -1));
+        let bang = parser.match_token(BANG).expect("BANG token");
+        let colon = parser.match_token(COLON).expect("COLON token");
+        let mut root = ParserRuleContext::new(RULE_START, -1);
+        parser.add_parse_child(&mut root, required_rule);
+        parser.add_parse_child(&mut root, bang);
+        parser.add_parse_child(&mut root, colon);
+        let root = parser.rule_node(root);
+        let malformed = parser.into_parsed_file(root);
+
+        assert_eq!(
+            validate_tree_structure(&malformed)
+                .expect_err("start context must contain at least one atom"),
+            TValidationError::InvalidChildCount {
+                context: "StartContext",
+                child: "atom",
+                minimum: 1,
+                actual: 0,
+            }
+        );
+    }
+
+    #[test]
     fn recovery_oriented_contexts_keep_fallible_required_accessors() {
         let parsed = parse("head ! : one", TLexer::new, TParser::start)
             .expect("clean recovery-oriented parse");
@@ -2738,6 +2766,8 @@ fn colliding_rule_and_alternative_label_context_names_compile() {
         "pub struct ObjectCreationExpressionContext<'a, State = StoredTreeContext>",
         "pub struct ObjectCreationExpressionLabelContext<'a, State = StoredTreeContext>",
         "pub struct ParenthesizedLabelContext<'a, State = StoredTreeContext>",
+        "pub struct StoredTreeRuleContext<'a, State = StoredTreeContext>",
+        "pub struct ValidatedTreeRuleContext<'a, State = StoredTreeContext>",
         "fn enter_object_creation_expression(&mut self",
         "fn enter_object_creation_expression_label(&mut self",
         "fn enter_parenthesized_label(&mut self",

--- a/tests/fixtures/antlr4-rust-gen/context-name-collision/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/context-name-collision/T.g4
@@ -22,3 +22,7 @@ everyRule
 storedTree
     : NEW
     ;
+
+validatedTree
+    : NEW
+    ;

--- a/tests/fixtures/antlr4-rust-gen/validated-tree/T.g4
+++ b/tests/fixtures/antlr4-rust-gen/validated-tree/T.g4
@@ -1,0 +1,64 @@
+grammar T;
+
+start
+    : required = requiredRule
+      optional = optionalRule?
+      bang = BANG
+      COLON
+      question = QUESTION?
+      items += atom+
+      EOF
+    ;
+
+requiredRule
+    : ID                 # Bare
+    | LPAREN ID RPAREN   # Wrapped
+    ;
+
+optionalRule
+    : LBRACK ID RBRACK
+    ;
+
+atom
+    : ID
+    ;
+
+BANG
+    : '!'
+    ;
+
+COLON
+    : ':'
+    ;
+
+QUESTION
+    : '?'
+    ;
+
+LPAREN
+    : '('
+    ;
+
+RPAREN
+    : ')'
+    ;
+
+LBRACK
+    : '['
+    ;
+
+RBRACK
+    : ']'
+    ;
+
+COMMA
+    : ','
+    ;
+
+ID
+    : [a-z]+
+    ;
+
+WS
+    : [ \t\r\n]+ -> skip
+    ;


### PR DESCRIPTION
## Summary

- add `parse_validated`, `parse_stream_validated`, and `ParseOutput::validate` as an explicit syntax-clean and structurally valid parse boundary
- generate typestate contexts whose required rule, token, and label accessors are infallible while optional and repeated accessors preserve their grammar cardinality
- generate validated listener and visitor surfaces while keeping the existing recovery-oriented APIs unchanged
- retain lexer diagnostic counts after delivery so validation cannot lose already-drained errors
- keep generated structural validation warning-free for contexts with no required-child checks
- document the validated-tree workflow and cover malformed trees, recovery, cardinality, alternatives, repetitions, and generated-name collisions

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --all-targets --all-features -- -D warnings`
- `cargo test --locked --all-targets --all-features --quiet`
- `RUSTFLAGS='-D warnings' cargo test --locked --all-features --test antlr4_rust_gen_cli token_group_label_shared_across_alternatives_unions_the_sets --quiet`
- `cargo run --release --quiet --bin antlr4-runtime-testsuite` (`357 passed, 0 failed, 0 skipped`)
- `git diff --check origin/main...HEAD`

Closes #239
