### PR TITLE
feat(codegen): expose structured generation diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 ```
 
 `Generation::inputs()` contains every resolved root, import, and token
-vocabulary. `Generation::outputs()` and `Generation::warnings()` expose the
-other build artifacts without process-global CLI state. Projects that commit
-generated source can omit the build dependency and use the command instead.
+vocabulary. `Generation::outputs()` exposes the written artifacts,
+`Generation::diagnostics()` exposes structured compiler warnings with exact
+source byte spans, and `Generation::warnings()` preserves CLI-form compiler and
+generator messages. Projects that commit generated source can omit the build
+dependency and use the command instead.
 
 ### 4. Generate from the command line
 

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -28,6 +28,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
+Successful generations expose structured compiler warnings through
+`Generation::diagnostics()`, including the diagnostic code, severity, source
+path, and exact UTF-8 byte span. `Generation::warnings()` retains the rendered
+CLI messages.
+
 Or install the command:
 
 ```bash

--- a/crates/antlr-rust-codegen/src/artifact.rs
+++ b/crates/antlr-rust-codegen/src/artifact.rs
@@ -3,12 +3,15 @@ use std::fs;
 use std::io;
 use std::path::{Component, Path, PathBuf};
 
+use crate::error::Diagnostic;
+
 /// Inventory returned by a completed generation.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Generation {
     inputs: Vec<PathBuf>,
     outputs: Vec<PathBuf>,
     warnings: Vec<String>,
+    diagnostics: Vec<Diagnostic>,
 }
 
 impl Generation {
@@ -16,11 +19,13 @@ impl Generation {
         inputs: Vec<PathBuf>,
         outputs: Vec<PathBuf>,
         warnings: Vec<String>,
+        diagnostics: Vec<Diagnostic>,
     ) -> Self {
         Self {
             inputs,
             outputs,
             warnings,
+            diagnostics,
         }
     }
 
@@ -34,9 +39,14 @@ impl Generation {
         &self.outputs
     }
 
-    /// Non-fatal compiler and transform diagnostics in CLI display form.
+    /// Non-fatal compiler and generator messages in CLI display form.
     pub fn warnings(&self) -> &[String] {
         &self.warnings
+    }
+
+    /// Structured non-fatal grammar compiler diagnostics.
+    pub fn diagnostics(&self) -> &[Diagnostic] {
+        &self.diagnostics
     }
 
     /// Emits Cargo rebuild directives for the complete resolved input graph.

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -31,7 +31,11 @@ pub(crate) fn generate(
         action_reference_parser,
     )
     .map_err(|error| compilation_error(&error, &args.roots))?;
-    let mut warnings = compilation_warning_messages(&compilation);
+    let diagnostics = compilation_diagnostics(&compilation);
+    let mut warnings = diagnostics
+        .iter()
+        .map(render_diagnostic)
+        .collect::<Vec<_>>();
     for warning in &warnings {
         report(warning).map_err(Error::generation)?;
     }
@@ -58,7 +62,7 @@ pub(crate) fn generate(
             optimization_manifest.expect("report mode enables the optimization manifest"),
         )?;
         let outputs = artifacts.write_to(&args.out_dir)?;
-        return Ok(Generation::new(inputs, outputs, warnings));
+        return Ok(Generation::new(inputs, outputs, warnings, diagnostics));
     }
 
     let mut grammar_options = Vec::new();
@@ -171,7 +175,7 @@ pub(crate) fn generate(
         artifacts.remove_if_present("optimizations.json")?;
     }
     let outputs = artifacts.write_to(&args.out_dir)?;
-    Ok(Generation::new(inputs, outputs, warnings))
+    Ok(Generation::new(inputs, outputs, warnings, diagnostics))
 }
 
 fn insert_rendered_module(
@@ -242,30 +246,57 @@ fn compilation_error(error: &grammar::diagnostic::CompilationError, roots: &[Pat
             diagnostic.message.clone(),
             path,
             position,
+            location.map(|_| source_byte_span(&diagnostic.primary)),
         ));
     }
     Error::compilation(message, diagnostics)
 }
 
-fn compilation_warning_messages(compilation: &grammar::compiler::Compilation) -> Vec<String> {
-    let mut messages = Vec::new();
-    for diagnostic in compilation
+fn compilation_diagnostics(compilation: &grammar::compiler::Compilation) -> Vec<Diagnostic> {
+    compilation
         .diagnostics
         .iter()
         .filter(|diagnostic| diagnostic.severity == grammar::diagnostic::Severity::Warning)
-    {
-        let source = compilation.sources.get(diagnostic.primary.source);
-        let path = source.map_or_else(
-            || "<grammar>".to_owned(),
-            |source| source.logical_path().display().to_string(),
-        );
-        let position = source
-            .and_then(|source| source.line_column(diagnostic.primary.bytes.start))
-            .map_or_else(String::new, |(line, column)| format!(":{line}:{column}"));
-        messages.push(format!(
-            "warning[{}]: {path}{position}: {}",
-            diagnostic.code, diagnostic.message
-        ));
-    }
-    messages
+        .map(|diagnostic| {
+            let path = compilation
+                .sources
+                .logical_path(diagnostic.primary.source)
+                .map(Path::to_path_buf);
+            let byte_span = path.as_ref().map(|_| source_byte_span(&diagnostic.primary));
+            let path = path.unwrap_or_else(|| PathBuf::from("<grammar>"));
+            let position = compilation
+                .sources
+                .line_column(diagnostic.primary.source, diagnostic.primary.bytes.start);
+            Diagnostic::new(
+                diagnostic.code,
+                Severity::Warning,
+                diagnostic.message.clone(),
+                path,
+                position,
+                byte_span,
+            )
+        })
+        .collect()
+}
+
+fn render_diagnostic(diagnostic: &Diagnostic) -> String {
+    let severity = match diagnostic.severity() {
+        Severity::Warning => "warning",
+        Severity::Error => "error",
+    };
+    let position = diagnostic
+        .line()
+        .zip(diagnostic.column())
+        .map_or_else(String::new, |(line, column)| format!(":{line}:{column}"));
+    format!(
+        "{severity}[{}]: {}{position}: {}",
+        diagnostic.code(),
+        diagnostic.path().display(),
+        diagnostic.message()
+    )
+}
+
+fn source_byte_span(span: &SourceSpan) -> std::ops::Range<usize> {
+    usize::try_from(span.bytes.start).expect("source offset exceeds usize")
+        ..usize::try_from(span.bytes.end).expect("source offset exceeds usize")
 }

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -231,6 +231,9 @@ fn compilation_error(error: &grammar::diagnostic::CompilationError, roots: &[Pat
         let path =
             location.map_or_else(|| fallback.to_path_buf(), |location| location.path.clone());
         let position = location.and_then(|location| location.position);
+        let primary = diagnostic.primary_source_span();
+        let structured_position = primary.and(position);
+        let byte_span = location.and(primary).map(source_byte_span);
         let display_position =
             position.map_or_else(String::new, |(line, column)| format!(":{line}:{column}"));
         let _ = writeln!(
@@ -245,8 +248,8 @@ fn compilation_error(error: &grammar::diagnostic::CompilationError, roots: &[Pat
             severity,
             diagnostic.message.clone(),
             path,
-            position,
-            location.map(|_| source_byte_span(&diagnostic.primary)),
+            structured_position,
+            byte_span,
         ));
     }
     Error::compilation(message, diagnostics)
@@ -258,15 +261,17 @@ fn compilation_diagnostics(compilation: &grammar::compiler::Compilation) -> Vec<
         .iter()
         .filter(|diagnostic| diagnostic.severity == grammar::diagnostic::Severity::Warning)
         .map(|diagnostic| {
-            let path = compilation
-                .sources
-                .logical_path(diagnostic.primary.source)
+            let primary = diagnostic.primary_source_span();
+            let path = primary
+                .and_then(|span| compilation.sources.logical_path(span.source))
                 .map(Path::to_path_buf);
-            let byte_span = path.as_ref().map(|_| source_byte_span(&diagnostic.primary));
+            let byte_span = primary.filter(|_| path.is_some()).map(source_byte_span);
             let path = path.unwrap_or_else(|| PathBuf::from("<grammar>"));
-            let position = compilation
-                .sources
-                .line_column(diagnostic.primary.source, diagnostic.primary.bytes.start);
+            let position = primary.and_then(|span| {
+                compilation
+                    .sources
+                    .line_column(span.source, span.bytes.start)
+            });
             Diagnostic::new(
                 diagnostic.code,
                 Severity::Warning,

--- a/crates/antlr-rust-codegen/src/error.rs
+++ b/crates/antlr-rust-codegen/src/error.rs
@@ -20,7 +20,7 @@ pub enum Severity {
     Error,
 }
 
-/// A located grammar compiler diagnostic.
+/// A grammar compiler diagnostic.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Diagnostic {
     code: &'static str,
@@ -77,6 +77,8 @@ impl Diagnostic {
     }
 
     /// Half-open UTF-8 byte range of the primary subject within [`Self::path`].
+    ///
+    /// Returns `None` when the diagnostic has no source-backed primary subject.
     pub fn byte_span(&self) -> Option<Range<usize>> {
         self.byte_span.clone()
     }

--- a/crates/antlr-rust-codegen/src/error.rs
+++ b/crates/antlr-rust-codegen/src/error.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
 
 /// Broad category of a generator failure.
@@ -28,6 +29,7 @@ pub struct Diagnostic {
     path: PathBuf,
     line: Option<usize>,
     column: Option<usize>,
+    byte_span: Option<Range<usize>>,
 }
 
 impl Diagnostic {
@@ -37,6 +39,7 @@ impl Diagnostic {
         message: String,
         path: PathBuf,
         position: Option<(usize, usize)>,
+        byte_span: Option<Range<usize>>,
     ) -> Self {
         Self {
             code,
@@ -45,6 +48,7 @@ impl Diagnostic {
             path,
             line: position.map(|(line, _)| line),
             column: position.map(|(_, column)| column),
+            byte_span,
         }
     }
 
@@ -70,6 +74,11 @@ impl Diagnostic {
 
     pub const fn column(&self) -> Option<usize> {
         self.column
+    }
+
+    /// Half-open UTF-8 byte range of the primary subject within [`Self::path`].
+    pub fn byte_span(&self) -> Option<Range<usize>> {
+        self.byte_span.clone()
     }
 }
 

--- a/crates/antlr-rust-codegen/src/grammar/compiler.rs
+++ b/crates/antlr-rust-codegen/src/grammar/compiler.rs
@@ -116,14 +116,11 @@ pub(crate) fn compile_with_action_reference_parser(
                     && unit.kind == GrammarKind::Parser
             })
             .or_else(|| integrated.grammar.units.first())
-            .map_or_else(
-                || super::frontend::SourceSpan::empty(super::frontend::SourceId::new(0)),
-                |unit| unit.span.clone(),
-            );
+            .map(|unit| unit.span.clone());
         let diagnostics = unknown_entries
             .into_iter()
             .map(|entry| {
-                Diagnostic::error(
+                Diagnostic::error_with_optional_span(
                     "G4S079",
                     span.clone(),
                     format!("configured parser entry rule {entry} is not defined"),

--- a/crates/antlr-rust-codegen/src/grammar/diagnostic.rs
+++ b/crates/antlr-rust-codegen/src/grammar/diagnostic.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use super::frontend::SourceSpan;
+use super::frontend::{SourceId, SourceSpan};
 use super::source::SourceSet;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -22,6 +22,7 @@ pub(crate) struct Diagnostic {
     pub(crate) severity: Severity,
     pub(crate) message: String,
     pub(crate) primary: SourceSpan,
+    primary_is_source_backed: bool,
     pub(crate) related: Vec<RelatedDiagnostic>,
 }
 
@@ -36,7 +37,30 @@ impl Diagnostic {
             severity: Severity::Error,
             message: message.into(),
             primary,
+            primary_is_source_backed: true,
             related: Vec::new(),
+        }
+    }
+
+    pub(crate) fn unlocated_error(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            severity: Severity::Error,
+            message: message.into(),
+            primary: SourceSpan::empty(SourceId::new(0)),
+            primary_is_source_backed: false,
+            related: Vec::new(),
+        }
+    }
+
+    pub(crate) fn error_with_optional_span(
+        code: &'static str,
+        primary: Option<SourceSpan>,
+        message: impl Into<String>,
+    ) -> Self {
+        match primary {
+            Some(primary) => Self::error(code, primary, message),
+            None => Self::unlocated_error(code, message),
         }
     }
 
@@ -50,8 +74,13 @@ impl Diagnostic {
             severity: Severity::Warning,
             message: message.into(),
             primary,
+            primary_is_source_backed: true,
             related: Vec::new(),
         }
+    }
+
+    pub(crate) fn primary_source_span(&self) -> Option<&SourceSpan> {
+        self.primary_is_source_backed.then_some(&self.primary)
     }
 
     #[must_use]

--- a/crates/antlr-rust-codegen/src/grammar/loader.rs
+++ b/crates/antlr-rust-codegen/src/grammar/loader.rs
@@ -96,9 +96,8 @@ impl Loader {
 
     fn run(&mut self) {
         if self.options.roots.is_empty() {
-            self.diagnostics.push(Diagnostic::error(
+            self.diagnostics.push(Diagnostic::unlocated_error(
                 "G4L001",
-                SourceSpan::empty(SourceId::new(0)),
                 "at least one grammar root is required",
             ));
             return;
@@ -142,9 +141,8 @@ impl Loader {
         let canonical = match fs::canonicalize(path) {
             Ok(path) => path,
             Err(error) => {
-                self.diagnostics.push(Diagnostic::error(
+                self.diagnostics.push(Diagnostic::unlocated_error(
                     "G4L002",
-                    SourceSpan::empty(SourceId::new(0)),
                     format!("cannot open grammar {}: {error}", path.display()),
                 ));
                 return None;
@@ -159,9 +157,8 @@ impl Loader {
         }) {
             Ok(input) => input,
             Err(error) => {
-                self.diagnostics.push(Diagnostic::error(
+                self.diagnostics.push(Diagnostic::unlocated_error(
                     "G4L002",
-                    SourceSpan::empty(SourceId::new(0)),
                     format!("cannot read grammar {}: {error}", canonical.display()),
                 ));
                 return None;

--- a/crates/antlr-rust-codegen/src/grammar/semantics.rs
+++ b/crates/antlr-rust-codegen/src/grammar/semantics.rs
@@ -839,11 +839,11 @@ fn import_dependency(
             if let Some(vocabulary) = compiled.get(grammar) {
                 destination.import(vocabulary);
             } else {
-                let span = dependency.declaration.as_ref().map_or_else(
-                    || SourceSpan::empty(SourceId::new(0)),
-                    |declaration| declaration.span.clone(),
-                );
-                diagnostics.push(Diagnostic::error(
+                let span = dependency
+                    .declaration
+                    .as_ref()
+                    .map(|declaration| declaration.span.clone());
+                diagnostics.push(Diagnostic::error_with_optional_span(
                     "G4S027",
                     span,
                     format!(
@@ -853,14 +853,14 @@ fn import_dependency(
             }
         }
         IntegratedVocabularySource::TokensFile(path) => {
-            let span = dependency.declaration.as_ref().map_or_else(
-                || SourceSpan::empty(SourceId::new(0)),
-                |declaration| declaration.span.clone(),
-            );
+            let span = dependency
+                .declaration
+                .as_ref()
+                .map(|declaration| declaration.span.clone());
             let text = match fs::read_to_string(path) {
                 Ok(text) => text,
                 Err(error) => {
-                    diagnostics.push(Diagnostic::error(
+                    diagnostics.push(Diagnostic::error_with_optional_span(
                         "G4S028",
                         span,
                         format!("cannot read token vocabulary {}: {error}", path.display()),
@@ -879,7 +879,7 @@ fn import_dependency(
                     continue;
                 }
                 let Some((name, number)) = line.rsplit_once('=') else {
-                    diagnostics.push(Diagnostic::error(
+                    diagnostics.push(Diagnostic::error_with_optional_span(
                         "G4S029",
                         span.clone(),
                         format!(
@@ -894,7 +894,7 @@ fn import_dependency(
                 let number = match number.trim().parse::<i32>() {
                     Ok(number) if number > INVALID_TOKEN_TYPE => number,
                     _ => {
-                        diagnostics.push(Diagnostic::error(
+                        diagnostics.push(Diagnostic::error_with_optional_span(
                             "G4S029",
                             span.clone(),
                             format!(
@@ -911,7 +911,7 @@ fn import_dependency(
                 } else if is_identifier(name) {
                     destination.define_name(name, Some(number), None, ids);
                 } else {
-                    diagnostics.push(Diagnostic::error(
+                    diagnostics.push(Diagnostic::error_with_optional_span(
                         "G4S029",
                         span.clone(),
                         format!(

--- a/crates/antlr-rust-codegen/src/grammar/snapshots/antlr_rust_codegen__grammar__semantics__tests__cross_rule_alternative_label_diagnostic.snap
+++ b/crates/antlr-rust-codegen/src/grammar/snapshots/antlr_rust_codegen__grammar__semantics__tests__cross_rule_alternative_label_diagnostic.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/antlr-rust-codegen/src/grammar/semantics.rs
-assertion_line: 3282
 expression: error.diagnostics()
 ---
 [
@@ -14,6 +13,7 @@ expression: error.diagnostics()
             ),
             bytes: 95..101,
         },
+        primary_is_source_backed: true,
         related: [
             RelatedDiagnostic {
                 span: SourceSpan {

--- a/crates/antlr-rust-codegen/src/grammar/validation.rs
+++ b/crates/antlr-rust-codegen/src/grammar/validation.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeSet;
 
 use super::diagnostic::Diagnostic;
-use super::frontend::{SourceId, SourceSpan};
+use super::frontend::SourceSpan;
 use super::model::{Block, ElementKind, ModelNodeId};
 use super::transform::TransformGrammar;
 
@@ -84,11 +84,8 @@ pub(crate) fn validate_model(grammar: &TransformGrammar) -> Result<(), Diagnosti
         .iter()
         .find(|node| grammar.provenance.origins(**node).is_empty())
     {
-        let span = grammar.units.first().map_or_else(
-            || SourceSpan::empty(SourceId::new(0)),
-            |unit| unit.span.clone(),
-        );
-        return Err(Diagnostic::error(
+        let span = grammar.units.first().map(|unit| unit.span.clone());
+        return Err(Diagnostic::error_with_optional_span(
             "G4T904",
             span,
             format!("model node {node:?} has no provenance"),

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/multi_recognizer.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/multi_recognizer.rs
@@ -132,6 +132,34 @@ mod generated_source_without_codegen_dependency {
 }
 
 #[test]
+fn builder_does_not_fabricate_spans_for_unreadable_later_roots() {
+    let temp = temporary_directory("builder-unlocated-diagnostic");
+    let loaded = temp.path().join("Loaded.g4");
+    let missing = temp.path().join("Missing.g4");
+    fs::write(&loaded, "lexer grammar Loaded;\nA: 'a';\n")
+        .expect("first grammar should be writable");
+
+    let error = Builder::new()
+        .grammar(&loaded)
+        .grammar(&missing)
+        .out_dir(temp.path().join("generated"))
+        .generate()
+        .expect_err("missing grammar root should fail");
+    let diagnostic = error
+        .diagnostics()
+        .iter()
+        .find(|diagnostic| diagnostic.code() == "G4L002")
+        .expect("missing root should produce G4L002");
+
+    assert!(
+        diagnostic.byte_span().is_none(),
+        "unlocated diagnostic must not borrow the first grammar's span: {diagnostic:#?}"
+    );
+    assert_eq!(diagnostic.line(), None);
+    assert_eq!(diagnostic.column(), None);
+}
+
+#[test]
 fn builder_exposes_structured_non_fatal_diagnostics_with_exact_spans() {
     let temp = temporary_directory("builder-structured-diagnostics");
     let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/multi_recognizer.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/multi_recognizer.rs
@@ -59,6 +59,7 @@ fn builder_and_cli_share_artifacts_warnings_and_structured_diagnostics() {
         [grammar.canonicalize().expect("grammar")]
     );
     assert!(generation.warnings().is_empty());
+    assert!(generation.diagnostics().is_empty());
     assert_generated_project(
         temp.path(),
         &["parity_lexer.rs", "parity_parser.rs"],
@@ -128,6 +129,47 @@ mod generated_source_without_codegen_dependency {
         assert!(stderr.contains(diagnostic.code()), "{stderr}");
         assert!(stderr.contains(diagnostic.message()), "{stderr}");
     }
+}
+
+#[test]
+fn builder_exposes_structured_non_fatal_diagnostics_with_exact_spans() {
+    let temp = temporary_directory("builder-structured-diagnostics");
+    let grammar = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/unreachable-rules/Reachability.g4");
+    let source = fs::read_to_string(&grammar).expect("fixture grammar should be readable");
+    let generation = Builder::new()
+        .grammar(&grammar)
+        .out_dir(temp.path().join("generated"))
+        .generate()
+        .expect("unreachable rules should remain non-fatal");
+
+    let unreachable = generation
+        .diagnostics()
+        .iter()
+        .filter(|diagnostic| diagnostic.code() == "G4S078")
+        .map(|diagnostic| {
+            assert_eq!(diagnostic.path(), grammar);
+            let span = diagnostic
+                .byte_span()
+                .expect("authored diagnostics should retain their source span");
+            let subject = source
+                .get(span.clone())
+                .expect("diagnostic span should be a valid UTF-8 source range");
+            (
+                diagnostic.code(),
+                diagnostic.severity(),
+                diagnostic.line(),
+                diagnostic.column(),
+                span,
+                subject,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    insta::assert_debug_snapshot!(
+        "builder_structured_non_fatal_diagnostics_with_exact_spans",
+        unreachable
+    );
 }
 
 #[test]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__multi_recognizer__builder_structured_non_fatal_diagnostics_with_exact_spans.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__multi_recognizer__builder_structured_non_fatal_diagnostics_with_exact_spans.snap
@@ -1,0 +1,30 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/multi_recognizer.rs
+expression: unreachable
+---
+[
+    (
+        "G4S078",
+        Warning,
+        Some(
+            28,
+        ),
+        Some(
+            0,
+        ),
+        183..191,
+        "deadRoot",
+    ),
+    (
+        "G4S078",
+        Warning,
+        Some(
+            32,
+        ),
+        Some(
+            0,
+        ),
+        220..230,
+        "deadHelper",
+    ),
+]


### PR DESCRIPTION
## Summary

- expose successful grammar compiler warnings through `Generation::diagnostics()`
- preserve each source-backed `Diagnostic` primary subject as an exact half-open UTF-8 byte span
- keep source-less diagnostics unlocated instead of fabricating a span from a fallback `SourceId`
- keep `antlr4-rust-gen` stderr and `Generation::warnings()` unchanged
- document and test code-based `G4S078` rule-name recovery through `Builder`

## Why

Library consumers could previously inspect structured diagnostics only when generation failed. Successful analysis warnings were reduced to CLI display strings, forcing callers to parse prose to recover subjects such as unreachable parser rule names.

The successful and failed paths now share the same public diagnostic shape, so callers can filter by code and slice the reported source path at `byte_span()`. Internal diagnostics also record whether their primary span came from source text: source-less loader and invariant errors return `None` for structured coordinates even when their synthetic fallback `SourceId` happens to resolve.

Closes #293

## Compatibility

This changes only the `antlr-rust-codegen` library API. Generated Rust and the runtime interface are unchanged, so the generated-code API revision remains unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Generation results now expose structured compiler and generator diagnostics.
  * Diagnostics include severity, source location, diagnostic codes, and precise UTF-8 byte spans.
  * Warnings remain available as rendered command-line messages.

* **Documentation**
  * Updated build-time generation documentation to clarify the distinction between inputs, outputs, structured diagnostics, and warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
