### PR TITLE
feat(codegen): add TestRig command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,69 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys",
+]
 
 [[package]]
 name = "antlr-rust-codegen"
@@ -22,6 +81,7 @@ dependencies = [
  "insta",
  "intl",
  "memchr",
+ "miette",
  "petgraph",
  "thiserror",
 ]
@@ -71,6 +131,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,6 +192,7 @@ version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim",
@@ -130,6 +215,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "displaydoc"
@@ -192,6 +283,12 @@ dependencies = [
  "libc",
  "r-efi",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "hashbrown"
@@ -337,6 +434,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743c21e11d6a1018820ee57bc5cbdc75d71462b1b0b5f188730a7c005cd55b1a"
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +470,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "cfg-if",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +510,18 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "owo-colors"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "petgraph"
@@ -430,6 +578,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustix"
@@ -512,6 +666,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
+
+[[package]]
+name = "supports-unicode"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
+
+[[package]]
 name = "syn"
 version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +733,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "unicode-linebreak",
+ "unicode-width 0.2.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,10 +790,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "windows-link"

--- a/README.md
+++ b/README.md
@@ -109,14 +109,17 @@ one deterministic source-set compilation.
 
 ### Run a grammar with TestRig
 
-Install the companion TestRig command from the codegen package:
+TestRig can run directly from a grammar-only project. The project does not need
+a `Cargo.toml`, generated Rust sources, or a runtime dependency; it only needs a
+Rust toolchain because TestRig invokes Cargo internally. Install the companion
+command from the codegen package:
 
 ```bash
 cargo install antlr-rust-codegen --bin antlr4-rust-testrig
 ```
 
-Pass a combined grammar, its parser start rule, and zero or more UTF-8 inputs.
-With no input files the command reads stdin:
+From the grammar project, pass a combined grammar, its parser start rule, and
+zero or more UTF-8 inputs. With no input files the command reads stdin:
 
 ```bash
 antlr4-rust-testrig JSON.g4 json --tokens --tree examples/*.json
@@ -134,7 +137,12 @@ antlr4-rust-testrig MyGrammarParser.g4 start \
 ```
 
 `--trace`, `--diagnostics`, and `--sll` expose the corresponding parser modes.
-TestRig processes every named input and returns a non-zero status when grammar
+Each invocation generates the recognizer and a grammar-specific runner in a
+temporary Cargo package, selects the matching `antlr-rust-runtime` release, and
+removes the generated package afterward. Cargo build artifacts are reused, so
+the first invocation can take longer while dependencies and the runner compile.
+
+TestRig processes every named input and returns a non-zero status when
 generation, temporary runner compilation, input reading, lexing, or parsing
 fails. Recovered lexer and parser syntax errors therefore fail CI even when a
 parse tree was produced.

--- a/README.md
+++ b/README.md
@@ -136,11 +136,14 @@ antlr4-rust-testrig MyGrammarParser.g4 start \
   tests/valid/*.txt
 ```
 
-`--trace`, `--diagnostics`, and `--sll` expose the corresponding parser modes.
+`--trace`, `--diagnostics`, and `--sll` expose the corresponding parser modes;
+exact-ambiguity diagnostics and SLL prediction are mutually exclusive.
 Each invocation generates the recognizer and a grammar-specific runner in a
 temporary Cargo package, selects the matching `antlr-rust-runtime` release, and
 removes the generated package afterward. Cargo build artifacts are reused, so
 the first invocation can take longer while dependencies and the runner compile.
+The shared target directory lives in the current user's cache directory; set
+`ANTLR4_RUST_TESTRIG_TARGET_DIR` to override it.
 
 TestRig processes every named input and returns a non-zero status when
 generation, temporary runner compilation, input reading, lexing, or parsing

--- a/README.md
+++ b/README.md
@@ -107,6 +107,38 @@ antlr4-rust-gen \
 Use multiple roots when a build should emit several independent recognizers in
 one deterministic source-set compilation.
 
+### Run a grammar with TestRig
+
+Install the companion TestRig command from the codegen package:
+
+```bash
+cargo install antlr-rust-codegen --bin antlr4-rust-testrig
+```
+
+Pass a combined grammar, its parser start rule, and zero or more UTF-8 inputs.
+With no input files the command reads stdin:
+
+```bash
+antlr4-rust-testrig JSON.g4 json --tokens --tree examples/*.json
+echo '{"ok":true}' | antlr4-rust-testrig JSON json --tree
+```
+
+For a lexer grammar, use the special start rule `tokens`. Pair split grammars
+with `--lexer-grammar` and the same import directories used for generation:
+
+```bash
+antlr4-rust-testrig MyGrammarParser.g4 start \
+  --lexer-grammar MyGrammarLexer.g4 \
+  --lib grammar \
+  tests/valid/*.txt
+```
+
+`--trace`, `--diagnostics`, and `--sll` expose the corresponding parser modes.
+TestRig processes every named input and returns a non-zero status when grammar
+generation, temporary runner compilation, input reading, lexing, or parsing
+fails. Recovered lexer and parser syntax errors therefore fail CI even when a
+parse tree was produced.
+
 ### Generated-source/runtime compatibility
 
 Every newly generated lexer and parser contains a compile-time generated-code

--- a/crates/antlr-rust-codegen/Cargo.toml
+++ b/crates/antlr-rust-codegen/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
-name = "antlr-rust-codegen"
-version.workspace = true
-edition.workspace = true
-rust-version.workspace = true
-description = "ANTLR v4 grammar compiler and Rust source generator"
-repository.workspace = true
-homepage.workspace = true
-documentation = "https://docs.rs/antlr-rust-codegen"
-license.workspace = true
+categories             = ["development-tools::build-utils", "parser-implementations", "parsing"]
+description            = "ANTLR v4 grammar compiler and Rust source generator"
+documentation          = "https://docs.rs/antlr-rust-codegen"
+edition.workspace      = true
+homepage.workspace     = true
+include                = ["/Cargo.toml", "/README.md", "/src/**"]
+keywords               = ["antlr", "antlr4", "codegen", "lexer", "parser"]
+license.workspace      = true
 license-file.workspace = true
-readme = "README.md"
-keywords = ["antlr", "antlr4", "codegen", "parser", "lexer"]
-categories = ["development-tools::build-utils", "parser-implementations", "parsing"]
-include = ["/Cargo.toml", "/README.md", "/src/**"]
+name                   = "antlr-rust-codegen"
+readme                 = "README.md"
+repository.workspace   = true
+rust-version.workspace = true
+version.workspace      = true
 
 [lib]
 name = "antlr_rust_codegen"
@@ -22,10 +22,14 @@ path = "src/lib.rs"
 name = "antlr4-rust-gen"
 path = "src/bin/antlr4-rust-gen.rs"
 
+[[bin]]
+name = "antlr4-rust-testrig"
+path = "src/bin/antlr4-rust-testrig.rs"
+
 [dependencies]
-antlr-rust-runtime.workspace = true
 antlr-rust-g4-parser.workspace = true
 antlr-rust-rs-parser.workspace = true
+antlr-rust-runtime.workspace = true
 clap = { version = "4.6.5", default-features = false, features = [
     "cargo",
     "derive",
@@ -43,8 +47,8 @@ petgraph = { version = "0.8.3", default-features = false, features = ["std"] }
 thiserror.workspace = true
 
 [dev-dependencies]
-hmac-sha256 = "1"
-insta.workspace = true
+hmac-sha256      = "1"
+insta.workspace  = true
 memchr.workspace = true
 
 [lints]

--- a/crates/antlr-rust-codegen/Cargo.toml
+++ b/crates/antlr-rust-codegen/Cargo.toml
@@ -32,6 +32,7 @@ antlr-rust-rs-parser.workspace = true
 antlr-rust-runtime.workspace = true
 clap = { version = "4.6.5", default-features = false, features = [
     "cargo",
+    "color",
     "derive",
     "env",
     "error-context",
@@ -43,6 +44,7 @@ clap = { version = "4.6.5", default-features = false, features = [
 icu_casemap = "2.2.0"
 icu_properties.workspace = true
 intl = { version = "0.6.0", default-features = false, features = ["full", "normalization"] }
+miette = { version = "7.6.0", default-features = false, features = ["fancy"] }
 petgraph = { version = "0.8.3", default-features = false, features = ["std"] }
 thiserror.workspace = true
 

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -60,9 +60,12 @@ antlr4-rust-testrig MyParser.g4 start \
 The command generates and compiles a temporary grammar-specific runner with the
 matching runtime because Rust cannot reflectively load recognizer types or call
 a rule by name. It removes the temporary package afterward while retaining
-Cargo build artifacts for subsequent invocations. It processes every input and
-exits non-zero if generation, compilation, input reading, lexing, or parsing
-reports an error, so the same command can be used as a test runner.
+Cargo build artifacts in the current user's cache for subsequent invocations;
+set `ANTLR4_RUST_TESTRIG_TARGET_DIR` to override that location. Parser
+`--diagnostics` and `--sll` modes are mutually exclusive. The command processes
+every input and exits non-zero if generation, compilation, input reading,
+lexing, or parsing reports an error, so the same command can be used as a test
+runner.
 
 The runtime, codegen, and internal parser packages are released in lockstep.
 

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -39,6 +39,28 @@ Or install the command:
 cargo install antlr-rust-codegen --bin antlr4-rust-gen
 ```
 
+The package also provides `antlr4-rust-testrig` for running a grammar directly
+against UTF-8 files or stdin:
+
+```bash
+cargo install antlr-rust-codegen --bin antlr4-rust-testrig
+antlr4-rust-testrig JSON.g4 json --tokens --tree example.json
+```
+
+Use `tokens` as the start rule for a lexer grammar. For split grammars, pass
+the parser grammar first and pair it with `--lexer-grammar`:
+
+```bash
+antlr4-rust-testrig MyParser.g4 start \
+    --lexer-grammar MyLexer.g4 --lib grammar inputs/*.txt
+```
+
+The command generates and compiles a temporary grammar-specific runner because
+Rust cannot reflectively load recognizer types or call a rule by name. It
+processes every input and exits non-zero if generation, compilation, input
+reading, lexing, or parsing reports an error, so the same command can be used
+as a test runner.
+
 The runtime, codegen, and internal parser packages are released in lockstep.
 
 ## Internal module ownership

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -61,11 +61,12 @@ The command generates and compiles a temporary grammar-specific runner with the
 matching runtime because Rust cannot reflectively load recognizer types or call
 a rule by name. It removes the temporary package afterward while retaining
 Cargo build artifacts in the current user's cache for subsequent invocations;
-set `ANTLR4_RUST_TESTRIG_TARGET_DIR` to override that location. Parser
-`--diagnostics` and `--sll` modes are mutually exclusive. The command processes
-every input and exits non-zero if generation, compilation, input reading,
-lexing, or parsing reports an error, so the same command can be used as a test
-runner.
+set `ANTLR4_RUST_TESTRIG_TARGET_DIR` to override that location. `--trace`,
+`--diagnostics`, and `--sll` expose the corresponding parser modes;
+exact-ambiguity diagnostics and SLL prediction are mutually exclusive. The
+command processes every input and exits non-zero if generation, compilation,
+input reading, lexing, or parsing reports an error, so the same command can be
+used as a test runner.
 
 The runtime, codegen, and internal parser packages are released in lockstep.
 

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -40,7 +40,9 @@ cargo install antlr-rust-codegen --bin antlr4-rust-gen
 ```
 
 The package also provides `antlr4-rust-testrig` for running a grammar directly
-against UTF-8 files or stdin:
+against UTF-8 files or stdin. A grammar-only project needs no `Cargo.toml`,
+generated Rust sources, or runtime dependency; only a Rust toolchain is
+required because TestRig invokes Cargo internally:
 
 ```bash
 cargo install antlr-rust-codegen --bin antlr4-rust-testrig
@@ -55,11 +57,12 @@ antlr4-rust-testrig MyParser.g4 start \
     --lexer-grammar MyLexer.g4 --lib grammar inputs/*.txt
 ```
 
-The command generates and compiles a temporary grammar-specific runner because
-Rust cannot reflectively load recognizer types or call a rule by name. It
-processes every input and exits non-zero if generation, compilation, input
-reading, lexing, or parsing reports an error, so the same command can be used
-as a test runner.
+The command generates and compiles a temporary grammar-specific runner with the
+matching runtime because Rust cannot reflectively load recognizer types or call
+a rule by name. It removes the temporary package afterward while retaining
+Cargo build artifacts for subsequent invocations. It processes every input and
+exits non-zero if generation, compilation, input reading, lexing, or parsing
+reports an error, so the same command can be used as a test runner.
 
 The runtime, codegen, and internal parser packages are released in lockstep.
 

--- a/crates/antlr-rust-codegen/src/bin/antlr4-rust-gen.rs
+++ b/crates/antlr-rust-codegen/src/bin/antlr4-rust-gen.rs
@@ -1,3 +1,3 @@
-fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> miette::Result<()> {
     antlr_rust_codegen::run_cli()
 }

--- a/crates/antlr-rust-codegen/src/bin/antlr4-rust-testrig.rs
+++ b/crates/antlr-rust-codegen/src/bin/antlr4-rust-testrig.rs
@@ -1,0 +1,3 @@
+fn main() -> Result<std::process::ExitCode, Box<dyn std::error::Error>> {
+    antlr_rust_codegen::run_testrig_cli()
+}

--- a/crates/antlr-rust-codegen/src/bin/antlr4-rust-testrig.rs
+++ b/crates/antlr-rust-codegen/src/bin/antlr4-rust-testrig.rs
@@ -1,3 +1,3 @@
-fn main() -> Result<std::process::ExitCode, Box<dyn std::error::Error>> {
+fn main() -> miette::Result<std::process::ExitCode> {
     antlr_rust_codegen::run_testrig_cli()
 }

--- a/crates/antlr-rust-codegen/src/builder.rs
+++ b/crates/antlr-rust-codegen/src/builder.rs
@@ -239,6 +239,7 @@ impl Builder {
             prune_unreachable: self.prune_unreachable,
             optimize_precedence_ladders: self.optimize_precedence_ladders,
             report_precedence_ladders: self.report_precedence_ladders,
+            test_rig: None,
         })
     }
 }

--- a/crates/antlr-rust-codegen/src/cli.rs
+++ b/crates/antlr-rust-codegen/src/cli.rs
@@ -154,6 +154,7 @@ impl CliArgs {
             prune_unreachable: self.prune_unreachable,
             optimize_precedence_ladders: self.optimize_precedence_ladders,
             report_precedence_ladders: self.report_precedence_ladders,
+            test_rig: None,
         })
     }
 }

--- a/crates/antlr-rust-codegen/src/cli.rs
+++ b/crates/antlr-rust-codegen/src/cli.rs
@@ -2,18 +2,19 @@ use std::io::{self, Write as _};
 use std::path::PathBuf;
 
 use clap::{ArgAction, Parser};
+use miette::{Context as _, IntoDiagnostic as _};
 
 use crate::builder::{ActionMode, UnknownSemanticPolicy};
 use crate::config::CompilerConfig;
 use crate::driver::generate;
-use crate::error::Error;
 use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
 use crate::semantics::{SemPatternFile, load_sem_patterns, normalize_option_hook};
 
-pub(crate) fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
+pub(crate) fn run_cli() -> miette::Result<()> {
     let args = CliArgs::parse().into_config()?;
     let mut stderr = io::stderr().lock();
-    generate(&args, |message| writeln!(stderr, "{message}")).map_err(Error::into_io_error)?;
+    generate(&args, |message| writeln!(stderr, "{message}"))
+        .map_err(crate::cli_report::codegen_error)?;
     Ok(())
 }
 
@@ -129,12 +130,14 @@ struct CliArgs {
 }
 
 impl CliArgs {
-    fn into_config(self) -> Result<CompilerConfig, Box<dyn std::error::Error>> {
+    fn into_config(self) -> miette::Result<CompilerConfig> {
         let sem_patterns_path = self.sem_patterns;
-        let sem_patterns = sem_patterns_path
-            .as_deref()
-            .map_or_else(|| Ok(SemPatternFile::default()), load_sem_patterns)
-            .map_err(|error| format!("failed to load --sem-patterns: {error}"))?;
+        let sem_patterns = match sem_patterns_path.as_deref() {
+            Some(path) => load_sem_patterns(path)
+                .into_diagnostic()
+                .wrap_err("failed to load --sem-patterns")?,
+            None => SemPatternFile::default(),
+        };
         Ok(CompilerConfig {
             roots: self.roots,
             library_directories: self.library_directories,

--- a/crates/antlr-rust-codegen/src/cli_report.rs
+++ b/crates/antlr-rust-codegen/src/cli_report.rs
@@ -13,6 +13,19 @@ pub(crate) fn codegen_error(error: CodegenError) -> miette::Report {
     miette::Report::new(CodegenErrorReport::new(error))
 }
 
+pub(crate) fn install_handler_from_env() {
+    let Some(width) = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|width| *width > 0)
+    else {
+        return;
+    };
+    let _ = miette::set_hook(Box::new(move |_| {
+        Box::new(miette::MietteHandlerOpts::new().width(width).build())
+    }));
+}
+
 #[derive(Debug)]
 struct CodegenErrorReport {
     error: CodegenError,

--- a/crates/antlr-rust-codegen/src/cli_report.rs
+++ b/crates/antlr-rust-codegen/src/cli_report.rs
@@ -1,0 +1,163 @@
+use std::error::Error as StdError;
+use std::fmt;
+use std::fs;
+use std::ops::Range;
+
+use miette::{LabeledSpan, NamedSource, SourceCode};
+
+use crate::error::{
+    Diagnostic as CodegenDiagnostic, Error as CodegenError, ErrorKind, Severity as CodegenSeverity,
+};
+
+pub(crate) fn codegen_error(error: CodegenError) -> miette::Report {
+    miette::Report::new(CodegenErrorReport::new(error))
+}
+
+#[derive(Debug)]
+struct CodegenErrorReport {
+    error: CodegenError,
+    message: String,
+    code: &'static str,
+    related: Vec<CodegenDiagnosticReport>,
+}
+
+impl CodegenErrorReport {
+    fn new(error: CodegenError) -> Self {
+        let message = if error.kind() == ErrorKind::Compilation {
+            let error_count = error
+                .diagnostics()
+                .iter()
+                .filter(|diagnostic| diagnostic.severity() == CodegenSeverity::Error)
+                .count();
+            format!("grammar compilation failed with {error_count} error(s)")
+        } else {
+            error.to_string()
+        };
+        let code = match error.kind() {
+            ErrorKind::Configuration => "antlr4_rust_codegen::configuration",
+            ErrorKind::Compilation => "antlr4_rust_codegen::compilation",
+            ErrorKind::Generation => "antlr4_rust_codegen::generation",
+            ErrorKind::Filesystem => "antlr4_rust_codegen::filesystem",
+        };
+        let related = error
+            .diagnostics()
+            .iter()
+            .map(CodegenDiagnosticReport::new)
+            .collect();
+        Self {
+            error,
+            message,
+            code,
+            related,
+        }
+    }
+}
+
+impl fmt::Display for CodegenErrorReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl StdError for CodegenErrorReport {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        StdError::source(&self.error).filter(|source| source.to_string() != self.message)
+    }
+}
+
+impl miette::Diagnostic for CodegenErrorReport {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new(self.code))
+    }
+
+    fn related(&self) -> Option<Box<dyn Iterator<Item = &dyn miette::Diagnostic> + '_>> {
+        if self.related.is_empty() {
+            return None;
+        }
+        let related: Box<dyn Iterator<Item = &dyn miette::Diagnostic>> = Box::new(
+            self.related
+                .iter()
+                .map(|diagnostic| -> &dyn miette::Diagnostic { diagnostic }),
+        );
+        Some(related)
+    }
+}
+
+#[derive(Debug)]
+struct CodegenDiagnosticReport {
+    code: &'static str,
+    severity: miette::Severity,
+    message: String,
+    source: Option<NamedSource<String>>,
+    span: Option<Range<usize>>,
+}
+
+impl CodegenDiagnosticReport {
+    fn new(diagnostic: &CodegenDiagnostic) -> Self {
+        let span = diagnostic.byte_span();
+        let source = span.as_ref().and_then(|span| {
+            let contents = fs::read_to_string(diagnostic.path()).ok()?;
+            (span.end <= contents.len()).then(|| {
+                NamedSource::new(diagnostic.path().display().to_string(), contents)
+                    .with_language("ANTLR")
+            })
+        });
+        let message = if source.is_some() {
+            diagnostic.message().to_owned()
+        } else {
+            let position = diagnostic
+                .line()
+                .zip(diagnostic.column())
+                .map_or_else(String::new, |(line, column)| format!(":{line}:{column}"));
+            format!(
+                "{}{position}: {}",
+                diagnostic.path().display(),
+                diagnostic.message()
+            )
+        };
+        let severity = match diagnostic.severity() {
+            CodegenSeverity::Warning => miette::Severity::Warning,
+            CodegenSeverity::Error => miette::Severity::Error,
+        };
+        let span = source.is_some().then_some(span).flatten();
+        Self {
+            code: diagnostic.code(),
+            severity,
+            message,
+            source,
+            span,
+        }
+    }
+}
+
+impl fmt::Display for CodegenDiagnosticReport {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl StdError for CodegenDiagnosticReport {}
+
+impl miette::Diagnostic for CodegenDiagnosticReport {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new(self.code))
+    }
+
+    fn severity(&self) -> Option<miette::Severity> {
+        Some(self.severity)
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        self.source
+            .as_ref()
+            .map(|source| -> &dyn SourceCode { source })
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.span.as_ref().map(|span| {
+            let labels: Box<dyn Iterator<Item = LabeledSpan>> =
+                Box::new(std::iter::once(LabeledSpan::underline(span.clone())));
+            labels
+        })
+    }
+}

--- a/crates/antlr-rust-codegen/src/config.rs
+++ b/crates/antlr-rust-codegen/src/config.rs
@@ -4,6 +4,11 @@ use std::path::PathBuf;
 use crate::semantics::{SemPatternFile, SemUnknownPolicy};
 
 #[derive(Debug)]
+pub(crate) struct TestRigConfig {
+    pub(crate) start_rule: String,
+}
+
+#[derive(Debug)]
 pub(crate) struct CompilerConfig {
     pub(crate) roots: Vec<PathBuf>,
     pub(crate) library_directories: Vec<PathBuf>,
@@ -31,4 +36,6 @@ pub(crate) struct CompilerConfig {
     pub(crate) optimize_precedence_ladders: bool,
     /// Analyze the same pass on a shadow model and emit only its manifest.
     pub(crate) report_precedence_ladders: bool,
+    /// Emit a temporary-crate entry point for `antlr4-rust-testrig`.
+    pub(crate) test_rig: Option<TestRigConfig>,
 }

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -9,6 +9,9 @@ use crate::semantics::{
     enforce_require_full_options, enforce_require_full_semantics, enforce_sem_unknown,
     grammar_option_warning_messages, render_decisions_manifest, render_semantics_manifest,
 };
+use crate::test_rig::{
+    MAIN_PATH as TEST_RIG_MAIN_PATH, TestRigLexer, TestRigParser, render_test_rig,
+};
 
 pub(crate) fn generate(
     args: &CompilerConfig,
@@ -71,6 +74,8 @@ pub(crate) fn generate(
     let mut rendered_modules = BTreeMap::<PathBuf, String>::new();
     let mut emitted_lexers = BTreeSet::new();
     let mut emitted_parsers = BTreeSet::new();
+    let mut test_rig_lexers = Vec::new();
+    let mut test_rig_parsers = Vec::new();
 
     for root in &compilation.roots {
         if let Some(grammar) = root.lexer
@@ -104,6 +109,9 @@ pub(crate) fn generate(
             );
             let module = render_lexer_model(&render_model)?;
             insert_rendered_module(&mut rendered_modules, &grammar_name, module)?;
+            if args.test_rig.is_some() {
+                test_rig_lexers.push(TestRigLexer::new(grammar_name.clone()));
+            }
             manifest_grammars.push(("lexer", grammar_name, entries));
         }
 
@@ -141,6 +149,12 @@ pub(crate) fn generate(
                 },
             )?;
             insert_rendered_module(&mut rendered_modules, &grammar_name, module)?;
+            if args.test_rig.is_some() {
+                test_rig_parsers.push(TestRigParser::new(
+                    grammar_name.clone(),
+                    data.rule_names.clone(),
+                ));
+            }
             decision_report_grammars.push(DecisionReportGrammar {
                 name: grammar_name.clone(),
                 rule_names: data.rule_names.clone(),
@@ -173,6 +187,12 @@ pub(crate) fn generate(
         artifacts.insert("optimizations.json", manifest)?;
     } else {
         artifacts.remove_if_present("optimizations.json")?;
+    }
+    if let Some(test_rig) = &args.test_rig {
+        artifacts.insert(
+            TEST_RIG_MAIN_PATH,
+            render_test_rig(&test_rig.start_rule, &test_rig_lexers, &test_rig_parsers)?,
+        )?;
     }
     let outputs = artifacts.write_to(&args.out_dir)?;
     Ok(Generation::new(inputs, outputs, warnings, diagnostics))

--- a/crates/antlr-rust-codegen/src/error.rs
+++ b/crates/antlr-rust-codegen/src/error.rs
@@ -139,18 +139,6 @@ impl Error {
     pub fn diagnostics(&self) -> &[Diagnostic] {
         &self.diagnostics
     }
-
-    pub(crate) fn into_io_error(mut self) -> io::Error {
-        self.source.take().unwrap_or_else(|| {
-            let kind =
-                if self.kind == ErrorKind::Configuration || self.kind == ErrorKind::Compilation {
-                    io::ErrorKind::InvalidInput
-                } else {
-                    io::ErrorKind::Other
-                };
-            io::Error::new(kind, self.message)
-        })
-    }
 }
 
 impl fmt::Display for Error {

--- a/crates/antlr-rust-codegen/src/lib.rs
+++ b/crates/antlr-rust-codegen/src/lib.rs
@@ -3,6 +3,7 @@
 mod artifact;
 mod builder;
 mod cli;
+mod cli_report;
 mod config;
 mod driver;
 pub(crate) mod embedded;
@@ -46,12 +47,12 @@ pub(crate) use structural::{structural_embedded_model, structural_predicates};
 /// The public [`Builder`] API is the preferred integration point for build
 /// scripts. This function exists for the package's binary adapter.
 #[doc(hidden)]
-pub fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
+pub fn run_cli() -> miette::Result<()> {
     cli::run_cli()
 }
 
 /// Runs the `antlr4-rust-testrig` command using the process arguments.
 #[doc(hidden)]
-pub fn run_testrig_cli() -> Result<std::process::ExitCode, Box<dyn std::error::Error>> {
+pub fn run_testrig_cli() -> miette::Result<std::process::ExitCode> {
     testrig_cli::run_cli()
 }

--- a/crates/antlr-rust-codegen/src/lib.rs
+++ b/crates/antlr-rust-codegen/src/lib.rs
@@ -17,6 +17,8 @@ mod parser;
 mod rust_output;
 mod semantics;
 mod structural;
+mod test_rig;
+mod testrig_cli;
 
 pub use artifact::Generation;
 pub use builder::{ActionMode, Builder, UnknownSemanticPolicy};
@@ -46,4 +48,10 @@ pub(crate) use structural::{structural_embedded_model, structural_predicates};
 #[doc(hidden)]
 pub fn run_cli() -> Result<(), Box<dyn std::error::Error>> {
     cli::run_cli()
+}
+
+/// Runs the `antlr4-rust-testrig` command using the process arguments.
+#[doc(hidden)]
+pub fn run_testrig_cli() -> Result<std::process::ExitCode, Box<dyn std::error::Error>> {
+    testrig_cli::run_cli()
 }

--- a/crates/antlr-rust-codegen/src/lib.rs
+++ b/crates/antlr-rust-codegen/src/lib.rs
@@ -48,11 +48,13 @@ pub(crate) use structural::{structural_embedded_model, structural_predicates};
 /// scripts. This function exists for the package's binary adapter.
 #[doc(hidden)]
 pub fn run_cli() -> miette::Result<()> {
+    cli_report::install_handler_from_env();
     cli::run_cli()
 }
 
 /// Runs the `antlr4-rust-testrig` command using the process arguments.
 #[doc(hidden)]
 pub fn run_testrig_cli() -> miette::Result<std::process::ExitCode> {
+    cli_report::install_handler_from_env();
     testrig_cli::run_cli()
 }

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
@@ -7,7 +7,7 @@ expression: rendered
 #[path = "../demo_lexer.rs"]
 mod generated_lexer;
 
-use generated_lexer::DemoLexer;
+use generated_lexer::DemoLexer as TestRigGeneratedLexer;
 
 use std::ffi::OsString;
 use std::fmt;
@@ -110,6 +110,12 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
                 ));
             }
         }
+    }
+    if options.diagnostics && options.sll {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--diagnostics cannot be used with --sll",
+        ));
     }
     Ok((options, inputs))
 }
@@ -239,7 +245,7 @@ fn process(
     options: Options,
 ) -> miette::Result<bool> {
     let source = diagnostic_source(&input);
-    let lexer = DemoLexer::new(input);
+    let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
@@ -1,0 +1,131 @@
+---
+source: crates/antlr-rust-codegen/src/test_rig.rs
+expression: rendered
+---
+#![allow(clippy::print_stderr, clippy::print_stdout)]
+
+#[path = "../demo_lexer.rs"]
+mod generated_lexer;
+
+use generated_lexer::DemoLexer;
+
+use std::ffi::OsString;
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use antlr4_runtime::{CommonTokenStream, InputStream};
+
+#[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
+#[derive(Clone, Copy, Debug, Default)]
+struct Options {
+    tokens: bool,
+    tree: bool,
+    trace: bool,
+    diagnostics: bool,
+    sll: bool,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<bool, Box<dyn std::error::Error>> {
+    let (options, input_files) = options_and_inputs()?;
+    if input_files.is_empty() {
+        let stdin = io::stdin();
+        let input = InputStream::from_reader(stdin.lock())?;
+        return process(input, options);
+    }
+
+    let show_names = input_files.len() > 1;
+    let mut success = true;
+    for input_file in input_files {
+        let path = PathBuf::from(input_file);
+        if show_names {
+            eprintln!("{}", path.display());
+        }
+        match process_file(&path, options) {
+            Ok(input_success) => success &= input_success,
+            Err(error) => {
+                eprintln!("error: {}: {error}", path.display());
+                success = false;
+            }
+        }
+    }
+    Ok(success)
+}
+
+fn process_file(
+    path: &std::path::Path,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let input = InputStream::from_reader_with_source_name(
+        File::open(path)?,
+        path.display().to_string(),
+    )?;
+    process(input, options)
+}
+
+fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
+    let mut options = Options::default();
+    let mut inputs = Vec::new();
+    let mut arguments = std::env::args_os().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.to_str() {
+            Some("--tokens") => options.tokens = true,
+            Some("--tree") => options.tree = true,
+            Some("--trace") => options.trace = true,
+            Some("--diagnostics") => options.diagnostics = true,
+            Some("--sll") => options.sll = true,
+            Some("--") => {
+                inputs.extend(arguments);
+                break;
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unexpected runner argument {}", argument.to_string_lossy()),
+                ));
+            }
+        }
+    }
+    Ok((options, inputs))
+}
+
+fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
+    tokens: &mut CommonTokenStream<L>,
+) -> usize {
+    tokens.fill();
+    let count = tokens.number_of_source_errors();
+    for error in tokens.drain_source_errors() {
+        if !tokens.token_source().report_error(&error) {
+            eprintln!("line {}:{} {}", error.line, error.column, error.message);
+        }
+    }
+    count
+}
+
+
+fn process(
+    input: InputStream,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let lexer = DemoLexer::new(input);
+    let mut tokens = CommonTokenStream::try_new(lexer)?;
+    let lexer_errors = report_lexer_errors(&mut tokens);
+    if options.tokens {
+        for token in tokens.tokens() {
+            println!("{token}");
+        }
+    }
+    Ok(lexer_errors == 0)
+}

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
@@ -10,12 +10,24 @@ mod generated_lexer;
 use generated_lexer::DemoLexer;
 
 use std::ffi::OsString;
+use std::fmt;
 use std::fs::File;
 use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
-use antlr4_runtime::{CommonTokenStream, InputStream};
+use antlr4_runtime::{
+    CharStream as _, CommonTokenStream, InputStream, IntStream as _,
+};
+use miette::{
+    Context as _, Diagnostic, IntoDiagnostic as _, LabeledSpan, NamedSource, SourceCode,
+};
+
+const LEXER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::lexer";
+
+type SharedSource = Arc<NamedSource<Arc<str>>>;
 
 #[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
@@ -27,22 +39,23 @@ struct Options {
     sll: bool,
 }
 
-fn main() -> ExitCode {
-    match run() {
-        Ok(true) => ExitCode::SUCCESS,
-        Ok(false) => ExitCode::FAILURE,
-        Err(error) => {
-            eprintln!("error: {error}");
-            ExitCode::FAILURE
-        }
-    }
+fn main() -> miette::Result<ExitCode> {
+    Ok(if run()? {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
 }
 
-fn run() -> Result<bool, Box<dyn std::error::Error>> {
-    let (options, input_files) = options_and_inputs()?;
+fn run() -> miette::Result<bool> {
+    let (options, input_files) = options_and_inputs()
+        .into_diagnostic()
+        .wrap_err("invalid TestRig runner arguments")?;
     if input_files.is_empty() {
         let stdin = io::stdin();
-        let input = InputStream::from_reader(stdin.lock())?;
+        let input = InputStream::from_reader_with_source_name(stdin.lock(), "<stdin>")
+            .into_diagnostic()
+            .wrap_err("failed to read standard input")?;
         return process(input, options);
     }
 
@@ -56,7 +69,7 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
         match process_file(&path, options) {
             Ok(input_success) => success &= input_success,
             Err(error) => {
-                eprintln!("error: {}: {error}", path.display());
+                eprintln!("Error: {error:?}");
                 success = false;
             }
         }
@@ -64,14 +77,14 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
     Ok(success)
 }
 
-fn process_file(
-    path: &std::path::Path,
-    options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    let input = InputStream::from_reader_with_source_name(
-        File::open(path)?,
-        path.display().to_string(),
-    )?;
+fn process_file(path: &std::path::Path, options: Options) -> miette::Result<bool> {
+    let file = File::open(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open input {}", path.display()))?;
+    let input =
+        InputStream::from_reader_with_source_name(file, path.display().to_string())
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read input {}", path.display()))?;
     process(input, options)
 }
 
@@ -101,15 +114,121 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
     Ok((options, inputs))
 }
 
+#[derive(Debug)]
+struct SyntaxDiagnostic {
+    code: &'static str,
+    message: String,
+    source: SharedSource,
+    span: Option<Range<usize>>,
+}
+
+impl SyntaxDiagnostic {
+    fn new(
+        code: &'static str,
+        source: SharedSource,
+        line: usize,
+        column: usize,
+        span: Option<Range<usize>>,
+        message: String,
+    ) -> Self {
+        let span = span
+            .filter(|span| span.start <= span.end && span.end <= source.inner().len())
+            .or_else(|| position_span(source.inner(), line, column));
+        let message = if span.is_some() {
+            message
+        } else {
+            format!("{}:{line}:{column}: {message}", source.name())
+        };
+        Self {
+            code,
+            message,
+            source,
+            span,
+        }
+    }
+}
+
+impl fmt::Display for SyntaxDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SyntaxDiagnostic {}
+
+impl Diagnostic for SyntaxDiagnostic {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new(self.code))
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        Some(self.source.as_ref())
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.span.as_ref().map(|span| {
+            let label = if span.is_empty() {
+                LabeledSpan::at_offset(span.start, "here")
+            } else {
+                LabeledSpan::underline(span.clone())
+            };
+            let labels: Box<dyn Iterator<Item = LabeledSpan>> =
+                Box::new(std::iter::once(label));
+            labels
+        })
+    }
+}
+
+fn diagnostic_source(input: &InputStream) -> SharedSource {
+    let contents: Arc<str> = input
+        .source_text()
+        .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
+    Arc::new(NamedSource::new(input.source_name(), contents))
+}
+
+fn position_span(source: &str, line: usize, column: usize) -> Option<Range<usize>> {
+    let line_index = line.checked_sub(1)?;
+    let mut line_start = 0;
+    for _ in 0..line_index {
+        line_start += source.get(line_start..)?.find('\n')? + 1;
+    }
+    let remainder = source.get(line_start..)?;
+    let line_length = remainder.find('\n').unwrap_or(remainder.len());
+    let line_text = remainder.get(..line_length)?;
+    let relative = line_text
+        .char_indices()
+        .nth(column)
+        .map(|(offset, _)| offset)
+        .or_else(|| (line_text.chars().count() == column).then_some(line_text.len()))?;
+    let length = line_text
+        .get(relative..)?
+        .chars()
+        .next()
+        .map_or(0, char::len_utf8);
+    let start = line_start + relative;
+    Some(start..start + length)
+}
+
+fn report_diagnostic(diagnostic: SyntaxDiagnostic) {
+    eprintln!("Error: {:?}", miette::Report::new(diagnostic));
+}
+
 fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
     tokens: &mut CommonTokenStream<L>,
+    source: &SharedSource,
 ) -> usize {
     tokens.fill();
-    let count = tokens.number_of_source_errors();
-    for error in tokens.drain_source_errors() {
-        if !tokens.token_source().report_error(&error) {
-            eprintln!("line {}:{} {}", error.line, error.column, error.message);
-        }
+    let errors = tokens.drain_source_errors();
+    let count = errors.len();
+    for error in errors {
+        report_diagnostic(SyntaxDiagnostic::new(
+            LEXER_DIAGNOSTIC_CODE,
+            Arc::clone(source),
+            error.line,
+            error.column,
+            error.span,
+            error.message,
+        ));
     }
     count
 }
@@ -118,10 +237,13 @@ fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
 fn process(
     input: InputStream,
     options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> miette::Result<bool> {
+    let source = diagnostic_source(&input);
     let lexer = DemoLexer::new(input);
-    let mut tokens = CommonTokenStream::try_new(lexer)?;
-    let lexer_errors = report_lexer_errors(&mut tokens);
+    let mut tokens = CommonTokenStream::try_new(lexer)
+        .into_diagnostic()
+        .wrap_err("failed to buffer lexer tokens")?;
+    let lexer_errors = report_lexer_errors(&mut tokens, &source);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
@@ -39,7 +39,21 @@ struct Options {
     sll: bool,
 }
 
+fn install_miette_handler() {
+    let Some(width) = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|width| *width > 0)
+    else {
+        return;
+    };
+    let _ = miette::set_hook(Box::new(move |_| {
+        Box::new(miette::MietteHandlerOpts::new().width(width).build())
+    }));
+}
+
 fn main() -> miette::Result<ExitCode> {
+    install_miette_handler();
     Ok(if run()? {
         ExitCode::SUCCESS
     } else {

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__lexer_runner_rendered.snap
@@ -16,6 +16,7 @@ use std::io;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use antlr4_runtime::{
@@ -28,6 +29,49 @@ use miette::{
 const LEXER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::lexer";
 
 type SharedSource = Arc<NamedSource<Arc<str>>>;
+
+#[derive(Debug)]
+struct DiagnosticSource {
+    name: String,
+    contents: Option<Rc<str>>,
+    shared: Option<SharedSource>,
+}
+
+impl DiagnosticSource {
+    fn new(input: &InputStream) -> Self {
+        Self {
+            name: input.source_name().to_owned(),
+            contents: input.source_text(),
+            shared: None,
+        }
+    }
+
+    fn report(&mut self, diagnostics: Vec<PendingDiagnostic>) {
+        if diagnostics.is_empty() {
+            return;
+        }
+        let source = self.shared();
+        for diagnostic in diagnostics {
+            report_diagnostic(SyntaxDiagnostic::new(
+                Arc::clone(&source),
+                diagnostic,
+            ));
+        }
+    }
+
+    fn shared(&mut self) -> SharedSource {
+        if let Some(source) = &self.shared {
+            return Arc::clone(source);
+        }
+        let contents: Arc<str> = self
+            .contents
+            .take()
+            .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
+        let source = Arc::new(NamedSource::new(self.name.clone(), contents));
+        self.shared = Some(Arc::clone(&source));
+        source
+    }
+}
 
 #[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
@@ -135,6 +179,15 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
 }
 
 #[derive(Debug)]
+struct PendingDiagnostic {
+    code: &'static str,
+    line: usize,
+    column: usize,
+    span: Option<Range<usize>>,
+    message: String,
+}
+
+#[derive(Debug)]
 struct SyntaxDiagnostic {
     code: &'static str,
     message: String,
@@ -143,14 +196,14 @@ struct SyntaxDiagnostic {
 }
 
 impl SyntaxDiagnostic {
-    fn new(
-        code: &'static str,
-        source: SharedSource,
-        line: usize,
-        column: usize,
-        span: Option<Range<usize>>,
-        message: String,
-    ) -> Self {
+    fn new(source: SharedSource, diagnostic: PendingDiagnostic) -> Self {
+        let PendingDiagnostic {
+            code,
+            line,
+            column,
+            span,
+            message,
+        } = diagnostic;
         let span = span
             .filter(|span| span.start <= span.end && span.end <= source.inner().len())
             .or_else(|| position_span(source.inner(), line, column));
@@ -199,13 +252,6 @@ impl Diagnostic for SyntaxDiagnostic {
     }
 }
 
-fn diagnostic_source(input: &InputStream) -> SharedSource {
-    let contents: Arc<str> = input
-        .source_text()
-        .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
-    Arc::new(NamedSource::new(input.source_name(), contents))
-}
-
 fn position_span(source: &str, line: usize, column: usize) -> Option<Range<usize>> {
     let line_index = line.checked_sub(1)?;
     let mut line_start = 0;
@@ -233,24 +279,21 @@ fn report_diagnostic(diagnostic: SyntaxDiagnostic) {
     eprintln!("Error: {:?}", miette::Report::new(diagnostic));
 }
 
-fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
+fn lexer_diagnostics<L: antlr4_runtime::TokenSource>(
     tokens: &mut CommonTokenStream<L>,
-    source: &SharedSource,
-) -> usize {
+) -> Vec<PendingDiagnostic> {
     tokens.fill();
-    let errors = tokens.drain_source_errors();
-    let count = errors.len();
-    for error in errors {
-        report_diagnostic(SyntaxDiagnostic::new(
-            LEXER_DIAGNOSTIC_CODE,
-            Arc::clone(source),
-            error.line,
-            error.column,
-            error.span,
-            error.message,
-        ));
-    }
-    count
+    tokens
+        .drain_source_errors()
+        .into_iter()
+        .map(|error| PendingDiagnostic {
+            code: LEXER_DIAGNOSTIC_CODE,
+            line: error.line,
+            column: error.column,
+            span: error.span,
+            message: error.message,
+        })
+        .collect()
 }
 
 
@@ -258,12 +301,14 @@ fn process(
     input: InputStream,
     options: Options,
 ) -> miette::Result<bool> {
-    let source = diagnostic_source(&input);
+    let mut source = DiagnosticSource::new(&input);
     let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
-    let lexer_errors = report_lexer_errors(&mut tokens, &source);
+    let diagnostics = lexer_diagnostics(&mut tokens);
+    let lexer_errors = diagnostics.len();
+    source.report(diagnostics);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
@@ -1,0 +1,220 @@
+---
+source: crates/antlr-rust-codegen/src/test_rig.rs
+expression: rendered
+---
+#![allow(clippy::print_stderr, clippy::print_stdout)]
+
+#[path = "../demo_lexer.rs"]
+mod generated_lexer;
+#[path = "../demo_parser.rs"]
+mod generated_parser;
+
+use antlr4_runtime::{
+    AntlrError, EnterRuleEvent, ParseListener, Parser as _, PredictionMode,
+};
+use generated_lexer::DemoLexer;
+use generated_parser::DemoParser;
+
+use std::ffi::OsString;
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use antlr4_runtime::{CommonTokenStream, InputStream};
+
+#[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
+#[derive(Clone, Copy, Debug, Default)]
+struct Options {
+    tokens: bool,
+    tree: bool,
+    trace: bool,
+    diagnostics: bool,
+    sll: bool,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<bool, Box<dyn std::error::Error>> {
+    let (options, input_files) = options_and_inputs()?;
+    if input_files.is_empty() {
+        let stdin = io::stdin();
+        let input = InputStream::from_reader(stdin.lock())?;
+        return process(input, options);
+    }
+
+    let show_names = input_files.len() > 1;
+    let mut success = true;
+    for input_file in input_files {
+        let path = PathBuf::from(input_file);
+        if show_names {
+            eprintln!("{}", path.display());
+        }
+        match process_file(&path, options) {
+            Ok(input_success) => success &= input_success,
+            Err(error) => {
+                eprintln!("error: {}: {error}", path.display());
+                success = false;
+            }
+        }
+    }
+    Ok(success)
+}
+
+fn process_file(
+    path: &std::path::Path,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let input = InputStream::from_reader_with_source_name(
+        File::open(path)?,
+        path.display().to_string(),
+    )?;
+    process(input, options)
+}
+
+fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
+    let mut options = Options::default();
+    let mut inputs = Vec::new();
+    let mut arguments = std::env::args_os().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.to_str() {
+            Some("--tokens") => options.tokens = true,
+            Some("--tree") => options.tree = true,
+            Some("--trace") => options.trace = true,
+            Some("--diagnostics") => options.diagnostics = true,
+            Some("--sll") => options.sll = true,
+            Some("--") => {
+                inputs.extend(arguments);
+                break;
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unexpected runner argument {}", argument.to_string_lossy()),
+                ));
+            }
+        }
+    }
+    Ok((options, inputs))
+}
+
+fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
+    tokens: &mut CommonTokenStream<L>,
+) -> usize {
+    tokens.fill();
+    let count = tokens.number_of_source_errors();
+    for error in tokens.drain_source_errors() {
+        if !tokens.token_source().report_error(&error) {
+            eprintln!("line {}:{} {}", error.line, error.column, error.message);
+        }
+    }
+    count
+}
+
+
+#[derive(Debug)]
+struct TraceListener {
+    rule_names: &'static [&'static str],
+    depth: usize,
+}
+
+impl TraceListener {
+    const fn new(rule_names: &'static [&'static str]) -> Self {
+        Self {
+            rule_names,
+            depth: 0,
+        }
+    }
+
+    fn rule_name(&self, rule_index: usize) -> &str {
+        self.rule_names
+            .get(rule_index)
+            .copied()
+            .unwrap_or("<unknown>")
+    }
+}
+
+impl ParseListener for TraceListener {
+    fn enter_every_rule(&mut self, event: &EnterRuleEvent<'_>) -> Result<(), AntlrError> {
+        let lookahead = event
+            .current
+            .map_or_else(|| "<EOF>".to_owned(), |token| token.to_string());
+        eprintln!(
+            "{}enter   {}, LT(1)={lookahead}",
+            "  ".repeat(self.depth),
+            self.rule_name(event.rule_index),
+        );
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn exit_every_rule(&mut self, rule_index: usize) {
+        self.depth = self.depth.saturating_sub(1);
+        eprintln!(
+            "{}exit    {}",
+            "  ".repeat(self.depth),
+            self.rule_name(rule_index),
+        );
+    }
+}
+
+fn process(
+    input: InputStream,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let lexer = DemoLexer::new(input);
+    let mut tokens = CommonTokenStream::try_new(lexer)?;
+    let lexer_errors = report_lexer_errors(&mut tokens);
+    if options.tokens {
+        for token in tokens.tokens() {
+            println!("{token}");
+        }
+    }
+
+    let mut parser = DemoParser::new(tokens);
+    if options.tree {
+        parser.set_build_parse_trees(true);
+    }
+    if options.diagnostics {
+        parser.set_report_diagnostic_errors(true);
+        parser.set_prediction_mode(PredictionMode::LlExactAmbigDetection);
+    }
+    if options.sll {
+        parser.set_prediction_mode(PredictionMode::Sll);
+    }
+    if options.trace {
+        parser.add_parse_listener(TraceListener::new(
+            generated_parser::rule_names(),
+        ));
+    }
+
+    let result = parser.reset_rule();
+    let parser_errors = parser.number_of_syntax_errors();
+    let root = match result {
+        Ok(root) => Some(root),
+        Err(error) => {
+            if !matches!(error, AntlrError::ParserError { .. }) {
+                eprintln!("error: {error}");
+            }
+            None
+        }
+    };
+    if options.tree && let Some(root) = root {
+        println!(
+            "{}",
+            parser
+                .node(root)
+                .to_string_tree(Some(&parser), parser.token_store()),
+        );
+    }
+    Ok(lexer_errors == 0 && parser_errors == 0 && root.is_some())
+}

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
@@ -13,9 +13,9 @@ use antlr4_runtime::{
     AntlrError, EnterRuleEvent, ErrorListener, ParseListener, Parser as _, PredictionMode,
     Recognizer, SyntaxErrorEvent,
 };
+use generated_lexer::DemoLexer as TestRigGeneratedLexer;
+use generated_parser::DemoParser as TestRigGeneratedParser;
 use std::sync::Mutex;
-use generated_lexer::DemoLexer;
-use generated_parser::DemoParser;
 
 use std::ffi::OsString;
 use std::fmt;
@@ -118,6 +118,12 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
                 ));
             }
         }
+    }
+    if options.diagnostics && options.sll {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--diagnostics cannot be used with --sll",
+        ));
     }
     Ok((options, inputs))
 }
@@ -344,7 +350,7 @@ fn process(
     options: Options,
 ) -> miette::Result<bool> {
     let source = diagnostic_source(&input);
-    let lexer = DemoLexer::new(input);
+    let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
@@ -355,19 +361,16 @@ fn process(
         }
     }
 
-    let mut parser = DemoParser::new(tokens);
+    let mut parser = TestRigGeneratedParser::new(tokens);
     let parser_diagnostics =
         DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE, Arc::clone(&source));
     parser.remove_error_listeners();
     parser.add_error_listener(parser_diagnostics.clone());
-    if options.tree {
-        parser.set_build_parse_trees(true);
-    }
+    parser.set_build_parse_trees(options.tree);
     if options.diagnostics {
         parser.set_report_diagnostic_errors(true);
         parser.set_prediction_mode(PredictionMode::LlExactAmbigDetection);
-    }
-    if options.sll {
+    } else if options.sll {
         parser.set_prediction_mode(PredictionMode::Sll);
     }
     if options.trace {

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
@@ -10,18 +10,32 @@ mod generated_lexer;
 mod generated_parser;
 
 use antlr4_runtime::{
-    AntlrError, EnterRuleEvent, ParseListener, Parser as _, PredictionMode,
+    AntlrError, EnterRuleEvent, ErrorListener, ParseListener, Parser as _, PredictionMode,
+    Recognizer, SyntaxErrorEvent,
 };
+use std::sync::Mutex;
 use generated_lexer::DemoLexer;
 use generated_parser::DemoParser;
 
 use std::ffi::OsString;
+use std::fmt;
 use std::fs::File;
 use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
-use antlr4_runtime::{CommonTokenStream, InputStream};
+use antlr4_runtime::{
+    CharStream as _, CommonTokenStream, InputStream, IntStream as _,
+};
+use miette::{
+    Context as _, Diagnostic, IntoDiagnostic as _, LabeledSpan, NamedSource, SourceCode,
+};
+
+const LEXER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::lexer";
+
+type SharedSource = Arc<NamedSource<Arc<str>>>;
 
 #[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
@@ -33,22 +47,23 @@ struct Options {
     sll: bool,
 }
 
-fn main() -> ExitCode {
-    match run() {
-        Ok(true) => ExitCode::SUCCESS,
-        Ok(false) => ExitCode::FAILURE,
-        Err(error) => {
-            eprintln!("error: {error}");
-            ExitCode::FAILURE
-        }
-    }
+fn main() -> miette::Result<ExitCode> {
+    Ok(if run()? {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
 }
 
-fn run() -> Result<bool, Box<dyn std::error::Error>> {
-    let (options, input_files) = options_and_inputs()?;
+fn run() -> miette::Result<bool> {
+    let (options, input_files) = options_and_inputs()
+        .into_diagnostic()
+        .wrap_err("invalid TestRig runner arguments")?;
     if input_files.is_empty() {
         let stdin = io::stdin();
-        let input = InputStream::from_reader(stdin.lock())?;
+        let input = InputStream::from_reader_with_source_name(stdin.lock(), "<stdin>")
+            .into_diagnostic()
+            .wrap_err("failed to read standard input")?;
         return process(input, options);
     }
 
@@ -62,7 +77,7 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
         match process_file(&path, options) {
             Ok(input_success) => success &= input_success,
             Err(error) => {
-                eprintln!("error: {}: {error}", path.display());
+                eprintln!("Error: {error:?}");
                 success = false;
             }
         }
@@ -70,14 +85,14 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
     Ok(success)
 }
 
-fn process_file(
-    path: &std::path::Path,
-    options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    let input = InputStream::from_reader_with_source_name(
-        File::open(path)?,
-        path.display().to_string(),
-    )?;
+fn process_file(path: &std::path::Path, options: Options) -> miette::Result<bool> {
+    let file = File::open(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open input {}", path.display()))?;
+    let input =
+        InputStream::from_reader_with_source_name(file, path.display().to_string())
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read input {}", path.display()))?;
     process(input, options)
 }
 
@@ -107,19 +122,176 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
     Ok((options, inputs))
 }
 
+#[derive(Debug)]
+struct SyntaxDiagnostic {
+    code: &'static str,
+    message: String,
+    source: SharedSource,
+    span: Option<Range<usize>>,
+}
+
+impl SyntaxDiagnostic {
+    fn new(
+        code: &'static str,
+        source: SharedSource,
+        line: usize,
+        column: usize,
+        span: Option<Range<usize>>,
+        message: String,
+    ) -> Self {
+        let span = span
+            .filter(|span| span.start <= span.end && span.end <= source.inner().len())
+            .or_else(|| position_span(source.inner(), line, column));
+        let message = if span.is_some() {
+            message
+        } else {
+            format!("{}:{line}:{column}: {message}", source.name())
+        };
+        Self {
+            code,
+            message,
+            source,
+            span,
+        }
+    }
+}
+
+impl fmt::Display for SyntaxDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SyntaxDiagnostic {}
+
+impl Diagnostic for SyntaxDiagnostic {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new(self.code))
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        Some(self.source.as_ref())
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.span.as_ref().map(|span| {
+            let label = if span.is_empty() {
+                LabeledSpan::at_offset(span.start, "here")
+            } else {
+                LabeledSpan::underline(span.clone())
+            };
+            let labels: Box<dyn Iterator<Item = LabeledSpan>> =
+                Box::new(std::iter::once(label));
+            labels
+        })
+    }
+}
+
+fn diagnostic_source(input: &InputStream) -> SharedSource {
+    let contents: Arc<str> = input
+        .source_text()
+        .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
+    Arc::new(NamedSource::new(input.source_name(), contents))
+}
+
+fn position_span(source: &str, line: usize, column: usize) -> Option<Range<usize>> {
+    let line_index = line.checked_sub(1)?;
+    let mut line_start = 0;
+    for _ in 0..line_index {
+        line_start += source.get(line_start..)?.find('\n')? + 1;
+    }
+    let remainder = source.get(line_start..)?;
+    let line_length = remainder.find('\n').unwrap_or(remainder.len());
+    let line_text = remainder.get(..line_length)?;
+    let relative = line_text
+        .char_indices()
+        .nth(column)
+        .map(|(offset, _)| offset)
+        .or_else(|| (line_text.chars().count() == column).then_some(line_text.len()))?;
+    let length = line_text
+        .get(relative..)?
+        .chars()
+        .next()
+        .map_or(0, char::len_utf8);
+    let start = line_start + relative;
+    Some(start..start + length)
+}
+
+fn report_diagnostic(diagnostic: SyntaxDiagnostic) {
+    eprintln!("Error: {:?}", miette::Report::new(diagnostic));
+}
+
 fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
     tokens: &mut CommonTokenStream<L>,
+    source: &SharedSource,
 ) -> usize {
     tokens.fill();
-    let count = tokens.number_of_source_errors();
-    for error in tokens.drain_source_errors() {
-        if !tokens.token_source().report_error(&error) {
-            eprintln!("line {}:{} {}", error.line, error.column, error.message);
-        }
+    let errors = tokens.drain_source_errors();
+    let count = errors.len();
+    for error in errors {
+        report_diagnostic(SyntaxDiagnostic::new(
+            LEXER_DIAGNOSTIC_CODE,
+            Arc::clone(source),
+            error.line,
+            error.column,
+            error.span,
+            error.message,
+        ));
     }
     count
 }
 
+
+const PARSER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::parser";
+
+#[derive(Clone, Debug)]
+struct DiagnosticCollector {
+    code: &'static str,
+    source: SharedSource,
+    diagnostics: Arc<Mutex<Vec<SyntaxDiagnostic>>>,
+}
+
+impl DiagnosticCollector {
+    fn new(code: &'static str, source: SharedSource) -> Self {
+        Self {
+            code,
+            source,
+            diagnostics: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn report(&self) {
+        let diagnostics = {
+            let mut diagnostics = self
+                .diagnostics
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *diagnostics)
+        };
+        for diagnostic in diagnostics {
+            report_diagnostic(diagnostic);
+        }
+    }
+}
+
+impl<R> ErrorListener<R> for DiagnosticCollector
+where
+    R: Recognizer + ?Sized,
+{
+    fn syntax_error(&mut self, _recognizer: &R, event: &SyntaxErrorEvent<'_>) {
+        self.diagnostics
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(SyntaxDiagnostic::new(
+                self.code,
+                Arc::clone(&self.source),
+                event.line,
+                event.column,
+                event.span.clone(),
+                event.message.to_owned(),
+            ));
+    }
+}
 
 #[derive(Debug)]
 struct TraceListener {
@@ -170,10 +342,13 @@ impl ParseListener for TraceListener {
 fn process(
     input: InputStream,
     options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> miette::Result<bool> {
+    let source = diagnostic_source(&input);
     let lexer = DemoLexer::new(input);
-    let mut tokens = CommonTokenStream::try_new(lexer)?;
-    let lexer_errors = report_lexer_errors(&mut tokens);
+    let mut tokens = CommonTokenStream::try_new(lexer)
+        .into_diagnostic()
+        .wrap_err("failed to buffer lexer tokens")?;
+    let lexer_errors = report_lexer_errors(&mut tokens, &source);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");
@@ -181,6 +356,10 @@ fn process(
     }
 
     let mut parser = DemoParser::new(tokens);
+    let parser_diagnostics =
+        DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE, Arc::clone(&source));
+    parser.remove_error_listeners();
+    parser.add_error_listener(parser_diagnostics.clone());
     if options.tree {
         parser.set_build_parse_trees(true);
     }
@@ -203,11 +382,12 @@ fn process(
         Ok(root) => Some(root),
         Err(error) => {
             if !matches!(error, AntlrError::ParserError { .. }) {
-                eprintln!("error: {error}");
+                eprintln!("Error: {:?}", miette::Report::msg(error.to_string()));
             }
             None
         }
     };
+    parser_diagnostics.report();
     if options.tree && let Some(root) = root {
         println!(
             "{}",

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
@@ -24,6 +24,7 @@ use std::io;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use antlr4_runtime::{
@@ -36,6 +37,49 @@ use miette::{
 const LEXER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::lexer";
 
 type SharedSource = Arc<NamedSource<Arc<str>>>;
+
+#[derive(Debug)]
+struct DiagnosticSource {
+    name: String,
+    contents: Option<Rc<str>>,
+    shared: Option<SharedSource>,
+}
+
+impl DiagnosticSource {
+    fn new(input: &InputStream) -> Self {
+        Self {
+            name: input.source_name().to_owned(),
+            contents: input.source_text(),
+            shared: None,
+        }
+    }
+
+    fn report(&mut self, diagnostics: Vec<PendingDiagnostic>) {
+        if diagnostics.is_empty() {
+            return;
+        }
+        let source = self.shared();
+        for diagnostic in diagnostics {
+            report_diagnostic(SyntaxDiagnostic::new(
+                Arc::clone(&source),
+                diagnostic,
+            ));
+        }
+    }
+
+    fn shared(&mut self) -> SharedSource {
+        if let Some(source) = &self.shared {
+            return Arc::clone(source);
+        }
+        let contents: Arc<str> = self
+            .contents
+            .take()
+            .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
+        let source = Arc::new(NamedSource::new(self.name.clone(), contents));
+        self.shared = Some(Arc::clone(&source));
+        source
+    }
+}
 
 #[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
@@ -143,6 +187,15 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
 }
 
 #[derive(Debug)]
+struct PendingDiagnostic {
+    code: &'static str,
+    line: usize,
+    column: usize,
+    span: Option<Range<usize>>,
+    message: String,
+}
+
+#[derive(Debug)]
 struct SyntaxDiagnostic {
     code: &'static str,
     message: String,
@@ -151,14 +204,14 @@ struct SyntaxDiagnostic {
 }
 
 impl SyntaxDiagnostic {
-    fn new(
-        code: &'static str,
-        source: SharedSource,
-        line: usize,
-        column: usize,
-        span: Option<Range<usize>>,
-        message: String,
-    ) -> Self {
+    fn new(source: SharedSource, diagnostic: PendingDiagnostic) -> Self {
+        let PendingDiagnostic {
+            code,
+            line,
+            column,
+            span,
+            message,
+        } = diagnostic;
         let span = span
             .filter(|span| span.start <= span.end && span.end <= source.inner().len())
             .or_else(|| position_span(source.inner(), line, column));
@@ -207,13 +260,6 @@ impl Diagnostic for SyntaxDiagnostic {
     }
 }
 
-fn diagnostic_source(input: &InputStream) -> SharedSource {
-    let contents: Arc<str> = input
-        .source_text()
-        .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
-    Arc::new(NamedSource::new(input.source_name(), contents))
-}
-
 fn position_span(source: &str, line: usize, column: usize) -> Option<Range<usize>> {
     let line_index = line.checked_sub(1)?;
     let mut line_start = 0;
@@ -241,24 +287,21 @@ fn report_diagnostic(diagnostic: SyntaxDiagnostic) {
     eprintln!("Error: {:?}", miette::Report::new(diagnostic));
 }
 
-fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
+fn lexer_diagnostics<L: antlr4_runtime::TokenSource>(
     tokens: &mut CommonTokenStream<L>,
-    source: &SharedSource,
-) -> usize {
+) -> Vec<PendingDiagnostic> {
     tokens.fill();
-    let errors = tokens.drain_source_errors();
-    let count = errors.len();
-    for error in errors {
-        report_diagnostic(SyntaxDiagnostic::new(
-            LEXER_DIAGNOSTIC_CODE,
-            Arc::clone(source),
-            error.line,
-            error.column,
-            error.span,
-            error.message,
-        ));
-    }
-    count
+    tokens
+        .drain_source_errors()
+        .into_iter()
+        .map(|error| PendingDiagnostic {
+            code: LEXER_DIAGNOSTIC_CODE,
+            line: error.line,
+            column: error.column,
+            span: error.span,
+            message: error.message,
+        })
+        .collect()
 }
 
 
@@ -267,30 +310,23 @@ const PARSER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::parser";
 #[derive(Clone, Debug)]
 struct DiagnosticCollector {
     code: &'static str,
-    source: SharedSource,
-    diagnostics: Arc<Mutex<Vec<SyntaxDiagnostic>>>,
+    diagnostics: Arc<Mutex<Vec<PendingDiagnostic>>>,
 }
 
 impl DiagnosticCollector {
-    fn new(code: &'static str, source: SharedSource) -> Self {
+    fn new(code: &'static str) -> Self {
         Self {
             code,
-            source,
             diagnostics: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    fn report(&self) {
-        let diagnostics = {
-            let mut diagnostics = self
-                .diagnostics
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            std::mem::take(&mut *diagnostics)
-        };
-        for diagnostic in diagnostics {
-            report_diagnostic(diagnostic);
-        }
+    fn take(&self) -> Vec<PendingDiagnostic> {
+        let mut diagnostics = self
+            .diagnostics
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::mem::take(&mut *diagnostics)
     }
 }
 
@@ -302,14 +338,13 @@ where
         self.diagnostics
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push(SyntaxDiagnostic::new(
-                self.code,
-                Arc::clone(&self.source),
-                event.line,
-                event.column,
-                event.span.clone(),
-                event.message.to_owned(),
-            ));
+            .push(PendingDiagnostic {
+                code: self.code,
+                line: event.line,
+                column: event.column,
+                span: event.span.clone(),
+                message: event.message.to_owned(),
+            });
     }
 }
 
@@ -363,12 +398,14 @@ fn process(
     input: InputStream,
     options: Options,
 ) -> miette::Result<bool> {
-    let source = diagnostic_source(&input);
+    let mut source = DiagnosticSource::new(&input);
     let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
-    let lexer_errors = report_lexer_errors(&mut tokens, &source);
+    let lexer_diagnostics = lexer_diagnostics(&mut tokens);
+    let lexer_errors = lexer_diagnostics.len();
+    source.report(lexer_diagnostics);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");
@@ -376,8 +413,7 @@ fn process(
     }
 
     let mut parser = TestRigGeneratedParser::new(tokens);
-    let parser_diagnostics =
-        DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE, Arc::clone(&source));
+    let parser_diagnostics = DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE);
     parser.remove_error_listeners();
     parser.add_error_listener(parser_diagnostics.clone());
     parser.set_build_parse_trees(options.tree);
@@ -404,7 +440,7 @@ fn process(
             None
         }
     };
-    parser_diagnostics.report();
+    source.report(parser_diagnostics.take());
     if options.tree && let Some(root) = root {
         println!(
             "{}",

--- a/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
+++ b/crates/antlr-rust-codegen/src/snapshots/antlr_rust_codegen__test_rig__tests__parser_runner_rendered.snap
@@ -47,7 +47,21 @@ struct Options {
     sll: bool,
 }
 
+fn install_miette_handler() {
+    let Some(width) = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|width| *width > 0)
+    else {
+        return;
+    };
+    let _ = miette::set_hook(Box::new(move |_| {
+        Box::new(miette::MietteHandlerOpts::new().width(width).build())
+    }));
+}
+
 fn main() -> miette::Result<ExitCode> {
+    install_miette_handler();
     Ok(if run()? {
         ExitCode::SUCCESS
     } else {

--- a/crates/antlr-rust-codegen/src/test_rig.rs
+++ b/crates/antlr-rust-codegen/src/test_rig.rs
@@ -184,6 +184,7 @@ use std::io;
 use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::rc::Rc;
 use std::sync::Arc;
 
 use antlr4_runtime::{
@@ -196,6 +197,49 @@ use miette::{
 const LEXER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::lexer";
 
 type SharedSource = Arc<NamedSource<Arc<str>>>;
+
+#[derive(Debug)]
+struct DiagnosticSource {
+    name: String,
+    contents: Option<Rc<str>>,
+    shared: Option<SharedSource>,
+}
+
+impl DiagnosticSource {
+    fn new(input: &InputStream) -> Self {
+        Self {
+            name: input.source_name().to_owned(),
+            contents: input.source_text(),
+            shared: None,
+        }
+    }
+
+    fn report(&mut self, diagnostics: Vec<PendingDiagnostic>) {
+        if diagnostics.is_empty() {
+            return;
+        }
+        let source = self.shared();
+        for diagnostic in diagnostics {
+            report_diagnostic(SyntaxDiagnostic::new(
+                Arc::clone(&source),
+                diagnostic,
+            ));
+        }
+    }
+
+    fn shared(&mut self) -> SharedSource {
+        if let Some(source) = &self.shared {
+            return Arc::clone(source);
+        }
+        let contents: Arc<str> = self
+            .contents
+            .take()
+            .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
+        let source = Arc::new(NamedSource::new(self.name.clone(), contents));
+        self.shared = Some(Arc::clone(&source));
+        source
+    }
+}
 
 #[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
@@ -303,6 +347,15 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
 }
 
 #[derive(Debug)]
+struct PendingDiagnostic {
+    code: &'static str,
+    line: usize,
+    column: usize,
+    span: Option<Range<usize>>,
+    message: String,
+}
+
+#[derive(Debug)]
 struct SyntaxDiagnostic {
     code: &'static str,
     message: String,
@@ -311,14 +364,14 @@ struct SyntaxDiagnostic {
 }
 
 impl SyntaxDiagnostic {
-    fn new(
-        code: &'static str,
-        source: SharedSource,
-        line: usize,
-        column: usize,
-        span: Option<Range<usize>>,
-        message: String,
-    ) -> Self {
+    fn new(source: SharedSource, diagnostic: PendingDiagnostic) -> Self {
+        let PendingDiagnostic {
+            code,
+            line,
+            column,
+            span,
+            message,
+        } = diagnostic;
         let span = span
             .filter(|span| span.start <= span.end && span.end <= source.inner().len())
             .or_else(|| position_span(source.inner(), line, column));
@@ -367,13 +420,6 @@ impl Diagnostic for SyntaxDiagnostic {
     }
 }
 
-fn diagnostic_source(input: &InputStream) -> SharedSource {
-    let contents: Arc<str> = input
-        .source_text()
-        .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
-    Arc::new(NamedSource::new(input.source_name(), contents))
-}
-
 fn position_span(source: &str, line: usize, column: usize) -> Option<Range<usize>> {
     let line_index = line.checked_sub(1)?;
     let mut line_start = 0;
@@ -401,24 +447,21 @@ fn report_diagnostic(diagnostic: SyntaxDiagnostic) {
     eprintln!("Error: {:?}", miette::Report::new(diagnostic));
 }
 
-fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
+fn lexer_diagnostics<L: antlr4_runtime::TokenSource>(
     tokens: &mut CommonTokenStream<L>,
-    source: &SharedSource,
-) -> usize {
+) -> Vec<PendingDiagnostic> {
     tokens.fill();
-    let errors = tokens.drain_source_errors();
-    let count = errors.len();
-    for error in errors {
-        report_diagnostic(SyntaxDiagnostic::new(
-            LEXER_DIAGNOSTIC_CODE,
-            Arc::clone(source),
-            error.line,
-            error.column,
-            error.span,
-            error.message,
-        ));
-    }
-    count
+    tokens
+        .drain_source_errors()
+        .into_iter()
+        .map(|error| PendingDiagnostic {
+            code: LEXER_DIAGNOSTIC_CODE,
+            line: error.line,
+            column: error.column,
+            span: error.span,
+            message: error.message,
+        })
+        .collect()
 }
 "#;
 
@@ -435,12 +478,14 @@ fn process(
     input: InputStream,
     options: Options,
 ) -> miette::Result<bool> {
-    let source = diagnostic_source(&input);
+    let mut source = DiagnosticSource::new(&input);
     let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
-    let lexer_errors = report_lexer_errors(&mut tokens, &source);
+    let diagnostics = lexer_diagnostics(&mut tokens);
+    let lexer_errors = diagnostics.len();
+    source.report(diagnostics);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");
@@ -472,30 +517,23 @@ const PARSER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::parser";
 #[derive(Clone, Debug)]
 struct DiagnosticCollector {
     code: &'static str,
-    source: SharedSource,
-    diagnostics: Arc<Mutex<Vec<SyntaxDiagnostic>>>,
+    diagnostics: Arc<Mutex<Vec<PendingDiagnostic>>>,
 }
 
 impl DiagnosticCollector {
-    fn new(code: &'static str, source: SharedSource) -> Self {
+    fn new(code: &'static str) -> Self {
         Self {
             code,
-            source,
             diagnostics: Arc::new(Mutex::new(Vec::new())),
         }
     }
 
-    fn report(&self) {
-        let diagnostics = {
-            let mut diagnostics = self
-                .diagnostics
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner);
-            std::mem::take(&mut *diagnostics)
-        };
-        for diagnostic in diagnostics {
-            report_diagnostic(diagnostic);
-        }
+    fn take(&self) -> Vec<PendingDiagnostic> {
+        let mut diagnostics = self
+            .diagnostics
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::mem::take(&mut *diagnostics)
     }
 }
 
@@ -507,14 +545,13 @@ where
         self.diagnostics
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .push(SyntaxDiagnostic::new(
-                self.code,
-                Arc::clone(&self.source),
-                event.line,
-                event.column,
-                event.span.clone(),
-                event.message.to_owned(),
-            ));
+            .push(PendingDiagnostic {
+                code: self.code,
+                line: event.line,
+                column: event.column,
+                span: event.span.clone(),
+                message: event.message.to_owned(),
+            });
     }
 }
 
@@ -568,12 +605,14 @@ fn process(
     input: InputStream,
     options: Options,
 ) -> miette::Result<bool> {
-    let source = diagnostic_source(&input);
+    let mut source = DiagnosticSource::new(&input);
     let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
-    let lexer_errors = report_lexer_errors(&mut tokens, &source);
+    let lexer_diagnostics = lexer_diagnostics(&mut tokens);
+    let lexer_errors = lexer_diagnostics.len();
+    source.report(lexer_diagnostics);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");
@@ -581,8 +620,7 @@ fn process(
     }
 
     let mut parser = TestRigGeneratedParser::new(tokens);
-    let parser_diagnostics =
-        DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE, Arc::clone(&source));
+    let parser_diagnostics = DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE);
     parser.remove_error_listeners();
     parser.add_error_listener(parser_diagnostics.clone());
     parser.set_build_parse_trees(options.tree);
@@ -609,7 +647,7 @@ fn process(
             None
         }
     };
-    parser_diagnostics.report();
+    source.report(parser_diagnostics.take());
     if options.tree && let Some(root) = root {
         println!(
             "{}",

--- a/crates/antlr-rust-codegen/src/test_rig.rs
+++ b/crates/antlr-rust-codegen/src/test_rig.rs
@@ -178,12 +178,24 @@ fn render_parser_runner(lexer: &TestRigLexer, parser: &TestRigParser, rule_metho
 }
 
 const RUNNER_PREAMBLE: &str = r#"use std::ffi::OsString;
+use std::fmt;
 use std::fs::File;
 use std::io;
+use std::ops::Range;
 use std::path::PathBuf;
 use std::process::ExitCode;
+use std::sync::Arc;
 
-use antlr4_runtime::{CommonTokenStream, InputStream};
+use antlr4_runtime::{
+    CharStream as _, CommonTokenStream, InputStream, IntStream as _,
+};
+use miette::{
+    Context as _, Diagnostic, IntoDiagnostic as _, LabeledSpan, NamedSource, SourceCode,
+};
+
+const LEXER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::lexer";
+
+type SharedSource = Arc<NamedSource<Arc<str>>>;
 
 #[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
@@ -195,22 +207,23 @@ struct Options {
     sll: bool,
 }
 
-fn main() -> ExitCode {
-    match run() {
-        Ok(true) => ExitCode::SUCCESS,
-        Ok(false) => ExitCode::FAILURE,
-        Err(error) => {
-            eprintln!("error: {error}");
-            ExitCode::FAILURE
-        }
-    }
+fn main() -> miette::Result<ExitCode> {
+    Ok(if run()? {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
 }
 
-fn run() -> Result<bool, Box<dyn std::error::Error>> {
-    let (options, input_files) = options_and_inputs()?;
+fn run() -> miette::Result<bool> {
+    let (options, input_files) = options_and_inputs()
+        .into_diagnostic()
+        .wrap_err("invalid TestRig runner arguments")?;
     if input_files.is_empty() {
         let stdin = io::stdin();
-        let input = InputStream::from_reader(stdin.lock())?;
+        let input = InputStream::from_reader_with_source_name(stdin.lock(), "<stdin>")
+            .into_diagnostic()
+            .wrap_err("failed to read standard input")?;
         return process(input, options);
     }
 
@@ -224,7 +237,7 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
         match process_file(&path, options) {
             Ok(input_success) => success &= input_success,
             Err(error) => {
-                eprintln!("error: {}: {error}", path.display());
+                eprintln!("Error: {error:?}");
                 success = false;
             }
         }
@@ -232,14 +245,14 @@ fn run() -> Result<bool, Box<dyn std::error::Error>> {
     Ok(success)
 }
 
-fn process_file(
-    path: &std::path::Path,
-    options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
-    let input = InputStream::from_reader_with_source_name(
-        File::open(path)?,
-        path.display().to_string(),
-    )?;
+fn process_file(path: &std::path::Path, options: Options) -> miette::Result<bool> {
+    let file = File::open(path)
+        .into_diagnostic()
+        .wrap_err_with(|| format!("failed to open input {}", path.display()))?;
+    let input =
+        InputStream::from_reader_with_source_name(file, path.display().to_string())
+            .into_diagnostic()
+            .wrap_err_with(|| format!("failed to read input {}", path.display()))?;
     process(input, options)
 }
 
@@ -269,15 +282,121 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
     Ok((options, inputs))
 }
 
+#[derive(Debug)]
+struct SyntaxDiagnostic {
+    code: &'static str,
+    message: String,
+    source: SharedSource,
+    span: Option<Range<usize>>,
+}
+
+impl SyntaxDiagnostic {
+    fn new(
+        code: &'static str,
+        source: SharedSource,
+        line: usize,
+        column: usize,
+        span: Option<Range<usize>>,
+        message: String,
+    ) -> Self {
+        let span = span
+            .filter(|span| span.start <= span.end && span.end <= source.inner().len())
+            .or_else(|| position_span(source.inner(), line, column));
+        let message = if span.is_some() {
+            message
+        } else {
+            format!("{}:{line}:{column}: {message}", source.name())
+        };
+        Self {
+            code,
+            message,
+            source,
+            span,
+        }
+    }
+}
+
+impl fmt::Display for SyntaxDiagnostic {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for SyntaxDiagnostic {}
+
+impl Diagnostic for SyntaxDiagnostic {
+    fn code(&self) -> Option<Box<dyn fmt::Display + '_>> {
+        Some(Box::new(self.code))
+    }
+
+    fn source_code(&self) -> Option<&dyn SourceCode> {
+        Some(self.source.as_ref())
+    }
+
+    fn labels(&self) -> Option<Box<dyn Iterator<Item = LabeledSpan> + '_>> {
+        self.span.as_ref().map(|span| {
+            let label = if span.is_empty() {
+                LabeledSpan::at_offset(span.start, "here")
+            } else {
+                LabeledSpan::underline(span.clone())
+            };
+            let labels: Box<dyn Iterator<Item = LabeledSpan>> =
+                Box::new(std::iter::once(label));
+            labels
+        })
+    }
+}
+
+fn diagnostic_source(input: &InputStream) -> SharedSource {
+    let contents: Arc<str> = input
+        .source_text()
+        .map_or_else(|| Arc::from(""), |contents| Arc::from(contents.as_ref()));
+    Arc::new(NamedSource::new(input.source_name(), contents))
+}
+
+fn position_span(source: &str, line: usize, column: usize) -> Option<Range<usize>> {
+    let line_index = line.checked_sub(1)?;
+    let mut line_start = 0;
+    for _ in 0..line_index {
+        line_start += source.get(line_start..)?.find('\n')? + 1;
+    }
+    let remainder = source.get(line_start..)?;
+    let line_length = remainder.find('\n').unwrap_or(remainder.len());
+    let line_text = remainder.get(..line_length)?;
+    let relative = line_text
+        .char_indices()
+        .nth(column)
+        .map(|(offset, _)| offset)
+        .or_else(|| (line_text.chars().count() == column).then_some(line_text.len()))?;
+    let length = line_text
+        .get(relative..)?
+        .chars()
+        .next()
+        .map_or(0, char::len_utf8);
+    let start = line_start + relative;
+    Some(start..start + length)
+}
+
+fn report_diagnostic(diagnostic: SyntaxDiagnostic) {
+    eprintln!("Error: {:?}", miette::Report::new(diagnostic));
+}
+
 fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
     tokens: &mut CommonTokenStream<L>,
+    source: &SharedSource,
 ) -> usize {
     tokens.fill();
-    let count = tokens.number_of_source_errors();
-    for error in tokens.drain_source_errors() {
-        if !tokens.token_source().report_error(&error) {
-            eprintln!("line {}:{} {}", error.line, error.column, error.message);
-        }
+    let errors = tokens.drain_source_errors();
+    let count = errors.len();
+    for error in errors {
+        report_diagnostic(SyntaxDiagnostic::new(
+            LEXER_DIAGNOSTIC_CODE,
+            Arc::clone(source),
+            error.line,
+            error.column,
+            error.span,
+            error.message,
+        ));
     }
     count
 }
@@ -295,10 +414,13 @@ __RUNNER_PREAMBLE__
 fn process(
     input: InputStream,
     options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> miette::Result<bool> {
+    let source = diagnostic_source(&input);
     let lexer = __LEXER_TYPE__::new(input);
-    let mut tokens = CommonTokenStream::try_new(lexer)?;
-    let lexer_errors = report_lexer_errors(&mut tokens);
+    let mut tokens = CommonTokenStream::try_new(lexer)
+        .into_diagnostic()
+        .wrap_err("failed to buffer lexer tokens")?;
+    let lexer_errors = report_lexer_errors(&mut tokens, &source);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");
@@ -316,12 +438,65 @@ mod generated_lexer;
 mod generated_parser;
 
 use antlr4_runtime::{
-    AntlrError, EnterRuleEvent, ParseListener, Parser as _, PredictionMode,
+    AntlrError, EnterRuleEvent, ErrorListener, ParseListener, Parser as _, PredictionMode,
+    Recognizer, SyntaxErrorEvent,
 };
+use std::sync::Mutex;
 use generated_lexer::__LEXER_TYPE__;
 use generated_parser::__PARSER_TYPE__;
 
 __RUNNER_PREAMBLE__
+
+const PARSER_DIAGNOSTIC_CODE: &str = "antlr4_rust_testrig::parser";
+
+#[derive(Clone, Debug)]
+struct DiagnosticCollector {
+    code: &'static str,
+    source: SharedSource,
+    diagnostics: Arc<Mutex<Vec<SyntaxDiagnostic>>>,
+}
+
+impl DiagnosticCollector {
+    fn new(code: &'static str, source: SharedSource) -> Self {
+        Self {
+            code,
+            source,
+            diagnostics: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    fn report(&self) {
+        let diagnostics = {
+            let mut diagnostics = self
+                .diagnostics
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            std::mem::take(&mut *diagnostics)
+        };
+        for diagnostic in diagnostics {
+            report_diagnostic(diagnostic);
+        }
+    }
+}
+
+impl<R> ErrorListener<R> for DiagnosticCollector
+where
+    R: Recognizer + ?Sized,
+{
+    fn syntax_error(&mut self, _recognizer: &R, event: &SyntaxErrorEvent<'_>) {
+        self.diagnostics
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(SyntaxDiagnostic::new(
+                self.code,
+                Arc::clone(&self.source),
+                event.line,
+                event.column,
+                event.span.clone(),
+                event.message.to_owned(),
+            ));
+    }
+}
 
 #[derive(Debug)]
 struct TraceListener {
@@ -372,10 +547,13 @@ impl ParseListener for TraceListener {
 fn process(
     input: InputStream,
     options: Options,
-) -> Result<bool, Box<dyn std::error::Error>> {
+) -> miette::Result<bool> {
+    let source = diagnostic_source(&input);
     let lexer = __LEXER_TYPE__::new(input);
-    let mut tokens = CommonTokenStream::try_new(lexer)?;
-    let lexer_errors = report_lexer_errors(&mut tokens);
+    let mut tokens = CommonTokenStream::try_new(lexer)
+        .into_diagnostic()
+        .wrap_err("failed to buffer lexer tokens")?;
+    let lexer_errors = report_lexer_errors(&mut tokens, &source);
     if options.tokens {
         for token in tokens.tokens() {
             println!("{token}");
@@ -383,6 +561,10 @@ fn process(
     }
 
     let mut parser = __PARSER_TYPE__::new(tokens);
+    let parser_diagnostics =
+        DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE, Arc::clone(&source));
+    parser.remove_error_listeners();
+    parser.add_error_listener(parser_diagnostics.clone());
     if options.tree {
         parser.set_build_parse_trees(true);
     }
@@ -405,11 +587,12 @@ fn process(
         Ok(root) => Some(root),
         Err(error) => {
             if !matches!(error, AntlrError::ParserError { .. }) {
-                eprintln!("error: {error}");
+                eprintln!("Error: {:?}", miette::Report::msg(error.to_string()));
             }
             None
         }
     };
+    parser_diagnostics.report();
     if options.tree && let Some(root) = root {
         println!(
             "{}",

--- a/crates/antlr-rust-codegen/src/test_rig.rs
+++ b/crates/antlr-rust-codegen/src/test_rig.rs
@@ -279,6 +279,12 @@ fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
             }
         }
     }
+    if options.diagnostics && options.sll {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "--diagnostics cannot be used with --sll",
+        ));
+    }
     Ok((options, inputs))
 }
 
@@ -407,7 +413,7 @@ const LEXER_RUNNER_TEMPLATE: &str = r#"#![allow(clippy::print_stderr, clippy::pr
 #[path = "../__LEXER_MODULE__.rs"]
 mod generated_lexer;
 
-use generated_lexer::__LEXER_TYPE__;
+use generated_lexer::__LEXER_TYPE__ as TestRigGeneratedLexer;
 
 __RUNNER_PREAMBLE__
 
@@ -416,7 +422,7 @@ fn process(
     options: Options,
 ) -> miette::Result<bool> {
     let source = diagnostic_source(&input);
-    let lexer = __LEXER_TYPE__::new(input);
+    let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
@@ -441,9 +447,9 @@ use antlr4_runtime::{
     AntlrError, EnterRuleEvent, ErrorListener, ParseListener, Parser as _, PredictionMode,
     Recognizer, SyntaxErrorEvent,
 };
+use generated_lexer::__LEXER_TYPE__ as TestRigGeneratedLexer;
+use generated_parser::__PARSER_TYPE__ as TestRigGeneratedParser;
 use std::sync::Mutex;
-use generated_lexer::__LEXER_TYPE__;
-use generated_parser::__PARSER_TYPE__;
 
 __RUNNER_PREAMBLE__
 
@@ -549,7 +555,7 @@ fn process(
     options: Options,
 ) -> miette::Result<bool> {
     let source = diagnostic_source(&input);
-    let lexer = __LEXER_TYPE__::new(input);
+    let lexer = TestRigGeneratedLexer::new(input);
     let mut tokens = CommonTokenStream::try_new(lexer)
         .into_diagnostic()
         .wrap_err("failed to buffer lexer tokens")?;
@@ -560,19 +566,16 @@ fn process(
         }
     }
 
-    let mut parser = __PARSER_TYPE__::new(tokens);
+    let mut parser = TestRigGeneratedParser::new(tokens);
     let parser_diagnostics =
         DiagnosticCollector::new(PARSER_DIAGNOSTIC_CODE, Arc::clone(&source));
     parser.remove_error_listeners();
     parser.add_error_listener(parser_diagnostics.clone());
-    if options.tree {
-        parser.set_build_parse_trees(true);
-    }
+    parser.set_build_parse_trees(options.tree);
     if options.diagnostics {
         parser.set_report_diagnostic_errors(true);
         parser.set_prediction_mode(PredictionMode::LlExactAmbigDetection);
-    }
-    if options.sll {
+    } else if options.sll {
         parser.set_prediction_mode(PredictionMode::Sll);
     }
     if options.trace {

--- a/crates/antlr-rust-codegen/src/test_rig.rs
+++ b/crates/antlr-rust-codegen/src/test_rig.rs
@@ -207,7 +207,21 @@ struct Options {
     sll: bool,
 }
 
+fn install_miette_handler() {
+    let Some(width) = std::env::var("COLUMNS")
+        .ok()
+        .and_then(|value| value.parse::<usize>().ok())
+        .filter(|width| *width > 0)
+    else {
+        return;
+    };
+    let _ = miette::set_hook(Box::new(move |_| {
+        Box::new(miette::MietteHandlerOpts::new().width(width).build())
+    }));
+}
+
 fn main() -> miette::Result<ExitCode> {
+    install_miette_handler();
     Ok(if run()? {
         ExitCode::SUCCESS
     } else {

--- a/crates/antlr-rust-codegen/src/test_rig.rs
+++ b/crates/antlr-rust-codegen/src/test_rig.rs
@@ -1,0 +1,489 @@
+use std::io;
+
+use crate::parser::parser_public_rule_method_names;
+use crate::rust_output::{module_name, replace_all, rust_type_name};
+
+pub(crate) const LEXER_START_RULE: &str = "tokens";
+pub(crate) const MAIN_PATH: &str = "__antlr4_rust_testrig/main.rs";
+
+#[derive(Debug)]
+pub(crate) struct TestRigLexer {
+    grammar_name: String,
+}
+
+impl TestRigLexer {
+    pub(crate) const fn new(grammar_name: String) -> Self {
+        Self { grammar_name }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct TestRigParser {
+    grammar_name: String,
+    rule_names: Vec<String>,
+    rule_methods: Vec<String>,
+}
+
+impl TestRigParser {
+    pub(crate) fn new(grammar_name: String, rule_names: Vec<String>) -> Self {
+        let rule_methods = parser_public_rule_method_names(&rule_names);
+        Self {
+            grammar_name,
+            rule_names,
+            rule_methods,
+        }
+    }
+}
+
+pub(crate) fn render_test_rig(
+    start_rule: &str,
+    lexers: &[TestRigLexer],
+    parsers: &[TestRigParser],
+) -> io::Result<String> {
+    if start_rule == LEXER_START_RULE {
+        let lexer = select_lexer(lexers, None)?;
+        return Ok(render_lexer_runner(lexer));
+    }
+
+    let (parser, rule_index) = select_parser(parsers, start_rule)?;
+    let lexer = select_lexer(lexers, Some(parser))?;
+    let rule_method = parser
+        .rule_methods
+        .get(rule_index)
+        .expect("parser rule names and rendered methods have equal lengths");
+    Ok(render_parser_runner(lexer, parser, rule_method))
+}
+
+fn select_parser<'a>(
+    parsers: &'a [TestRigParser],
+    start_rule: &str,
+) -> io::Result<(&'a TestRigParser, usize)> {
+    let matches = parsers
+        .iter()
+        .filter_map(|parser| {
+            parser
+                .rule_names
+                .iter()
+                .position(|rule| rule == start_rule)
+                .map(|index| (parser, index))
+        })
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [selected] => Ok(*selected),
+        [] => {
+            let available = parsers
+                .iter()
+                .flat_map(|parser| {
+                    parser
+                        .rule_names
+                        .iter()
+                        .map(|rule| format!("{}.{}", parser.grammar_name, rule))
+                })
+                .collect::<Vec<_>>()
+                .join(", ");
+            let suffix = if available.is_empty() {
+                "no parser was generated".to_owned()
+            } else {
+                format!("available rules: {available}")
+            };
+            Err(invalid_input(format!(
+                "test rig start rule `{start_rule}` was not found; {suffix}"
+            )))
+        }
+        _ => {
+            let owners = matches
+                .iter()
+                .map(|(parser, _)| parser.grammar_name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            Err(invalid_input(format!(
+                "test rig start rule `{start_rule}` is ambiguous across parsers: {owners}"
+            )))
+        }
+    }
+}
+
+fn select_lexer<'a>(
+    lexers: &'a [TestRigLexer],
+    parser: Option<&TestRigParser>,
+) -> io::Result<&'a TestRigLexer> {
+    match lexers {
+        [lexer] => return Ok(lexer),
+        [] => {
+            return Err(invalid_input(
+                "test rig requires a generated lexer; use a combined grammar or pass \
+                 --lexer-grammar for a split grammar",
+            ));
+        }
+        _ => {}
+    }
+
+    if let Some(parser) = parser {
+        let parser_stem = parser
+            .grammar_name
+            .strip_suffix("Parser")
+            .unwrap_or(&parser.grammar_name);
+        let matches = lexers
+            .iter()
+            .filter(|lexer| {
+                lexer
+                    .grammar_name
+                    .strip_suffix("Lexer")
+                    .unwrap_or(&lexer.grammar_name)
+                    == parser_stem
+            })
+            .collect::<Vec<_>>();
+        if let [lexer] = matches.as_slice() {
+            return Ok(*lexer);
+        }
+    }
+
+    let names = lexers
+        .iter()
+        .map(|lexer| lexer.grammar_name.as_str())
+        .collect::<Vec<_>>()
+        .join(", ");
+    Err(invalid_input(format!(
+        "test rig cannot choose a lexer from multiple generated lexers: {names}"
+    )))
+}
+
+fn invalid_input(message: impl Into<String>) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidInput, message.into())
+}
+
+fn render_lexer_runner(lexer: &TestRigLexer) -> String {
+    let mut rendered = assemble_runner(LEXER_RUNNER_TEMPLATE);
+    for (placeholder, value) in [
+        ("__LEXER_MODULE__", module_name(&lexer.grammar_name)),
+        ("__LEXER_TYPE__", rust_type_name(&lexer.grammar_name)),
+    ] {
+        rendered = replace_all(&rendered, placeholder, &value);
+    }
+    rendered
+}
+
+fn render_parser_runner(lexer: &TestRigLexer, parser: &TestRigParser, rule_method: &str) -> String {
+    let mut rendered = assemble_runner(PARSER_RUNNER_TEMPLATE);
+    for (placeholder, value) in [
+        ("__LEXER_MODULE__", module_name(&lexer.grammar_name)),
+        ("__LEXER_TYPE__", rust_type_name(&lexer.grammar_name)),
+        ("__PARSER_MODULE__", module_name(&parser.grammar_name)),
+        ("__PARSER_TYPE__", rust_type_name(&parser.grammar_name)),
+        ("__RULE_METHOD__", rule_method.to_owned()),
+    ] {
+        rendered = replace_all(&rendered, placeholder, &value);
+    }
+    rendered
+}
+
+const RUNNER_PREAMBLE: &str = r#"use std::ffi::OsString;
+use std::fs::File;
+use std::io;
+use std::path::PathBuf;
+use std::process::ExitCode;
+
+use antlr4_runtime::{CommonTokenStream, InputStream};
+
+#[derive(Clone, Copy, Debug, Default)]
+struct Options {
+    tokens: bool,
+    tree: bool,
+    trace: bool,
+    diagnostics: bool,
+    sll: bool,
+}
+
+fn main() -> ExitCode {
+    match run() {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(error) => {
+            eprintln!("error: {error}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+fn run() -> Result<bool, Box<dyn std::error::Error>> {
+    let (options, input_files) = options_and_inputs()?;
+    if input_files.is_empty() {
+        let stdin = io::stdin();
+        let input = InputStream::from_reader(stdin.lock())?;
+        return process(input, options);
+    }
+
+    let show_names = input_files.len() > 1;
+    let mut success = true;
+    for input_file in input_files {
+        let path = PathBuf::from(input_file);
+        if show_names {
+            eprintln!("{}", path.display());
+        }
+        match process_file(&path, options) {
+            Ok(input_success) => success &= input_success,
+            Err(error) => {
+                eprintln!("error: {}: {error}", path.display());
+                success = false;
+            }
+        }
+    }
+    Ok(success)
+}
+
+fn process_file(
+    path: &std::path::Path,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let input = InputStream::from_reader_with_source_name(
+        File::open(path)?,
+        path.display().to_string(),
+    )?;
+    process(input, options)
+}
+
+fn options_and_inputs() -> io::Result<(Options, Vec<OsString>)> {
+    let mut options = Options::default();
+    let mut inputs = Vec::new();
+    let mut arguments = std::env::args_os().skip(1);
+    while let Some(argument) = arguments.next() {
+        match argument.to_str() {
+            Some("--tokens") => options.tokens = true,
+            Some("--tree") => options.tree = true,
+            Some("--trace") => options.trace = true,
+            Some("--diagnostics") => options.diagnostics = true,
+            Some("--sll") => options.sll = true,
+            Some("--") => {
+                inputs.extend(arguments);
+                break;
+            }
+            _ => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    format!("unexpected runner argument {}", argument.to_string_lossy()),
+                ));
+            }
+        }
+    }
+    Ok((options, inputs))
+}
+
+fn report_lexer_errors<L: antlr4_runtime::TokenSource>(
+    tokens: &mut CommonTokenStream<L>,
+) -> usize {
+    tokens.fill();
+    let count = tokens.number_of_source_errors();
+    for error in tokens.drain_source_errors() {
+        if !tokens.token_source().report_error(&error) {
+            eprintln!("line {}:{} {}", error.line, error.column, error.message);
+        }
+    }
+    count
+}
+"#;
+
+const LEXER_RUNNER_TEMPLATE: &str = r#"#![allow(clippy::print_stderr, clippy::print_stdout)]
+
+#[path = "../__LEXER_MODULE__.rs"]
+mod generated_lexer;
+
+use generated_lexer::__LEXER_TYPE__;
+
+__RUNNER_PREAMBLE__
+
+fn process(
+    input: InputStream,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let lexer = __LEXER_TYPE__::new(input);
+    let mut tokens = CommonTokenStream::try_new(lexer)?;
+    let lexer_errors = report_lexer_errors(&mut tokens);
+    if options.tokens {
+        for token in tokens.tokens() {
+            println!("{token}");
+        }
+    }
+    let _ = (
+        options.tree,
+        options.trace,
+        options.diagnostics,
+        options.sll,
+    );
+    Ok(lexer_errors == 0)
+}
+"#;
+
+const PARSER_RUNNER_TEMPLATE: &str = r#"#![allow(clippy::print_stderr, clippy::print_stdout)]
+
+#[path = "../__LEXER_MODULE__.rs"]
+mod generated_lexer;
+#[path = "../__PARSER_MODULE__.rs"]
+mod generated_parser;
+
+use antlr4_runtime::{
+    AntlrError, EnterRuleEvent, ParseListener, Parser as _, PredictionMode,
+};
+use generated_lexer::__LEXER_TYPE__;
+use generated_parser::__PARSER_TYPE__;
+
+__RUNNER_PREAMBLE__
+
+#[derive(Debug)]
+struct TraceListener {
+    rule_names: &'static [&'static str],
+    depth: usize,
+}
+
+impl TraceListener {
+    const fn new(rule_names: &'static [&'static str]) -> Self {
+        Self {
+            rule_names,
+            depth: 0,
+        }
+    }
+
+    fn rule_name(&self, rule_index: usize) -> &str {
+        self.rule_names
+            .get(rule_index)
+            .copied()
+            .unwrap_or("<unknown>")
+    }
+}
+
+impl ParseListener for TraceListener {
+    fn enter_every_rule(&mut self, event: &EnterRuleEvent<'_>) -> Result<(), AntlrError> {
+        let lookahead = event
+            .current
+            .map_or_else(|| "<EOF>".to_owned(), |token| token.to_string());
+        eprintln!(
+            "{}enter   {}, LT(1)={lookahead}",
+            "  ".repeat(self.depth),
+            self.rule_name(event.rule_index),
+        );
+        self.depth += 1;
+        Ok(())
+    }
+
+    fn exit_every_rule(&mut self, rule_index: usize) {
+        self.depth = self.depth.saturating_sub(1);
+        eprintln!(
+            "{}exit    {}",
+            "  ".repeat(self.depth),
+            self.rule_name(rule_index),
+        );
+    }
+}
+
+fn process(
+    input: InputStream,
+    options: Options,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    let lexer = __LEXER_TYPE__::new(input);
+    let mut tokens = CommonTokenStream::try_new(lexer)?;
+    let lexer_errors = report_lexer_errors(&mut tokens);
+    if options.tokens {
+        for token in tokens.tokens() {
+            println!("{token}");
+        }
+    }
+
+    let mut parser = __PARSER_TYPE__::new(tokens);
+    if options.tree {
+        parser.set_build_parse_trees(true);
+    }
+    if options.diagnostics {
+        parser.set_report_diagnostic_errors(true);
+        parser.set_prediction_mode(PredictionMode::LlExactAmbigDetection);
+    }
+    if options.sll {
+        parser.set_prediction_mode(PredictionMode::Sll);
+    }
+    if options.trace {
+        parser.add_parse_listener(TraceListener::new(
+            generated_parser::rule_names(),
+        ));
+    }
+
+    let result = parser.__RULE_METHOD__();
+    let parser_errors = parser.number_of_syntax_errors();
+    let root = match result {
+        Ok(root) => Some(root),
+        Err(error) => {
+            if !matches!(error, AntlrError::ParserError { .. }) {
+                eprintln!("error: {error}");
+            }
+            None
+        }
+    };
+    if options.tree && let Some(root) = root {
+        println!(
+            "{}",
+            parser
+                .node(root)
+                .to_string_tree(Some(&parser), parser.token_store()),
+        );
+    }
+    Ok(lexer_errors == 0 && parser_errors == 0 && root.is_some())
+}
+
+"#;
+
+fn assemble_runner(template: &str) -> String {
+    replace_all(template, "__RUNNER_PREAMBLE__", RUNNER_PREAMBLE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lexer(name: &str) -> TestRigLexer {
+        TestRigLexer::new(name.to_owned())
+    }
+
+    fn parser(name: &str, rules: &[&str]) -> TestRigParser {
+        TestRigParser::new(
+            name.to_owned(),
+            rules.iter().map(|rule| (*rule).to_owned()).collect(),
+        )
+    }
+
+    #[test]
+    fn renders_rule_dispatch_with_generated_method_name() {
+        let rendered = render_test_rig(
+            "reset",
+            &[lexer("DemoLexer")],
+            &[parser("DemoParser", &["start", "reset"])],
+        )
+        .expect("test rig should render");
+
+        assert!(rendered.contains("parser.reset_rule()"));
+        assert!(rendered.contains(r#"#[path = "../demo_lexer.rs"]"#));
+        assert!(rendered.contains(r#"#[path = "../demo_parser.rs"]"#));
+    }
+
+    #[test]
+    fn rejects_unknown_and_ambiguous_rules() {
+        let missing = render_test_rig(
+            "missing",
+            &[lexer("DemoLexer")],
+            &[parser("DemoParser", &["start"])],
+        )
+        .expect_err("missing start rule should fail");
+        assert!(
+            missing
+                .to_string()
+                .contains("available rules: DemoParser.start")
+        );
+
+        let ambiguous = render_test_rig(
+            "start",
+            &[lexer("DemoLexer")],
+            &[
+                parser("FirstParser", &["start"]),
+                parser("SecondParser", &["start"]),
+            ],
+        )
+        .expect_err("ambiguous start rule should fail");
+        assert!(ambiguous.to_string().contains("FirstParser, SecondParser"));
+    }
+}

--- a/crates/antlr-rust-codegen/src/test_rig.rs
+++ b/crates/antlr-rust-codegen/src/test_rig.rs
@@ -185,6 +185,7 @@ use std::process::ExitCode;
 
 use antlr4_runtime::{CommonTokenStream, InputStream};
 
+#[allow(dead_code)] // Parser-only flags remain accepted for lexer-only TestRig invocations.
 #[derive(Clone, Copy, Debug, Default)]
 struct Options {
     tokens: bool,
@@ -303,12 +304,6 @@ fn process(
             println!("{token}");
         }
     }
-    let _ = (
-        options.tree,
-        options.trace,
-        options.diagnostics,
-        options.sll,
-    );
     Ok(lexer_errors == 0)
 }
 "#;
@@ -433,6 +428,7 @@ fn assemble_runner(template: &str) -> String {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // `insta` assertion macros unwrap internal I/O.
 mod tests {
     use super::*;
 
@@ -448,7 +444,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_rule_dispatch_with_generated_method_name() {
+    fn renders_parser_runner_with_generated_method_name() {
         let rendered = render_test_rig(
             "reset",
             &[lexer("DemoLexer")],
@@ -456,9 +452,44 @@ mod tests {
         )
         .expect("test rig should render");
 
-        assert!(rendered.contains("parser.reset_rule()"));
-        assert!(rendered.contains(r#"#[path = "../demo_lexer.rs"]"#));
-        assert!(rendered.contains(r#"#[path = "../demo_parser.rs"]"#));
+        insta::assert_snapshot!("parser_runner_rendered", rendered);
+    }
+
+    #[test]
+    fn renders_lexer_runner_for_tokens_start_rule() {
+        let rendered = render_test_rig("tokens", &[lexer("DemoLexer")], &[])
+            .expect("lexer test rig should render");
+
+        insta::assert_snapshot!("lexer_runner_rendered", rendered);
+    }
+
+    #[test]
+    fn selects_lexer_by_parser_stem_among_multiple_candidates() {
+        let lexers = [lexer("OtherLexer"), lexer("DemoLexer")];
+        let parser = parser("DemoParser", &["start"]);
+
+        let selected =
+            select_lexer(&lexers, Some(&parser)).expect("matching lexer should be selected");
+
+        insta::assert_snapshot!(&selected.grammar_name, @"DemoLexer");
+    }
+
+    #[test]
+    fn rejects_missing_and_unmatched_lexers() {
+        let missing = select_lexer(&[], None).expect_err("missing lexer should fail");
+        insta::assert_snapshot!(
+            missing.to_string(),
+            @"test rig requires a generated lexer; use a combined grammar or pass --lexer-grammar for a split grammar"
+        );
+
+        let lexers = [lexer("FirstLexer"), lexer("SecondLexer")];
+        let parser = parser("DemoParser", &["start"]);
+        let unmatched = select_lexer(&lexers, Some(&parser))
+            .expect_err("unmatched lexer candidates should fail");
+        insta::assert_snapshot!(
+            unmatched.to_string(),
+            @"test rig cannot choose a lexer from multiple generated lexers: FirstLexer, SecondLexer"
+        );
     }
 
     #[test]
@@ -469,10 +500,9 @@ mod tests {
             &[parser("DemoParser", &["start"])],
         )
         .expect_err("missing start rule should fail");
-        assert!(
-            missing
-                .to_string()
-                .contains("available rules: DemoParser.start")
+        insta::assert_snapshot!(
+            missing.to_string(),
+            @"test rig start rule `missing` was not found; available rules: DemoParser.start"
         );
 
         let ambiguous = render_test_rig(
@@ -484,6 +514,9 @@ mod tests {
             ],
         )
         .expect_err("ambiguous start rule should fail");
-        assert!(ambiguous.to_string().contains("FirstParser, SecondParser"));
+        insta::assert_snapshot!(
+            ambiguous.to_string(),
+            @"test rig start rule `start` is ambiguous across parsers: FirstParser, SecondParser"
+        );
     }
 }

--- a/crates/antlr-rust-codegen/src/testrig_cli.rs
+++ b/crates/antlr-rust-codegen/src/testrig_cli.rs
@@ -83,7 +83,7 @@ struct CliArgs {
     trace: bool,
 
     /// Report exact-ambiguity prediction diagnostics.
-    #[arg(long)]
+    #[arg(long, conflicts_with = "sll")]
     diagnostics: bool,
 
     /// Use SLL prediction mode instead of LL.
@@ -181,7 +181,7 @@ impl CliArgs {
             .arg("--manifest-path")
             .arg(project.manifest())
             .arg("--target-dir")
-            .arg(target_directory())
+            .arg(target_directory(project))
             .arg("--");
         for (enabled, flag) in [
             (self.tokens, "--tokens"),
@@ -337,16 +337,50 @@ fn toml_string(path: &Path) -> io::Result<String> {
     Ok(escaped)
 }
 
-fn target_directory() -> PathBuf {
-    std::env::var_os(TARGET_DIR_ENV).map_or_else(
-        || {
-            std::env::temp_dir().join(format!(
-                "antlr4-rust-testrig-target-{}",
-                env!("CARGO_PKG_VERSION")
-            ))
-        },
-        PathBuf::from,
+fn target_directory(project: &TemporaryProject) -> PathBuf {
+    select_target_directory(
+        std::env::var_os(TARGET_DIR_ENV).map(PathBuf::from),
+        user_cache_directory(),
+        &project.root,
     )
+}
+
+fn select_target_directory(
+    configured: Option<PathBuf>,
+    user_cache: Option<PathBuf>,
+    project_root: &Path,
+) -> PathBuf {
+    configured.unwrap_or_else(|| {
+        user_cache.map_or_else(
+            || project_root.join("target"),
+            |cache| {
+                cache
+                    .join("antlr4-rust-testrig")
+                    .join(env!("CARGO_PKG_VERSION"))
+                    .join("target")
+            },
+        )
+    })
+}
+
+fn user_cache_directory() -> Option<PathBuf> {
+    if let Some(cache) = std::env::var_os("XDG_CACHE_HOME").filter(|value| !value.is_empty()) {
+        return Some(PathBuf::from(cache));
+    }
+    if cfg!(target_os = "windows")
+        && let Some(cache) = std::env::var_os("LOCALAPPDATA").filter(|value| !value.is_empty())
+    {
+        return Some(PathBuf::from(cache));
+    }
+    let home = std::env::var_os("HOME")
+        .filter(|value| !value.is_empty())
+        .or_else(|| std::env::var_os("USERPROFILE").filter(|value| !value.is_empty()))?;
+    let home = PathBuf::from(home);
+    Some(if cfg!(target_os = "macos") {
+        home.join("Library").join("Caches")
+    } else {
+        home.join(".cache")
+    })
 }
 
 #[cfg(test)]
@@ -365,6 +399,28 @@ mod tests {
         assert_eq!(
             toml_string(path).expect("path should escape"),
             r#""a\\b\"c""#
+        );
+    }
+
+    #[test]
+    fn target_directory_prefers_override_then_user_cache_then_project() {
+        let configured = PathBuf::from("configured");
+        let cache = PathBuf::from("cache");
+        let project = Path::new("project");
+        assert_eq!(
+            select_target_directory(Some(configured.clone()), Some(cache.clone()), project),
+            configured
+        );
+        assert_eq!(
+            select_target_directory(None, Some(cache), project),
+            PathBuf::from("cache")
+                .join("antlr4-rust-testrig")
+                .join(env!("CARGO_PKG_VERSION"))
+                .join("target")
+        );
+        assert_eq!(
+            select_target_directory(None, None, project),
+            project.join("target")
         );
     }
 }

--- a/crates/antlr-rust-codegen/src/testrig_cli.rs
+++ b/crates/antlr-rust-codegen/src/testrig_cli.rs
@@ -1,0 +1,361 @@
+use std::collections::BTreeSet;
+use std::ffi::OsString;
+use std::fs;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use clap::Parser;
+
+use crate::builder::{ActionMode, UnknownSemanticPolicy};
+use crate::config::{CompilerConfig, TestRigConfig};
+use crate::driver::generate;
+use crate::error::Error;
+use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
+use crate::semantics::{SemPatternFile, load_sem_patterns, normalize_option_hook};
+
+const TARGET_DIR_ENV: &str = "ANTLR4_RUST_TESTRIG_TARGET_DIR";
+const RUNTIME_PATH_ENV: &str = "ANTLR4_RUST_TESTRIG_RUNTIME";
+static NEXT_PROJECT_ID: AtomicU64 = AtomicU64::new(0);
+
+pub(crate) fn run_cli() -> Result<ExitCode, Box<dyn std::error::Error>> {
+    let args = CliArgs::parse();
+    let project = TemporaryProject::new()?;
+    let config = args.compiler_config(&project.source_directory())?;
+    let mut stderr = io::stderr().lock();
+    generate(&config, |message| writeln!(stderr, "{message}")).map_err(Error::into_io_error)?;
+    project.write_manifest()?;
+    let status = args.run_generated(&project)?;
+    Ok(if status.success() {
+        ExitCode::SUCCESS
+    } else {
+        ExitCode::FAILURE
+    })
+}
+
+#[derive(Debug, Parser)]
+#[command(
+    name = "antlr4-rust-testrig",
+    version = clap::crate_version!(),
+    about = "Generate and run an ANTLR Rust recognizer against test inputs"
+)]
+struct CliArgs {
+    /// Combined, parser, or lexer grammar to run.
+    #[arg(value_name = "GRAMMAR[.g4]")]
+    grammar: PathBuf,
+
+    /// Parser start rule, or `tokens` for lexer-only execution.
+    #[arg(value_name = "START_RULE")]
+    start_rule: String,
+
+    /// UTF-8 input files. Reads stdin when omitted.
+    #[arg(value_name = "INPUT")]
+    input_files: Vec<PathBuf>,
+
+    /// Lexer grammar paired with a split parser grammar.
+    #[arg(long, value_name = "LEXER[.g4]")]
+    lexer_grammar: Option<PathBuf>,
+
+    /// Add an import/token-vocabulary lookup directory.
+    #[arg(short = 'I', long = "lib", value_name = "DIR")]
+    library_directories: Vec<PathBuf>,
+
+    /// Print every buffered token, including hidden-channel tokens and EOF.
+    #[arg(long)]
+    tokens: bool,
+
+    /// Print the parse tree.
+    #[arg(long)]
+    tree: bool,
+
+    /// Print parser rule enter/exit events.
+    #[arg(long)]
+    trace: bool,
+
+    /// Report exact-ambiguity prediction diagnostics.
+    #[arg(long)]
+    diagnostics: bool,
+
+    /// Use SLL prediction mode instead of LL.
+    #[arg(long)]
+    sll: bool,
+
+    /// Ignore unsupported lexer actions.
+    #[arg(long)]
+    allow_unsupported_lexer_actions: bool,
+
+    /// Choose how grammar action and predicate bodies are interpreted.
+    #[arg(long, value_enum, default_value = "templates")]
+    actions: ActionMode,
+
+    /// Choose the unsupported semantic predicate policy.
+    #[arg(long, value_enum, default_value = "assume-true")]
+    sem_unknown: UnknownSemanticPolicy,
+
+    /// Load semantic helper patterns.
+    #[arg(long, value_name = "FILE")]
+    sem_patterns: Option<PathBuf>,
+
+    /// Acknowledge an option implemented by caller hooks.
+    #[arg(
+        long = "option-hook",
+        value_name = "KEY=VALUE",
+        value_parser = normalize_option_hook,
+        allow_hyphen_values = true
+    )]
+    option_hooks: Vec<String>,
+
+    /// Fail if any semantic coordinate or option is unsupported.
+    #[arg(long)]
+    require_full_semantics: bool,
+
+    /// Compile decisions provable within K tokens into static dispatch tables.
+    #[arg(
+        long,
+        value_name = "K",
+        value_parser = clap::value_parser!(u8)
+            .range(1..=i64::from(MAX_FIXED_LOOKAHEAD_FLAG))
+    )]
+    fixed_lookahead: Option<u8>,
+}
+
+impl CliArgs {
+    fn compiler_config(
+        &self,
+        output_directory: &Path,
+    ) -> Result<CompilerConfig, Box<dyn std::error::Error>> {
+        let mut roots = Vec::with_capacity(usize::from(self.lexer_grammar.is_some()) + 1);
+        if let Some(lexer) = &self.lexer_grammar {
+            roots.push(grammar_path(lexer));
+        }
+        roots.push(grammar_path(&self.grammar));
+
+        let sem_patterns_path = self.sem_patterns.clone();
+        let sem_patterns = sem_patterns_path
+            .as_deref()
+            .map_or_else(|| Ok(SemPatternFile::default()), load_sem_patterns)
+            .map_err(|error| format!("failed to load --sem-patterns: {error}"))?;
+        Ok(CompilerConfig {
+            roots,
+            library_directories: self.library_directories.clone(),
+            out_dir: output_directory.to_path_buf(),
+            require_generated_parser: false,
+            allow_unsupported_lexer_actions: self.allow_unsupported_lexer_actions,
+            sem_unknown: self.sem_unknown.into_internal(),
+            sem_patterns,
+            sem_patterns_path,
+            require_full_semantics: self.require_full_semantics,
+            option_hooks: self.option_hooks.iter().cloned().collect::<BTreeSet<_>>(),
+            generate_listener: false,
+            generate_visitor: false,
+            embedded_actions: self.actions == ActionMode::Embedded,
+            fixed_lookahead: self.fixed_lookahead.map(usize::from),
+            entry_rules: BTreeSet::new(),
+            prune_unreachable: false,
+            optimize_precedence_ladders: false,
+            report_precedence_ladders: false,
+            test_rig: Some(TestRigConfig {
+                start_rule: self.start_rule.clone(),
+            }),
+        })
+    }
+
+    fn run_generated(
+        &self,
+        project: &TemporaryProject,
+    ) -> Result<std::process::ExitStatus, io::Error> {
+        let cargo = std::env::var_os("CARGO").unwrap_or_else(|| OsString::from("cargo"));
+        let mut command = Command::new(cargo);
+        command
+            .arg("run")
+            .arg("--quiet")
+            .arg("--manifest-path")
+            .arg(project.manifest())
+            .arg("--target-dir")
+            .arg(target_directory())
+            .arg("--");
+        for (enabled, flag) in [
+            (self.tokens, "--tokens"),
+            (self.tree, "--tree"),
+            (self.trace, "--trace"),
+            (self.diagnostics, "--diagnostics"),
+            (self.sll, "--sll"),
+        ] {
+            if enabled {
+                command.arg(flag);
+            }
+        }
+        command.arg("--").args(&self.input_files);
+        command.env("CARGO_TERM_COLOR", "never").status()
+    }
+}
+
+fn grammar_path(path: &Path) -> PathBuf {
+    if path.extension().is_none() {
+        path.with_extension("g4")
+    } else {
+        path.to_path_buf()
+    }
+}
+
+#[derive(Debug)]
+struct TemporaryProject {
+    root: PathBuf,
+    package_name: String,
+}
+
+impl TemporaryProject {
+    fn new() -> io::Result<Self> {
+        loop {
+            let identifier = NEXT_PROJECT_ID.fetch_add(1, Ordering::Relaxed);
+            let package_name = format!(
+                "antlr4-rust-testrig-runner-{}-{identifier}",
+                std::process::id()
+            );
+            let root = std::env::temp_dir().join(&package_name);
+            match fs::create_dir(&root) {
+                Ok(()) => {
+                    fs::create_dir(root.join("src"))?;
+                    return Ok(Self { root, package_name });
+                }
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {}
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn source_directory(&self) -> PathBuf {
+        self.root.join("src")
+    }
+
+    fn manifest(&self) -> PathBuf {
+        self.root.join("Cargo.toml")
+    }
+
+    fn write_manifest(&self) -> io::Result<()> {
+        let runtime = runtime_dependency()?;
+        fs::write(
+            self.manifest(),
+            format!(
+                "[workspace]\n\n\
+                 [package]\n\
+                 name = \"{}\"\n\
+                 version = \"0.0.0\"\n\
+                 edition = \"2024\"\n\
+                 publish = false\n\n\
+                 [[bin]]\n\
+                 name = \"{}\"\n\
+                 path = \"src/{}\"\n\n\
+                 [dependencies]\n\
+                 {runtime}\n",
+                self.package_name,
+                self.package_name,
+                crate::test_rig::MAIN_PATH,
+            ),
+        )
+    }
+}
+
+impl Drop for TemporaryProject {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+fn runtime_dependency() -> io::Result<String> {
+    if let Some(configured) = std::env::var_os(RUNTIME_PATH_ENV) {
+        return runtime_path_dependency(&PathBuf::from(configured));
+    }
+
+    let sibling = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .map(|crates| crates.join("antlr-rust-runtime"));
+    if let Some(sibling) = sibling
+        && sibling.join("Cargo.toml").is_file()
+    {
+        return runtime_path_dependency(&sibling);
+    }
+
+    Ok(format!(
+        "antlr-rust-runtime = \"={}\"\n",
+        env!("CARGO_PKG_VERSION")
+    ))
+}
+
+fn runtime_path_dependency(path: &Path) -> io::Result<String> {
+    let absolute = fs::canonicalize(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "cannot resolve runtime path from {RUNTIME_PATH_ENV}: {}: {error}",
+                path.display()
+            ),
+        )
+    })?;
+    Ok(format!(
+        "antlr-rust-runtime = {{ path = {} }}\n",
+        toml_string(&absolute)?
+    ))
+}
+
+fn toml_string(path: &Path) -> io::Result<String> {
+    let value = path.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("runtime path is not valid UTF-8: {}", path.display()),
+        )
+    })?;
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => escaped.push_str("\\\""),
+            '\\' => escaped.push_str("\\\\"),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            character if character.is_control() => {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "runtime path contains an unsupported control character",
+                ));
+            }
+            character => escaped.push(character),
+        }
+    }
+    escaped.push('"');
+    Ok(escaped)
+}
+
+fn target_directory() -> PathBuf {
+    std::env::var_os(TARGET_DIR_ENV).map_or_else(
+        || {
+            std::env::temp_dir().join(format!(
+                "antlr4-rust-testrig-target-{}",
+                env!("CARGO_PKG_VERSION")
+            ))
+        },
+        PathBuf::from,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn adds_the_grammar_extension_only_when_absent() {
+        assert_eq!(grammar_path(Path::new("Demo")), PathBuf::from("Demo.g4"));
+        assert_eq!(grammar_path(Path::new("Demo.g4")), PathBuf::from("Demo.g4"));
+    }
+
+    #[test]
+    fn toml_path_escaping_handles_quotes_and_backslashes() {
+        let path = Path::new("a\\b\"c");
+        assert_eq!(
+            toml_string(path).expect("path should escape"),
+            r#""a\\b\"c""#
+        );
+    }
+}

--- a/crates/antlr-rust-codegen/src/testrig_cli.rs
+++ b/crates/antlr-rust-codegen/src/testrig_cli.rs
@@ -207,6 +207,20 @@ fn grammar_path(path: &Path) -> PathBuf {
     }
 }
 
+#[cfg(unix)]
+fn create_private_directory(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt as _;
+
+    let mut builder = fs::DirBuilder::new();
+    builder.mode(0o700);
+    builder.create(path)
+}
+
+#[cfg(not(unix))]
+fn create_private_directory(path: &Path) -> io::Result<()> {
+    fs::create_dir(path)
+}
+
 #[derive(Debug)]
 struct TemporaryProject {
     root: PathBuf,
@@ -222,7 +236,7 @@ impl TemporaryProject {
                 std::process::id()
             );
             let root = std::env::temp_dir().join(&package_name);
-            match fs::create_dir(&root) {
+            match create_private_directory(&root) {
                 Ok(()) => {
                     fs::create_dir(root.join("src"))?;
                     return Ok(Self { root, package_name });
@@ -422,5 +436,19 @@ mod tests {
             select_target_directory(None, None, project),
             project.join("target")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn temporary_project_directory_is_private() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let project = TemporaryProject::new().expect("temporary project should be created");
+        let mode = fs::metadata(&project.root)
+            .expect("temporary project should have metadata")
+            .permissions()
+            .mode();
+
+        assert_eq!(mode & 0o077, 0);
     }
 }

--- a/crates/antlr-rust-codegen/src/testrig_cli.rs
+++ b/crates/antlr-rust-codegen/src/testrig_cli.rs
@@ -7,11 +7,11 @@ use std::process::{Command, ExitCode};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use clap::Parser;
+use miette::{Context as _, IntoDiagnostic as _};
 
 use crate::builder::{ActionMode, UnknownSemanticPolicy};
 use crate::config::{CompilerConfig, TestRigConfig};
 use crate::driver::generate;
-use crate::error::Error;
 use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
 use crate::semantics::{SemPatternFile, load_sem_patterns, normalize_option_hook};
 
@@ -19,14 +19,23 @@ const TARGET_DIR_ENV: &str = "ANTLR4_RUST_TESTRIG_TARGET_DIR";
 const RUNTIME_PATH_ENV: &str = "ANTLR4_RUST_TESTRIG_RUNTIME";
 static NEXT_PROJECT_ID: AtomicU64 = AtomicU64::new(0);
 
-pub(crate) fn run_cli() -> Result<ExitCode, Box<dyn std::error::Error>> {
+pub(crate) fn run_cli() -> miette::Result<ExitCode> {
     let args = CliArgs::parse();
-    let project = TemporaryProject::new()?;
+    let project = TemporaryProject::new()
+        .into_diagnostic()
+        .wrap_err("failed to create temporary TestRig project")?;
     let config = args.compiler_config(&project.source_directory())?;
     let mut stderr = io::stderr().lock();
-    generate(&config, |message| writeln!(stderr, "{message}")).map_err(Error::into_io_error)?;
-    project.write_manifest()?;
-    let status = args.run_generated(&project)?;
+    generate(&config, |message| writeln!(stderr, "{message}"))
+        .map_err(crate::cli_report::codegen_error)?;
+    project
+        .write_manifest()
+        .into_diagnostic()
+        .wrap_err("failed to write temporary TestRig manifest")?;
+    let status = args
+        .run_generated(&project)
+        .into_diagnostic()
+        .wrap_err("failed to execute temporary TestRig runner")?;
     Ok(if status.success() {
         ExitCode::SUCCESS
     } else {
@@ -121,10 +130,7 @@ struct CliArgs {
 }
 
 impl CliArgs {
-    fn compiler_config(
-        &self,
-        output_directory: &Path,
-    ) -> Result<CompilerConfig, Box<dyn std::error::Error>> {
+    fn compiler_config(&self, output_directory: &Path) -> miette::Result<CompilerConfig> {
         let mut roots = Vec::with_capacity(usize::from(self.lexer_grammar.is_some()) + 1);
         if let Some(lexer) = &self.lexer_grammar {
             roots.push(grammar_path(lexer));
@@ -132,10 +138,12 @@ impl CliArgs {
         roots.push(grammar_path(&self.grammar));
 
         let sem_patterns_path = self.sem_patterns.clone();
-        let sem_patterns = sem_patterns_path
-            .as_deref()
-            .map_or_else(|| Ok(SemPatternFile::default()), load_sem_patterns)
-            .map_err(|error| format!("failed to load --sem-patterns: {error}"))?;
+        let sem_patterns = match sem_patterns_path.as_deref() {
+            Some(path) => load_sem_patterns(path)
+                .into_diagnostic()
+                .wrap_err("failed to load --sem-patterns")?,
+            None => SemPatternFile::default(),
+        };
         Ok(CompilerConfig {
             roots,
             library_directories: self.library_directories.clone(),
@@ -248,7 +256,8 @@ impl TemporaryProject {
                  name = \"{}\"\n\
                  path = \"src/{}\"\n\n\
                  [dependencies]\n\
-                 {runtime}\n",
+                 {runtime}\
+                 miette = {{ version = \"=7.6.0\", default-features = false, features = [\"fancy\"] }}\n",
                 self.package_name,
                 self.package_name,
                 crate::test_rig::MAIN_PATH,

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli.rs
@@ -16,6 +16,8 @@ mod parser;
 mod semantics;
 #[path = "antlr4_rust_gen_cli/support.rs"]
 mod support;
+#[path = "antlr4_rust_gen_cli/testrig.rs"]
+mod testrig;
 #[path = "antlr4_rust_gen_cli/transforms.rs"]
 mod transforms;
 #[path = "antlr4_rust_gen_cli/typed_tree.rs"]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/compatibility.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/compatibility.rs
@@ -880,11 +880,8 @@ fn unsupported_antlr4rust_surface_fails_at_its_semantic_coordinate() {
             .path()
             .to_str()
             .expect("temporary directory path should be UTF-8");
-        diagnostics.push(
-            utf8(&output.stderr)
-                .replace(path, "$GRAMMAR")
-                .replace(root, "$TMP"),
-        );
+        let stderr = replace_miette_path(utf8(&output.stderr), path, "$GRAMMAR");
+        diagnostics.push(replace_miette_path(&stderr, root, "$TMP"));
     }
     insta::assert_snapshot!(
         "unsupported_antlr4rust_surface_diagnostics",

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/diagnostics.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/diagnostics.rs
@@ -90,7 +90,8 @@ fn lexer_left_recursion_reports_each_cycle_without_partial_outputs() {
     ]);
     assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
     assert_eq!(utf8(&output.stdout), "");
-    let stderr = utf8(&output.stderr).replace(
+    let stderr = replace_miette_path(
+        utf8(&output.stderr),
         grammar
             .to_str()
             .expect("fixture path should be valid Unicode"),

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/diagnostics.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/diagnostics.rs
@@ -96,7 +96,10 @@ fn lexer_left_recursion_reports_each_cycle_without_partial_outputs() {
             .expect("fixture path should be valid Unicode"),
         "<grammar>",
     );
-    insta::assert_snapshot!("lexer_left_recursion_diagnostics", stderr);
+    insta::assert_snapshot!(
+        "lexer_left_recursion_diagnostics",
+        normalize_cli_snapshot(&stderr)
+    );
     assert!(!out.exists(), "failed compilation emitted output");
 }
 
@@ -117,10 +120,18 @@ fn imported_source_diagnostics_report_the_import_path() {
     ]);
     assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
     let stderr = utf8(&output.stderr);
-    let delegate_diagnostic = format!("error[G4F003]: {}", fixture.join("Delegate.g4").display());
-    let wrong_root_diagnostic = format!("error[G4F003]: {}", root.display());
-    assert!(stderr.contains(&delegate_diagnostic), "{stderr}");
-    assert!(!stderr.contains(&wrong_root_diagnostic), "{stderr}");
+    let missing_semicolon = stderr
+        .split_once("Error: G4F003")
+        .and_then(|(_, remainder)| remainder.split("\nError:").next())
+        .expect("missing-semicolon diagnostic should be rendered");
+    assert!(
+        missing_semicolon.contains(&fixture.join("Delegate.g4").display().to_string()),
+        "{stderr}"
+    );
+    assert!(
+        !missing_semicolon.contains(&format!("{}:", root.display())),
+        "{stderr}"
+    );
     assert!(!out.exists(), "failed compilation emitted output");
 }
 

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__compatibility__unsupported_antlr4rust_surface_diagnostics.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__compatibility__unsupported_antlr4rust_surface_diagnostics.snap
@@ -4,98 +4,64 @@ expression: "diagnostics.join(\"\\n\")"
 ---
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:4:6: cannot
-  │ lower embedded parser predicate coordinate (0, 0) in rule start:
-  │ antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor
+  × $GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:4:6: cannot
-  │ lower embedded parser predicate coordinate (0, 0) in rule start:
-  │ antlr4rust compatibility lowering: unsupported `_localctx.context`
-  │ accessor
+  × $GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: antlr4rust compatibility lowering: unsupported `_localctx.context` accessor
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:4:6: cannot
-  │ lower embedded parser predicate coordinate (0, 0) in rule start:
-  │ antlr4rust compatibility lowering: `recog.input.la` accepts exactly one
-  │ offset argument
+  × $GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: antlr4rust compatibility lowering: `recog.input.la` accepts exactly one offset argument
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:4:6: cannot lower embedded parser predicate
-  │ coordinate (0, 0) in rule start: cannot classify embedded Rust syntax: at
-  │ 1:15: no viable alternative at input 'let_broken=(;'
+  × $GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: cannot classify embedded Rust syntax: at 1:15: no viable alternative at input 'let_broken=(;'
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:4:6: cannot
-  │ lower embedded parser @init in rule start (0): antlr4rust compatibility
-  │ lowering: unsupported `recog.input.peek` accessor
+  × $GRAMMAR:4:6: cannot lower embedded parser @init in rule start (0): antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:4:7: cannot
-  │ lower embedded parser @after in rule start (0): antlr4rust compatibility
-  │ lowering: unsupported `recog.input.peek` accessor
+  × $GRAMMAR:4:7: cannot lower embedded parser @after in rule start (0): antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:3:7: cannot
-  │ lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust
-  │ compatibility lowering: `recog.input` is only supported in embedded parser
-  │ bodies
+  × $GRAMMAR:3:7: cannot lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust compatibility lowering: `recog.input` is only supported in embedded parser bodies
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:3:7:
-  │ cannot lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust
-  │ compatibility lowering: `_localctx` is only supported in embedded parser
-  │ bodies
+  × $GRAMMAR:3:7: cannot lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust compatibility lowering: `_localctx` is only supported in embedded parser bodies
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:3:0:
-  │ cannot lower embedded antlr4rust compatibility accessors in rule start
-  │ (0): antlr4rust compatibility accessor `item_all` in StartContext is
-  │ ambiguous between parser rule `item` and parser rule `item_all`
+  × $GRAMMAR:3:0: cannot lower embedded antlr4rust compatibility accessors in rule start (0): antlr4rust compatibility accessor `item_all` in StartContext is ambiguous between parser rule `item` and parser rule `item_all`
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:
-  │ cannot lower embedded parser member field type: cannot classify embedded
-  │ Rust syntax: at 1:64: no viable alternative at input
-  │ 'type__Antlr4RustMemberField=[u8;BadMemberFieldTypeParser_A+]'
+  × $GRAMMAR: cannot lower embedded parser member field type: cannot classify embedded Rust syntax: at 1:64: no viable alternative at input 'type__Antlr4RustMemberField=[u8;BadMemberFieldTypeParser_A+]'
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR: cannot lower embedded parser member field
-  │ initializer: cannot classify embedded Rust syntax: at 2:0: no viable
-  │ alternative at input 'BadMemberFieldInitializerParser_A+}'
+  × $GRAMMAR: cannot lower embedded parser member field initializer: cannot classify embedded Rust syntax: at 2:0: no viable alternative at input 'BadMemberFieldInitializerParser_A+}'
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:
-  │ cannot lower embedded parser member impl item: cannot classify embedded
-  │ Rust syntax: at 1:54: no viable alternative at input
-  │ 'BadMemberImplItemParser_A+}'
+  × $GRAMMAR: cannot lower embedded parser member impl item: cannot classify embedded Rust syntax: at 1:54: no viable alternative at input 'BadMemberImplItemParser_A+}'
 
 
 Error: antlr4_rust_codegen::generation
 
-  × $GRAMMAR:
-  │ cannot lower embedded parser member module item: cannot classify embedded
-  │ Rust syntax: at 2:51: no viable alternative at input
-  │ 'BadMemberModuleItemParser_A+}'
+  × $GRAMMAR: cannot lower embedded parser member module item: cannot classify embedded Rust syntax: at 2:51: no viable alternative at input 'BadMemberModuleItemParser_A+}'

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__compatibility__unsupported_antlr4rust_surface_diagnostics.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__compatibility__unsupported_antlr4rust_surface_diagnostics.snap
@@ -1,29 +1,101 @@
 ---
-source: tests/antlr4_rust_gen_cli/compatibility.rs
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/compatibility.rs
 expression: "diagnostics.join(\"\\n\")"
 ---
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor" }
+Error: antlr4_rust_codegen::generation
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: antlr4rust compatibility lowering: unsupported `_localctx.context` accessor" }
+  × $GRAMMAR:4:6: cannot
+  │ lower embedded parser predicate coordinate (0, 0) in rule start:
+  │ antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: antlr4rust compatibility lowering: `recog.input.la` accepts exactly one offset argument" }
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:4:6: cannot lower embedded parser predicate coordinate (0, 0) in rule start: cannot classify embedded Rust syntax: at 1:15: no viable alternative at input 'let_broken=(;'" }
+Error: antlr4_rust_codegen::generation
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:4:6: cannot lower embedded parser @init in rule start (0): antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor" }
+  × $GRAMMAR:4:6: cannot
+  │ lower embedded parser predicate coordinate (0, 0) in rule start:
+  │ antlr4rust compatibility lowering: unsupported `_localctx.context`
+  │ accessor
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:4:7: cannot lower embedded parser @after in rule start (0): antlr4rust compatibility lowering: unsupported `recog.input.peek` accessor" }
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:3:7: cannot lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust compatibility lowering: `recog.input` is only supported in embedded parser bodies" }
+Error: antlr4_rust_codegen::generation
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:3:7: cannot lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust compatibility lowering: `_localctx` is only supported in embedded parser bodies" }
+  × $GRAMMAR:4:6: cannot
+  │ lower embedded parser predicate coordinate (0, 0) in rule start:
+  │ antlr4rust compatibility lowering: `recog.input.la` accepts exactly one
+  │ offset argument
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR:3:0: cannot lower embedded antlr4rust compatibility accessors in rule start (0): antlr4rust compatibility accessor `item_all` in StartContext is ambiguous between parser rule `item` and parser rule `item_all`" }
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR: cannot lower embedded parser member field type: cannot classify embedded Rust syntax: at 1:64: no viable alternative at input 'type__Antlr4RustMemberField=[u8;BadMemberFieldTypeParser_A+]'" }
+Error: antlr4_rust_codegen::generation
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR: cannot lower embedded parser member field initializer: cannot classify embedded Rust syntax: at 2:0: no viable alternative at input 'BadMemberFieldInitializerParser_A+}'" }
+  × $GRAMMAR:4:6: cannot lower embedded parser predicate
+  │ coordinate (0, 0) in rule start: cannot classify embedded Rust syntax: at
+  │ 1:15: no viable alternative at input 'let_broken=(;'
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR: cannot lower embedded parser member impl item: cannot classify embedded Rust syntax: at 1:54: no viable alternative at input 'BadMemberImplItemParser_A+}'" }
 
-Error: Custom { kind: InvalidData, error: "$GRAMMAR: cannot lower embedded parser member module item: cannot classify embedded Rust syntax: at 2:51: no viable alternative at input 'BadMemberModuleItemParser_A+}'" }
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:4:6: cannot
+  │ lower embedded parser @init in rule start (0): antlr4rust compatibility
+  │ lowering: unsupported `recog.input.peek` accessor
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:4:7: cannot
+  │ lower embedded parser @after in rule start (0): antlr4rust compatibility
+  │ lowering: unsupported `recog.input.peek` accessor
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:3:7: cannot
+  │ lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust
+  │ compatibility lowering: `recog.input` is only supported in embedded parser
+  │ bodies
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:3:7:
+  │ cannot lower embedded lexer action coordinate (0, 0) in rule A: antlr4rust
+  │ compatibility lowering: `_localctx` is only supported in embedded parser
+  │ bodies
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:3:0:
+  │ cannot lower embedded antlr4rust compatibility accessors in rule start
+  │ (0): antlr4rust compatibility accessor `item_all` in StartContext is
+  │ ambiguous between parser rule `item` and parser rule `item_all`
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:
+  │ cannot lower embedded parser member field type: cannot classify embedded
+  │ Rust syntax: at 1:64: no viable alternative at input
+  │ 'type__Antlr4RustMemberField=[u8;BadMemberFieldTypeParser_A+]'
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR: cannot lower embedded parser member field
+  │ initializer: cannot classify embedded Rust syntax: at 2:0: no viable
+  │ alternative at input 'BadMemberFieldInitializerParser_A+}'
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:
+  │ cannot lower embedded parser member impl item: cannot classify embedded
+  │ Rust syntax: at 1:54: no viable alternative at input
+  │ 'BadMemberImplItemParser_A+}'
+
+
+Error: antlr4_rust_codegen::generation
+
+  × $GRAMMAR:
+  │ cannot lower embedded parser member module item: cannot classify embedded
+  │ Rust syntax: at 2:51: no viable alternative at input
+  │ 'BadMemberModuleItemParser_A+}'

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__diagnostics__lexer_left_recursion_diagnostics.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__diagnostics__lexer_left_recursion_diagnostics.snap
@@ -1,5 +1,27 @@
 ---
-source: tests/antlr4_rust_gen_cli/diagnostics.rs
-expression: stderr
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/diagnostics.rs
+expression: normalize_cli_snapshot(&stderr)
 ---
-Error: Custom { kind: InvalidInput, error: "error[G4A005]: <grammar>:3:0: mutually left-recursive rules: [A]\nerror[G4A005]: <grammar>:4:0: mutually left-recursive rules: [B, C]\n" }
+Error: antlr4_rust_codegen::compilation
+
+  × grammar compilation failed with 2 error(s)
+
+Error: G4A005
+
+  × mutually left-recursive rules: [A]
+   ╭─[<grammar>:3:1]
+ 2 │
+ 3 │ A : A 'a' | 'x' ;
+   · ─────────────────
+ 4 │ B : C 'b' | 'y' ;
+   ╰────
+
+Error: G4A005
+
+  × mutually left-recursive rules: [B, C]
+   ╭─[<grammar>:4:1]
+ 3 │ A : A 'a' | 'x' ;
+ 4 │ B : C 'b' | 'y' ;
+   · ─────────────────
+ 5 │ C : B 'c' ;
+   ╰────

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__semantics__parser_action_hook_signature_conflict_diagnostic.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__semantics__parser_action_hook_signature_conflict_diagnostic.snap
@@ -4,5 +4,4 @@ expression: normalize_current_package_version(stderr)
 ---
 Error: antlr4_rust_codegen::generation
 
-  × typed semantic helper Mark has conflicting literal signatures [String] and
-  │ [Integer]
+  × typed semantic helper Mark has conflicting literal signatures [String] and [Integer]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__semantics__parser_action_hook_signature_conflict_diagnostic.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__semantics__parser_action_hook_signature_conflict_diagnostic.snap
@@ -1,5 +1,8 @@
 ---
-source: tests/antlr4_rust_gen_cli/semantics.rs
-expression: normalize_current_package_version(&stderr)
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/semantics.rs
+expression: normalize_current_package_version(stderr)
 ---
-Error: Custom { kind: InvalidData, error: "typed semantic helper Mark has conflicting literal signatures [String] and [Integer]" }
+Error: antlr4_rust_codegen::generation
+
+  × typed semantic helper Mark has conflicting literal signatures [String] and
+  │ [Integer]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__antlr4_rust_testrig_help.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__antlr4_rust_testrig_help.snap
@@ -1,0 +1,46 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: utf8(&output.stdout)
+---
+Generate and run an ANTLR Rust recognizer against test inputs
+
+Usage: antlr4-rust-testrig [OPTIONS] <GRAMMAR[.g4]> <START_RULE> [INPUT]...
+
+Arguments:
+  <GRAMMAR[.g4]>  Combined, parser, or lexer grammar to run
+  <START_RULE>    Parser start rule, or `tokens` for lexer-only execution
+  [INPUT]...      UTF-8 input files. Reads stdin when omitted
+
+Options:
+      --lexer-grammar <LEXER[.g4]>
+          Lexer grammar paired with a split parser grammar
+  -I, --lib <DIR>
+          Add an import/token-vocabulary lookup directory
+      --tokens
+          Print every buffered token, including hidden-channel tokens and EOF
+      --tree
+          Print the parse tree
+      --trace
+          Print parser rule enter/exit events
+      --diagnostics
+          Report exact-ambiguity prediction diagnostics
+      --sll
+          Use SLL prediction mode instead of LL
+      --allow-unsupported-lexer-actions
+          Ignore unsupported lexer actions
+      --actions <ACTIONS>
+          Choose how grammar action and predicate bodies are interpreted [default: templates] [possible values: templates, embedded]
+      --sem-unknown <SEM_UNKNOWN>
+          Choose the unsupported semantic predicate policy [default: assume-true] [possible values: assume-true, assume-false, hook, error]
+      --sem-patterns <FILE>
+          Load semantic helper patterns
+      --option-hook <KEY=VALUE>
+          Acknowledge an option implemented by caller hooks
+      --require-full-semantics
+          Fail if any semantic coordinate or option is unsupported
+      --fixed-lookahead <K>
+          Compile decisions provable within K tokens into static dispatch tables
+  -h, --help
+          Print help
+  -V, --version
+          Print version

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__colliding_recognizer_names_tree.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__colliding_recognizer_names_tree.snap
@@ -1,0 +1,5 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: utf8(&output.stdout)
+---
+(start collision <EOF>)

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__conflicting_prediction_modes.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__conflicting_prediction_modes.snap
@@ -1,0 +1,9 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: normalize_cli_snapshot(utf8(&output.stderr))
+---
+error: the argument '--diagnostics' cannot be used with '--sll'
+
+Usage: antlr4-rust-testrig --diagnostics <GRAMMAR[.g4]> <START_RULE> [INPUT]...
+
+For more information, try '--help'.

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__lexer_only_syntax_error.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__lexer_only_syntax_error.snap
@@ -1,0 +1,11 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: normalize_cli_snapshot(utf8(&lexer_output.stderr))
+---
+Error: antlr4_rust_testrig::lexer
+
+  × token recognition error at: '@'
+   ╭─[<stdin>:1:1]
+ 1 │ @
+   · ─
+   ╰────

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__lexer_syntax_error.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__lexer_syntax_error.snap
@@ -1,0 +1,18 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: "normalize_test_directory(utf8(&lexer_output.stderr), directory.path())"
+---
+Error: antlr4_rust_testrig::lexer
+
+  × token recognition error at: '@'
+   ╭─[<test-directory>/lexer-error.txt:1:1]
+ 1 │ @
+   · ─
+   ╰────
+
+Error: antlr4_rust_testrig::parser
+
+  × missing ID at '<EOF>'
+   ╭─[<test-directory>/lexer-error.txt:2:1]
+ 1 │ @
+   ╰────

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__parser_runner_stdout.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__parser_runner_stdout.snap
@@ -1,0 +1,7 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: utf8(&valid_output.stdout)
+---
+[@0,0:4='hello',<1>,1:0]
+[@1,6:5='<EOF>',<-1>,2:0]
+(start hello <EOF>)

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__parser_runner_trace.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__parser_runner_trace.snap
@@ -1,0 +1,6 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: utf8(&valid_output.stderr)
+---
+enter   start, LT(1)=[@0,0:4='hello',<1>,1:0]
+exit    start

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__parser_syntax_error.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__parser_syntax_error.snap
@@ -1,0 +1,11 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: "normalize_test_directory(utf8(&parser_output.stderr), directory.path())"
+---
+Error: antlr4_rust_testrig::parser
+
+  × extraneous input 'world' expecting <EOF>
+   ╭─[<test-directory>/parser-error.txt:1:7]
+ 1 │ hello world
+   ·       ─────
+   ╰────

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__split_parser_tree.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__split_parser_tree.snap
@@ -1,0 +1,5 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: utf8(&output.stdout)
+---
+(start split <EOF>)

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__unknown_start_rule_diagnostic.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__unknown_start_rule_diagnostic.snap
@@ -1,8 +1,7 @@
 ---
 source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
-expression: utf8(&rule_output.stderr)
+expression: normalize_cli_snapshot(utf8(&rule_output.stderr))
 ---
 Error: antlr4_rust_codegen::generation
 
-  × test rig start rule `missing` was not found; available rules:
-  │ TestRigParser.start
+  × test rig start rule `missing` was not found; available rules: TestRigParser.start

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__unknown_start_rule_diagnostic.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__testrig__unknown_start_rule_diagnostic.snap
@@ -1,0 +1,8 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+expression: utf8(&rule_output.stderr)
+---
+Error: antlr4_rust_codegen::generation
+
+  × test rig start rule `missing` was not found; available rules:
+  │ TestRigParser.start

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__transforms__configured_entry_rule_not_found.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__transforms__configured_entry_rule_not_found.snap
@@ -1,5 +1,59 @@
 ---
-source: tests/antlr4_rust_gen_cli/transforms.rs
-expression: stderr
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/transforms.rs
+expression: normalize_cli_snapshot(&stderr)
 ---
-Error: Custom { kind: InvalidInput, error: "error[G4S079]: <grammar>:1:0: configured parser entry rule missing is not defined\n" }
+Error: antlr4_rust_codegen::compilation
+
+  × grammar compilation failed with 1 error(s)
+
+Error: G4S079
+
+  × configured parser entry rule missing is not defined
+    ╭─[<grammar>:1:1]
+  1 │ ╭─▶ grammar Reachability;
+  2 │ │
+  3 │ │   start
+  4 │ │       : live EOF
+  5 │ │       ;
+  6 │ │
+  7 │ │   script
+  8 │ │       : live end
+  9 │ │       ;
+ 10 │ │
+ 11 │ │   alternate
+ 12 │ │       : EOF
+ 13 │ │       | ID
+ 14 │ │       ;
+ 15 │ │
+ 16 │ │   end
+ 17 │ │       : EOF
+ 18 │ │       ;
+ 19 │ │
+ 20 │ │   manual
+ 21 │ │       : live
+ 22 │ │       ;
+ 23 │ │
+ 24 │ │   live
+ 25 │ │       : ID
+ 26 │ │       ;
+ 27 │ │
+ 28 │ │   deadRoot
+ 29 │ │       : ID deadHelper?
+ 30 │ │       ;
+ 31 │ │
+ 32 │ │   deadHelper
+ 33 │ │       : ID deadRoot?
+ 34 │ │       ;
+ 35 │ │
+ 36 │ │   fragment LETTER
+ 37 │ │       : [a-z]
+ 38 │ │       ;
+ 39 │ │
+ 40 │ │   ID
+ 41 │ │       : LETTER+
+ 42 │ │       ;
+ 43 │ │
+ 44 │ │   WS
+ 45 │ │       : [ \t\r\n]+ -> skip
+ 46 │ ╰─▶     ;
+    ╰────

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__transforms__precedence_ladder_authored_semantic_errors.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__transforms__precedence_ladder_authored_semantic_errors.snap
@@ -1,26 +1,26 @@
 ---
-source: tests/antlr4_rust_gen_cli/transforms.rs
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/transforms.rs
 expression: diagnostics
 ---
 [
     (
         "DuplicateRule",
         "--optimize-precedence-ladders",
-        "Error: Custom { kind: InvalidInput, error: \"error[G4S002]: $TMP/DuplicateRule/DuplicateRule.g4:5:0: rule low is redefined\\n\" }\n",
+        "Error: antlr4_rust_codegen::compilation\n\n  × grammar compilation failed with 1 error(s)\n\nError: G4S002\n\n  × rule low is redefined\n   ╭─[$TMP/DuplicateRule/DuplicateRule.g4:5:1]\n 4 │ low : atom ('*' atom)* ;\n 5 │ low : atom ;\n   · ────────────\n 6 │ atom : INT ;\n   ╰────\n\n",
     ),
     (
         "DuplicateRule",
         "--report-precedence-ladders",
-        "Error: Custom { kind: InvalidInput, error: \"error[G4S002]: $TMP/DuplicateRule/DuplicateRule.g4:5:0: rule low is redefined\\n\" }\n",
+        "Error: antlr4_rust_codegen::compilation\n\n  × grammar compilation failed with 1 error(s)\n\nError: G4S002\n\n  × rule low is redefined\n   ╭─[$TMP/DuplicateRule/DuplicateRule.g4:5:1]\n 4 │ low : atom ('*' atom)* ;\n 5 │ low : atom ;\n   · ────────────\n 6 │ atom : INT ;\n   ╰────\n\n",
     ),
     (
         "DuplicateLabel",
         "--optimize-precedence-ladders",
-        "Error: Custom { kind: InvalidInput, error: \"error[G4S013]: $TMP/DuplicateLabel/DuplicateLabel.g4:4:25: alternative label Shared is redefined\\n\" }\n",
+        "Error: antlr4_rust_codegen::compilation\n\n  × grammar compilation failed with 1 error(s)\n\nError: G4S013\n\n  × alternative label Shared is redefined\n   ╭─[$TMP/DuplicateLabel/DuplicateLabel.g4:4:26]\n 3 │ high : low ('+' low)* # Shared ;\n 4 │ low : atom ('*' atom)* # Shared ;\n   ·                          ──────\n 5 │ atom : INT ;\n   ╰────\n\n",
     ),
     (
         "DuplicateLabel",
         "--report-precedence-ladders",
-        "Error: Custom { kind: InvalidInput, error: \"error[G4S013]: $TMP/DuplicateLabel/DuplicateLabel.g4:4:25: alternative label Shared is redefined\\n\" }\n",
+        "Error: antlr4_rust_codegen::compilation\n\n  × grammar compilation failed with 1 error(s)\n\nError: G4S013\n\n  × alternative label Shared is redefined\n   ╭─[$TMP/DuplicateLabel/DuplicateLabel.g4:4:26]\n 3 │ high : low ('+' low)* # Shared ;\n 4 │ low : atom ('*' atom)* # Shared ;\n   ·                          ──────\n 5 │ atom : INT ;\n   ╰────\n\n",
     ),
 ]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
@@ -1,8 +1,9 @@
 pub(super) use std::collections::BTreeSet;
 pub(super) use std::ffi::OsStr;
 pub(super) use std::fs;
+use std::io::Write as _;
 pub(super) use std::path::{Path, PathBuf};
-pub(super) use std::process::{Command, Output};
+pub(super) use std::process::{Command, Output, Stdio};
 pub(super) use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(super) fn run_antlr4_rust_gen(args: &[impl AsRef<OsStr>]) -> Output {
@@ -10,6 +11,35 @@ pub(super) fn run_antlr4_rust_gen(args: &[impl AsRef<OsStr>]) -> Output {
         .args(args)
         .output()
         .expect("antlr4-rust-gen should run")
+}
+
+pub(super) fn run_antlr4_rust_testrig(args: &[impl AsRef<OsStr>]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_antlr4-rust-testrig"))
+        .args(args)
+        .output()
+        .expect("antlr4-rust-testrig should run")
+}
+
+pub(super) fn run_antlr4_rust_testrig_with_stdin(
+    args: &[impl AsRef<OsStr>],
+    input: &[u8],
+) -> Output {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_antlr4-rust-testrig"))
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("antlr4-rust-testrig should start");
+    child
+        .stdin
+        .take()
+        .expect("testrig stdin should be piped")
+        .write_all(input)
+        .expect("testrig input should be writable");
+    child
+        .wait_with_output()
+        .expect("antlr4-rust-testrig should finish")
 }
 
 pub(super) fn assert_generated_modules_compile(temp_dir: &Path, modules: &[&str]) {

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
@@ -48,7 +48,8 @@ fn cli_command(binary: &str) -> Command {
         .env("NO_COLOR", "1")
         .env("CLICOLOR", "0")
         .env("CLICOLOR_FORCE", "0")
-        .env("NO_GRAPHICS", "0");
+        .env("NO_GRAPHICS", "0")
+        .env("COLUMNS", "4096");
     command
 }
 

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
@@ -7,14 +7,14 @@ pub(super) use std::process::{Command, Output, Stdio};
 pub(super) use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(super) fn run_antlr4_rust_gen(args: &[impl AsRef<OsStr>]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_antlr4-rust-gen"))
+    cli_command(env!("CARGO_BIN_EXE_antlr4-rust-gen"))
         .args(args)
         .output()
         .expect("antlr4-rust-gen should run")
 }
 
 pub(super) fn run_antlr4_rust_testrig(args: &[impl AsRef<OsStr>]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_antlr4-rust-testrig"))
+    cli_command(env!("CARGO_BIN_EXE_antlr4-rust-testrig"))
         .args(args)
         .output()
         .expect("antlr4-rust-testrig should run")
@@ -24,7 +24,7 @@ pub(super) fn run_antlr4_rust_testrig_with_stdin(
     args: &[impl AsRef<OsStr>],
     input: &[u8],
 ) -> Output {
-    let mut child = Command::new(env!("CARGO_BIN_EXE_antlr4-rust-testrig"))
+    let mut child = cli_command(env!("CARGO_BIN_EXE_antlr4-rust-testrig"))
         .args(args)
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -40,6 +40,16 @@ pub(super) fn run_antlr4_rust_testrig_with_stdin(
     child
         .wait_with_output()
         .expect("antlr4-rust-testrig should finish")
+}
+
+fn cli_command(binary: &str) -> Command {
+    let mut command = Command::new(binary);
+    command
+        .env("NO_COLOR", "1")
+        .env("CLICOLOR", "0")
+        .env("CLICOLOR_FORCE", "0")
+        .env("NO_GRAPHICS", "0");
+    command
 }
 
 pub(super) fn assert_generated_modules_compile(temp_dir: &Path, modules: &[&str]) {
@@ -128,6 +138,64 @@ pub(super) fn run_generated_project(
 
 pub(super) fn utf8(bytes: &[u8]) -> &str {
     std::str::from_utf8(bytes).expect("process output should be UTF-8")
+}
+
+pub(super) fn normalize_cli_snapshot(value: &str) -> String {
+    let mut normalized = value
+        .lines()
+        .map(str::trim_end)
+        .collect::<Vec<_>>()
+        .join("\n");
+    if value.ends_with('\n') {
+        normalized.push('\n');
+    }
+    normalized
+}
+
+pub(super) fn replace_miette_path(value: &str, path: &str, replacement: &str) -> String {
+    let Some(first) = path.chars().next() else {
+        return value.to_owned();
+    };
+    let mut first_buffer = [0; 4];
+    let first: &str = first.encode_utf8(&mut first_buffer);
+    let mut normalized = value.to_owned();
+    let mut search_from = 0;
+    while let Some(relative_start) = normalized[search_from..].find(first) {
+        let start = search_from + relative_start;
+        let Some(end) = wrapped_path_end(&normalized, start, path) else {
+            search_from = start + first.len();
+            continue;
+        };
+        normalized.replace_range(start..end, replacement);
+        search_from = start + replacement.len();
+    }
+    normalized
+}
+
+fn wrapped_path_end(value: &str, start: usize, path: &str) -> Option<usize> {
+    const CONTINUATION: &str = "\n  │ ";
+    let mut cursor = start;
+    for expected in path.chars() {
+        while value.get(cursor..)?.starts_with(CONTINUATION) {
+            cursor += CONTINUATION.len();
+        }
+        let actual = value.get(cursor..)?.chars().next()?;
+        if actual != expected {
+            return None;
+        }
+        cursor += actual.len_utf8();
+    }
+    Some(cursor)
+}
+
+#[test]
+fn miette_path_normalization_handles_message_wrapping() {
+    let path = "/tmp/antlr-rust-gen-long/Example.g4";
+    let rendered = "  × /tmp/antlr-rust-gen-\n  │ long/Example.g4:4:6: invalid input";
+    assert_eq!(
+        replace_miette_path(rendered, path, "$GRAMMAR"),
+        "  × $GRAMMAR:4:6: invalid input"
+    );
 }
 
 pub(super) fn normalize_current_package_version(value: &str) -> String {

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
@@ -1,0 +1,197 @@
+#![allow(clippy::disallowed_methods)] // `insta` assertion macros unwrap internal I/O.
+#[allow(clippy::wildcard_imports)]
+use super::support::*;
+
+fn write_combined_grammar(directory: &Path) -> PathBuf {
+    let grammar = directory.join("TestRig.g4");
+    fs::write(
+        &grammar,
+        "grammar TestRig;\n\
+         start : ID EOF ;\n\
+         ID : [a-z]+ ;\n\
+         WS : [ \\t\\r\\n]+ -> skip ;\n",
+    )
+    .expect("grammar should be writable");
+    grammar
+}
+
+#[test]
+fn help_describes_test_runner_inputs_and_modes() {
+    let output = run_antlr4_rust_testrig(&["--help"]);
+
+    assert!(output.status.success(), "stderr: {}", utf8(&output.stderr));
+    assert_eq!(utf8(&output.stderr), "");
+    insta::assert_snapshot!("antlr4_rust_testrig_help", utf8(&output.stdout));
+}
+
+#[test]
+fn parser_runner_prints_requested_views_and_fails_on_each_error_source() {
+    let directory = temporary_directory("testrig-parser");
+    let grammar = write_combined_grammar(directory.path());
+    let grammar_without_extension = grammar.with_extension("");
+    let valid = directory.path().join("valid.txt");
+    let parser_error = directory.path().join("parser-error.txt");
+    let lexer_error = directory.path().join("lexer-error.txt");
+    fs::write(&valid, "hello\n").expect("valid input should be writable");
+    fs::write(&parser_error, "hello world\n").expect("parser-error input should be writable");
+    fs::write(&lexer_error, "@\n").expect("lexer-error input should be writable");
+
+    let valid_output = run_antlr4_rust_testrig(&[
+        grammar_without_extension.as_os_str(),
+        OsStr::new("start"),
+        OsStr::new("--tokens"),
+        OsStr::new("--tree"),
+        OsStr::new("--trace"),
+        OsStr::new("--diagnostics"),
+        OsStr::new("--sll"),
+        valid.as_os_str(),
+    ]);
+    assert!(
+        valid_output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&valid_output.stdout),
+        utf8(&valid_output.stderr)
+    );
+    insta::assert_snapshot!("parser_runner_stdout", utf8(&valid_output.stdout));
+    insta::assert_snapshot!("parser_runner_trace", utf8(&valid_output.stderr));
+
+    let parser_output = run_antlr4_rust_testrig(&[
+        grammar.as_os_str(),
+        OsStr::new("start"),
+        parser_error.as_os_str(),
+    ]);
+    assert!(
+        !parser_output.status.success(),
+        "parser syntax errors must fail the runner"
+    );
+    assert!(
+        utf8(&parser_output.stderr).contains("extraneous input 'world' expecting <EOF>"),
+        "{}",
+        utf8(&parser_output.stderr)
+    );
+
+    let lexer_output = run_antlr4_rust_testrig(&[
+        grammar.as_os_str(),
+        OsStr::new("start"),
+        lexer_error.as_os_str(),
+    ]);
+    assert!(
+        !lexer_output.status.success(),
+        "lexer syntax errors must fail the runner"
+    );
+    assert!(
+        utf8(&lexer_output.stderr).contains("token recognition error at: '@'"),
+        "{}",
+        utf8(&lexer_output.stderr)
+    );
+}
+
+#[test]
+fn stdin_and_split_grammars_are_supported() {
+    let directory = temporary_directory("testrig-split");
+    let lexer = directory.path().join("SplitLexer.g4");
+    let parser = directory.path().join("SplitParser.g4");
+    fs::write(
+        &lexer,
+        "lexer grammar SplitLexer;\n\
+         ID : [a-z]+ ;\n\
+         WS : [ \\t\\r\\n]+ -> skip ;\n",
+    )
+    .expect("lexer grammar should be writable");
+    fs::write(
+        &parser,
+        "parser grammar SplitParser;\n\
+         options { tokenVocab = SplitLexer; }\n\
+         start : ID EOF ;\n",
+    )
+    .expect("parser grammar should be writable");
+
+    let output = run_antlr4_rust_testrig_with_stdin(
+        &[
+            parser.as_os_str(),
+            OsStr::new("start"),
+            OsStr::new("--lexer-grammar"),
+            lexer.as_os_str(),
+            OsStr::new("--lib"),
+            directory.path().as_os_str(),
+            OsStr::new("--tree"),
+        ],
+        b"split\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    assert_eq!(utf8(&output.stdout), "(start split <EOF>)\n");
+    assert_eq!(utf8(&output.stderr), "");
+}
+
+#[test]
+fn lexer_only_and_unknown_rule_failures_are_nonzero() {
+    let directory = temporary_directory("testrig-lexer");
+    let lexer = directory.path().join("Main.g4");
+    fs::write(
+        &lexer,
+        "lexer grammar Main;\n\
+         ID : [a-z]+ ;\n\
+         WS : [ \\t\\r\\n]+ -> skip ;\n",
+    )
+    .expect("lexer grammar should be writable");
+
+    let lexer_output =
+        run_antlr4_rust_testrig_with_stdin(&[lexer.as_os_str(), OsStr::new("tokens")], b"@\n");
+    assert!(!lexer_output.status.success());
+    assert!(
+        utf8(&lexer_output.stderr).contains("token recognition error at: '@'"),
+        "{}",
+        utf8(&lexer_output.stderr)
+    );
+
+    let grammar = write_combined_grammar(directory.path());
+    let rule_output = run_antlr4_rust_testrig(&[grammar.as_os_str(), OsStr::new("missing")]);
+    assert!(!rule_output.status.success());
+    assert!(
+        utf8(&rule_output.stderr).contains("test rig start rule `missing` was not found"),
+        "{}",
+        utf8(&rule_output.stderr)
+    );
+}
+
+#[test]
+fn multiple_inputs_continue_after_an_error_and_return_failure() {
+    let directory = temporary_directory("testrig-multiple");
+    let grammar = write_combined_grammar(directory.path());
+    let first = directory.path().join("first.txt");
+    let invalid = directory.path().join("invalid.txt");
+    let missing = directory.path().join("missing.txt");
+    let last = directory.path().join("last.txt");
+    fs::write(&first, "first\n").expect("first input should be writable");
+    fs::write(&invalid, "two words\n").expect("invalid input should be writable");
+    fs::write(&last, "last\n").expect("last input should be writable");
+
+    let output = run_antlr4_rust_testrig(&[
+        grammar.as_os_str(),
+        OsStr::new("start"),
+        OsStr::new("--tree"),
+        first.as_os_str(),
+        invalid.as_os_str(),
+        missing.as_os_str(),
+        last.as_os_str(),
+    ]);
+
+    assert!(!output.status.success());
+    let stdout = utf8(&output.stdout);
+    assert!(stdout.contains("(start first <EOF>)"));
+    assert!(stdout.contains("(start two words <EOF>)"));
+    assert!(stdout.contains("(start last <EOF>)"));
+    let stderr = utf8(&output.stderr);
+    assert!(stderr.contains(&first.display().to_string()));
+    assert!(stderr.contains(&invalid.display().to_string()));
+    assert!(stderr.contains(&missing.display().to_string()));
+    assert!(stderr.contains(&last.display().to_string()));
+    assert!(stderr.contains("extraneous input 'words' expecting <EOF>"));
+    assert!(stderr.contains(&format!("error: {}:", missing.display())));
+}

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
@@ -125,7 +125,7 @@ fn stdin_and_split_grammars_are_supported() {
         utf8(&output.stdout),
         utf8(&output.stderr)
     );
-    assert_eq!(utf8(&output.stdout), "(start split <EOF>)\n");
+    insta::assert_snapshot!("split_parser_tree", utf8(&output.stdout));
     assert_eq!(utf8(&output.stderr), "");
 }
 

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
@@ -47,7 +47,6 @@ fn parser_runner_prints_requested_views_and_fails_on_each_error_source() {
         OsStr::new("--tree"),
         OsStr::new("--trace"),
         OsStr::new("--diagnostics"),
-        OsStr::new("--sll"),
         valid.as_os_str(),
     ]);
     assert!(
@@ -128,6 +127,60 @@ fn stdin_and_split_grammars_are_supported() {
         utf8(&output.stderr)
     );
     insta::assert_snapshot!("split_parser_tree", utf8(&output.stdout));
+    assert_eq!(utf8(&output.stderr), "");
+}
+
+#[test]
+fn prediction_modes_are_mutually_exclusive() {
+    let output = run_antlr4_rust_testrig(&["TestRig.g4", "start", "--diagnostics", "--sll"]);
+
+    assert!(!output.status.success());
+    insta::assert_snapshot!(
+        "conflicting_prediction_modes",
+        normalize_cli_snapshot(utf8(&output.stderr))
+    );
+}
+
+#[test]
+fn generated_recognizer_names_do_not_collide_with_runner_imports() {
+    let directory = temporary_directory("testrig-colliding-imports");
+    let lexer = directory.path().join("InputStream.g4");
+    let parser = directory.path().join("AntlrError.g4");
+    fs::write(
+        &lexer,
+        "lexer grammar InputStream;\n\
+         ID : [a-z]+ ;\n\
+         WS : [ \\t\\r\\n]+ -> skip ;\n",
+    )
+    .expect("lexer grammar should be writable");
+    fs::write(
+        &parser,
+        "parser grammar AntlrError;\n\
+         options { tokenVocab = InputStream; }\n\
+         start : ID EOF ;\n",
+    )
+    .expect("parser grammar should be writable");
+
+    let output = run_antlr4_rust_testrig_with_stdin(
+        &[
+            parser.as_os_str(),
+            OsStr::new("start"),
+            OsStr::new("--lexer-grammar"),
+            lexer.as_os_str(),
+            OsStr::new("--lib"),
+            directory.path().as_os_str(),
+            OsStr::new("--tree"),
+        ],
+        b"collision\n",
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    insta::assert_snapshot!("colliding_recognizer_names_tree", utf8(&output.stdout));
     assert_eq!(utf8(&output.stderr), "");
 }
 

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
@@ -16,7 +16,8 @@ fn write_combined_grammar(directory: &Path) -> PathBuf {
 }
 
 fn normalize_test_directory(value: &str, directory: &Path) -> String {
-    normalize_cli_snapshot(&value.replace(&directory.display().to_string(), "<test-directory>"))
+    let directory = directory.display().to_string();
+    normalize_cli_snapshot(&replace_miette_path(value, &directory, "<test-directory>"))
 }
 
 #[test]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/testrig.rs
@@ -15,6 +15,10 @@ fn write_combined_grammar(directory: &Path) -> PathBuf {
     grammar
 }
 
+fn normalize_test_directory(value: &str, directory: &Path) -> String {
+    normalize_cli_snapshot(&value.replace(&directory.display().to_string(), "<test-directory>"))
+}
+
 #[test]
 fn help_describes_test_runner_inputs_and_modes() {
     let output = run_antlr4_rust_testrig(&["--help"]);
@@ -64,10 +68,9 @@ fn parser_runner_prints_requested_views_and_fails_on_each_error_source() {
         !parser_output.status.success(),
         "parser syntax errors must fail the runner"
     );
-    assert!(
-        utf8(&parser_output.stderr).contains("extraneous input 'world' expecting <EOF>"),
-        "{}",
-        utf8(&parser_output.stderr)
+    insta::assert_snapshot!(
+        "parser_syntax_error",
+        normalize_test_directory(utf8(&parser_output.stderr), directory.path())
     );
 
     let lexer_output = run_antlr4_rust_testrig(&[
@@ -79,10 +82,9 @@ fn parser_runner_prints_requested_views_and_fails_on_each_error_source() {
         !lexer_output.status.success(),
         "lexer syntax errors must fail the runner"
     );
-    assert!(
-        utf8(&lexer_output.stderr).contains("token recognition error at: '@'"),
-        "{}",
-        utf8(&lexer_output.stderr)
+    insta::assert_snapshot!(
+        "lexer_syntax_error",
+        normalize_test_directory(utf8(&lexer_output.stderr), directory.path())
     );
 }
 
@@ -144,19 +146,17 @@ fn lexer_only_and_unknown_rule_failures_are_nonzero() {
     let lexer_output =
         run_antlr4_rust_testrig_with_stdin(&[lexer.as_os_str(), OsStr::new("tokens")], b"@\n");
     assert!(!lexer_output.status.success());
-    assert!(
-        utf8(&lexer_output.stderr).contains("token recognition error at: '@'"),
-        "{}",
-        utf8(&lexer_output.stderr)
+    insta::assert_snapshot!(
+        "lexer_only_syntax_error",
+        normalize_cli_snapshot(utf8(&lexer_output.stderr))
     );
 
     let grammar = write_combined_grammar(directory.path());
     let rule_output = run_antlr4_rust_testrig(&[grammar.as_os_str(), OsStr::new("missing")]);
     assert!(!rule_output.status.success());
-    assert!(
-        utf8(&rule_output.stderr).contains("test rig start rule `missing` was not found"),
-        "{}",
-        utf8(&rule_output.stderr)
+    insta::assert_snapshot!(
+        "unknown_start_rule_diagnostic",
+        normalize_cli_snapshot(utf8(&rule_output.stderr))
     );
 }
 
@@ -193,5 +193,5 @@ fn multiple_inputs_continue_after_an_error_and_return_failure() {
     assert!(stderr.contains(&missing.display().to_string()));
     assert!(stderr.contains(&last.display().to_string()));
     assert!(stderr.contains("extraneous input 'words' expecting <EOF>"));
-    assert!(stderr.contains(&format!("error: {}:", missing.display())));
+    assert!(stderr.contains("failed to open input"), "{stderr}");
 }

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/transforms.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/transforms.rs
@@ -350,7 +350,10 @@ fn configured_entry_rule_must_name_a_parser_rule() {
             .expect("fixture path should be valid Unicode"),
         "<grammar>",
     );
-    insta::assert_snapshot!("configured_entry_rule_not_found", stderr);
+    insta::assert_snapshot!(
+        "configured_entry_rule_not_found",
+        normalize_cli_snapshot(&stderr)
+    );
     assert!(!out.exists(), "invalid entry selection emitted output");
 }
 

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/transforms.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/transforms.rs
@@ -47,7 +47,8 @@ fn unreachable_parser_rules_warn_without_pruning() {
         utf8(&output.stdout),
         utf8(&output.stderr)
     );
-    let stderr = utf8(&output.stderr).replace(
+    let stderr = replace_miette_path(
+        utf8(&output.stderr),
         grammar
             .to_str()
             .expect("fixture path should be valid Unicode"),
@@ -86,7 +87,8 @@ fn prune_unreachable_is_transitive_loud_and_preserves_explicit_entries() {
         utf8(&output.stdout),
         utf8(&output.stderr)
     );
-    let stderr = utf8(&output.stderr).replace(
+    let stderr = replace_miette_path(
+        utf8(&output.stderr),
         grammar
             .to_str()
             .expect("fixture path should be valid Unicode"),
@@ -344,7 +346,8 @@ fn configured_entry_rule_must_name_a_parser_rule() {
         out.as_os_str(),
     ]);
     assert!(!output.status.success(), "stdout: {}", utf8(&output.stdout));
-    let stderr = utf8(&output.stderr).replace(
+    let stderr = replace_miette_path(
+        utf8(&output.stderr),
         grammar
             .to_str()
             .expect("fixture path should be valid Unicode"),
@@ -857,7 +860,8 @@ WS : [ \t\r\n]+ -> skip ;
             diagnostics.push((
                 grammar_name,
                 flag,
-                stderr.replace(
+                replace_miette_path(
+                    stderr,
                     temp.path()
                         .to_str()
                         .expect("temporary path should be UTF-8"),

--- a/tools/release/verify-package-contents.sh
+++ b/tools/release/verify-package-contents.sh
@@ -48,6 +48,7 @@ case "$package" in
         ;;
     antlr-rust-codegen)
         require_file "src/bin/antlr4-rust-gen.rs"
+        require_file "src/bin/antlr4-rust-testrig.rs"
         require_file "src/grammar/unicode_decomposition.bin"
         require_file "src/lib.rs"
         if grep -Eq '(^|/)(tests|fixtures|codegen-direct)(/|$)' <<<"$listing"; then


### PR DESCRIPTION
## Summary

- add `antlr4-rust-testrig` as a second binary in `antlr-rust-codegen`
- generate and compile a temporary grammar-specific runner for combined, split, and lexer-only grammars
- support token, tree, trace, diagnostics, and SLL output modes over stdin or multiple input files
- render codegen, input, lexer, and parser failures with Miette `fancy` diagnostics and enable Clap colors
- keep parse-only runs tree-free, reject conflicting prediction modes, and isolate generated recognizer names
- return a non-zero status for generation, compilation, input, lexer, and parser errors
- document installing and running TestRig directly in a non-Rust, grammar-only project

## Design

TestRig stays in `antlr-rust-codegen` rather than a dedicated crate. Rust cannot
reflectively load a generated recognizer or invoke a parser rule by name, so the
command needs codegen's grammar metadata and rule-name normalization to emit
static dispatch. A separate crate would expose or duplicate those internals and
would only move the existing Clap dependency.

The generated runner lives below `src/__antlr4_rust_testrig/` so grammars named
`Main` cannot collide with its entry point. Named inputs are all attempted and
their results are aggregated, making recovered lexer and parser syntax errors
fail test automation even when a tree can still be produced.

Generated recognizers are imported through private aliases so valid grammar
names cannot collide with runner helpers. Parse trees are built only for
`--tree`, and `--diagnostics` conflicts with `--sll` rather than silently
changing prediction mode. Cargo artifacts are shared through the current
user's cache, with `ANTLR4_RUST_TESTRIG_TARGET_DIR` as an override and a
per-run private fallback when no user cache is available. The generated
project root is created atomically with mode `0700` on Unix so grammar sources
and embedded actions are not exposed through a shared temporary directory.

Codegen diagnostics retain their structured codes and source spans through
Miette. The temporary runner uses the same reporting style for input I/O,
lexer, and parser failures. It retains the runtime's `Rc`-backed input and only
copies the full source into Miette's `Arc`-backed representation when a
diagnostic is rendered. Snapshot subprocesses force color off through the
standard color-control environment variables, while normal terminal use keeps
the `fancy` renderer and Clap styling.

This does not change the generated recognizer/runtime interface, so the
generated-code API revision remains unchanged.

Closes #289.

## Validation

- `cargo test --locked --workspace --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- `ANTLR_RUST_RELEASE_ALLOW_DIRTY=1 tools/release/verify-package-contents.sh antlr-rust-codegen`
- `cargo package --locked -p antlr-rust-codegen --allow-dirty`
- forced-color smoke checks for Clap and generated TestRig diagnostics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `antlr4-rust-testrig` command for running generated lexer and parser grammars.
  - Supports combined or split grammars, stdin or file inputs, lexer-only mode, parser rules, token/tree/trace output, diagnostics, and prediction options.
  - Provides clear success and failure statuses with detailed diagnostics.

- **Documentation**
  - Added comprehensive usage documentation covering installation, configuration, caching, temporary artifacts, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->