### PR TITLE
refactor(codegen)!: parse CLI with clap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
   `antlr-rust-codegen` package. Install the binary from that package or add it
   as a build dependency and use `Builder`; generated/runtime API revision 3 is
   unchanged.
+* Replace `antlr4-rust-gen`'s handwritten argument parser with `clap` and remove
+  the ANTLR-style `-listener`, `-no-listener`, `-visitor`, and `-no-visitor`
+  spellings. Use the corresponding double-dash options.
 
 ## [0.28.0](https://github.com/ophi-dev/antlr-rust-runtime/compare/v0.27.0...v0.28.0) (2026-08-04)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,12 +3,19 @@
 version = 4
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "antlr-rust-codegen"
 version = "0.28.0"
 dependencies = [
  "antlr-rust-g4-parser",
  "antlr-rust-rs-parser",
  "antlr-rust-runtime",
+ "clap",
  "hmac-sha256",
  "icu_casemap",
  "icu_properties",
@@ -86,6 +93,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "clap"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
 name = "displaydoc"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +207,12 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hmac-sha256"
@@ -419,7 +471,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -454,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.0"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fac314a64dc9a36e61a9eb4261a5e9bbfbc922b27e518af97bc32b926cf967"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -516,7 +574,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.0",
+ "syn 3.0.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,14 +31,9 @@ antlr-rust-g4-parser = { path = "crates/antlr-rust-g4-parser", version = "=0.28.
 antlr-rust-rs-parser = { path = "crates/antlr-rust-rs-parser", version = "=0.28.0" }
 antlr-rust-codegen = { path = "crates/antlr-rust-codegen", version = "=0.28.0" }
 # x-release-please-end
-hmac-sha256 = "1"
-icu_casemap = "2.2.0"
 icu_properties = { version = "2.2.0", features = ["alloc"] }
 insta = { version = "1", default-features = false }
-intl = { version = "0.6.0", default-features = false, features = ["full", "normalization"] }
 memchr = "2"
-petgraph = { version = "0.8.3", default-features = false, features = ["std"] }
-stacker = "0.1.24"
 thiserror = "2"
 
 [workspace.lints.rust]

--- a/README.md
+++ b/README.md
@@ -240,9 +240,7 @@ with `--visitor`, `<Grammar>ValidatedVisitor` traits traverse this surface
 without `MissingChildError` plumbing. The original listener, visitor, and
 `ParsedFile` context APIs remain recovery-oriented and fallible.
 
-`--no-visitor` disables visitor generation. The generator also accepts ANTLR's
-single-dash spellings (`-listener`, `-no-listener`, `-visitor`,
-`-no-visitor`).
+`--no-visitor` disables visitor generation.
 
 Call the generated parser helper for the compact path:
 

--- a/crates/antlr-rust-codegen/Cargo.toml
+++ b/crates/antlr-rust-codegen/Cargo.toml
@@ -26,14 +26,24 @@ path = "src/bin/antlr4-rust-gen.rs"
 antlr-rust-runtime.workspace = true
 antlr-rust-g4-parser.workspace = true
 antlr-rust-rs-parser.workspace = true
-icu_casemap.workspace = true
+clap = { version = "4.6.5", default-features = false, features = [
+    "cargo",
+    "derive",
+    "env",
+    "error-context",
+    "help",
+    "std",
+    "suggestions",
+    "usage",
+] }
+icu_casemap = "2.2.0"
 icu_properties.workspace = true
-intl.workspace = true
-petgraph.workspace = true
+intl = { version = "0.6.0", default-features = false, features = ["full", "normalization"] }
+petgraph = { version = "0.8.3", default-features = false, features = ["std"] }
 thiserror.workspace = true
 
 [dev-dependencies]
-hmac-sha256.workspace = true
+hmac-sha256 = "1"
 insta.workspace = true
 memchr.workspace = true
 

--- a/crates/antlr-rust-codegen/src/builder.rs
+++ b/crates/antlr-rust-codegen/src/builder.rs
@@ -1,16 +1,19 @@
 use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 
+use clap::ValueEnum;
+
 use crate::artifact::Generation;
-use crate::cli::CompilerConfig;
+use crate::config::CompilerConfig;
 use crate::driver;
 use crate::error::Error;
+use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
 use crate::semantics::{
     SemPatternFile, SemUnknownPolicy, load_sem_patterns, normalize_option_hook,
 };
 
 /// How grammar action and predicate bodies are interpreted.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum ActionMode {
     #[default]
     Templates,
@@ -18,13 +21,24 @@ pub enum ActionMode {
 }
 
 /// Runtime policy for semantic coordinates that cannot be translated.
-#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, ValueEnum)]
 pub enum UnknownSemanticPolicy {
     #[default]
     AssumeTrue,
     AssumeFalse,
     Hook,
     Error,
+}
+
+impl UnknownSemanticPolicy {
+    pub(crate) const fn into_internal(self) -> SemUnknownPolicy {
+        match self {
+            Self::AssumeTrue => SemUnknownPolicy::AssumeTrue,
+            Self::AssumeFalse => SemUnknownPolicy::AssumeFalse,
+            Self::Hook => SemUnknownPolicy::Hook,
+            Self::Error => SemUnknownPolicy::Error,
+        }
+    }
 }
 
 /// Configures grammar compilation and Rust source generation.
@@ -191,7 +205,7 @@ impl Builder {
         }
         if self
             .fixed_lookahead
-            .is_some_and(|depth| !(1..=8).contains(&depth))
+            .is_some_and(|depth| !(1..=usize::from(MAX_FIXED_LOOKAHEAD_FLAG)).contains(&depth))
         {
             return Err(Error::configuration(
                 "fixed lookahead must be between 1 and 8",
@@ -212,12 +226,7 @@ impl Builder {
             out_dir: output_directory,
             require_generated_parser: self.require_generated_parser,
             allow_unsupported_lexer_actions: self.allow_unsupported_lexer_actions,
-            sem_unknown: match self.semantic_policy {
-                UnknownSemanticPolicy::AssumeTrue => SemUnknownPolicy::AssumeTrue,
-                UnknownSemanticPolicy::AssumeFalse => SemUnknownPolicy::AssumeFalse,
-                UnknownSemanticPolicy::Hook => SemUnknownPolicy::Hook,
-                UnknownSemanticPolicy::Error => SemUnknownPolicy::Error,
-            },
+            sem_unknown: self.semantic_policy.into_internal(),
             sem_patterns: semantic_patterns,
             sem_patterns_path: semantic_patterns_path,
             require_full_semantics: self.require_full_semantics,

--- a/crates/antlr-rust-codegen/src/cli.rs
+++ b/crates/antlr-rust-codegen/src/cli.rs
@@ -1,250 +1,200 @@
-use std::collections::BTreeSet;
-use std::env;
 use std::io::{self, Write as _};
 use std::path::PathBuf;
 
+use clap::{ArgAction, Parser};
+
+use crate::builder::{ActionMode, UnknownSemanticPolicy};
+use crate::config::CompilerConfig;
 use crate::driver::generate;
 use crate::error::Error;
 use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
-use crate::semantics::{
-    SemPatternFile, SemUnknownPolicy, load_sem_patterns, normalize_option_hook,
-};
+use crate::semantics::{SemPatternFile, load_sem_patterns, normalize_option_hook};
 
 pub(crate) fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
-    let args = match CompilerConfig::parse_from(env::args().skip(1))? {
-        CliCommand::Generate(args) => *args,
-        CliCommand::Help => {
-            let mut stdout = io::stdout().lock();
-            writeln!(stdout, "{}", usage())?;
-            return Ok(());
-        }
-        CliCommand::Version => {
-            let mut stdout = io::stdout().lock();
-            writeln!(stdout, "antlr4-rust-gen {}", env!("CARGO_PKG_VERSION"))?;
-            return Ok(());
-        }
-    };
+    let args = CliArgs::parse().into_config()?;
     let mut stderr = io::stderr().lock();
     generate(&args, |message| writeln!(stderr, "{message}")).map_err(Error::into_io_error)?;
     Ok(())
 }
 
-#[derive(Debug)]
-pub(crate) struct CompilerConfig {
-    pub(crate) roots: Vec<PathBuf>,
-    pub(crate) library_directories: Vec<PathBuf>,
-    pub(crate) out_dir: PathBuf,
-    pub(crate) require_generated_parser: bool,
-    pub(crate) allow_unsupported_lexer_actions: bool,
-    pub(crate) sem_unknown: SemUnknownPolicy,
-    pub(crate) sem_patterns: SemPatternFile,
-    pub(crate) sem_patterns_path: Option<PathBuf>,
-    pub(crate) require_full_semantics: bool,
-    pub(crate) option_hooks: BTreeSet<String>,
-    pub(crate) generate_listener: bool,
-    pub(crate) generate_visitor: bool,
-    /// `--actions embedded`: the grammar contains real Rust action/predicate
-    /// bodies (rendered through a `.test.stg`); splice them verbatim after
-    /// `$`-attribute translation instead of recognizing template markup.
-    pub(crate) embedded_actions: bool,
-    /// `--fixed-lookahead <k>`: compile decisions whose alternatives are
-    /// pairwise disjoint within `k` tokens of lookahead into static dispatch
-    /// tables instead of adaptive prediction. `None` keeps the default
-    /// routing (Java parity).
-    pub(crate) fixed_lookahead: Option<usize>,
-    /// Parser entry rules configured for reachability diagnostics and pruning.
-    pub(crate) entry_rules: BTreeSet<String>,
-    /// Remove parser rules unreachable from every inferred/configured entry.
-    pub(crate) prune_unreachable: bool,
-    /// Recognition-preserving source rewrite from issue #225.
-    pub(crate) optimize_precedence_ladders: bool,
-    /// Analyze the same pass on a shadow model and emit only its manifest.
-    pub(crate) report_precedence_ladders: bool,
+#[derive(Debug, Parser)]
+#[command(
+    name = "antlr4-rust-gen",
+    version = clap::crate_version!(),
+    about = clap::crate_description!(),
+    args_override_self = true
+)]
+struct CliArgs {
+    /// ANTLR grammar roots to compile.
+    #[arg(value_name = "ROOT.g4", required = true)]
+    roots: Vec<PathBuf>,
+
+    /// Add an import/token-vocabulary lookup directory.
+    #[arg(short = 'I', long = "lib", value_name = "DIR")]
+    library_directories: Vec<PathBuf>,
+
+    /// Write generated Rust files to this directory.
+    #[arg(long, value_name = "DIR", default_value = ".")]
+    out_dir: PathBuf,
+
+    /// Require generated bodies for every parser rule.
+    #[arg(long)]
+    require_generated_parser: bool,
+
+    /// Ignore unsupported lexer actions.
+    #[arg(long)]
+    allow_unsupported_lexer_actions: bool,
+
+    /// Generate the typed listener and walker (default).
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        overrides_with = "no_listener"
+    )]
+    listener: bool,
+
+    /// Do not generate the typed listener or walker.
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        overrides_with = "listener"
+    )]
+    no_listener: bool,
+
+    /// Generate the typed visitor.
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        overrides_with = "no_visitor"
+    )]
+    visitor: bool,
+
+    /// Do not generate the typed visitor (default).
+    #[arg(
+        long,
+        action = ArgAction::SetTrue,
+        overrides_with = "visitor"
+    )]
+    no_visitor: bool,
+
+    /// Choose how grammar action and predicate bodies are interpreted.
+    #[arg(long, value_enum, default_value = "templates")]
+    actions: ActionMode,
+
+    /// Choose the unsupported semantic predicate policy.
+    #[arg(long, value_enum, default_value = "assume-true")]
+    sem_unknown: UnknownSemanticPolicy,
+
+    /// Load semantic helper patterns.
+    #[arg(long, value_name = "FILE")]
+    sem_patterns: Option<PathBuf>,
+
+    /// Acknowledge an option implemented by caller hooks.
+    #[arg(
+        long = "option-hook",
+        value_name = "KEY=VALUE",
+        value_parser = normalize_option_hook,
+        allow_hyphen_values = true
+    )]
+    option_hooks: Vec<String>,
+
+    /// Fail if any semantic coordinate or option is unsupported.
+    #[arg(long)]
+    require_full_semantics: bool,
+
+    /// Compile decisions provable within K tokens into static dispatch tables.
+    #[arg(
+        long,
+        value_name = "K",
+        value_parser = clap::value_parser!(u8)
+            .range(1..=i64::from(MAX_FIXED_LOOKAHEAD_FLAG))
+    )]
+    fixed_lookahead: Option<u8>,
+
+    /// Declare a parser entry rule by bare name (repeatable).
+    #[arg(long = "entry-rule", value_name = "NAME")]
+    entry_rules: Vec<String>,
+
+    /// Remove parser rules unreachable from every entry rule.
+    #[arg(long)]
+    prune_unreachable: bool,
+
+    /// Collapse proven linear precedence ladders (changes tree/API).
+    #[arg(long, conflicts_with = "report_precedence_ladders")]
+    optimize_precedence_ladders: bool,
+
+    /// Dry-run precedence-ladder analysis and emit only optimizations.json.
+    #[arg(long, conflicts_with = "optimize_precedence_ladders")]
+    report_precedence_ladders: bool,
 }
 
-enum CliCommand {
-    Generate(Box<CompilerConfig>),
-    Help,
-    Version,
-}
-
-impl CompilerConfig {
-    fn parse_from(arguments: impl IntoIterator<Item = String>) -> Result<CliCommand, String> {
-        let mut roots = Vec::new();
-        let mut library_directories = Vec::new();
-        let mut out_dir = None;
-        let mut require_generated_parser = false;
-        let mut allow_unsupported_lexer_actions = false;
-        let mut embedded_actions = false;
-        let mut sem_unknown = SemUnknownPolicy::default();
-        let mut sem_patterns = SemPatternFile::default();
-        let mut sem_patterns_path = None;
-        let mut require_full_semantics = false;
-        let mut option_hooks = BTreeSet::new();
-        let mut generate_listener = true;
-        let mut generate_visitor = false;
-        let mut fixed_lookahead = None;
-        let mut entry_rules = BTreeSet::new();
-        let mut prune_unreachable = false;
-        let mut optimize_precedence_ladders = false;
-        let mut report_precedence_ladders = false;
-        let mut positional_only = false;
-
-        let mut iter = arguments.into_iter();
-        while let Some(arg) = iter.next() {
-            if positional_only {
-                roots.push(PathBuf::from(arg));
-                continue;
-            }
-            match arg.as_str() {
-                "--" => positional_only = true,
-                "-I" | "--lib" => {
-                    library_directories.push(PathBuf::from(next_arg(&mut iter, &arg)?));
-                }
-                "--out-dir" => out_dir = Some(PathBuf::from(next_arg(&mut iter, "--out-dir")?)),
-                "--require-generated-parser" => require_generated_parser = true,
-                "--allow-unsupported-lexer-actions" => allow_unsupported_lexer_actions = true,
-                "-listener" | "--listener" => generate_listener = true,
-                "-no-listener" | "--no-listener" => generate_listener = false,
-                "-visitor" | "--visitor" => generate_visitor = true,
-                "-no-visitor" | "--no-visitor" => generate_visitor = false,
-                "--sem-patterns" => {
-                    let path = PathBuf::from(next_arg(&mut iter, "--sem-patterns")?);
-                    sem_patterns = load_sem_patterns(&path)
-                        .map_err(|error| format!("failed to load --sem-patterns: {error}"))?;
-                    sem_patterns_path = Some(path);
-                }
-                "--require-full-semantics" => require_full_semantics = true,
-                "--option-hook" => {
-                    let value = next_arg(&mut iter, "--option-hook")?;
-                    option_hooks.insert(normalize_option_hook(&value)?);
-                }
-                "--actions" => {
-                    let value = next_arg(&mut iter, "--actions")?;
-                    match value.as_str() {
-                        "embedded" => embedded_actions = true,
-                        "templates" => embedded_actions = false,
-                        other => {
-                            return Err(format!(
-                                "unknown --actions mode {other:?} (expected embedded|templates)"
-                            ));
-                        }
-                    }
-                }
-                "--sem-unknown" => {
-                    sem_unknown =
-                        SemUnknownPolicy::parse_flag(&next_arg(&mut iter, "--sem-unknown")?)?;
-                }
-                "--fixed-lookahead" => {
-                    let value = next_arg(&mut iter, "--fixed-lookahead")?;
-                    let depth = value
-                        .parse::<usize>()
-                        .ok()
-                        .filter(|depth| (1..=MAX_FIXED_LOOKAHEAD_FLAG).contains(depth));
-                    match depth {
-                        Some(depth) => fixed_lookahead = Some(depth),
-                        None => {
-                            return Err(format!(
-                                "--fixed-lookahead expects an integer between 1 and {MAX_FIXED_LOOKAHEAD_FLAG}; got {value}\n\n{}",
-                                usage()
-                            ));
-                        }
-                    }
-                }
-                "--entry-rule" => {
-                    entry_rules.insert(next_arg(&mut iter, "--entry-rule")?);
-                }
-                "--prune-unreachable" => {
-                    prune_unreachable = true;
-                }
-                "--optimize-precedence-ladders" => {
-                    optimize_precedence_ladders = true;
-                }
-                "--report-precedence-ladders" => {
-                    report_precedence_ladders = true;
-                }
-                "--help" | "-h" => return Ok(CliCommand::Help),
-                "--version" | "-V" => return Ok(CliCommand::Version),
-                other if other.starts_with("-I") && other.len() > 2 => {
-                    library_directories.push(PathBuf::from(&other[2..]));
-                }
-                other if other.starts_with('-') => {
-                    return Err(format!("unknown argument {other}\n\n{}", usage()));
-                }
-                root => roots.push(PathBuf::from(root)),
-            }
-        }
-
-        if roots.is_empty() {
-            return Err(format!(
-                "at least one grammar root is required\n\n{}",
-                usage()
-            ));
-        }
-        if optimize_precedence_ladders && report_precedence_ladders {
-            return Err(format!(
-                "--optimize-precedence-ladders and --report-precedence-ladders are mutually exclusive\n\n{}",
-                usage()
-            ));
-        }
-
-        Ok(CliCommand::Generate(Box::new(Self {
-            roots,
-            library_directories,
-            out_dir: out_dir.unwrap_or_else(|| PathBuf::from(".")),
-            require_generated_parser,
-            allow_unsupported_lexer_actions,
-            sem_unknown,
+impl CliArgs {
+    fn into_config(self) -> Result<CompilerConfig, Box<dyn std::error::Error>> {
+        let sem_patterns_path = self.sem_patterns;
+        let sem_patterns = sem_patterns_path
+            .as_deref()
+            .map_or_else(|| Ok(SemPatternFile::default()), load_sem_patterns)
+            .map_err(|error| format!("failed to load --sem-patterns: {error}"))?;
+        Ok(CompilerConfig {
+            roots: self.roots,
+            library_directories: self.library_directories,
+            out_dir: self.out_dir,
+            require_generated_parser: self.require_generated_parser,
+            allow_unsupported_lexer_actions: self.allow_unsupported_lexer_actions,
+            sem_unknown: self.sem_unknown.into_internal(),
             sem_patterns,
             sem_patterns_path,
-            require_full_semantics,
-            option_hooks,
-            generate_listener,
-            generate_visitor,
-            embedded_actions,
-            fixed_lookahead,
-            entry_rules,
-            prune_unreachable,
-            optimize_precedence_ladders,
-            report_precedence_ladders,
-        })))
+            require_full_semantics: self.require_full_semantics,
+            option_hooks: self.option_hooks.into_iter().collect(),
+            generate_listener: self.listener || !self.no_listener,
+            generate_visitor: self.visitor && !self.no_visitor,
+            embedded_actions: self.actions == ActionMode::Embedded,
+            fixed_lookahead: self.fixed_lookahead.map(usize::from),
+            entry_rules: self.entry_rules.into_iter().collect(),
+            prune_unreachable: self.prune_unreachable,
+            optimize_precedence_ladders: self.optimize_precedence_ladders,
+            report_precedence_ladders: self.report_precedence_ladders,
+        })
     }
 }
 
-fn next_arg(iter: &mut impl Iterator<Item = String>, flag: &str) -> Result<String, String> {
-    iter.next()
-        .ok_or_else(|| format!("{flag} requires a value\n\n{}", usage()))
-}
+#[cfg(test)]
+mod tests {
+    use clap::Parser as _;
 
-pub(crate) fn usage() -> String {
-    "\
-Usage: antlr4-rust-gen [OPTIONS] ROOT.g4...
+    use super::CliArgs;
+    use crate::semantics::SemUnknownPolicy;
 
-Options:
-  -I, --lib DIR                    Add an import/token-vocabulary lookup directory
-  --out-dir DIR                    Write generated Rust files to DIR
-  --actions embedded|templates     Select real embedded actions or template metadata
-  --require-generated-parser       Require generated bodies for every parser rule
-  --allow-unsupported-lexer-actions
-                                   Ignore unsupported lexer actions
-  -listener, --listener            Generate the typed listener and walker (default)
-  -no-listener, --no-listener      Do not generate the typed listener or walker
-  -visitor, --visitor              Generate the typed visitor
-  -no-visitor, --no-visitor        Do not generate the typed visitor (default)
-  --sem-unknown error|hook|assume-true|assume-false
-                                   Choose unsupported semantic predicate policy
-  --sem-patterns FILE              Load semantic helper patterns
-  --option-hook KEY=VALUE          Acknowledge an option implemented by caller hooks
-  --require-full-semantics         Fail if any semantic coordinate or option is unsupported
-  --fixed-lookahead K              Compile decisions provable within K tokens of lookahead
-                                   into static dispatch tables (off by default; every
-                                   remaining decision keeps adaptive prediction)
-  --entry-rule NAME                Declare a parser entry rule by bare name (repeatable;
-                                   applies to every generated parser defining NAME)
-  --prune-unreachable              Remove parser rules unreachable from every entry rule
-  --optimize-precedence-ladders    Collapse proven linear precedence ladders (changes tree/API)
-  --report-precedence-ladders      Dry-run the pass and emit only optimizations.json
-  -V, --version                    Print version
-  -h, --help                       Print this help"
-        .to_owned()
+    #[test]
+    fn derives_typed_defaults() {
+        let args =
+            CliArgs::try_parse_from(["antlr4-rust-gen", "T.g4"]).expect("minimal CLI should parse");
+        let config = args
+            .into_config()
+            .expect("minimal CLI should produce compiler configuration");
+
+        assert!(!config.embedded_actions);
+        assert_eq!(config.sem_unknown, SemUnknownPolicy::AssumeTrue);
+        assert!(config.generate_listener);
+        assert!(!config.generate_visitor);
+    }
+
+    #[test]
+    fn paired_generation_flags_use_the_last_value() {
+        let args = CliArgs::try_parse_from([
+            "antlr4-rust-gen",
+            "--no-listener",
+            "--listener",
+            "--visitor",
+            "--no-visitor",
+            "T.g4",
+        ])
+        .expect("paired flags should override each other");
+        let config = args
+            .into_config()
+            .expect("paired flags should produce compiler configuration");
+
+        assert!(config.generate_listener);
+        assert!(!config.generate_visitor);
+    }
 }

--- a/crates/antlr-rust-codegen/src/config.rs
+++ b/crates/antlr-rust-codegen/src/config.rs
@@ -1,0 +1,34 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+
+use crate::semantics::{SemPatternFile, SemUnknownPolicy};
+
+#[derive(Debug)]
+pub(crate) struct CompilerConfig {
+    pub(crate) roots: Vec<PathBuf>,
+    pub(crate) library_directories: Vec<PathBuf>,
+    pub(crate) out_dir: PathBuf,
+    pub(crate) require_generated_parser: bool,
+    pub(crate) allow_unsupported_lexer_actions: bool,
+    pub(crate) sem_unknown: SemUnknownPolicy,
+    pub(crate) sem_patterns: SemPatternFile,
+    pub(crate) sem_patterns_path: Option<PathBuf>,
+    pub(crate) require_full_semantics: bool,
+    pub(crate) option_hooks: BTreeSet<String>,
+    pub(crate) generate_listener: bool,
+    pub(crate) generate_visitor: bool,
+    /// The grammar contains real Rust action/predicate bodies rendered through
+    /// a `.test.stg`, rather than template metadata.
+    pub(crate) embedded_actions: bool,
+    /// Compile decisions whose alternatives are pairwise disjoint within this
+    /// token depth into static dispatch tables.
+    pub(crate) fixed_lookahead: Option<usize>,
+    /// Parser entry rules configured for reachability diagnostics and pruning.
+    pub(crate) entry_rules: BTreeSet<String>,
+    /// Remove parser rules unreachable from every inferred/configured entry.
+    pub(crate) prune_unreachable: bool,
+    /// Recognition-preserving source rewrite from issue #225.
+    pub(crate) optimize_precedence_ladders: bool,
+    /// Analyze the same pass on a shadow model and emit only its manifest.
+    pub(crate) report_precedence_ladders: bool,
+}

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -1,4 +1,4 @@
-use crate::cli::CompilerConfig;
+use crate::config::CompilerConfig;
 use crate::generator::prelude::*;
 use crate::lexer::{LexerRenderModel, render_lexer_model};
 use crate::optimization::OptimizationPlan;

--- a/crates/antlr-rust-codegen/src/generator/tests.rs
+++ b/crates/antlr-rust-codegen/src/generator/tests.rs
@@ -4854,27 +4854,6 @@ fn runtime_channel_names_are_dense_by_value() {
 }
 
 #[test]
-fn sem_unknown_flag_values_parse() {
-    assert_eq!(
-        SemUnknownPolicy::parse_flag("error").expect("error parses"),
-        SemUnknownPolicy::Error
-    );
-    assert_eq!(
-        SemUnknownPolicy::parse_flag("assume-true").expect("assume-true parses"),
-        SemUnknownPolicy::AssumeTrue
-    );
-    assert_eq!(
-        SemUnknownPolicy::parse_flag("assume-false").expect("assume-false parses"),
-        SemUnknownPolicy::AssumeFalse
-    );
-    assert_eq!(
-        SemUnknownPolicy::parse_flag("hook").expect("hook parses"),
-        SemUnknownPolicy::Hook
-    );
-    assert!(SemUnknownPolicy::parse_flag("bogus").is_err());
-}
-
-#[test]
 fn set_lexer_predicate_template_replaces_or_appends() {
     // A per-coordinate override must WIN over a built-in translation, so
     // setting a covered coordinate replaces its template rather than adding

--- a/crates/antlr-rust-codegen/src/lib.rs
+++ b/crates/antlr-rust-codegen/src/lib.rs
@@ -3,6 +3,7 @@
 mod artifact;
 mod builder;
 mod cli;
+mod config;
 mod driver;
 pub(crate) mod embedded;
 mod error;

--- a/crates/antlr-rust-codegen/src/optimization/config.rs
+++ b/crates/antlr-rust-codegen/src/optimization/config.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use crate::cli::CompilerConfig;
+use crate::config::CompilerConfig;
 use crate::error::Error;
 use crate::grammar::compiler::Compilation;
 use crate::grammar::rule_reachability::EntryRuleConfig;

--- a/crates/antlr-rust-codegen/src/parser/decision.rs
+++ b/crates/antlr-rust-codegen/src/parser/decision.rs
@@ -13,7 +13,7 @@ struct DecisionAltLook {
 /// Upper bound accepted by `--fixed-lookahead`. Dispatch-table size and
 /// analysis cost grow with depth; beyond a few tokens the tier stops paying
 /// for itself, so cap the flag rather than let a typo explode generation.
-pub(crate) const MAX_FIXED_LOOKAHEAD_FLAG: usize = 8;
+pub(crate) const MAX_FIXED_LOOKAHEAD_FLAG: u8 = 8;
 /// Per-alternative cap on lookahead rectangles gathered by the fixed-LL(k)
 /// walk. This is an *analysis* budget: generous enough that ordinary
 /// decisions get an honest disjoint / not-disjoint verdict (fan-outy

--- a/crates/antlr-rust-codegen/src/semantics/inventory.rs
+++ b/crates/antlr-rust-codegen/src/semantics/inventory.rs
@@ -176,10 +176,7 @@ pub(crate) fn enforce_require_full_options(
 
 pub(crate) fn normalize_option_hook(value: &str) -> Result<String, String> {
     let Some((key, option_value)) = value.split_once('=') else {
-        return Err(format!(
-            "--option-hook requires KEY=VALUE; got {value:?}\n\n{}",
-            usage()
-        ));
+        return Err(format!("--option-hook requires KEY=VALUE; got {value:?}"));
     };
     let key = key.trim();
     let option_value = option_value.trim();
@@ -190,10 +187,7 @@ pub(crate) fn normalize_option_hook(value: &str) -> Result<String, String> {
         || !key_chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
         || option_value.is_empty()
     {
-        return Err(format!(
-            "--option-hook requires KEY=VALUE; got {value:?}\n\n{}",
-            usage()
-        ));
+        return Err(format!("--option-hook requires KEY=VALUE; got {value:?}"));
     }
     Ok(format!("{key}={option_value}"))
 }
@@ -631,8 +625,7 @@ pub(crate) fn collect_structural_grammar_options(
 /// Reads the lexer ATN to locate serialized custom action coordinates.
 pub(crate) fn lexer_custom_actions(data: &LexerCodegenData<'_>) -> Vec<(i32, i32)> {
     let atn = data.lexer_atn();
-    atn
-        .lexer_actions()
+    atn.lexer_actions()
         .iter()
         .filter_map(|action| match action {
             LexerAction::Custom {

--- a/crates/antlr-rust-codegen/src/semantics/mod.rs
+++ b/crates/antlr-rust-codegen/src/semantics/mod.rs
@@ -1,4 +1,3 @@
-use crate::cli::usage;
 use crate::generator::prelude::*;
 use crate::parser::{
     DecisionReportRow, DecisionTierReport, LexerTypedHookKind, LexerTypedHookMapping,

--- a/crates/antlr-rust-codegen/src/semantics/model.rs
+++ b/crates/antlr-rust-codegen/src/semantics/model.rs
@@ -23,19 +23,6 @@ pub(crate) enum SemUnknownPolicy {
 }
 
 impl SemUnknownPolicy {
-    pub(crate) fn parse_flag(value: &str) -> Result<Self, String> {
-        match value {
-            "error" => Ok(Self::Error),
-            "hook" => Ok(Self::Hook),
-            "assume-true" => Ok(Self::AssumeTrue),
-            "assume-false" => Ok(Self::AssumeFalse),
-            other => Err(format!(
-                "--sem-unknown accepts error, hook, assume-true, or assume-false; got {other}\n\n{}",
-                usage()
-            )),
-        }
-    }
-
     const fn manifest_name(self) -> &'static str {
         match self {
             Self::AssumeTrue => "assume-true",

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/cli.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/cli.rs
@@ -14,24 +14,7 @@ fn long_help_describes_source_only_cli() {
     );
     assert_eq!(utf8(&output.stderr), "");
 
-    let stdout = utf8(&output.stdout);
-    assert!(
-        stdout.starts_with("Usage: antlr4-rust-gen [OPTIONS] ROOT.g4...\n"),
-        "{stdout}"
-    );
-    assert!(stdout.contains("  -I, --lib DIR"), "{stdout}");
-    assert!(stdout.contains("  --option-hook KEY=VALUE"), "{stdout}");
-    assert!(stdout.contains("  --entry-rule NAME"), "{stdout}");
-    assert!(stdout.contains("  --prune-unreachable"), "{stdout}");
-    assert!(stdout.contains("  -listener, --listener"), "{stdout}");
-    assert!(stdout.contains("  -no-listener, --no-listener"), "{stdout}");
-    assert!(stdout.contains("  -visitor, --visitor"), "{stdout}");
-    assert!(stdout.contains("  -no-visitor, --no-visitor"), "{stdout}");
-    assert!(!stdout.contains("--lexer "), "{stdout}");
-    assert!(!stdout.contains("--parser "), "{stdout}");
-    assert!(!stdout.contains("--grammar "), "{stdout}");
-    assert!(stdout.contains("  -V, --version"), "{stdout}");
-    assert!(stdout.contains("  -h, --help"), "{stdout}");
+    insta::assert_snapshot!("antlr4_rust_gen_help", utf8(&output.stdout));
 }
 
 #[test]
@@ -164,7 +147,7 @@ fn help_flag_as_option_value_is_not_intercepted() {
 
     let stderr = utf8(&output.stderr);
     assert!(stderr.contains("--option-hook requires KEY=VALUE"));
-    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+    assert!(stderr.contains("For more information, try '--help'."));
 }
 
 #[test]
@@ -177,7 +160,7 @@ fn version_flags_as_option_values_are_not_intercepted() {
 
         let stderr = utf8(&output.stderr);
         assert!(stderr.contains("--option-hook requires KEY=VALUE"));
-        assert!(stderr.contains("Usage: antlr4-rust-gen"));
+        assert!(stderr.contains("For more information, try '--help'."));
     }
 }
 
@@ -190,7 +173,8 @@ fn missing_roots_report_usage_on_stderr() {
     assert_eq!(utf8(&output.stdout), "");
 
     let stderr = utf8(&output.stderr);
-    assert!(stderr.contains("at least one grammar root is required"));
+    assert!(stderr.contains("required arguments were not provided"));
+    assert!(stderr.contains("<ROOT.g4>..."));
     assert!(stderr.contains("Usage: antlr4-rust-gen"));
 }
 
@@ -202,7 +186,7 @@ fn unknown_arguments_report_usage_on_stderr() {
     assert_eq!(utf8(&output.stdout), "");
 
     let stderr = utf8(&output.stderr);
-    assert!(stderr.contains("unknown argument --bogus"));
+    assert!(stderr.contains("unexpected argument '--bogus'"));
     assert!(stderr.contains("Usage: antlr4-rust-gen"));
 }
 
@@ -219,9 +203,21 @@ fn legacy_interp_flags_are_rejected() {
         assert!(!output.status.success(), "{flag} unexpectedly succeeded");
         let stderr = utf8(&output.stderr);
         assert!(
-            stderr.contains(&format!("unknown argument {flag}")),
+            stderr.contains(&format!("unexpected argument '{flag}'")),
             "{stderr}"
         );
+    }
+}
+
+#[test]
+fn antlr_single_dash_generation_flags_are_rejected() {
+    for flag in ["-listener", "-no-listener", "-visitor", "-no-visitor"] {
+        let output = run_antlr4_rust_gen(&[flag, "T.g4"]);
+
+        assert!(!output.status.success(), "{flag} unexpectedly succeeded");
+        let stderr = utf8(&output.stderr);
+        assert!(stderr.contains("unexpected argument"), "{stderr}");
+        assert!(stderr.contains("Usage: antlr4-rust-gen"), "{stderr}");
     }
 }
 
@@ -233,5 +229,5 @@ fn option_hook_requires_a_key_value_assignment() {
     assert_eq!(utf8(&output.stdout), "");
     let stderr = utf8(&output.stderr);
     assert!(stderr.contains("--option-hook requires KEY=VALUE"));
-    assert!(stderr.contains("Usage: antlr4-rust-gen"));
+    assert!(stderr.contains("For more information, try '--help'."));
 }

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__cli__antlr4_rust_gen_help.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__cli__antlr4_rust_gen_help.snap
@@ -1,0 +1,52 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/cli.rs
+expression: utf8(&output.stdout)
+---
+ANTLR v4 grammar compiler and Rust source generator
+
+Usage: antlr4-rust-gen [OPTIONS] <ROOT.g4>...
+
+Arguments:
+  <ROOT.g4>...  ANTLR grammar roots to compile
+
+Options:
+  -I, --lib <DIR>
+          Add an import/token-vocabulary lookup directory
+      --out-dir <DIR>
+          Write generated Rust files to this directory [default: .]
+      --require-generated-parser
+          Require generated bodies for every parser rule
+      --allow-unsupported-lexer-actions
+          Ignore unsupported lexer actions
+      --listener
+          Generate the typed listener and walker (default)
+      --no-listener
+          Do not generate the typed listener or walker
+      --visitor
+          Generate the typed visitor
+      --no-visitor
+          Do not generate the typed visitor (default)
+      --actions <ACTIONS>
+          Choose how grammar action and predicate bodies are interpreted [default: templates] [possible values: templates, embedded]
+      --sem-unknown <SEM_UNKNOWN>
+          Choose the unsupported semantic predicate policy [default: assume-true] [possible values: assume-true, assume-false, hook, error]
+      --sem-patterns <FILE>
+          Load semantic helper patterns
+      --option-hook <KEY=VALUE>
+          Acknowledge an option implemented by caller hooks
+      --require-full-semantics
+          Fail if any semantic coordinate or option is unsupported
+      --fixed-lookahead <K>
+          Compile decisions provable within K tokens into static dispatch tables
+      --entry-rule <NAME>
+          Declare a parser entry rule by bare name (repeatable)
+      --prune-unreachable
+          Remove parser rules unreachable from every entry rule
+      --optimize-precedence-ladders
+          Collapse proven linear precedence ladders (changes tree/API)
+      --report-precedence-ladders
+          Dry-run precedence-ladder analysis and emit only optimizations.json
+  -h, --help
+          Print help
+  -V, --version
+          Print version

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/typed_tree.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/typed_tree.rs
@@ -1410,8 +1410,8 @@ fn listener_and_visitor_generation_can_be_disabled_independently() {
 
     let output = run_antlr4_rust_gen(&[
         grammar.as_os_str(),
-        OsStr::new("-no-listener"),
-        OsStr::new("-visitor"),
+        OsStr::new("--no-listener"),
+        OsStr::new("--visitor"),
         OsStr::new("--out-dir"),
         visitor_only.as_os_str(),
     ]);

--- a/crates/antlr-rust-runtime/Cargo.toml
+++ b/crates/antlr-rust-runtime/Cargo.toml
@@ -25,7 +25,7 @@ perf-counters = []
 
 [dependencies]
 memchr.workspace = true
-stacker.workspace = true
+stacker = "0.1.24"
 thiserror.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

* replace `antlr4-rust-gen`'s handwritten argument parser with `clap` derives
* enable clap's `derive`, `env`, and `cargo` features and use Cargo metadata for help/version output
* remove the ANTLR-style `-listener`, `-no-listener`, `-visitor`, and `-no-visitor` aliases
* move shared compiler configuration out of the CLI module
* declare single-consumer third-party dependencies in their owning crate manifests

## Compatibility

This intentionally breaks the four legacy single-dash generation flags; their
double-dash forms remain supported. Generated source and the runtime interface
are unchanged, so the generated-code API revision remains at 3.

`clap` is a dependency of `antlr-rust-codegen` only. The runtime dependency tree
does not include it.

## Validation

* `cargo test --locked --workspace --all-features`
* `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
* `cargo fmt --all -- --check`
* `git diff origin/main --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized command-line parsing with improved help, version information, option validation, and clearer error messages.
  * Added support for explicit action-mode and unknown-semantic-policy options.
* **Bug Fixes**
  * Corrected lookahead limit validation to consistently enforce the configured maximum.
  * Rejected unsupported single-dash forms for listener and visitor options.
* **Documentation**
  * Clarified that `--no-visitor` disables visitor generation.
* **Tests**
  * Updated command-line coverage and snapshots for the revised interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->