### PR TITLE
feat(codegen): run trusted Rust support bundles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +84,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -64,13 +95,15 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "antlr-rust-codegen"
 version = "0.30.0"
 dependencies = [
+ "anstream",
+ "anstyle",
  "antlr-rust-g4-parser",
  "antlr-rust-rs-parser",
  "antlr-rust-runtime",
@@ -83,7 +116,13 @@ dependencies = [
  "memchr",
  "miette",
  "petgraph",
+ "rustpython-pylib",
+ "rustpython-vm",
+ "serde",
+ "sha2",
+ "tempfile",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -131,6 +170,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "ascii"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
+
+[[package]]
+name = "attribute-derive"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05832cdddc8f2650cc2cc187cc2e952b8c133a48eb055f35211f61ee81502d77"
+dependencies = [
+ "attribute-derive-macro",
+ "derive-where",
+ "manyhow",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "attribute-derive-macro"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7cdbbd4bd005c5d3e2e9c885e6fa575db4f4a3572335b974d8db853b6beb61"
+dependencies = [
+ "collection_literals",
+ "interpolator",
+ "manyhow",
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "quote-use",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +242,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
+name = "bitflagset"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64b6ee310aa7af14142c8c9121775774ff601ae055ed98ba7fac96098bcde1b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+ "radium",
+ "ref-cast",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -175,6 +318,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -217,10 +377,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
+name = "collection_literals"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2550f75b8cfac212855f6b1885455df8eaee8fe8e246b647d69146142e016084"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compact_str"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "derive-where"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d08b3a0bcc0d079199cd476b2cae8435016ec11d1c0986c6901c5ac223041534"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "displaydoc"
@@ -232,6 +485,18 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "either"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+
+[[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
 name = "equivalent"
@@ -246,14 +511,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "exitcode"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de853764b47027c2e862a995c34978ffa63c1501f2e15f987ba11bd4f9bba193"
 
 [[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "fd-lock"
+version = "4.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
+dependencies = [
+ "cfg-if",
+ "rustix",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -274,6 +562,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "futures-core"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
+
+[[package]]
+name = "futures-util"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "get-size-derive2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b6d1e2f75c16bfbcd0f95d84f99858a6e2f885c2287d1f5c3a96e8444a34b4"
+dependencies = [
+ "attribute-derive",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "get-size2"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cf31a6d70300cf81461098f7797571362387ef4bf85d32ac47eaa59b3a5a1a"
+dependencies = [
+ "compact_str",
+ "get-size-derive2",
+ "hashbrown 0.16.1",
+ "ordermap",
+ "smallvec",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width 0.2.2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -281,7 +665,7 @@ checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -291,12 +675,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
+name = "glob"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -312,10 +722,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
 name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "icu_casemap"
@@ -428,10 +889,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolator"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
 name = "intl"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743c21e11d6a1018820ee57bc5cbdc75d71462b1b0b5f188730a7c005cd55b1a"
+
+[[package]]
+name = "is-macro"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57a3e447e24c22647738e4607f1df1e0ec6f72e16182c4cd199f647cdfb0e4"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "is_ci"
@@ -446,10 +925,106 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "junction"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfc352a66ba903c23239ef51e809508b6fc2b0f90e3476ac7a9ff47e863ae95"
+dependencies = [
+ "scopeguard",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "lexical-parse-float"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a9f232fbd6f550bc0137dcb5f99ab674071ac2d690ac69704593cb4abbea56"
+dependencies = [
+ "lexical-parse-integer",
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-parse-integer"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7a039f8fb9c19c996cd7b2fcce303c1b2874fe1aca544edc85c4a5f8489b34"
+dependencies = [
+ "lexical-util",
+]
+
+[[package]]
+name = "lexical-util"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2604dd126bb14f13fb5d1bd6a66155079cb9fa655b37f875b3a742c705dbed17"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libffi"
+version = "5.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed185dbb87539a100c1b36c219e16e71572c6d4d4fed3ded898140f755adeaaf"
+dependencies = [
+ "libc",
+ "libffi-sys",
+]
+
+[[package]]
+name = "libffi-sys"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25831b230b6a90bdea9f28339c1d00d59773a1c492e8ca09b1ad80e56394c261"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -464,10 +1039,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
+name = "log"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lz4_flex"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef0d4ed8669f8f8826eb00dc878084aa8f253506c4fd5e8f58f5bce72ddb97e"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "malachite-base"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f44099731f17094b07825c88ccb5fbd1bfa1f82fafff7daa33e8b8652db16e"
+dependencies = [
+ "hashbrown 0.16.1",
+ "itertools",
+ "libm",
+ "ryu",
+]
+
+[[package]]
+name = "malachite-bigint"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc58206ba15e9c406e20c95c5f86efa07b12f94080945908e910b3a0faa23fef"
+dependencies = [
+ "malachite-base",
+ "malachite-nz",
+ "num-integer",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "malachite-nz"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a137660cdba20f136c8a223125f08088adb4e0b72fbb8466f08c43e31cc0427d"
+dependencies = [
+ "itertools",
+ "libm",
+ "malachite-base",
+ "wide",
+]
+
+[[package]]
+name = "malachite-q"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ffcbeed95e34c0fcc3864ccd146e129cbbf7de1513d3afbcfb47c7674c82d94"
+dependencies = [
+ "itertools",
+ "libm",
+ "malachite-base",
+ "malachite-nz",
+]
+
+[[package]]
+name = "manyhow"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33efb3ca6d3b07393750d4030418d594ab1139cee518f0dc88db70fec873587"
+dependencies = [
+ "manyhow-macros",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "manyhow-macros"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fce34d199b78b6e6073abf984c9cf5fd3e9330145a93ee0738a7443e371495"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "miette"
@@ -497,6 +1189,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -518,10 +1290,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "optional"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978aa494585d3ca4ad74929863093e87cac9790d81fe7aba2b3dc2890643a0fc"
+
+[[package]]
+name = "ordermap"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f7476a5b122ff1fce7208e7ee9dccd0a516e835f5b8b19b8f3c98a34cf757c1"
+dependencies = [
+ "indexmap",
+]
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
+
+[[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "petgraph"
@@ -535,6 +1351,103 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pmutil"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a40bc70c2c58040d2d8b167ba9a5ff59fc9dab7ad44771cfde3dcfde7a09c6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -543,6 +1456,26 @@ dependencies = [
  "serde_core",
  "writeable",
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "proc-macro-utils"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeaf08a13de400bc215877b5bdc088f241b12eb42f0a548d3390dc1c56bb7071"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "smallvec",
 ]
 
 [[package]]
@@ -574,16 +1507,155 @@ dependencies = [
 ]
 
 [[package]]
+name = "quote-use"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9619db1197b497a36178cfc736dc96b271fe918875fbf1344c436a7e93d0321e"
+dependencies = [
+ "quote",
+ "quote-use-macros",
+]
+
+[[package]]
+name = "quote-use-macros"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82ebfb7faafadc06a7ab141a6f67bcfb24cb8beb158c6fe933f2f035afa99f35"
+dependencies = [
+ "proc-macro-utils",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "radium"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1775bc532a9bfde46e26eba441ca1171b91608d14a3bae71fea371f18a00cffe"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
+
+[[package]]
+name = "result-like"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bffa194499266bd8a1ac7da6ac7355aa0f81ffa1a5db2baaf20dd13854fd6f4e"
+dependencies = [
+ "result-like-derive",
+]
+
+[[package]]
+name = "result-like-derive"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d3b03471c9700a3a6bd166550daaa6124cb4a146ea139fb028e4edaa8f4277"
+dependencies = [
+ "pmutil",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustix"
@@ -595,8 +1667,374 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "rustpython-codegen"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e4fc1331357a7afc6d52d637796a946b1efaaca07c914132f8fd4fd69d595f"
+dependencies = [
+ "ahash",
+ "bitflags",
+ "indexmap",
+ "itertools",
+ "log",
+ "malachite-bigint",
+ "memchr",
+ "num-complex",
+ "num-traits",
+ "rustpython-compiler-core",
+ "rustpython-literal",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_text_size",
+ "rustpython-wtf8",
+ "thiserror",
+ "unicode_names2 2.0.0",
+]
+
+[[package]]
+name = "rustpython-common"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3c0808a170ea900e0489a06d6aa04ce5d27d62b347836c2f98df958f47f243"
+dependencies = [
+ "ascii",
+ "bitflags",
+ "cfg-if",
+ "getrandom 0.3.4",
+ "itertools",
+ "libc",
+ "lock_api",
+ "malachite-base",
+ "malachite-bigint",
+ "malachite-q",
+ "nix",
+ "num-complex",
+ "num-traits",
+ "radium",
+ "rustpython-literal",
+ "rustpython-wtf8",
+ "siphasher",
+ "unicode_names2 2.0.0",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustpython-compiler"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7fa83b852bbc5461c5214060099d7597785d201aa0bf1a87d77967518f60144"
+dependencies = [
+ "rustpython-codegen",
+ "rustpython-compiler-core",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_parser",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "thiserror",
+]
+
+[[package]]
+name = "rustpython-compiler-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f18ba67b55aec49c3e2d223bbdcacff0d7e0f5d304fb0e64b044b8dca13c7c"
+dependencies = [
+ "bitflags",
+ "bitflagset",
+ "itertools",
+ "lz4_flex",
+ "malachite-bigint",
+ "num-complex",
+ "rustpython-ruff_source_file",
+ "rustpython-wtf8",
+]
+
+[[package]]
+name = "rustpython-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6c04350bee9e54b241b93675a0558c2b33fe982213e47a6da0924898af0f2"
+dependencies = [
+ "rustpython-compiler",
+ "rustpython-derive-impl",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "rustpython-derive-impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322d64ea8a21d52cd769db0f6190b6e7c17963b13c8c17f39d7364e68af96731"
+dependencies = [
+ "itertools",
+ "maplit",
+ "proc-macro2",
+ "quote",
+ "rustpython-compiler-core",
+ "rustpython-doc",
+ "syn 2.0.119",
+ "syn-ext",
+ "textwrap",
+]
+
+[[package]]
+name = "rustpython-doc"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f286d8b5872aa53dceb7a8d8c6a29fe85150f0a137fecf1c9a3e0a8345cbc19b"
+dependencies = [
+ "phf 0.13.1",
+]
+
+[[package]]
+name = "rustpython-literal"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcb46f7afce00e4797f82062e09881ec5e7226d858104bf4a8a9c3b996de2b4a"
+dependencies = [
+ "hexf-parse",
+ "is-macro",
+ "lexical-parse-float",
+ "num-traits",
+ "rustpython-wtf8",
+ "unic-ucd-category",
+]
+
+[[package]]
+name = "rustpython-pylib"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1878a8c2fb45dfcbcee1d4bba8d4a3d9b65c4f20dc70d08179c3efa223bbab"
+dependencies = [
+ "glob",
+ "rustpython-compiler-core",
+ "rustpython-derive",
+]
+
+[[package]]
+name = "rustpython-ruff_python_ast"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f021ff72cabf5e2cd6d8ec8813d376a8445a228dc610ab56c27bd9054cda70d4"
+dependencies = [
+ "aho-corasick",
+ "bitflags",
+ "compact_str",
+ "get-size2",
+ "is-macro",
+ "memchr",
+ "rustc-hash",
+ "rustpython-ruff_python_trivia",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "thiserror",
+]
+
+[[package]]
+name = "rustpython-ruff_python_parser"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e6ee78bd9671fb5766664b2695fe1f2a92a961f4d9101646c570d8acdb1e0b"
+dependencies = [
+ "bitflags",
+ "bstr",
+ "compact_str",
+ "get-size2",
+ "memchr",
+ "rustc-hash",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_trivia",
+ "rustpython-ruff_text_size",
+ "static_assertions",
+ "unicode-ident",
+ "unicode-normalization",
+ "unicode_names2 1.3.0",
+]
+
+[[package]]
+name = "rustpython-ruff_python_trivia"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79e7cfd1056f3a02ff0d2d0e4474286ca963260782f878b7b81c1dd87432e682"
+dependencies = [
+ "itertools",
+ "rustpython-ruff_source_file",
+ "rustpython-ruff_text_size",
+ "unicode-ident",
+]
+
+[[package]]
+name = "rustpython-ruff_source_file"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "948107aad62ddb12a11fc7bf68a49e52a0b0a3737d415a2505e54f5a9edac737"
+dependencies = [
+ "memchr",
+ "rustpython-ruff_text_size",
+]
+
+[[package]]
+name = "rustpython-ruff_text_size"
+version = "0.15.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8291ee0f5a779e54ccd4e0151a0c426f8b49a123f99b5b6545db17ccdd4277aa"
+dependencies = [
+ "get-size2",
+]
+
+[[package]]
+name = "rustpython-sre_engine"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad4b7bd82b2a531f7c2ad96864ce11285959fc7d8524f1ba54db8ce3a23a3d2c"
+dependencies = [
+ "bitflags",
+ "num_enum",
+ "optional",
+ "rustpython-wtf8",
+]
+
+[[package]]
+name = "rustpython-vm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1880770161cef896bf9c7e065dae574e3b4c3cf6172e485f1ce86f0483816ab2"
+dependencies = [
+ "ahash",
+ "ascii",
+ "bitflags",
+ "bstr",
+ "caseless",
+ "cfg-if",
+ "chrono",
+ "constant_time_eq",
+ "crossbeam-utils",
+ "errno",
+ "exitcode",
+ "getrandom 0.3.4",
+ "glob",
+ "half",
+ "hex",
+ "indexmap",
+ "is-macro",
+ "itertools",
+ "junction",
+ "libc",
+ "libffi",
+ "libloading",
+ "log",
+ "malachite-bigint",
+ "memchr",
+ "nix",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "num_cpus",
+ "num_enum",
+ "optional",
+ "parking_lot",
+ "paste",
+ "psm",
+ "result-like",
+ "rustix",
+ "rustpython-codegen",
+ "rustpython-common",
+ "rustpython-compiler",
+ "rustpython-compiler-core",
+ "rustpython-derive",
+ "rustpython-literal",
+ "rustpython-ruff_python_ast",
+ "rustpython-ruff_python_parser",
+ "rustpython-ruff_text_size",
+ "rustpython-sre_engine",
+ "rustyline",
+ "scoped-tls",
+ "scopeguard",
+ "static_assertions",
+ "strum",
+ "strum_macros",
+ "thiserror",
+ "timsort",
+ "uname",
+ "unic-ucd-bidi",
+ "unic-ucd-category",
+ "unic-ucd-ident",
+ "unicode-casing",
+ "which",
+ "widestring",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustpython-wtf8"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada88d2f69ff5516d69e0f3294e9db2ff8ee71a15291b8f3f8584f07ad1ca28d"
+dependencies = [
+ "ascii",
+ "bstr",
+ "itertools",
+ "memchr",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
+
+[[package]]
+name = "rustyline"
+version = "17.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e902948a25149d50edc1a8e0141aad50f54e22ba83ff988cf8f7c9ef07f50564"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "clipboard-win",
+ "fd-lock",
+ "home",
+ "libc",
+ "log",
+ "memchr",
+ "nix",
+ "radix_trie",
+ "unicode-segmentation",
+ "unicode-width 0.2.2",
+ "utf8parse",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe_arch"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
@@ -629,6 +2067,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +2097,24 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "stable_deref_trait"
@@ -656,14 +2132,38 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "supports-color"
@@ -709,6 +2209,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn-ext"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b126de4ef6c2a628a68609dd00733766c3b015894698a438ebdf374933fc31d1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,10 +2237,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -739,7 +2250,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -773,6 +2284,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "timsort"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "639ce8ef6d2ba56be0383a94dd13b92138d58de44c62618303bb798fa92bdc00"
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,6 +2299,151 @@ dependencies = [
  "serde_core",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
+name = "toml"
+version = "0.9.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.7.5+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56353a2a665ad0f41a421187180aab746c8c325620617ad883a99a1cbe66d2"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
+
+[[package]]
+name = "typenum"
+version = "1.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uname"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b72f89f0ca32e4db1c04e2a72f5345d59796d4866a1ee0609084569f73683dc8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "unic-char-property"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
+dependencies = [
+ "unic-char-range",
+]
+
+[[package]]
+name = "unic-char-range"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
+
+[[package]]
+name = "unic-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
+
+[[package]]
+name = "unic-ucd-bidi"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1d568b51222484e1f8209ce48caa6b430bf352962b877d592c29ab31fb53d8c"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-category"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8d4591f5fcfe1bd4453baaf803c40e1b1e69ff8455c47620440b46efef91c0"
+dependencies = [
+ "matches",
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-ident"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e230a37c0381caa9219d67cf063aa3a375ffed5bf541a452db16e744bdab6987"
+dependencies = [
+ "unic-char-property",
+ "unic-char-range",
+ "unic-ucd-version",
+]
+
+[[package]]
+name = "unic-ucd-version"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
+dependencies = [
+ "unic-common",
+]
+
+[[package]]
+name = "unicode-casing"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "061dbb8cc7f108532b6087a0065eff575e892a4bcb503dc57323a197457cc202"
 
 [[package]]
 name = "unicode-ident"
@@ -796,6 +2458,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +2483,48 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode_names2"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1673eca9782c84de5f81b82e4109dcfb3611c8ba0d52930ec4a9478f547b2dd"
+dependencies = [
+ "phf 0.11.3",
+ "unicode_names2_generator 1.3.0",
+]
+
+[[package]]
+name = "unicode_names2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d189085656ca1203291e965444e7f6a2723fbdd1dd9f34f8482e79bafd8338a0"
+dependencies = [
+ "phf 0.11.3",
+ "unicode_names2_generator 2.0.0",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91e5b84611016120197efd7dc93ef76774f4e084cd73c9fb3ea4a86c570c56e"
+dependencies = [
+ "getopts",
+ "log",
+ "phf_codegen",
+ "rand",
+]
+
+[[package]]
+name = "unicode_names2_generator"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1262662dc96937c71115228ce2e1d30f41db71a7a45d3459e98783ef94052214"
+dependencies = [
+ "phf_codegen",
+ "rand",
+]
 
 [[package]]
 name = "utf8_iter"
@@ -820,10 +2539,172 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasip2"
+version = "1.0.4+wasi-0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.126"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "which"
+version = "8.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "wide"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be99e8317aa9f08e7d16e13033ca43faab59ab582b1d0feab7b385424c42f8b1"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
+name = "widestring"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
 
 [[package]]
 name = "windows-sys"
@@ -833,6 +2714,153 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm 0.52.6",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -861,6 +2889,26 @@ dependencies = [
  "quote",
  "syn 2.0.119",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -789,6 +789,21 @@ its source spelling and a colliding native helper is exposed as `context_*`.
 Labeled alternatives currently materialize `_localctx` through the base rule
 context, so alternative-only children remain outside this compatibility surface.
 
+The CLI also discovers the current grammars-v4 C and Java
+`Rust/transformGrammar.py` files next to grammar roots. It fingerprints the
+`Rust/` folder and requires explicit trust before running the transform with
+bundled RustPython in a child over a disposable grammar-tree copy. Interactive
+choices can trust once, the exact revision, or the repository; non-interactive
+invocations fail with the exact `--trust-rust-support sha256:...` argument.
+This trusted-source path does not claim to sandbox the host. It stages inputs
+to preserve the checkout and automatically emits transformed grammars and
+shipped Rust support modules under `antlr-rust-support/`, plus a
+`rust-support.json` audit manifest.
+
+Python compatibility is intentionally pinned to the imports and filesystem
+operations used by those two transforms. Other or future sibling scripts must
+be evaluated explicitly before they are considered supported.
+
 ### Decision Tiers and `--fixed-lookahead`
 
 ANTLR always generates an adaptive `ALL(*)` recognizer: every decision point

--- a/crates/antlr-rust-codegen/Cargo.toml
+++ b/crates/antlr-rust-codegen/Cargo.toml
@@ -27,6 +27,8 @@ name = "antlr4-rust-testrig"
 path = "src/bin/antlr4-rust-testrig.rs"
 
 [dependencies]
+anstream = "1"
+anstyle = "1"
 antlr-rust-g4-parser.workspace = true
 antlr-rust-rs-parser.workspace = true
 antlr-rust-runtime.workspace = true
@@ -46,7 +48,19 @@ icu_properties.workspace = true
 intl = { version = "0.6.0", default-features = false, features = ["full", "normalization"] }
 miette = { version = "7.6.0", default-features = false, features = ["fancy"] }
 petgraph = { version = "0.8.3", default-features = false, features = ["std"] }
+rustpython-pylib = { version = "0.5.0", features = ["freeze-stdlib"] }
+rustpython-vm = { version = "0.5.0", default-features = false, features = [
+    "compiler",
+    "freeze-stdlib",
+    "gc",
+    "host_env",
+    "stdio",
+] }
+serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
+tempfile = "3"
 thiserror.workspace = true
+toml = "0.9"
 
 [dev-dependencies]
 hmac-sha256      = "1"

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -56,6 +56,9 @@ Transformed grammars, shipped `.rs` support files, and `rust-support.json` are
 emitted with the generated sources so the inputs remain inspectable. Embedded
 actions, strict semantics, generated-only parser coverage, and `superClass`
 acknowledgement are selected automatically for those staged sources.
+Shipped helpers are available through the generated recognizer module's stable
+`rust_support` re-export, for example
+`c_parser::rust_support::c_parser_base::reset_symbol_table()`.
 
 Non-interactive use fails before execution and prints the exact opt-in:
 

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -50,6 +50,8 @@ revision, trust the repository, or abort.
 The approved transform runs with bundled RustPython in a child process over a
 disposable copy of the complete grammar directory. This is a trusted-source
 workflow, not a security sandbox. The original checkout is never modified.
+The child has a 30-second deadline and bounded output capture; use
+`--rust-support-timeout SECONDS` for a slower trusted transform.
 Transformed grammars, shipped `.rs` support files, and `rust-support.json` are
 emitted with the generated sources so the inputs remain inspectable. Embedded
 actions, strict semantics, generated-only parser coverage, and `superClass`

--- a/crates/antlr-rust-codegen/README.md
+++ b/crates/antlr-rust-codegen/README.md
@@ -39,6 +39,41 @@ Or install the command:
 cargo install antlr-rust-codegen --bin antlr4-rust-gen
 ```
 
+## Trusted grammars-v4 Rust support
+
+`antlr4-rust-gen` recognizes a sibling `Rust/transformGrammar.py` for the
+current C and Java target-support folders in `antlr/grammars-v4`. Before
+executing one, an interactive terminal shows its repository, revision, and
+content fingerprint and offers four choices: trust once, trust the exact
+revision, trust the repository, or abort.
+
+The approved transform runs with bundled RustPython in a child process over a
+disposable copy of the complete grammar directory. This is a trusted-source
+workflow, not a security sandbox. The original checkout is never modified.
+Transformed grammars, shipped `.rs` support files, and `rust-support.json` are
+emitted with the generated sources so the inputs remain inspectable. Embedded
+actions, strict semantics, generated-only parser coverage, and `superClass`
+acknowledgement are selected automatically for those staged sources.
+
+Non-interactive use fails before execution and prints the exact opt-in:
+
+```bash
+antlr4-rust-gen JavaLexer.g4 JavaParser.g4 \
+    --trust-rust-support sha256:<fingerprint> \
+    --out-dir src/generated
+```
+
+Persisted choices live in
+`$XDG_CONFIG_HOME/antlr4-rust/trusted-support.toml` (or the platform config
+directory). Set `ANTLR4_RUST_TRUST_STORE` to use a different file. Automatic
+transform execution is currently an `antlr4-rust-gen` CLI feature; the
+`Builder` API does not execute sibling scripts.
+
+The bundled Python compatibility target is deliberately limited to the imports
+and filesystem operations used by the two existing grammars-v4 transforms
+(`c/Rust` and `java/java/Rust`). A future transform with additional Python
+requirements is a new compatibility decision, not implicitly supported.
+
 The package also provides `antlr4-rust-testrig` for running a grammar directly
 against UTF-8 files or stdin. A grammar-only project needs no `Cargo.toml`,
 generated Rust sources, or runtime dependency; only a Rust toolchain is

--- a/crates/antlr-rust-codegen/src/builder.rs
+++ b/crates/antlr-rust-codegen/src/builder.rs
@@ -8,6 +8,7 @@ use crate::config::CompilerConfig;
 use crate::driver;
 use crate::error::Error;
 use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
+use crate::rust_support::RustSupportOptions;
 use crate::semantics::{
     SemPatternFile, SemUnknownPolicy, load_sem_patterns, normalize_option_hook,
 };
@@ -240,6 +241,7 @@ impl Builder {
             optimize_precedence_ladders: self.optimize_precedence_ladders,
             report_precedence_ladders: self.report_precedence_ladders,
             test_rig: None,
+            rust_support: RustSupportOptions::disabled(),
         })
     }
 }

--- a/crates/antlr-rust-codegen/src/cli.rs
+++ b/crates/antlr-rust-codegen/src/cli.rs
@@ -1,5 +1,6 @@
 use std::io::{self, IsTerminal as _, Write as _};
 use std::path::PathBuf;
+use std::time::Duration;
 
 use clap::{ArgAction, Parser};
 use miette::{Context as _, IntoDiagnostic as _};
@@ -155,6 +156,15 @@ struct CliArgs {
         value_parser = parse_trust_fingerprint
     )]
     trusted_rust_support: Vec<String>,
+
+    /// Maximum time allowed for a trusted Rust support transform.
+    #[arg(
+        long = "rust-support-timeout",
+        value_name = "SECONDS",
+        default_value_t = 30,
+        value_parser = clap::value_parser!(u64).range(1..=3600)
+    )]
+    rust_support_timeout: u64,
 }
 
 impl CliArgs {
@@ -192,6 +202,7 @@ impl CliArgs {
                 interactive: io::stdin().is_terminal() && io::stderr().is_terminal(),
                 child_executable: Some(std::env::current_exe().into_diagnostic()?),
                 trust_store_path: std::env::var_os("ANTLR4_RUST_TRUST_STORE").map(PathBuf::from),
+                transform_timeout: Duration::from_secs(self.rust_support_timeout),
             },
         })
     }

--- a/crates/antlr-rust-codegen/src/cli.rs
+++ b/crates/antlr-rust-codegen/src/cli.rs
@@ -1,4 +1,4 @@
-use std::io::{self, Write as _};
+use std::io::{self, IsTerminal as _, Write as _};
 use std::path::PathBuf;
 
 use clap::{ArgAction, Parser};
@@ -8,14 +8,34 @@ use crate::builder::{ActionMode, UnknownSemanticPolicy};
 use crate::config::CompilerConfig;
 use crate::driver::generate;
 use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
+use crate::rust_support::{RustSupportOptions, parse_trust_fingerprint, run_transform_child};
 use crate::semantics::{SemPatternFile, load_sem_patterns, normalize_option_hook};
 
 pub(crate) fn run_cli() -> miette::Result<()> {
-    let args = CliArgs::parse().into_config()?;
-    let mut stderr = io::stderr().lock();
-    generate(&args, |message| writeln!(stderr, "{message}"))
+    if let Some(staging_directory) = transform_child_argument()? {
+        return run_transform_child(&staging_directory);
+    }
+    let args = CliArgs::parse();
+    let config = args.into_config()?;
+    generate(&config, |message| writeln!(io::stderr(), "{message}"))
         .map_err(crate::cli_report::codegen_error)?;
     Ok(())
+}
+
+fn transform_child_argument() -> miette::Result<Option<PathBuf>> {
+    let mut arguments = std::env::args_os().skip(1);
+    if arguments.next().as_deref() != Some(std::ffi::OsStr::new("--__antlr-rust-transform")) {
+        return Ok(None);
+    }
+    let directory = arguments.next().map(PathBuf::from).ok_or_else(|| {
+        miette::miette!("--__antlr-rust-transform requires a staged grammar directory")
+    })?;
+    if arguments.next().is_some() {
+        return Err(miette::miette!(
+            "--__antlr-rust-transform accepts exactly one staged grammar directory"
+        ));
+    }
+    Ok(Some(directory))
 }
 
 #[derive(Debug, Parser)]
@@ -127,6 +147,14 @@ struct CliArgs {
     /// Dry-run precedence-ladder analysis and emit only optimizations.json.
     #[arg(long, conflicts_with = "optimize_precedence_ladders")]
     report_precedence_ladders: bool,
+
+    /// Trust one exact sibling Rust support bundle fingerprint.
+    #[arg(
+        long = "trust-rust-support",
+        value_name = "SHA256",
+        value_parser = parse_trust_fingerprint
+    )]
+    trusted_rust_support: Vec<String>,
 }
 
 impl CliArgs {
@@ -158,6 +186,13 @@ impl CliArgs {
             optimize_precedence_ladders: self.optimize_precedence_ladders,
             report_precedence_ladders: self.report_precedence_ladders,
             test_rig: None,
+            rust_support: RustSupportOptions {
+                enabled: true,
+                trusted_fingerprints: self.trusted_rust_support.into_iter().collect(),
+                interactive: io::stdin().is_terminal() && io::stderr().is_terminal(),
+                child_executable: Some(std::env::current_exe().into_diagnostic()?),
+                trust_store_path: std::env::var_os("ANTLR4_RUST_TRUST_STORE").map(PathBuf::from),
+            },
         })
     }
 }

--- a/crates/antlr-rust-codegen/src/config.rs
+++ b/crates/antlr-rust-codegen/src/config.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeSet;
 use std::path::PathBuf;
 
+use crate::rust_support::RustSupportOptions;
 use crate::semantics::{SemPatternFile, SemUnknownPolicy};
 
 #[derive(Debug)]
@@ -38,4 +39,6 @@ pub(crate) struct CompilerConfig {
     pub(crate) report_precedence_ladders: bool,
     /// Emit a temporary-crate entry point for `antlr4-rust-testrig`.
     pub(crate) test_rig: Option<TestRigConfig>,
+    /// Trusted sibling `Rust/transformGrammar.py` execution.
+    pub(crate) rust_support: RustSupportOptions,
 }

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -315,10 +315,12 @@ fn compilation_error(
             || fallback.to_path_buf(),
             |location| prepared_support.original_path(&location.path),
         );
-        let position = location.and_then(|location| location.position);
         let primary = diagnostic.primary_source_span();
-        let structured_position = primary.and(position);
         let remapped = location.is_some_and(|location| location.path != path);
+        let position = (!remapped)
+            .then(|| location.and_then(|location| location.position))
+            .flatten();
+        let structured_position = primary.and(position);
         let byte_span = (!remapped)
             .then(|| location.and(primary).map(source_byte_span))
             .flatten();
@@ -368,9 +370,13 @@ fn compilation_diagnostics(
                 .map(source_byte_span);
             let path = path.unwrap_or_else(|| PathBuf::from("<grammar>"));
             let position = primary.and_then(|span| {
-                compilation
-                    .sources
-                    .line_column(span.source, span.bytes.start)
+                (!remapped)
+                    .then(|| {
+                        compilation
+                            .sources
+                            .line_column(span.source, span.bytes.start)
+                    })
+                    .flatten()
             });
             Diagnostic::new(
                 diagnostic.code,

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -3,9 +3,10 @@ use crate::generator::prelude::*;
 use crate::lexer::{LexerRenderModel, render_lexer_model};
 use crate::optimization::OptimizationPlan;
 use crate::parser::{ParserRenderOptions, render_parser_with_decision_report};
+use crate::rust_support::{self, PreparedRustSupport};
 use crate::semantics::{
-    DecisionReportGrammar, GrammarOptionEntry, SemanticsEntry, collect_lexer_semantics,
-    collect_parser_semantics_for_mode, collect_structural_grammar_options,
+    DecisionReportGrammar, GrammarOptionEntry, SemUnknownPolicy, SemanticsEntry,
+    collect_lexer_semantics, collect_parser_semantics_for_mode, collect_structural_grammar_options,
     enforce_require_full_options, enforce_require_full_semantics, enforce_sem_unknown,
     grammar_option_warning_messages, render_decisions_manifest, render_semantics_manifest,
 };
@@ -17,24 +18,26 @@ pub(crate) fn generate(
     args: &CompilerConfig,
     mut report: impl FnMut(&str) -> io::Result<()>,
 ) -> Result<Generation, Error> {
+    let prepared_support = rust_support::prepare(args)?;
     let optimizations = OptimizationPlan::from_compiler_config(args)?;
-    let action_reference_parser: grammar::action::ActionReferenceParser = if args.embedded_actions {
-        embedded::action_references
-    } else {
-        grammar::action::action_references
-    };
+    let action_reference_parser: grammar::action::ActionReferenceParser =
+        if args.embedded_actions || prepared_support.has_bundles() {
+            embedded::action_references
+        } else {
+            grammar::action::action_references
+        };
     let compilation = grammar::compiler::compile_with_action_reference_parser(
         LoadOptions {
-            roots: args.roots.clone(),
-            library_directories: args.library_directories.clone(),
+            roots: prepared_support.roots().to_vec(),
+            library_directories: prepared_support.library_directories().to_vec(),
         },
         optimizations.transforms(),
         optimizations.report_only(),
         optimizations.entry_rules(),
         action_reference_parser,
     )
-    .map_err(|error| compilation_error(&error, &args.roots))?;
-    let diagnostics = compilation_diagnostics(&compilation);
+    .map_err(|error| compilation_error(&error, &args.roots, &prepared_support))?;
+    let diagnostics = compilation_diagnostics(&compilation, &prepared_support);
     let mut warnings = diagnostics
         .iter()
         .map(render_diagnostic)
@@ -49,14 +52,17 @@ pub(crate) fn generate(
     warnings.extend(optimization_messages);
     let mut inputs = compilation
         .input_paths()
-        .map(Path::to_path_buf)
+        .map(|path| prepared_support.original_path(path))
         .collect::<Vec<_>>();
+    inputs.extend(prepared_support.additional_inputs());
     if let Some(path) = &args.sem_patterns_path {
         let path = fs::canonicalize(path).map_err(Error::generation)?;
         if !inputs.contains(&path) {
             inputs.push(path);
         }
     }
+    let mut seen_inputs = BTreeSet::new();
+    inputs.retain(|path| seen_inputs.insert(path.clone()));
     let optimization_manifest = optimizations.render_manifest(&compilation);
     if optimizations.report_only() {
         let mut artifacts = GeneratedArtifacts::default();
@@ -85,29 +91,37 @@ pub(crate) fn generate(
                 .lexer(grammar)
                 .expect("compiled root lexer artifact exists");
             let data = LexerCodegenData::from_compiled(compiled, &compilation.sources);
-            grammar_options.extend(collect_structural_grammar_options(
-                &data,
-                &args.option_hooks,
-            )?);
+            let support_enabled =
+                source_uses_rust_support(&data, &compilation.sources, &prepared_support);
+            let option_hooks = option_hooks(args, &data, support_enabled);
+            grammar_options.extend(collect_structural_grammar_options(&data, &option_hooks)?);
+            let embedded_actions = args.embedded_actions || support_enabled;
+            let sem_unknown = if support_enabled {
+                SemUnknownPolicy::Error
+            } else {
+                args.sem_unknown
+            };
+            let require_full_semantics = args.require_full_semantics || support_enabled;
             let entries = collect_lexer_semantics(
                 &data,
-                args.embedded_actions,
+                embedded_actions,
                 args.allow_unsupported_lexer_actions,
-                args.sem_unknown,
+                sem_unknown,
                 &args.sem_patterns,
             )?;
-            enforce_sem_unknown(args.sem_unknown, &entries)?;
-            enforce_require_full_semantics(args.require_full_semantics, &entries)?;
+            enforce_sem_unknown(sem_unknown, &entries)?;
+            enforce_require_full_semantics(require_full_semantics, &entries)?;
             let grammar_name = compiled.semantic.recognizer.name.clone();
             let render_model = LexerRenderModel::new(
                 &grammar_name,
                 &data,
                 args.allow_unsupported_lexer_actions,
-                args.sem_unknown,
+                sem_unknown,
                 &args.sem_patterns,
-                args.embedded_actions,
+                embedded_actions,
             );
-            let module = render_lexer_model(&render_model)?;
+            let mut module = render_lexer_model(&render_model)?;
+            prepared_support.decorate_rendered_module(&mut module);
             insert_rendered_module(&mut rendered_modules, &grammar_name, module)?;
             if args.test_rig.is_some() {
                 test_rig_lexers.push(TestRigLexer::new(grammar_name.clone()));
@@ -122,32 +136,40 @@ pub(crate) fn generate(
                 .parser(grammar)
                 .expect("compiled root parser artifact exists");
             let data = ParserCodegenData::from_compiled(compiled, &compilation.sources);
-            grammar_options.extend(collect_structural_grammar_options(
-                &data,
-                &args.option_hooks,
-            )?);
+            let support_enabled =
+                source_uses_rust_support(&data, &compilation.sources, &prepared_support);
+            let option_hooks = option_hooks(args, &data, support_enabled);
+            grammar_options.extend(collect_structural_grammar_options(&data, &option_hooks)?);
+            let embedded_actions = args.embedded_actions || support_enabled;
+            let sem_unknown = if support_enabled {
+                SemUnknownPolicy::Error
+            } else {
+                args.sem_unknown
+            };
+            let require_full_semantics = args.require_full_semantics || support_enabled;
             let entries = collect_parser_semantics_for_mode(
                 &data,
-                args.embedded_actions,
-                args.sem_unknown,
+                embedded_actions,
+                sem_unknown,
                 &args.sem_patterns,
             )?;
-            enforce_sem_unknown(args.sem_unknown, &entries)?;
-            enforce_require_full_semantics(args.require_full_semantics, &entries)?;
+            enforce_sem_unknown(sem_unknown, &entries)?;
+            enforce_require_full_semantics(require_full_semantics, &entries)?;
             let grammar_name = compiled.semantic.recognizer.name.clone();
-            let (module, decision_report_rows) = render_parser_with_decision_report(
+            let (mut module, decision_report_rows) = render_parser_with_decision_report(
                 &grammar_name,
                 &data,
                 ParserRenderOptions {
-                    require_generated_parser: args.require_generated_parser,
-                    embedded: args.embedded_actions,
+                    require_generated_parser: args.require_generated_parser || support_enabled,
+                    embedded: embedded_actions,
                     generate_listener: args.generate_listener,
                     generate_visitor: args.generate_visitor,
-                    sem_unknown: args.sem_unknown,
+                    sem_unknown,
                     patterns: Some(&args.sem_patterns),
                     fixed_lookahead: args.fixed_lookahead,
                 },
             )?;
+            prepared_support.decorate_rendered_module(&mut module);
             insert_rendered_module(&mut rendered_modules, &grammar_name, module)?;
             if args.test_rig.is_some() {
                 test_rig_parsers.push(TestRigParser::new(
@@ -170,9 +192,16 @@ pub(crate) fn generate(
         report(warning).map_err(Error::generation)?;
     }
     warnings.extend(option_warnings);
-    enforce_require_full_options(args.require_full_semantics, &grammar_options)?;
-    let manifest =
-        render_semantics_manifest(args.sem_unknown, &grammar_options, &manifest_grammars);
+    enforce_require_full_options(
+        args.require_full_semantics || prepared_support.has_bundles(),
+        &grammar_options,
+    )?;
+    let manifest_policy = if prepared_support.has_bundles() {
+        SemUnknownPolicy::Error
+    } else {
+        args.sem_unknown
+    };
+    let manifest = render_semantics_manifest(manifest_policy, &grammar_options, &manifest_grammars);
 
     let mut artifacts = GeneratedArtifacts::default();
     for (path, module) in rendered_modules {
@@ -194,8 +223,38 @@ pub(crate) fn generate(
             render_test_rig(&test_rig.start_rule, &test_rig_lexers, &test_rig_parsers)?,
         )?;
     }
+    prepared_support.add_artifacts(&mut artifacts)?;
     let outputs = artifacts.write_to(&args.out_dir)?;
     Ok(Generation::new(inputs, outputs, warnings, diagnostics))
+}
+
+fn source_uses_rust_support(
+    data: &RecognizerCodegenData<'_>,
+    sources: &SourceSet,
+    prepared_support: &PreparedRustSupport,
+) -> bool {
+    data.semantic
+        .and_then(|semantic| sources.canonical_path(semantic.unit.source))
+        .is_some_and(|source| prepared_support.supports_source(source))
+}
+
+fn option_hooks(
+    args: &CompilerConfig,
+    data: &RecognizerCodegenData<'_>,
+    support_enabled: bool,
+) -> BTreeSet<String> {
+    let mut hooks = args.option_hooks.clone();
+    if support_enabled && let Some(semantic) = data.semantic {
+        hooks.extend(
+            semantic
+                .unit
+                .options
+                .iter()
+                .filter(|option| option.name.value == "superClass")
+                .map(|option| format!("{}={}", option.name.value, option.value.value)),
+        );
+    }
+    hooks
 }
 
 fn insert_rendered_module(
@@ -236,7 +295,11 @@ fn deduplicate_grammar_options(options: &mut Vec<GrammarOptionEntry>) {
     });
 }
 
-fn compilation_error(error: &grammar::diagnostic::CompilationError, roots: &[PathBuf]) -> Error {
+fn compilation_error(
+    error: &grammar::diagnostic::CompilationError,
+    roots: &[PathBuf],
+    prepared_support: &PreparedRustSupport,
+) -> Error {
     let fallback = roots
         .first()
         .map_or_else(|| Path::new("<grammar>"), PathBuf::as_path);
@@ -248,12 +311,17 @@ fn compilation_error(error: &grammar::diagnostic::CompilationError, roots: &[Pat
             grammar::diagnostic::Severity::Error => ("error", Severity::Error),
         };
         let location = error.location(index);
-        let path =
-            location.map_or_else(|| fallback.to_path_buf(), |location| location.path.clone());
+        let path = location.map_or_else(
+            || fallback.to_path_buf(),
+            |location| prepared_support.original_path(&location.path),
+        );
         let position = location.and_then(|location| location.position);
         let primary = diagnostic.primary_source_span();
         let structured_position = primary.and(position);
-        let byte_span = location.and(primary).map(source_byte_span);
+        let remapped = location.is_some_and(|location| location.path != path);
+        let byte_span = (!remapped)
+            .then(|| location.and(primary).map(source_byte_span))
+            .flatten();
         let display_position =
             position.map_or_else(String::new, |(line, column)| format!(":{line}:{column}"));
         let _ = writeln!(
@@ -275,17 +343,29 @@ fn compilation_error(error: &grammar::diagnostic::CompilationError, roots: &[Pat
     Error::compilation(message, diagnostics)
 }
 
-fn compilation_diagnostics(compilation: &grammar::compiler::Compilation) -> Vec<Diagnostic> {
+fn compilation_diagnostics(
+    compilation: &grammar::compiler::Compilation,
+    prepared_support: &PreparedRustSupport,
+) -> Vec<Diagnostic> {
     compilation
         .diagnostics
         .iter()
         .filter(|diagnostic| diagnostic.severity == grammar::diagnostic::Severity::Warning)
         .map(|diagnostic| {
             let primary = diagnostic.primary_source_span();
-            let path = primary
+            let source_path = primary
                 .and_then(|span| compilation.sources.logical_path(span.source))
                 .map(Path::to_path_buf);
-            let byte_span = primary.filter(|_| path.is_some()).map(source_byte_span);
+            let path = source_path
+                .as_deref()
+                .map(|path| prepared_support.original_path(path));
+            let remapped = source_path
+                .as_ref()
+                .zip(path.as_ref())
+                .is_some_and(|(source, original)| source != original);
+            let byte_span = primary
+                .filter(|_| path.is_some() && !remapped)
+                .map(source_byte_span);
             let path = path.unwrap_or_else(|| PathBuf::from("<grammar>"));
             let position = primary.and_then(|span| {
                 compilation

--- a/crates/antlr-rust-codegen/src/driver.rs
+++ b/crates/antlr-rust-codegen/src/driver.rs
@@ -94,7 +94,11 @@ pub(crate) fn generate(
             let support_enabled =
                 source_uses_rust_support(&data, &compilation.sources, &prepared_support);
             let option_hooks = option_hooks(args, &data, support_enabled);
-            grammar_options.extend(collect_structural_grammar_options(&data, &option_hooks)?);
+            let options = collect_structural_grammar_options(&data, &option_hooks)?;
+            if support_enabled {
+                enforce_require_full_options(true, &options)?;
+            }
+            grammar_options.extend(options);
             let embedded_actions = args.embedded_actions || support_enabled;
             let sem_unknown = if support_enabled {
                 SemUnknownPolicy::Error
@@ -139,7 +143,11 @@ pub(crate) fn generate(
             let support_enabled =
                 source_uses_rust_support(&data, &compilation.sources, &prepared_support);
             let option_hooks = option_hooks(args, &data, support_enabled);
-            grammar_options.extend(collect_structural_grammar_options(&data, &option_hooks)?);
+            let options = collect_structural_grammar_options(&data, &option_hooks)?;
+            if support_enabled {
+                enforce_require_full_options(true, &options)?;
+            }
+            grammar_options.extend(options);
             let embedded_actions = args.embedded_actions || support_enabled;
             let sem_unknown = if support_enabled {
                 SemUnknownPolicy::Error
@@ -192,11 +200,8 @@ pub(crate) fn generate(
         report(warning).map_err(Error::generation)?;
     }
     warnings.extend(option_warnings);
-    enforce_require_full_options(
-        args.require_full_semantics || prepared_support.has_bundles(),
-        &grammar_options,
-    )?;
-    let manifest_policy = if prepared_support.has_bundles() {
+    enforce_require_full_options(args.require_full_semantics, &grammar_options)?;
+    let manifest_policy = if prepared_support.all_roots_supported() {
         SemUnknownPolicy::Error
     } else {
         args.sem_unknown

--- a/crates/antlr-rust-codegen/src/lib.rs
+++ b/crates/antlr-rust-codegen/src/lib.rs
@@ -16,6 +16,7 @@ mod lexer;
 mod optimization;
 mod parser;
 mod rust_output;
+mod rust_support;
 mod semantics;
 mod structural;
 mod test_rig;

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 use std::ffi::OsStr;
-use std::fs;
+use std::fs::{self, OpenOptions};
 use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -38,8 +38,9 @@ impl BundleIdentity {
 pub(crate) fn identify(
     grammar_directory: &Path,
     support_directory: &Path,
+    fingerprint_root: &Path,
 ) -> io::Result<BundleIdentity> {
-    let fingerprint = fingerprint_directory(support_directory)?;
+    let fingerprint = fingerprint_directory(fingerprint_root)?;
     let git_root = git_output(grammar_directory, ["rev-parse", "--show-toplevel"])
         .map(PathBuf::from)
         .filter(|path| path.is_absolute());
@@ -190,32 +191,7 @@ pub(crate) struct TrustStore {
 impl TrustStore {
     pub(crate) fn load(path: Option<PathBuf>) -> io::Result<Self> {
         let path = path.or_else(default_trust_store_path);
-        let contents = match path.as_deref().map(fs::read_to_string).transpose() {
-            Ok(contents) => contents,
-            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
-            Err(error) => return Err(error),
-        };
-        let file = match contents {
-            Some(contents) => toml::from_str::<TrustFile>(&contents).map_err(|error| {
-                io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    format!("invalid Rust support trust store: {error}"),
-                )
-            })?,
-            None => TrustFile {
-                version: 1,
-                ..TrustFile::default()
-            },
-        };
-        if file.version != 1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                format!(
-                    "unsupported Rust support trust store version {}",
-                    file.version
-                ),
-            ));
-        }
+        let file = read_trust_file(path.as_deref())?;
         Ok(Self { path, file })
     }
 
@@ -251,7 +227,22 @@ impl TrustStore {
             )
         })?;
         fs::create_dir_all(parent)?;
-        let contents = toml::to_string_pretty(&self.file).map_err(io::Error::other)?;
+        let mut lock_path = path.as_os_str().to_os_string();
+        lock_path.push(".lock");
+        let lock = OpenOptions::new()
+            .create(true)
+            .read(true)
+            .truncate(false)
+            .write(true)
+            .open(PathBuf::from(lock_path))?;
+        lock.lock()?;
+
+        let mut merged = read_trust_file(Some(path))?;
+        merged
+            .repositories
+            .extend(self.file.repositories.iter().cloned());
+        merged.revisions.extend(self.file.revisions.iter().cloned());
+        let contents = toml::to_string_pretty(&merged).map_err(io::Error::other)?;
         let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
         temporary.write_all(contents.as_bytes())?;
         temporary
@@ -259,6 +250,36 @@ impl TrustStore {
             .map_err(|error| error.error)
             .map(drop)
     }
+}
+
+fn read_trust_file(path: Option<&Path>) -> io::Result<TrustFile> {
+    let contents = match path.map(fs::read_to_string).transpose() {
+        Ok(contents) => contents,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+        Err(error) => return Err(error),
+    };
+    let file = match contents {
+        Some(contents) => toml::from_str::<TrustFile>(&contents).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("invalid Rust support trust store: {error}"),
+            )
+        })?,
+        None => TrustFile {
+            version: 1,
+            ..TrustFile::default()
+        },
+    };
+    if file.version != 1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "unsupported Rust support trust store version {}",
+                file.version
+            ),
+        ));
+    }
+    Ok(file)
 }
 
 fn default_trust_store_path() -> Option<PathBuf> {
@@ -277,6 +298,11 @@ fn default_trust_store_path() -> Option<PathBuf> {
                 .join("trusted-support.toml"),
         );
     }
+    #[cfg(target_os = "windows")]
+    let home = std::env::var_os("USERPROFILE")
+        .or_else(|| std::env::var_os("HOME"))
+        .map(PathBuf::from)?;
+    #[cfg(not(target_os = "windows"))]
     let home = std::env::var_os("HOME").map(PathBuf::from)?;
     #[cfg(target_os = "macos")]
     return Some(
@@ -302,6 +328,8 @@ fn default_trust_store_path() -> Option<PathBuf> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Barrier};
+
     use super::{BundleIdentity, TrustStore};
 
     #[test]
@@ -331,5 +359,44 @@ mod tests {
             .expect("repository trust should persist");
         let store = TrustStore::load(Some(path)).expect("repository store should reload");
         assert!(store.trusts_repository(&identity));
+    }
+
+    #[test]
+    fn concurrent_writers_merge_trust_decisions() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let path = temporary.path().join("trusted-support.toml");
+        let barrier = Arc::new(Barrier::new(2));
+        let mut handles = Vec::new();
+        for repository in ["https://example.test/first", "https://example.test/second"] {
+            let path = path.clone();
+            let barrier = Arc::clone(&barrier);
+            handles.push(std::thread::spawn(move || {
+                let identity = BundleIdentity {
+                    repository: repository.to_owned(),
+                    revision: Some("0123456789abcdef".to_owned()),
+                    bundle_path: "grammar/Rust".to_owned(),
+                    fingerprint: format!("sha256:{}", "a".repeat(64)),
+                };
+                let mut store = TrustStore::load(Some(path)).expect("concurrent store should load");
+                barrier.wait();
+                store
+                    .trust_repository(&identity)
+                    .expect("concurrent trust should persist");
+            }));
+        }
+        for handle in handles {
+            handle.join().expect("trust writer should not panic");
+        }
+
+        let store = TrustStore::load(Some(path)).expect("merged store should load");
+        for repository in ["https://example.test/first", "https://example.test/second"] {
+            let identity = BundleIdentity {
+                repository: repository.to_owned(),
+                revision: Some("0123456789abcdef".to_owned()),
+                bundle_path: "grammar/Rust".to_owned(),
+                fingerprint: format!("sha256:{}", "a".repeat(64)),
+            };
+            assert!(store.trusts_repository(&identity));
+        }
     }
 }

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -1,0 +1,335 @@
+use std::collections::BTreeSet;
+use std::ffi::OsStr;
+use std::fs;
+use std::io::{self, Write as _};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct BundleIdentity {
+    pub(crate) repository: String,
+    pub(crate) revision: Option<String>,
+    pub(crate) bundle_path: String,
+    pub(crate) fingerprint: String,
+}
+
+impl BundleIdentity {
+    pub(crate) fn revision_key(&self) -> String {
+        format!(
+            "{}@{}#{}",
+            self.repository,
+            self.revision.as_deref().unwrap_or("unversioned"),
+            self.fingerprint
+        )
+    }
+
+    pub(crate) fn source_label(&self) -> String {
+        if self.bundle_path.is_empty() {
+            self.repository.clone()
+        } else {
+            format!("{}/{}", self.repository, self.bundle_path)
+        }
+    }
+}
+
+pub(crate) fn identify(
+    grammar_directory: &Path,
+    support_directory: &Path,
+) -> io::Result<BundleIdentity> {
+    let fingerprint = fingerprint_directory(support_directory)?;
+    let git_root = git_output(grammar_directory, ["rev-parse", "--show-toplevel"])
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute());
+    let repository = git_output(grammar_directory, ["config", "--get", "remote.origin.url"])
+        .map(|remote| normalize_repository(&remote))
+        .or_else(|| git_root.as_ref().map(|path| path.display().to_string()))
+        .unwrap_or_else(|| grammar_directory.display().to_string());
+    let revision = git_output(grammar_directory, ["rev-parse", "HEAD"]);
+    let bundle_path = git_root
+        .as_deref()
+        .and_then(|root| support_directory.strip_prefix(root).ok())
+        .map(path_key)
+        .transpose()?
+        .unwrap_or_else(|| {
+            support_directory
+                .file_name()
+                .and_then(OsStr::to_str)
+                .unwrap_or("Rust")
+                .to_owned()
+        });
+    Ok(BundleIdentity {
+        repository,
+        revision,
+        bundle_path,
+        fingerprint,
+    })
+}
+
+pub(crate) fn fingerprint_directory(directory: &Path) -> io::Result<String> {
+    let mut files = Vec::new();
+    collect_files(directory, directory, &mut files)?;
+    files.sort_by(|left, right| left.0.cmp(&right.0));
+
+    let mut digest = Sha256::new();
+    digest.update(b"antlr-rust-support-v1\0");
+    for (relative, path) in files {
+        let contents = fs::read(path)?;
+        digest.update(relative.len().to_be_bytes());
+        digest.update(relative.as_bytes());
+        digest.update(contents.len().to_be_bytes());
+        digest.update(contents);
+    }
+    Ok(format!("sha256:{}", hex_lower(&digest.finalize())))
+}
+
+fn collect_files(
+    root: &Path,
+    directory: &Path,
+    files: &mut Vec<(String, PathBuf)>,
+) -> io::Result<()> {
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "Rust target-support bundles may not contain symlinks: {}",
+                    path.display()
+                ),
+            ));
+        }
+        if file_type.is_dir() {
+            collect_files(root, &path, files)?;
+        } else if file_type.is_file() {
+            let relative = path
+                .strip_prefix(root)
+                .expect("collected path stays below support root");
+            files.push((path_key(relative)?, path));
+        }
+    }
+    Ok(())
+}
+
+fn path_key(path: &Path) -> io::Result<String> {
+    let text = path.to_str().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("Rust target-support path is not UTF-8: {}", path.display()),
+        )
+    })?;
+    Ok(text
+        .chars()
+        .map(|character| {
+            if character == std::path::MAIN_SEPARATOR {
+                '/'
+            } else {
+                character
+            }
+        })
+        .collect())
+}
+
+fn hex_lower(bytes: &[u8]) -> String {
+    const DIGITS: &[u8; 16] = b"0123456789abcdef";
+    let mut output = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        output.push(char::from(DIGITS[usize::from(byte >> 4)]));
+        output.push(char::from(DIGITS[usize::from(byte & 0x0f)]));
+    }
+    output
+}
+
+fn git_output<const N: usize>(directory: &Path, args: [&str; N]) -> Option<String> {
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(directory)
+        .args(args)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let value = std::str::from_utf8(&output.stdout).ok()?.trim();
+    (!value.is_empty()).then(|| value.to_owned())
+}
+
+fn normalize_repository(remote: &str) -> String {
+    let remote = remote.trim().trim_end_matches(".git");
+    if let Some((host, path)) = remote
+        .strip_prefix("git@")
+        .and_then(|value| value.split_once(':'))
+    {
+        return format!("https://{host}/{path}");
+    }
+    if let Some(value) = remote.strip_prefix("ssh://git@")
+        && let Some((host, path)) = value.split_once('/')
+    {
+        return format!("https://{host}/{path}");
+    }
+    remote.to_owned()
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+struct TrustFile {
+    version: u32,
+    repositories: BTreeSet<String>,
+    revisions: BTreeSet<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct TrustStore {
+    path: Option<PathBuf>,
+    file: TrustFile,
+}
+
+impl TrustStore {
+    pub(crate) fn load(path: Option<PathBuf>) -> io::Result<Self> {
+        let path = path.or_else(default_trust_store_path);
+        let contents = match path.as_deref().map(fs::read_to_string).transpose() {
+            Ok(contents) => contents,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => None,
+            Err(error) => return Err(error),
+        };
+        let file = match contents {
+            Some(contents) => toml::from_str::<TrustFile>(&contents).map_err(|error| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("invalid Rust support trust store: {error}"),
+                )
+            })?,
+            None => TrustFile {
+                version: 1,
+                ..TrustFile::default()
+            },
+        };
+        if file.version != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "unsupported Rust support trust store version {}",
+                    file.version
+                ),
+            ));
+        }
+        Ok(Self { path, file })
+    }
+
+    pub(crate) fn trusts_revision(&self, identity: &BundleIdentity) -> bool {
+        self.file.revisions.contains(&identity.revision_key())
+    }
+
+    pub(crate) fn trusts_repository(&self, identity: &BundleIdentity) -> bool {
+        self.file.repositories.contains(&identity.repository)
+    }
+
+    pub(crate) fn trust_revision(&mut self, identity: &BundleIdentity) -> io::Result<()> {
+        self.file.revisions.insert(identity.revision_key());
+        self.save()
+    }
+
+    pub(crate) fn trust_repository(&mut self, identity: &BundleIdentity) -> io::Result<()> {
+        self.file.repositories.insert(identity.repository.clone());
+        self.save()
+    }
+
+    fn save(&self) -> io::Result<()> {
+        let path = self.path.as_deref().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "cannot persist Rust support trust without a home/config directory",
+            )
+        })?;
+        let parent = path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("trust store has no parent directory: {}", path.display()),
+            )
+        })?;
+        fs::create_dir_all(parent)?;
+        let contents = toml::to_string_pretty(&self.file).map_err(io::Error::other)?;
+        let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+        temporary.write_all(contents.as_bytes())?;
+        temporary
+            .persist(path)
+            .map_err(|error| error.error)
+            .map(drop)
+    }
+}
+
+fn default_trust_store_path() -> Option<PathBuf> {
+    if let Some(path) = std::env::var_os("XDG_CONFIG_HOME") {
+        return Some(
+            PathBuf::from(path)
+                .join("antlr4-rust")
+                .join("trusted-support.toml"),
+        );
+    }
+    #[cfg(target_os = "windows")]
+    if let Some(path) = std::env::var_os("APPDATA") {
+        return Some(
+            PathBuf::from(path)
+                .join("antlr4-rust")
+                .join("trusted-support.toml"),
+        );
+    }
+    let home = std::env::var_os("HOME").map(PathBuf::from)?;
+    #[cfg(target_os = "macos")]
+    return Some(
+        home.join("Library")
+            .join("Application Support")
+            .join("antlr4-rust")
+            .join("trusted-support.toml"),
+    );
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    return Some(
+        home.join(".config")
+            .join("antlr4-rust")
+            .join("trusted-support.toml"),
+    );
+    #[cfg(target_os = "windows")]
+    Some(
+        home.join("AppData")
+            .join("Roaming")
+            .join("antlr4-rust")
+            .join("trusted-support.toml"),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BundleIdentity, TrustStore};
+
+    #[test]
+    fn persisted_scopes_round_trip() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let path = temporary.path().join("trusted-support.toml");
+        let identity = BundleIdentity {
+            repository: "https://example.test/grammars".to_owned(),
+            revision: Some("0123456789abcdef".to_owned()),
+            bundle_path: "grammar/Rust".to_owned(),
+            fingerprint: format!("sha256:{}", "a".repeat(64)),
+        };
+        let mut store = TrustStore::load(Some(path.clone())).expect("empty store should load");
+        assert!(!store.trusts_revision(&identity));
+        assert!(!store.trusts_repository(&identity));
+
+        store
+            .trust_revision(&identity)
+            .expect("revision trust should persist");
+        let store = TrustStore::load(Some(path.clone())).expect("revision store should reload");
+        assert!(store.trusts_revision(&identity));
+        assert!(!store.trusts_repository(&identity));
+
+        let mut store = store;
+        store
+            .trust_repository(&identity)
+            .expect("repository trust should persist");
+        let store = TrustStore::load(Some(path)).expect("repository store should reload");
+        assert!(store.trusts_repository(&identity));
+    }
+}

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -33,6 +33,21 @@ impl BundleIdentity {
             format!("{}/{}", self.repository, self.bundle_path)
         }
     }
+
+    pub(crate) fn artifact_id(&self) -> String {
+        let fingerprint = self
+            .fingerprint
+            .strip_prefix("sha256:")
+            .expect("fingerprints are normalized");
+        let mut digest = Sha256::new();
+        digest.update(self.repository.as_bytes());
+        digest.update(b"\0");
+        digest.update(self.revision.as_deref().unwrap_or("unversioned").as_bytes());
+        digest.update(b"\0");
+        digest.update(self.bundle_path.as_bytes());
+        let source = hex_lower(&digest.finalize());
+        format!("{}-{}", &fingerprint[..12], &source[..8])
+    }
 }
 
 pub(crate) fn identify(
@@ -398,5 +413,24 @@ mod tests {
             };
             assert!(store.trusts_repository(&identity));
         }
+    }
+
+    #[test]
+    fn artifact_ids_disambiguate_identical_bundle_contents() {
+        let fingerprint = format!("sha256:{}", "a".repeat(64));
+        let first = BundleIdentity {
+            repository: "https://example.test/grammars".to_owned(),
+            revision: Some("0123456789abcdef".to_owned()),
+            bundle_path: "first/Rust".to_owned(),
+            fingerprint: fingerprint.clone(),
+        };
+        let second = BundleIdentity {
+            repository: first.repository.clone(),
+            revision: first.revision.clone(),
+            bundle_path: "second/Rust".to_owned(),
+            fingerprint,
+        };
+
+        assert_ne!(first.artifact_id(), second.artifact_id());
     }
 }

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -194,10 +194,14 @@ fn normalize_repository(remote: &str) -> String {
     {
         return format!("https://{host}/{path}");
     }
-    if let Some(value) = remote.strip_prefix("ssh://git@")
-        && let Some((host, path)) = value.split_once('/')
-    {
-        return format!("https://{host}/{path}");
+    if let Some((scheme, remainder)) = remote.split_once("://") {
+        let authority_end = remainder.find('/').unwrap_or(remainder.len());
+        let (authority, path) = remainder.split_at(authority_end);
+        let host = authority
+            .rsplit_once('@')
+            .map_or(authority, |(_, host)| host);
+        let scheme = if scheme == "ssh" { "https" } else { scheme };
+        return format!("{scheme}://{host}{path}");
     }
     remote.to_owned()
 }
@@ -357,7 +361,23 @@ fn default_trust_store_path() -> Option<PathBuf> {
 mod tests {
     use std::sync::{Arc, Barrier};
 
-    use super::{BundleIdentity, TrustStore};
+    use super::{BundleIdentity, TrustStore, normalize_repository};
+
+    #[test]
+    fn repository_identity_strips_remote_credentials() {
+        assert_eq!(
+            normalize_repository("https://build:secret@github.com/example/grammars.git"),
+            "https://github.com/example/grammars"
+        );
+        assert_eq!(
+            normalize_repository("ssh://git@github.com/example/grammars.git"),
+            "https://github.com/example/grammars"
+        );
+        assert_eq!(
+            normalize_repository("git@github.com:example/grammars.git"),
+            "https://github.com/example/grammars"
+        );
+    }
 
     #[test]
     fn persisted_scopes_round_trip() {

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -93,9 +93,21 @@ pub(crate) fn fingerprint_directory(directory: &Path) -> io::Result<String> {
     digest.update(b"antlr-rust-support-v1\0");
     for (relative, path) in files {
         let contents = fs::read(path)?;
-        digest.update(relative.len().to_be_bytes());
+        let relative_len = u64::try_from(relative.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Rust support relative path length exceeds u64",
+            )
+        })?;
+        let contents_len = u64::try_from(contents.len()).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "Rust support file length exceeds u64",
+            )
+        })?;
+        digest.update(relative_len.to_be_bytes());
         digest.update(relative.as_bytes());
-        digest.update(contents.len().to_be_bytes());
+        digest.update(contents_len.to_be_bytes());
         digest.update(contents);
     }
     Ok(format!("sha256:{}", hex_lower(&digest.finalize())))

--- a/crates/antlr-rust-codegen/src/rust_support/mod.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/mod.rs
@@ -1,0 +1,511 @@
+mod identity;
+mod prompt;
+mod python;
+mod stage;
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::artifact::GeneratedArtifacts;
+use crate::config::CompilerConfig;
+use crate::error::Error;
+use crate::rust_output::replace_all;
+use identity::{BundleIdentity, TrustStore, identify};
+use prompt::TrustDecision;
+
+pub(crate) use python::run_transform_child;
+
+const TRANSFORM_FILE: &str = "transformGrammar.py";
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RustSupportOptions {
+    pub(crate) enabled: bool,
+    pub(crate) trusted_fingerprints: BTreeSet<String>,
+    pub(crate) interactive: bool,
+    pub(crate) child_executable: Option<PathBuf>,
+    pub(crate) trust_store_path: Option<PathBuf>,
+}
+
+impl RustSupportOptions {
+    pub(crate) fn disabled() -> Self {
+        Self::default()
+    }
+}
+
+pub(crate) fn parse_trust_fingerprint(value: &str) -> Result<String, String> {
+    let digest = value.strip_prefix("sha256:").unwrap_or(value);
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        return Err("expected sha256:<64 lowercase hexadecimal digits>".to_owned());
+    }
+    Ok(format!("sha256:{digest}"))
+}
+
+#[derive(Debug)]
+struct SupportFile {
+    source: PathBuf,
+    module_name: String,
+}
+
+#[derive(Debug)]
+struct PreparedBundle {
+    _temporary: tempfile::TempDir,
+    original_directory: PathBuf,
+    staged_directory: PathBuf,
+    identity: BundleIdentity,
+    generated_module: String,
+    artifact_directory: PathBuf,
+    support_files: Vec<SupportFile>,
+    transformed_grammars: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedRustSupport {
+    roots: Vec<PathBuf>,
+    library_directories: Vec<PathBuf>,
+    bundles: Vec<PreparedBundle>,
+}
+
+impl PreparedRustSupport {
+    pub(crate) fn roots(&self) -> &[PathBuf] {
+        &self.roots
+    }
+
+    pub(crate) fn library_directories(&self) -> &[PathBuf] {
+        &self.library_directories
+    }
+
+    pub(crate) const fn has_bundles(&self) -> bool {
+        !self.bundles.is_empty()
+    }
+
+    pub(crate) fn supports_source(&self, source: &Path) -> bool {
+        self.bundles
+            .iter()
+            .any(|bundle| source.starts_with(&bundle.staged_directory))
+    }
+
+    pub(crate) fn original_path(&self, path: &Path) -> PathBuf {
+        self.bundles
+            .iter()
+            .find_map(|bundle| {
+                path.strip_prefix(&bundle.staged_directory)
+                    .ok()
+                    .map(|relative| bundle.original_directory.join(relative))
+            })
+            .unwrap_or_else(|| path.to_path_buf())
+    }
+
+    pub(crate) fn decorate_rendered_module(&self, module: &mut String) {
+        for bundle in &self.bundles {
+            let reference = format!("super::{}::", bundle.generated_module);
+            if !module.contains(&reference) {
+                continue;
+            }
+            let declaration = format!(
+                "#[path = {path:?}]\nmod {module_name};\n\n",
+                path = bundle.artifact_directory.join("mod.rs").to_string_lossy(),
+                module_name = bundle.generated_module,
+            );
+            module.insert_str(0, &declaration);
+        }
+    }
+
+    pub(crate) fn add_artifacts(&self, artifacts: &mut GeneratedArtifacts) -> io::Result<()> {
+        for bundle in &self.bundles {
+            if !bundle.support_files.is_empty() {
+                let mut aggregator = String::from(
+                    "#![allow(warnings, missing_docs, clippy::all, clippy::pedantic, \
+                     clippy::nursery)]\n",
+                );
+                for support in &bundle.support_files {
+                    let _ = writeln!(aggregator, "pub(crate) mod {};", support.module_name);
+                    artifacts.insert(
+                        bundle
+                            .artifact_directory
+                            .join(support.source.file_name().expect("support file has a name")),
+                        fs::read(&support.source)?,
+                    )?;
+                }
+                artifacts.insert(bundle.artifact_directory.join("mod.rs"), aggregator)?;
+            }
+            for grammar in &bundle.transformed_grammars {
+                artifacts.insert(
+                    bundle
+                        .artifact_directory
+                        .join("transformed")
+                        .join(grammar.file_name().expect("grammar has a file name")),
+                    fs::read(grammar)?,
+                )?;
+            }
+        }
+        if !self.bundles.is_empty() {
+            artifacts.insert("rust-support.json", self.render_manifest())?;
+        }
+        Ok(())
+    }
+
+    pub(crate) fn additional_inputs(&self) -> impl Iterator<Item = PathBuf> + '_ {
+        self.bundles.iter().flat_map(|bundle| {
+            let script = bundle.original_directory.join("Rust").join(TRANSFORM_FILE);
+            std::iter::once(script)
+                .chain(
+                    bundle
+                        .support_files
+                        .iter()
+                        .map(|support| support.source.clone()),
+                )
+                .chain(
+                    bundle
+                        .transformed_grammars
+                        .iter()
+                        .filter_map(|grammar| grammar.file_name())
+                        .map(|name| bundle.original_directory.join(name))
+                        .filter(|path| path.is_file()),
+                )
+        })
+    }
+
+    fn render_manifest(&self) -> String {
+        let mut output = String::from("{\n  \"version\": 1,\n  \"bundles\": [\n");
+        for (index, bundle) in self.bundles.iter().enumerate() {
+            let comma = if index + 1 == self.bundles.len() {
+                ""
+            } else {
+                ","
+            };
+            let _ = writeln!(output, "    {{");
+            let _ = writeln!(
+                output,
+                "      \"source\": {},",
+                json_string(&bundle.identity.source_label())
+            );
+            let _ = writeln!(
+                output,
+                "      \"revision\": {},",
+                bundle
+                    .identity
+                    .revision
+                    .as_deref()
+                    .map_or_else(|| "null".to_owned(), json_string)
+            );
+            let _ = writeln!(
+                output,
+                "      \"fingerprint\": {},",
+                json_string(&bundle.identity.fingerprint)
+            );
+            let _ = writeln!(
+                output,
+                "      \"transform\": {},",
+                json_string("Rust/transformGrammar.py")
+            );
+            write_file_name_array(
+                &mut output,
+                "rustModules",
+                bundle
+                    .support_files
+                    .iter()
+                    .map(|support| support.source.as_path()),
+            );
+            output.push_str(",\n");
+            write_file_name_array(
+                &mut output,
+                "transformedGrammars",
+                bundle.transformed_grammars.iter().map(PathBuf::as_path),
+            );
+            output.push('\n');
+            let _ = writeln!(output, "    }}{comma}");
+        }
+        output.push_str("  ]\n}\n");
+        output
+    }
+}
+
+pub(crate) fn prepare(config: &CompilerConfig) -> Result<PreparedRustSupport, Error> {
+    if !config.rust_support.enabled {
+        return Ok(PreparedRustSupport {
+            roots: config.roots.clone(),
+            library_directories: config.library_directories.clone(),
+            bundles: Vec::new(),
+        });
+    }
+
+    let candidates = discover(&config.roots);
+    if candidates.is_empty() {
+        return Ok(PreparedRustSupport {
+            roots: config.roots.clone(),
+            library_directories: config.library_directories.clone(),
+            bundles: Vec::new(),
+        });
+    }
+    let executable = config
+        .rust_support
+        .child_executable
+        .as_deref()
+        .ok_or_else(|| {
+            Error::configuration(
+                "trusted Rust target support currently requires the antlr4-rust-gen CLI",
+            )
+        })?;
+    let mut trust_store = TrustStore::load(config.rust_support.trust_store_path.clone())
+        .map_err(Error::generation)?;
+    let mut roots = config.roots.clone();
+    let mut bundles = Vec::with_capacity(candidates.len());
+
+    for (directory, root_indexes) in candidates {
+        let support_directory = directory.join("Rust");
+        let identity = identify(&directory, &support_directory).map_err(Error::generation)?;
+        ensure_trusted(&config.rust_support, &identity, &mut trust_store)?;
+        let (temporary, staged_directory) =
+            stage::copy_grammar_directory(&directory).map_err(Error::generation)?;
+        stage::execute_transform(executable, &staged_directory).map_err(Error::generation)?;
+
+        let support_paths = stage::top_level_files_with_extension(&support_directory, "rs")
+            .map_err(Error::generation)?;
+        let fingerprint = identity
+            .fingerprint
+            .strip_prefix("sha256:")
+            .expect("fingerprints are normalized");
+        let suffix = fingerprint[..12].to_owned();
+        let generated_module = format!("__antlr_rust_support_{suffix}");
+        rewrite_support_paths(&staged_directory, &support_paths, &generated_module)
+            .map_err(Error::generation)?;
+        let transformed_grammars = stage::top_level_files_with_extension(&staged_directory, "g4")
+            .map_err(Error::generation)?;
+        for root_index in root_indexes {
+            let relative = canonical_relative_root(&config.roots[root_index], &directory)
+                .map_err(Error::generation)?;
+            let transformed = staged_directory.join(relative);
+            if !transformed.is_file() {
+                return Err(Error::configuration(format!(
+                    "Rust target transform did not preserve grammar root {}",
+                    config.roots[root_index].display()
+                )));
+            }
+            roots[root_index] = transformed;
+        }
+        let support_files = support_paths
+            .into_iter()
+            .map(|source| {
+                let module_name = source
+                    .file_stem()
+                    .and_then(|name| name.to_str())
+                    .expect("validated Rust support module name")
+                    .to_owned();
+                SupportFile {
+                    source,
+                    module_name,
+                }
+            })
+            .collect();
+        bundles.push(PreparedBundle {
+            _temporary: temporary,
+            original_directory: directory,
+            staged_directory,
+            identity,
+            generated_module,
+            artifact_directory: PathBuf::from("antlr-rust-support").join(&suffix),
+            support_files,
+            transformed_grammars,
+        });
+    }
+
+    let library_directories = config
+        .library_directories
+        .iter()
+        .map(|library| remap_library_directory(library, &bundles))
+        .collect();
+    Ok(PreparedRustSupport {
+        roots,
+        library_directories,
+        bundles,
+    })
+}
+
+fn discover(roots: &[PathBuf]) -> BTreeMap<PathBuf, Vec<usize>> {
+    let mut candidates = BTreeMap::<PathBuf, Vec<usize>>::new();
+    for (index, root) in roots.iter().enumerate() {
+        let Ok(canonical) = fs::canonicalize(root) else {
+            continue;
+        };
+        let Some(directory) = canonical.parent() else {
+            continue;
+        };
+        if directory.join("Rust").join(TRANSFORM_FILE).is_file() {
+            candidates
+                .entry(directory.to_path_buf())
+                .or_default()
+                .push(index);
+        }
+    }
+    candidates
+}
+
+fn ensure_trusted(
+    options: &RustSupportOptions,
+    identity: &BundleIdentity,
+    trust_store: &mut TrustStore,
+) -> Result<(), Error> {
+    if options.trusted_fingerprints.contains(&identity.fingerprint)
+        || trust_store.trusts_revision(identity)
+        || trust_store.trusts_repository(identity)
+    {
+        return Ok(());
+    }
+    if !options.interactive {
+        return Err(Error::configuration(format!(
+            "Rust target support is not trusted\n\nsource: {}\nfingerprint: {}\n\nrerun with \
+             --trust-rust-support {}",
+            identity.source_label(),
+            identity.fingerprint,
+            identity.fingerprint
+        )));
+    }
+    match prompt::ask(identity).map_err(Error::generation)? {
+        TrustDecision::Once => Ok(()),
+        TrustDecision::Revision => trust_store
+            .trust_revision(identity)
+            .map_err(Error::generation),
+        TrustDecision::Repository => trust_store
+            .trust_repository(identity)
+            .map_err(Error::generation),
+        TrustDecision::Abort => Err(Error::configuration(
+            "Rust target support execution was not approved",
+        )),
+    }
+}
+
+fn canonical_relative_root(root: &Path, directory: &Path) -> io::Result<PathBuf> {
+    let canonical = fs::canonicalize(root)?;
+    canonical
+        .strip_prefix(directory)
+        .map(Path::to_path_buf)
+        .map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "grammar root {} is outside its support directory {}",
+                    canonical.display(),
+                    directory.display()
+                ),
+            )
+        })
+}
+
+fn rewrite_support_paths(
+    staged_directory: &Path,
+    support_paths: &[PathBuf],
+    generated_module: &str,
+) -> io::Result<()> {
+    let modules = support_paths
+        .iter()
+        .map(|path| {
+            path.file_stem()
+                .and_then(|name| name.to_str())
+                .filter(|name| valid_rust_identifier(name))
+                .map(str::to_owned)
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!("invalid Rust support module name: {}", path.display()),
+                    )
+                })
+        })
+        .collect::<io::Result<Vec<_>>>()?;
+    for grammar in stage::top_level_files_with_extension(staged_directory, "g4")? {
+        let mut source = fs::read_to_string(&grammar)?;
+        let original = source.clone();
+        for module in &modules {
+            source = replace_all(
+                &source,
+                &format!("crate::{module}"),
+                &format!("super::{generated_module}::{module}"),
+            );
+        }
+        if source != original {
+            fs::write(grammar, source)?;
+        }
+    }
+    Ok(())
+}
+
+fn valid_rust_identifier(value: &str) -> bool {
+    let mut characters = value.chars();
+    characters
+        .next()
+        .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
+        && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn remap_library_directory(library: &Path, bundles: &[PreparedBundle]) -> PathBuf {
+    let Ok(canonical) = fs::canonicalize(library) else {
+        return library.to_path_buf();
+    };
+    for bundle in bundles {
+        if let Ok(relative) = canonical.strip_prefix(&bundle.original_directory) {
+            return bundle.staged_directory.join(relative);
+        }
+    }
+    library.to_path_buf()
+}
+
+fn json_string(value: &str) -> String {
+    let mut output = String::with_capacity(value.len() + 2);
+    output.push('"');
+    for character in value.chars() {
+        match character {
+            '"' => output.push_str("\\\""),
+            '\\' => output.push_str("\\\\"),
+            '\n' => output.push_str("\\n"),
+            '\r' => output.push_str("\\r"),
+            '\t' => output.push_str("\\t"),
+            character if character < '\u{20}' => {
+                let _ = write!(output, "\\u{:04x}", u32::from(character));
+            }
+            character => output.push(character),
+        }
+    }
+    output.push('"');
+    output
+}
+
+fn write_file_name_array<'a>(
+    output: &mut String,
+    name: &str,
+    paths: impl Iterator<Item = &'a Path>,
+) {
+    let _ = write!(output, "      {}: [", json_string(name));
+    for (index, path) in paths.enumerate() {
+        if index > 0 {
+            output.push_str(", ");
+        }
+        let file_name = path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .expect("validated support paths are UTF-8");
+        output.push_str(&json_string(file_name));
+    }
+    output.push(']');
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_trust_fingerprint;
+
+    #[test]
+    fn trust_fingerprint_parser_normalizes_the_prefix() {
+        let digest = "a".repeat(64);
+        assert_eq!(
+            parse_trust_fingerprint(&digest).expect("digest should parse"),
+            format!("sha256:{digest}")
+        );
+        assert!(parse_trust_fingerprint(&"A".repeat(64)).is_err());
+        assert!(parse_trust_fingerprint("sha256:abc").is_err());
+    }
+}

--- a/crates/antlr-rust-codegen/src/rust_support/mod.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/mod.rs
@@ -8,6 +8,7 @@ use std::fmt::Write as _;
 use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
 use crate::artifact::GeneratedArtifacts;
 use crate::config::CompilerConfig;
@@ -27,6 +28,7 @@ pub(crate) struct RustSupportOptions {
     pub(crate) interactive: bool,
     pub(crate) child_executable: Option<PathBuf>,
     pub(crate) trust_store_path: Option<PathBuf>,
+    pub(crate) transform_timeout: Duration,
 }
 
 impl RustSupportOptions {
@@ -146,7 +148,7 @@ impl PreparedRustSupport {
             }
         }
         if !self.bundles.is_empty() {
-            artifacts.insert("rust-support.json", self.render_manifest())?;
+            artifacts.insert("rust-support.json", self.render_manifest()?)?;
         }
         Ok(())
     }
@@ -159,7 +161,9 @@ impl PreparedRustSupport {
                     bundle
                         .support_files
                         .iter()
-                        .map(|support| support.source.clone()),
+                        .filter_map(|support| support.source.file_name())
+                        .map(|name| bundle.original_directory.join("Rust").join(name))
+                        .filter(|path| path.is_file()),
                 )
                 .chain(
                     bundle
@@ -172,7 +176,7 @@ impl PreparedRustSupport {
         })
     }
 
-    fn render_manifest(&self) -> String {
+    fn render_manifest(&self) -> io::Result<String> {
         let mut output = String::from("{\n  \"version\": 1,\n  \"bundles\": [\n");
         for (index, bundle) in self.bundles.iter().enumerate() {
             let comma = if index + 1 == self.bundles.len() {
@@ -212,18 +216,18 @@ impl PreparedRustSupport {
                     .support_files
                     .iter()
                     .map(|support| support.source.as_path()),
-            );
+            )?;
             output.push_str(",\n");
             write_file_name_array(
                 &mut output,
                 "transformedGrammars",
                 bundle.transformed_grammars.iter().map(PathBuf::as_path),
-            );
+            )?;
             output.push('\n');
             let _ = writeln!(output, "    }}{comma}");
         }
         output.push_str("  ]\n}\n");
-        output
+        Ok(output)
     }
 }
 
@@ -260,13 +264,20 @@ pub(crate) fn prepare(config: &CompilerConfig) -> Result<PreparedRustSupport, Er
 
     for (directory, root_indexes) in candidates {
         let support_directory = directory.join("Rust");
-        let identity = identify(&directory, &support_directory).map_err(Error::generation)?;
-        ensure_trusted(&config.rust_support, &identity, &mut trust_store)?;
         let (temporary, staged_directory) =
             stage::copy_grammar_directory(&directory).map_err(Error::generation)?;
-        stage::execute_transform(executable, &staged_directory).map_err(Error::generation)?;
+        let staged_support_directory = staged_directory.join("Rust");
+        let identity = identify(&directory, &support_directory, &staged_support_directory)
+            .map_err(Error::generation)?;
+        ensure_trusted(&config.rust_support, &identity, &mut trust_store)?;
+        stage::execute_transform(
+            executable,
+            &staged_directory,
+            config.rust_support.transform_timeout,
+        )
+        .map_err(Error::generation)?;
 
-        let support_paths = stage::top_level_files_with_extension(&support_directory, "rs")
+        let support_paths = stage::top_level_files_with_extension(&staged_support_directory, "rs")
             .map_err(Error::generation)?;
         let fingerprint = identity
             .fingerprint
@@ -479,7 +490,7 @@ fn write_file_name_array<'a>(
     output: &mut String,
     name: &str,
     paths: impl Iterator<Item = &'a Path>,
-) {
+) -> io::Result<()> {
     let _ = write!(output, "      {}: [", json_string(name));
     for (index, path) in paths.enumerate() {
         if index > 0 {
@@ -488,10 +499,16 @@ fn write_file_name_array<'a>(
         let file_name = path
             .file_name()
             .and_then(|value| value.to_str())
-            .expect("validated support paths are UTF-8");
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!("Rust support output path is not UTF-8: {}", path.display()),
+                )
+            })?;
         output.push_str(&json_string(file_name));
     }
     output.push(']');
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/antlr-rust-codegen/src/rust_support/mod.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/mod.rs
@@ -114,10 +114,11 @@ impl PreparedRustSupport {
             if !module.contains(&reference) {
                 continue;
             }
+            let module_path = portable_generated_path(&bundle.artifact_directory.join("mod.rs"));
             let declaration = format!(
                 "#[doc(hidden)]\n#[path = {path:?}]\npub mod {module_name};\n\
                  #[allow(unused_imports)]\npub use self::{module_name} as rust_support;\n\n",
-                path = bundle.artifact_directory.join("mod.rs").to_string_lossy(),
+                path = module_path,
                 module_name = bundle.generated_module,
             );
             module.insert_str(0, &declaration);
@@ -484,6 +485,19 @@ fn valid_rust_identifier(value: &str) -> bool {
         .next()
         .is_some_and(|character| character == '_' || character.is_ascii_alphabetic())
         && characters.all(|character| character == '_' || character.is_ascii_alphanumeric())
+}
+
+fn portable_generated_path(path: &Path) -> String {
+    path.to_string_lossy()
+        .chars()
+        .map(|character| {
+            if character == std::path::MAIN_SEPARATOR {
+                '/'
+            } else {
+                character
+            }
+        })
+        .collect()
 }
 
 fn remap_library_directory(library: &Path, bundles: &[PreparedBundle]) -> PathBuf {

--- a/crates/antlr-rust-codegen/src/rust_support/mod.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/mod.rs
@@ -262,8 +262,7 @@ pub(crate) fn prepare(config: &CompilerConfig) -> Result<PreparedRustSupport, Er
                 "trusted Rust target support currently requires the antlr4-rust-gen CLI",
             )
         })?;
-    let mut trust_store = TrustStore::load(config.rust_support.trust_store_path.clone())
-        .map_err(Error::generation)?;
+    let mut trust_store = None;
     let mut roots = config.roots.clone();
     let mut bundles = Vec::with_capacity(candidates.len());
 
@@ -373,12 +372,19 @@ fn discover(roots: &[PathBuf]) -> BTreeMap<PathBuf, Vec<usize>> {
 fn ensure_trusted(
     options: &RustSupportOptions,
     identity: &BundleIdentity,
-    trust_store: &mut TrustStore,
+    trust_store: &mut Option<TrustStore>,
 ) -> Result<(), Error> {
-    if options.trusted_fingerprints.contains(&identity.fingerprint)
-        || trust_store.trusts_revision(identity)
-        || trust_store.trusts_repository(identity)
-    {
+    if options.trusted_fingerprints.contains(&identity.fingerprint) {
+        return Ok(());
+    }
+    if trust_store.is_none() {
+        *trust_store =
+            Some(TrustStore::load(options.trust_store_path.clone()).map_err(Error::generation)?);
+    }
+    let trust_store = trust_store
+        .as_mut()
+        .expect("trust store is loaded before persisted decisions are checked");
+    if trust_store.trusts_revision(identity) || trust_store.trusts_repository(identity) {
         return Ok(());
     }
     if !options.interactive {

--- a/crates/antlr-rust-codegen/src/rust_support/mod.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/mod.rs
@@ -87,6 +87,10 @@ impl PreparedRustSupport {
         !self.bundles.is_empty()
     }
 
+    pub(crate) fn all_roots_supported(&self) -> bool {
+        self.has_bundles() && self.roots.iter().all(|root| self.supports_source(root))
+    }
+
     pub(crate) fn supports_source(&self, source: &Path) -> bool {
         self.bundles
             .iter()
@@ -111,7 +115,8 @@ impl PreparedRustSupport {
                 continue;
             }
             let declaration = format!(
-                "#[path = {path:?}]\nmod {module_name};\n\n",
+                "#[doc(hidden)]\n#[path = {path:?}]\npub mod {module_name};\n\
+                 #[allow(unused_imports)]\npub use self::{module_name} as rust_support;\n\n",
                 path = bundle.artifact_directory.join("mod.rs").to_string_lossy(),
                 module_name = bundle.generated_module,
             );
@@ -127,7 +132,7 @@ impl PreparedRustSupport {
                      clippy::nursery)]\n",
                 );
                 for support in &bundle.support_files {
-                    let _ = writeln!(aggregator, "pub(crate) mod {};", support.module_name);
+                    let _ = writeln!(aggregator, "pub mod {};", support.module_name);
                     artifacts.insert(
                         bundle
                             .artifact_directory

--- a/crates/antlr-rust-codegen/src/rust_support/mod.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/mod.rs
@@ -272,6 +272,14 @@ pub(crate) fn prepare(config: &CompilerConfig) -> Result<PreparedRustSupport, Er
         let (temporary, staged_directory) =
             stage::copy_grammar_directory(&directory).map_err(Error::generation)?;
         let staged_support_directory = staged_directory.join("Rust");
+        let ships_rust_modules =
+            !stage::top_level_files_with_extension(&staged_support_directory, "rs")
+                .map_err(Error::generation)?
+                .is_empty();
+        if ships_rust_modules {
+            stage::prepare_support_output_directory(&staged_directory)
+                .map_err(Error::generation)?;
+        }
         let identity = identify(&directory, &support_directory, &staged_support_directory)
             .map_err(Error::generation)?;
         ensure_trusted(&config.rust_support, &identity, &mut trust_store)?;
@@ -284,12 +292,11 @@ pub(crate) fn prepare(config: &CompilerConfig) -> Result<PreparedRustSupport, Er
 
         let support_paths = stage::top_level_files_with_extension(&staged_support_directory, "rs")
             .map_err(Error::generation)?;
-        let fingerprint = identity
-            .fingerprint
-            .strip_prefix("sha256:")
-            .expect("fingerprints are normalized");
-        let suffix = fingerprint[..12].to_owned();
-        let generated_module = format!("__antlr_rust_support_{suffix}");
+        let artifact_id = identity.artifact_id();
+        let generated_module = format!(
+            "__antlr_rust_support_{}",
+            replace_all(&artifact_id, "-", "_")
+        );
         rewrite_support_paths(&staged_directory, &support_paths, &generated_module)
             .map_err(Error::generation)?;
         let transformed_grammars = stage::top_level_files_with_extension(&staged_directory, "g4")
@@ -326,7 +333,7 @@ pub(crate) fn prepare(config: &CompilerConfig) -> Result<PreparedRustSupport, Er
             staged_directory,
             identity,
             generated_module,
-            artifact_directory: PathBuf::from("antlr-rust-support").join(&suffix),
+            artifact_directory: PathBuf::from("antlr-rust-support").join(artifact_id),
             support_files,
             transformed_grammars,
         });
@@ -446,6 +453,20 @@ fn rewrite_support_paths(
         }
         if source != original {
             fs::write(grammar, source)?;
+        }
+    }
+    for support in support_paths {
+        let mut source = fs::read_to_string(support)?;
+        let original = source.clone();
+        for module in &modules {
+            source = replace_all(
+                &source,
+                &format!("crate::{module}"),
+                &format!("super::{module}"),
+            );
+        }
+        if source != original {
+            fs::write(support, source)?;
         }
     }
     Ok(())

--- a/crates/antlr-rust-codegen/src/rust_support/prompt.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/prompt.rs
@@ -1,0 +1,107 @@
+use std::io::{self, Write as _};
+
+use anstream::{AutoStream, ColorChoice};
+use anstyle::{AnsiColor, Effects, Style};
+
+use super::identity::BundleIdentity;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum TrustDecision {
+    Once,
+    Revision,
+    Repository,
+    Abort,
+}
+
+pub(crate) fn ask(identity: &BundleIdentity) -> io::Result<TrustDecision> {
+    let mut output = AutoStream::new(io::stderr(), ColorChoice::Auto);
+    let mut input = io::stdin().lock();
+
+    let warning = miette::miette!(
+        severity = miette::Severity::Warning,
+        help = "Approve only if you trust this source. The transform runs in a disposable copy, \
+                but this trusted-source path is not a security sandbox.",
+        "the grammar ships executable Rust target support"
+    );
+    writeln!(output, "\n{warning:?}")?;
+    render_identity(&mut output, identity)?;
+    render_choices(&mut output)?;
+    read_decision(&mut input, &mut output)
+}
+
+fn render_identity(output: &mut impl io::Write, identity: &BundleIdentity) -> io::Result<()> {
+    let label = Style::new().effects(Effects::BOLD);
+    let value = Style::new().fg_color(Some(AnsiColor::Cyan.into()));
+    writeln!(
+        output,
+        "  {label}Source{label:#}       {value}{}{value:#}",
+        identity.source_label()
+    )?;
+    if let Some(revision) = &identity.revision {
+        writeln!(
+            output,
+            "  {label}Revision{label:#}     {value}{revision}{value:#}"
+        )?;
+    }
+    writeln!(
+        output,
+        "  {label}Fingerprint{label:#}  {value}{}{value:#}\n",
+        identity.fingerprint
+    )
+}
+
+fn render_choices(output: &mut impl io::Write) -> io::Result<()> {
+    let number = Style::new()
+        .fg_color(Some(AnsiColor::Cyan.into()))
+        .effects(Effects::BOLD);
+    writeln!(output, "  {number}1{number:#}  Trust once")?;
+    writeln!(output, "  {number}2{number:#}  Trust this exact revision")?;
+    writeln!(output, "  {number}3{number:#}  Trust this repository")?;
+    writeln!(output, "  {number}4{number:#}  Abort")
+}
+
+fn read_decision(
+    input: &mut impl io::BufRead,
+    output: &mut impl io::Write,
+) -> io::Result<TrustDecision> {
+    let prompt = Style::new()
+        .fg_color(Some(AnsiColor::Green.into()))
+        .effects(Effects::BOLD);
+    loop {
+        write!(output, "\n{prompt}?{prompt:#} Select [1-4]: ")?;
+        output.flush()?;
+        let mut line = String::new();
+        if input.read_line(&mut line)? == 0 {
+            return Ok(TrustDecision::Abort);
+        }
+        match line.trim() {
+            "1" => return Ok(TrustDecision::Once),
+            "2" => return Ok(TrustDecision::Revision),
+            "3" => return Ok(TrustDecision::Repository),
+            "4" => return Ok(TrustDecision::Abort),
+            _ => writeln!(output, "  Enter 1, 2, 3, or 4.")?,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{TrustDecision, read_decision};
+
+    #[test]
+    fn selection_reprompts_and_accepts_a_scope() {
+        let mut input = Cursor::new(b"no\n2\n");
+        let mut output = Vec::new();
+
+        let decision = read_decision(&mut input, &mut output).expect("prompt should be readable");
+
+        assert_eq!(decision, TrustDecision::Revision);
+        assert!(
+            String::from_utf8(output)
+                .expect("prompt output should be UTF-8")
+                .contains("Enter 1, 2, 3, or 4.")
+        );
+    }
+}

--- a/crates/antlr-rust-codegen/src/rust_support/python.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/python.rs
@@ -1,0 +1,61 @@
+use std::path::Path;
+
+use miette::{IntoDiagnostic as _, WrapErr as _};
+use rustpython_vm::common::rc::PyRc;
+use rustpython_vm::{Interpreter, Settings};
+
+const TRANSFORM_PATH: &str = "Rust/transformGrammar.py";
+
+pub(crate) fn run_transform_child(staging_directory: &Path) -> miette::Result<()> {
+    let staging_directory = std::fs::canonicalize(staging_directory)
+        .into_diagnostic()
+        .wrap_err("failed to open the staged grammar directory")?;
+    let script = staging_directory.join(TRANSFORM_PATH);
+    if !script.is_file() {
+        return Err(miette::miette!(
+            "staged Rust target transform does not exist: {}",
+            script.display()
+        ));
+    }
+    std::env::set_current_dir(&staging_directory)
+        .into_diagnostic()
+        .wrap_err("failed to enter the staged grammar directory")?;
+    let script = script.to_str().ok_or_else(|| {
+        miette::miette!(
+            "staged Rust target transform path is not UTF-8: {}",
+            script.display()
+        )
+    })?;
+
+    let mut settings = Settings::default();
+    settings.argv = vec![script.to_owned()];
+    settings.ignore_environment = true;
+    settings.import_site = false;
+    settings.install_signal_handlers = false;
+    settings.isolated = true;
+    settings.quiet = true;
+    settings.safe_path = true;
+    settings.user_site_directory = false;
+    settings.write_bytecode = false;
+
+    let builder = Interpreter::builder(settings);
+    let interpreter = builder
+        .add_frozen_modules(rustpython_pylib::FROZEN_STDLIB)
+        .init_hook(|vm| {
+            let state = PyRc::get_mut(&mut vm.state)
+                .expect("RustPython global state is uniquely owned during initialization");
+            state.config.paths.stdlib_dir = Some(rustpython_pylib::LIB_PATH.to_owned());
+        })
+        .build();
+    let exit_code = interpreter.run(|vm| {
+        let scope = vm.new_scope_with_main()?;
+        vm.run_script(scope, script)
+    });
+    if exit_code == 0 {
+        Ok(())
+    } else {
+        Err(miette::miette!(
+            "Rust target transform exited with status {exit_code}"
+        ))
+    }
+}

--- a/crates/antlr-rust-codegen/src/rust_support/stage.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/stage.rs
@@ -14,9 +14,12 @@ pub(crate) fn copy_grammar_directory(source: &Path) -> io::Result<(tempfile::Tem
         .tempdir()?;
     let staged = temporary.path().join("grammar");
     copy_directory(source, &staged)?;
-    // The current C transform copies support into this trgen-style directory.
-    fs::create_dir_all(staged.join("src"))?;
     Ok((temporary, fs::canonicalize(staged)?))
+}
+
+pub(crate) fn prepare_support_output_directory(staged: &Path) -> io::Result<()> {
+    // Bundles that ship Rust modules may copy generated support into this convention.
+    fs::create_dir_all(staged.join("src"))
 }
 
 fn copy_directory(source: &Path, destination: &Path) -> io::Result<()> {

--- a/crates/antlr-rust-codegen/src/rust_support/stage.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/stage.rs
@@ -1,0 +1,89 @@
+use std::ffi::OsStr;
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+pub(crate) fn copy_grammar_directory(source: &Path) -> io::Result<(tempfile::TempDir, PathBuf)> {
+    let temporary = tempfile::Builder::new()
+        .prefix("antlr-rust-support-")
+        .tempdir()?;
+    let staged = temporary.path().join("grammar");
+    copy_directory(source, &staged)?;
+    fs::create_dir_all(staged.join("src"))?;
+    Ok((temporary, fs::canonicalize(staged)?))
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "grammar directories with symlinks cannot be staged: {}",
+                    source_path.display()
+                ),
+            ));
+        }
+        if file_type.is_dir() {
+            copy_directory(&source_path, &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(source_path, destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn execute_transform(executable: &Path, staged: &Path) -> io::Result<()> {
+    let output = Command::new(executable)
+        .arg("--__antlr-rust-transform")
+        .arg(staged)
+        .current_dir(staged)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()?;
+    if output.status.success() {
+        return Ok(());
+    }
+    let stderr = bounded_output(&output.stderr);
+    let stdout = bounded_output(&output.stdout);
+    let stderr = if stderr.is_empty() {
+        String::new()
+    } else {
+        format!("\nstderr:\n{stderr}")
+    };
+    let stdout = if stdout.is_empty() {
+        String::new()
+    } else {
+        format!("\nstdout:\n{stdout}")
+    };
+    Err(io::Error::other(format!(
+        "Rust target transform failed with {}{stderr}{stdout}",
+        output.status
+    )))
+}
+
+fn bounded_output(bytes: &[u8]) -> String {
+    const LIMIT: usize = 64 * 1024;
+    let bytes = bytes.get(..bytes.len().min(LIMIT)).unwrap_or(bytes);
+    String::from_utf8_lossy(bytes).trim().to_owned()
+}
+
+pub(crate) fn top_level_files_with_extension(
+    directory: &Path,
+    extension: &str,
+) -> io::Result<Vec<PathBuf>> {
+    let mut files = fs::read_dir(directory)?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .filter(|path| path.is_file() && path.extension() == Some(OsStr::new(extension)))
+        .collect::<Vec<_>>();
+    files.sort();
+    Ok(files)
+}

--- a/crates/antlr-rust-codegen/src/rust_support/stage.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/stage.rs
@@ -3,6 +3,10 @@ use std::fs;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const OUTPUT_LIMIT: usize = 64 * 1024;
 
 pub(crate) fn copy_grammar_directory(source: &Path) -> io::Result<(tempfile::TempDir, PathBuf)> {
     let temporary = tempfile::Builder::new()
@@ -10,6 +14,7 @@ pub(crate) fn copy_grammar_directory(source: &Path) -> io::Result<(tempfile::Tem
         .tempdir()?;
     let staged = temporary.path().join("grammar");
     copy_directory(source, &staged)?;
+    // The current C transform copies support into this trgen-style directory.
     fs::create_dir_all(staged.join("src"))?;
     Ok((temporary, fs::canonicalize(staged)?))
 }
@@ -39,40 +44,94 @@ fn copy_directory(source: &Path, destination: &Path) -> io::Result<()> {
     Ok(())
 }
 
-pub(crate) fn execute_transform(executable: &Path, staged: &Path) -> io::Result<()> {
-    let output = Command::new(executable)
+pub(crate) fn execute_transform(
+    executable: &Path,
+    staged: &Path,
+    timeout: Duration,
+) -> io::Result<()> {
+    let mut child = Command::new(executable)
         .arg("--__antlr-rust-transform")
         .arg(staged)
         .current_dir(staged)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()?;
-    if output.status.success() {
+        .spawn()?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| io::Error::other("Rust target transform stdout pipe was not available"))?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| io::Error::other("Rust target transform stderr pipe was not available"))?;
+    let stdout_reader = thread::spawn(move || read_capped(stdout));
+    let stderr_reader = thread::spawn(move || read_capped(stderr));
+    let started = Instant::now();
+    let (status, timed_out) = loop {
+        if let Some(status) = child.try_wait()? {
+            break (status, false);
+        }
+        if started.elapsed() >= timeout {
+            let _ = child.kill();
+            break (child.wait()?, true);
+        }
+        #[allow(clippy::disallowed_methods)] // Synchronous child polling has no async runtime.
+        thread::sleep(Duration::from_millis(20));
+    };
+    let stdout = join_reader(stdout_reader, "stdout")?;
+    let stderr = join_reader(stderr_reader, "stderr")?;
+    let stderr = diagnostic_output("stderr", &stderr);
+    let stdout = diagnostic_output("stdout", &stdout);
+
+    if timed_out {
+        return Err(io::Error::new(
+            io::ErrorKind::TimedOut,
+            format!(
+                "Rust target transform exceeded its {} second deadline{stderr}{stdout}",
+                timeout.as_secs()
+            ),
+        ));
+    }
+    if status.success() {
         return Ok(());
     }
-    let stderr = bounded_output(&output.stderr);
-    let stdout = bounded_output(&output.stdout);
-    let stderr = if stderr.is_empty() {
-        String::new()
-    } else {
-        format!("\nstderr:\n{stderr}")
-    };
-    let stdout = if stdout.is_empty() {
-        String::new()
-    } else {
-        format!("\nstdout:\n{stdout}")
-    };
     Err(io::Error::other(format!(
-        "Rust target transform failed with {}{stderr}{stdout}",
-        output.status
+        "Rust target transform failed with {status}{stderr}{stdout}"
     )))
 }
 
-fn bounded_output(bytes: &[u8]) -> String {
-    const LIMIT: usize = 64 * 1024;
-    let bytes = bytes.get(..bytes.len().min(LIMIT)).unwrap_or(bytes);
-    String::from_utf8_lossy(bytes).trim().to_owned()
+fn read_capped(mut reader: impl io::Read) -> io::Result<Vec<u8>> {
+    let mut output = Vec::new();
+    let mut chunk = [0; 8192];
+    loop {
+        let count = reader.read(&mut chunk)?;
+        if count == 0 {
+            break;
+        }
+        let retained = count.min(OUTPUT_LIMIT.saturating_sub(output.len()));
+        output.extend_from_slice(&chunk[..retained]);
+    }
+    Ok(output)
+}
+
+fn join_reader(
+    reader: thread::JoinHandle<io::Result<Vec<u8>>>,
+    stream: &str,
+) -> io::Result<Vec<u8>> {
+    reader
+        .join()
+        .map_err(|_| io::Error::other(format!("Rust target transform {stream} reader panicked")))?
+}
+
+fn diagnostic_output(stream: &str, bytes: &[u8]) -> String {
+    let output = String::from_utf8_lossy(bytes);
+    let output = output.trim();
+    if output.is_empty() {
+        String::new()
+    } else {
+        format!("\n{stream}:\n{output}")
+    }
 }
 
 pub(crate) fn top_level_files_with_extension(
@@ -80,10 +139,23 @@ pub(crate) fn top_level_files_with_extension(
     extension: &str,
 ) -> io::Result<Vec<PathBuf>> {
     let mut files = fs::read_dir(directory)?
-        .filter_map(Result::ok)
-        .map(|entry| entry.path())
-        .filter(|path| path.is_file() && path.extension() == Some(OsStr::new(extension)))
-        .collect::<Vec<_>>();
+        .map(|entry| entry.map(|entry| entry.path()))
+        .collect::<io::Result<Vec<_>>>()?;
+    files.retain(|path| path.is_file() && path.extension() == Some(OsStr::new(extension)));
     files.sort();
     Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::{OUTPUT_LIMIT, read_capped};
+
+    #[test]
+    fn capped_reader_drains_without_retaining_unbounded_output() {
+        let input = vec![b'x'; OUTPUT_LIMIT + 1024];
+        let output = read_capped(Cursor::new(input)).expect("reader should succeed");
+        assert_eq!(output.len(), OUTPUT_LIMIT);
+    }
 }

--- a/crates/antlr-rust-codegen/src/testrig_cli.rs
+++ b/crates/antlr-rust-codegen/src/testrig_cli.rs
@@ -13,6 +13,7 @@ use crate::builder::{ActionMode, UnknownSemanticPolicy};
 use crate::config::{CompilerConfig, TestRigConfig};
 use crate::driver::generate;
 use crate::parser::MAX_FIXED_LOOKAHEAD_FLAG;
+use crate::rust_support::RustSupportOptions;
 use crate::semantics::{SemPatternFile, load_sem_patterns, normalize_option_hook};
 
 const TARGET_DIR_ENV: &str = "ANTLR4_RUST_TESTRIG_TARGET_DIR";
@@ -166,6 +167,7 @@ impl CliArgs {
             test_rig: Some(TestRigConfig {
                 start_rule: self.start_rule.clone(),
             }),
+            rust_support: RustSupportOptions::disabled(),
         })
     }
 

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli.rs
@@ -12,6 +12,8 @@ mod multi_recognizer;
 mod optimizations;
 #[path = "antlr4_rust_gen_cli/parser.rs"]
 mod parser;
+#[path = "antlr4_rust_gen_cli/rust_support.rs"]
+mod rust_support;
 #[path = "antlr4_rust_gen_cli/semantics.rs"]
 mod semantics;
 #[path = "antlr4_rust_gen_cli/support.rs"]

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
@@ -251,13 +251,7 @@ fn current_c_transform_wires_its_rust_support_module() {
         utf8(&output.stderr)
     );
     let parser = fs::read_to_string(generated.join("c_parser_parser.rs")).expect("C parser module");
-    let separator = if std::path::MAIN_SEPARATOR == '\\' {
-        "\\\\"
-    } else {
-        "/"
-    };
-    let support_path_prefix = format!("#[doc(hidden)]\n#[path = \"antlr-rust-support{separator}");
-    assert!(parser.starts_with(&support_path_prefix));
+    assert!(parser.starts_with("#[doc(hidden)]\n#[path = \"antlr-rust-support/"));
     assert!(parser.contains("super::__antlr_rust_support_"));
     assert!(parser.contains("pub use self::__antlr_rust_support_"));
     assert!(parser.contains(" as rust_support;"));

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
@@ -79,6 +79,36 @@ fn noninteractive_bundle_rejects_a_different_fingerprint() {
 }
 
 #[test]
+fn exact_fingerprint_does_not_require_a_readable_trust_store() {
+    let temp = temporary_directory("rust-support-explicit-trust");
+    let grammar = fixture("java/JavaParser.g4");
+    let lexer = fixture("java/JavaLexer.g4");
+    let generated = temp.path().join("generated");
+    let probe_store = temp.path().join("probe-trust.toml");
+    let untrusted = run_with_trust_store(&[&lexer, &grammar], &generated, &probe_store, None);
+    assert!(!untrusted.status.success());
+    let stderr = normalize_cli_snapshot(utf8(&untrusted.stderr));
+    let fingerprint = untrusted_fingerprint(&stderr).to_owned();
+
+    let corrupt_store = temp.path().join("corrupt-trust.toml");
+    fs::write(&corrupt_store, "not valid TOML = [")
+        .expect("corrupt trust store should be writable");
+    let output = run_with_trust_store(
+        &[&lexer, &grammar],
+        &generated,
+        &corrupt_store,
+        Some(&fingerprint),
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+}
+
+#[test]
 fn current_java_transform_runs_from_the_staged_tree() {
     let temp = temporary_directory("rust-support-java");
     let grammar = fixture("java/JavaParser.g4");

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
@@ -60,6 +60,25 @@ fn noninteractive_bundle_requires_its_exact_fingerprint() {
 }
 
 #[test]
+fn noninteractive_bundle_rejects_a_different_fingerprint() {
+    let temp = temporary_directory("rust-support-mismatched-trust");
+    let grammar = fixture("java/JavaParser.g4");
+    let generated = temp.path().join("generated");
+    let trust_store = temp.path().join("trust.toml");
+    let fingerprint = format!("sha256:{}", "0".repeat(64));
+
+    let output = run_with_trust_store(&[&grammar], &generated, &trust_store, Some(&fingerprint));
+
+    assert!(
+        !output.status.success(),
+        "mismatched support fingerprint unexpectedly ran"
+    );
+    let stderr = normalize_cli_snapshot(utf8(&output.stderr));
+    assert!(stderr.contains("Rust target support is not trusted"));
+    assert!(!generated.exists());
+}
+
+#[test]
 fn current_java_transform_runs_from_the_staged_tree() {
     let temp = temporary_directory("rust-support-java");
     let grammar = fixture("java/JavaParser.g4");
@@ -69,7 +88,9 @@ fn current_java_transform_runs_from_the_staged_tree() {
     let trust_store = temp.path().join("trust.toml");
 
     let untrusted = run_with_trust_store(&[&lexer, &grammar], &generated, &trust_store, None);
-    let fingerprint = untrusted_fingerprint(utf8(&untrusted.stderr)).to_owned();
+    assert!(!untrusted.status.success());
+    let untrusted_stderr = normalize_cli_snapshot(utf8(&untrusted.stderr));
+    let fingerprint = untrusted_fingerprint(&untrusted_stderr).to_owned();
     let output = run_with_trust_store(
         &[&lexer, &grammar],
         &generated,
@@ -136,7 +157,9 @@ fn current_c_transform_wires_its_rust_support_module() {
     let trust_store = temp.path().join("trust.toml");
 
     let untrusted = run_with_trust_store(&[&grammar], &generated, &trust_store, None);
-    let fingerprint = untrusted_fingerprint(utf8(&untrusted.stderr)).to_owned();
+    assert!(!untrusted.status.success());
+    let untrusted_stderr = normalize_cli_snapshot(utf8(&untrusted.stderr));
+    let fingerprint = untrusted_fingerprint(&untrusted_stderr).to_owned();
     let output = run_with_trust_store(&[&grammar], &generated, &trust_store, Some(&fingerprint));
 
     assert!(

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
@@ -251,7 +251,13 @@ fn current_c_transform_wires_its_rust_support_module() {
         utf8(&output.stderr)
     );
     let parser = fs::read_to_string(generated.join("c_parser_parser.rs")).expect("C parser module");
-    assert!(parser.starts_with("#[doc(hidden)]\n#[path = \"antlr-rust-support/"));
+    let separator = if std::path::MAIN_SEPARATOR == '\\' {
+        "\\\\"
+    } else {
+        "/"
+    };
+    let support_path_prefix = format!("#[doc(hidden)]\n#[path = \"antlr-rust-support{separator}");
+    assert!(parser.starts_with(&support_path_prefix));
     assert!(parser.contains("super::__antlr_rust_support_"));
     assert!(parser.contains("pub use self::__antlr_rust_support_"));
     assert!(parser.contains(" as rust_support;"));

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
@@ -1,0 +1,172 @@
+#![allow(clippy::disallowed_methods)] // insta assertion macros unwrap internal I/O.
+#[allow(clippy::wildcard_imports)]
+use super::support::*;
+
+fn fixture(name: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures/antlr4-rust-gen/rust-support")
+        .join(name)
+}
+
+fn untrusted_fingerprint(stderr: &str) -> &str {
+    let marker = "fingerprint: sha256:";
+    let start = stderr
+        .find(marker)
+        .expect("trust diagnostic should include a fingerprint")
+        + "fingerprint: ".len();
+    let end = stderr[start..]
+        .find(char::is_whitespace)
+        .map_or(stderr.len(), |offset| start + offset);
+    &stderr[start..end]
+}
+
+fn run_with_trust_store(
+    grammars: &[&Path],
+    output: &Path,
+    trust_store: &Path,
+    fingerprint: Option<&str>,
+) -> Output {
+    let mut command = cli_command(env!("CARGO_BIN_EXE_antlr4-rust-gen"));
+    command
+        .env("ANTLR4_RUST_TRUST_STORE", trust_store)
+        .args(grammars)
+        .arg("--out-dir")
+        .arg(output);
+    if let Some(fingerprint) = fingerprint {
+        command.arg("--trust-rust-support").arg(fingerprint);
+    }
+    command.output().expect("antlr4-rust-gen should run")
+}
+
+#[test]
+fn noninteractive_bundle_requires_its_exact_fingerprint() {
+    let temp = temporary_directory("rust-support-trust");
+    let grammar = fixture("java/JavaParser.g4");
+    let generated = temp.path().join("generated");
+    let trust_store = temp.path().join("trust.toml");
+
+    let output = run_with_trust_store(&[&grammar], &generated, &trust_store, None);
+
+    assert!(
+        !output.status.success(),
+        "untrusted support unexpectedly ran"
+    );
+    assert_eq!(utf8(&output.stdout), "");
+    let stderr = normalize_cli_snapshot(utf8(&output.stderr));
+    let fingerprint = untrusted_fingerprint(&stderr);
+    assert!(fingerprint.starts_with("sha256:"));
+    assert!(stderr.contains("--trust-rust-support sha256:"));
+    insta::assert_snapshot!("untrusted_rust_support_diagnostic", stderr);
+}
+
+#[test]
+fn current_java_transform_runs_from_the_staged_tree() {
+    let temp = temporary_directory("rust-support-java");
+    let grammar = fixture("java/JavaParser.g4");
+    let lexer = fixture("java/JavaLexer.g4");
+    let original = fs::read_to_string(&grammar).expect("fixture grammar should be readable");
+    let generated = temp.path().join("generated");
+    let trust_store = temp.path().join("trust.toml");
+
+    let untrusted = run_with_trust_store(&[&lexer, &grammar], &generated, &trust_store, None);
+    let fingerprint = untrusted_fingerprint(utf8(&untrusted.stderr)).to_owned();
+    let output = run_with_trust_store(
+        &[&lexer, &grammar],
+        &generated,
+        &trust_store,
+        Some(&fingerprint),
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    assert_eq!(
+        fs::read_to_string(&grammar).expect("fixture grammar should remain readable"),
+        original,
+        "the source checkout must not be transformed in place"
+    );
+    let transformed = fs::read_to_string(
+        generated
+            .join("antlr-rust-support")
+            .read_dir()
+            .expect("support artifact directory")
+            .next()
+            .expect("one support bundle")
+            .expect("support bundle entry")
+            .path()
+            .join("transformed/JavaParser.g4"),
+    )
+    .expect("transformed Java grammar should be emitted");
+    assert!(!transformed.contains("this.IsNotIdentifierAssign()"));
+    assert!(transformed.contains("recog.input.la(1)"));
+    let semantics =
+        fs::read_to_string(generated.join("semantics.json")).expect("semantics manifest");
+    assert!(semantics.contains(r#""policy": "error""#));
+    assert!(semantics.contains(r#""disposition": "hooked""#));
+    assert_generated_project(
+        temp.path(),
+        &["java_lexer.rs", "java_parser.rs"],
+        r#"
+#[cfg(test)]
+mod rust_support_java_tests {
+    use super::java_lexer::JavaLexer;
+    use super::java_parser::JavaParser;
+    use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
+
+    #[test]
+    fn transformed_predicate_executes() {
+        let lexer = JavaLexer::new(InputStream::new("identifier"));
+        let mut parser = JavaParser::new(CommonTokenStream::new(lexer));
+        assert!(parser.compilation_unit().is_ok());
+        assert_eq!(parser.number_of_syntax_errors(), 0);
+    }
+}
+"#,
+    );
+}
+
+#[test]
+fn current_c_transform_wires_its_rust_support_module() {
+    let temp = temporary_directory("rust-support-c");
+    let grammar = fixture("c/CParser.g4");
+    let generated = temp.path().join("generated");
+    let trust_store = temp.path().join("trust.toml");
+
+    let untrusted = run_with_trust_store(&[&grammar], &generated, &trust_store, None);
+    let fingerprint = untrusted_fingerprint(utf8(&untrusted.stderr)).to_owned();
+    let output = run_with_trust_store(&[&grammar], &generated, &trust_store, Some(&fingerprint));
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    let parser = fs::read_to_string(generated.join("c_parser_parser.rs")).expect("C parser module");
+    assert!(parser.starts_with("#[path = \"antlr-rust-support/"));
+    assert!(parser.contains("super::__antlr_rust_support_"));
+    assert!(!parser.contains("crate::c_parser_base"));
+    assert_generated_project(
+        temp.path(),
+        &["c_parser_lexer.rs", "c_parser_parser.rs"],
+        r#"
+#[cfg(test)]
+mod rust_support_c_tests {
+    use super::c_parser_lexer::CParserLexer;
+    use super::c_parser_parser::CParserParser;
+    use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
+
+    #[test]
+    fn support_actions_run_before_the_transformed_predicate() {
+        let lexer = CParserLexer::new(InputStream::new("name"));
+        let mut parser = CParserParser::new(CommonTokenStream::new(lexer));
+        assert!(parser.translation_unit().is_ok());
+        assert_eq!(parser.number_of_syntax_errors(), 0);
+    }
+}
+"#,
+    );
+}

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
@@ -150,6 +150,58 @@ mod rust_support_java_tests {
 }
 
 #[test]
+fn support_strictness_does_not_leak_to_an_unrelated_root() {
+    let temp = temporary_directory("rust-support-mixed-roots");
+    let grammar = fixture("java/JavaParser.g4");
+    let lexer = fixture("java/JavaLexer.g4");
+    let unrelated = temp.path().join("Unrelated.g4");
+    fs::write(
+        &unrelated,
+        "grammar Unrelated;\n\
+         options { superClass = UnrelatedBase; }\n\
+         root: ID EOF;\n\
+         ID: [a-z]+;\n\
+         WS: [ \\t\\r\\n]+ -> skip;\n",
+    )
+    .expect("unrelated grammar should be writable");
+    let generated = temp.path().join("generated");
+    let trust_store = temp.path().join("trust.toml");
+
+    let untrusted = run_with_trust_store(
+        &[&lexer, &grammar, &unrelated],
+        &generated,
+        &trust_store,
+        None,
+    );
+    assert!(!untrusted.status.success());
+    let untrusted_stderr = normalize_cli_snapshot(utf8(&untrusted.stderr));
+    let fingerprint = untrusted_fingerprint(&untrusted_stderr).to_owned();
+    let output = run_with_trust_store(
+        &[&lexer, &grammar, &unrelated],
+        &generated,
+        &trust_store,
+        Some(&fingerprint),
+    );
+
+    assert!(
+        output.status.success(),
+        "stdout: {}\nstderr: {}",
+        utf8(&output.stdout),
+        utf8(&output.stderr)
+    );
+    assert!(
+        utf8(&output.stderr)
+            .contains("warning: unsupported grammar option: superClass=UnrelatedBase")
+    );
+    let semantics =
+        fs::read_to_string(generated.join("semantics.json")).expect("semantics manifest");
+    assert!(semantics.contains(r#""policy": "assume-true""#));
+    assert!(semantics.contains(
+        r#""name": "superClass", "value": "UnrelatedBase", "line": 2, "column": 10, "disposition": "unsupported""#
+    ));
+}
+
+#[test]
 fn current_c_transform_wires_its_rust_support_module() {
     let temp = temporary_directory("rust-support-c");
     let grammar = fixture("c/CParser.g4");
@@ -169,8 +221,10 @@ fn current_c_transform_wires_its_rust_support_module() {
         utf8(&output.stderr)
     );
     let parser = fs::read_to_string(generated.join("c_parser_parser.rs")).expect("C parser module");
-    assert!(parser.starts_with("#[path = \"antlr-rust-support/"));
+    assert!(parser.starts_with("#[doc(hidden)]\n#[path = \"antlr-rust-support/"));
     assert!(parser.contains("super::__antlr_rust_support_"));
+    assert!(parser.contains("pub use self::__antlr_rust_support_"));
+    assert!(parser.contains(" as rust_support;"));
     assert!(!parser.contains("crate::c_parser_base"));
     assert_generated_project(
         temp.path(),
@@ -180,10 +234,12 @@ fn current_c_transform_wires_its_rust_support_module() {
 mod rust_support_c_tests {
     use super::c_parser_lexer::CParserLexer;
     use super::c_parser_parser::CParserParser;
+    use super::c_parser_parser::rust_support;
     use antlr4_runtime::{CommonTokenStream, InputStream, Parser as _};
 
     #[test]
     fn support_actions_run_before_the_transformed_predicate() {
+        rust_support::c_parser_base::reset_symbol_table();
         let lexer = CParserLexer::new(InputStream::new("name"));
         let mut parser = CParserParser::new(CommonTokenStream::new(lexer));
         assert!(parser.translation_unit().is_ok());

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__cli__antlr4_rust_gen_help.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__cli__antlr4_rust_gen_help.snap
@@ -46,6 +46,8 @@ Options:
           Collapse proven linear precedence ladders (changes tree/API)
       --report-precedence-ladders
           Dry-run precedence-ladder analysis and emit only optimizations.json
+      --trust-rust-support <SHA256>
+          Trust one exact sibling Rust support bundle fingerprint
   -h, --help
           Print help
   -V, --version

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__cli__antlr4_rust_gen_help.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__cli__antlr4_rust_gen_help.snap
@@ -48,6 +48,8 @@ Options:
           Dry-run precedence-ladder analysis and emit only optimizations.json
       --trust-rust-support <SHA256>
           Trust one exact sibling Rust support bundle fingerprint
+      --rust-support-timeout <SECONDS>
+          Maximum time allowed for a trusted Rust support transform [default: 30]
   -h, --help
           Print help
   -V, --version

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__rust_support__untrusted_rust_support_diagnostic.snap
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/snapshots/antlr4_rust_gen_cli__rust_support__untrusted_rust_support_diagnostic.snap
@@ -1,0 +1,12 @@
+---
+source: crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/rust_support.rs
+expression: stderr
+---
+Error: antlr4_rust_codegen::configuration
+
+  × Rust target support is not trusted
+  │
+  │ source: https://github.com/ophi-dev/antlr-rust-runtime/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/Rust
+  │ fingerprint: sha256:38f5f9c34534a5e2efc56bb2389af15fc0e5f62497a87d511e72e645b9f0d597
+  │
+  │ rerun with --trust-rust-support sha256:38f5f9c34534a5e2efc56bb2389af15fc0e5f62497a87d511e72e645b9f0d597

--- a/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
+++ b/crates/antlr-rust-codegen/tests/antlr4_rust_gen_cli/support.rs
@@ -42,7 +42,7 @@ pub(super) fn run_antlr4_rust_testrig_with_stdin(
         .expect("antlr4-rust-testrig should finish")
 }
 
-fn cli_command(binary: &str) -> Command {
+pub(super) fn cli_command(binary: &str) -> Command {
     let mut command = Command::new(binary);
     command
         .env("NO_COLOR", "1")
@@ -115,6 +115,11 @@ pub(super) fn run_generated_project(
         fs::copy(temp_dir.join("generated").join(module), source.join(module))
             .expect("generated module should be copied into the check crate");
     }
+    let generated_support = temp_dir.join("generated").join("antlr-rust-support");
+    if generated_support.is_dir() {
+        copy_directory(&generated_support, &source.join("antlr-rust-support"))
+            .expect("generated Rust support should be copied into the check crate");
+    }
 
     Command::new(env!("CARGO"))
         .args([
@@ -135,6 +140,21 @@ pub(super) fn run_generated_project(
         .env("CARGO_TERM_COLOR", "never")
         .output()
         .expect("cargo check should run")
+}
+
+fn copy_directory(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let source_path = entry.path();
+        let destination_path = destination.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_directory(&source_path, &destination_path)?;
+        } else {
+            fs::copy(source_path, destination_path)?;
+        }
+    }
+    Ok(())
 }
 
 pub(super) fn utf8(bytes: &[u8]) -> &str {

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/CParser.g4
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/CParser.g4
@@ -1,0 +1,15 @@
+grammar CParser;
+
+options {
+    superClass = CParserBase;
+}
+
+translationUnit
+    : {this.EnterScope();}
+      {this.IsTypedefName()}? Identifier
+      {this.ExitScope();}
+      EOF
+    ;
+
+Identifier: [a-z]+;
+WS: [ \t\r\n]+ -> skip;

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/Rust/c_parser_base.rs
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/Rust/c_parser_base.rs
@@ -6,6 +6,10 @@ thread_local! {
     static DEPTH: Cell<usize> = const { Cell::new(0) };
 }
 
+pub fn reset_symbol_table() {
+    DEPTH.set(0);
+}
+
 pub fn enter_scope() {
     DEPTH.set(DEPTH.get() + 1);
 }

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/Rust/c_parser_base.rs
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/Rust/c_parser_base.rs
@@ -1,0 +1,19 @@
+#![allow(dead_code)]
+
+use std::cell::Cell;
+
+thread_local! {
+    static DEPTH: Cell<usize> = const { Cell::new(0) };
+}
+
+pub fn enter_scope() {
+    DEPTH.set(DEPTH.get() + 1);
+}
+
+pub fn exit_scope() {
+    DEPTH.set(DEPTH.get().saturating_sub(1));
+}
+
+pub fn is_typedef_name(text: &str) -> bool {
+    DEPTH.get() == 1 && text == "name"
+}

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/Rust/transformGrammar.py
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/c/Rust/transformGrammar.py
@@ -1,0 +1,80 @@
+"""Pinned execution surface from grammars-v4 c/Rust/transformGrammar.py.
+
+Source commit: 42b1ea521705c126d84331186b221c9819db1058
+Source blob: 1f77ae3762e6a1bcdf49453e688749e34d9fbc76
+The fixture retains the current script's imports, staged rename/rewrite, support
+copy, and the predicate/action forms exercised by its C grammar.
+"""
+import re
+import shutil
+import sys
+from glob import glob
+from pathlib import Path
+
+
+def _lt(k: int) -> str:
+    return (
+        f"recog.input.lt({k})"
+        f".map(|t| t.get_text().to_owned())"
+        f".unwrap_or_default()"
+    )
+
+
+_IS_TYPEDEF_NAME = (
+    f"let __t1 = {_lt(1)}; "
+    "crate::c_parser_base::is_typedef_name(&__t1)"
+)
+
+ALL_REPLACEMENTS = [
+    (
+        r"\{this\.IsTypedefName\(\)\}\?",
+        "{" + _IS_TYPEDEF_NAME + "}?",
+    ),
+    (
+        r"\{this\.EnterScope\(\);\}",
+        "{crate::c_parser_base::enter_scope();}",
+    ),
+    (
+        r"\{this\.ExitScope\(\);\}",
+        "{crate::c_parser_base::exit_scope();}",
+    ),
+]
+
+
+def needs_transform() -> bool:
+    for f in glob("./*.g4"):
+        with open(f, encoding="utf-8") as fp:
+            content = fp.read()
+            for line in content.splitlines():
+                if not line.lstrip().startswith("//") and "this." in line:
+                    return True
+    return False
+
+
+def transform_grammar(file_path: str) -> None:
+    src = Path(file_path)
+    if not src.is_file():
+        print(f"Not found: {file_path}", file=sys.stderr)
+        sys.exit(1)
+    shutil.move(file_path, file_path + ".bak")
+    with open(file_path + ".bak", encoding="utf-8") as inp, \
+         open(file_path, "w", encoding="utf-8") as out:
+        for line in inp:
+            if not line.lstrip().startswith("//"):
+                for pattern, replacement in ALL_REPLACEMENTS:
+                    line = re.sub(pattern, replacement, line)
+            out.write(line)
+
+
+def copy_support() -> None:
+    source = Path(__file__).resolve().parent / "c_parser_base.rs"
+    destination = Path("src") / "c_parser_base.rs"
+    if source.is_file() and not destination.exists():
+        shutil.copy(source, destination)
+
+
+if __name__ == "__main__":
+    if needs_transform():
+        for file in glob("./*.g4"):
+            transform_grammar(file)
+    copy_support()

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/JavaLexer.g4
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/JavaLexer.g4
@@ -1,0 +1,21 @@
+lexer grammar JavaLexer;
+
+ASSIGN: '=';
+MODULE: 'module';
+OPEN: 'open';
+REQUIRES: 'requires';
+EXPORTS: 'exports';
+OPENS: 'opens';
+TO: 'to';
+USES: 'uses';
+PROVIDES: 'provides';
+WHEN: 'when';
+WITH: 'with';
+TRANSITIVE: 'transitive';
+YIELD: 'yield';
+SEALED: 'sealed';
+PERMITS: 'permits';
+RECORD: 'record';
+VAR: 'var';
+IDENTIFIER: [a-z]+;
+WS: [ \t\r\n]+ -> skip;

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/JavaParser.g4
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/JavaParser.g4
@@ -1,0 +1,8 @@
+parser grammar JavaParser;
+
+options {
+    tokenVocab = JavaLexer;
+    superClass = JavaParserBase;
+}
+
+compilationUnit : { this.IsNotIdentifierAssign() }? IDENTIFIER EOF;

--- a/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/Rust/transformGrammar.py
+++ b/crates/antlr-rust-codegen/tests/fixtures/antlr4-rust-gen/rust-support/java/Rust/transformGrammar.py
@@ -1,0 +1,53 @@
+"""Pinned execution surface from grammars-v4 java/java/Rust/transformGrammar.py.
+
+Source commit: 42b1ea521705c126d84331186b221c9819db1058
+Source blob: 9547fea684f0e54a8d38621cd78ed04170304a74
+Only the unrelated record-component replacement and phase-2 generated-file
+patch are omitted from this focused fixture.
+"""
+import sys
+import re
+import shutil
+from glob import glob
+from pathlib import Path
+
+_IS_NOT_IDENTIFIER_ASSIGN = (
+    "(!matches!(recog.input.la(1), "
+    "JavaParser_IDENTIFIER | JavaParser_MODULE | JavaParser_OPEN | "
+    "JavaParser_REQUIRES | JavaParser_EXPORTS | JavaParser_OPENS | "
+    "JavaParser_TO | JavaParser_USES | JavaParser_PROVIDES | "
+    "JavaParser_WHEN | JavaParser_WITH | JavaParser_TRANSITIVE | "
+    "JavaParser_YIELD | JavaParser_SEALED | JavaParser_PERMITS | "
+    "JavaParser_RECORD | JavaParser_VAR) "
+    "|| recog.input.la(2) != JavaParser_ASSIGN)"
+)
+
+
+def needs_transform():
+    for f in glob("./*.g4"):
+        with open(f, encoding="utf-8") as fp:
+            if "this." in fp.read():
+                return True
+    return False
+
+
+def transform_grammar(file_path):
+    print("Altering " + file_path)
+    if not Path(file_path).is_file():
+        print(f"Could not find file: {file_path}")
+        sys.exit(1)
+    shutil.move(file_path, file_path + ".bak")
+    with open(file_path + ".bak", "r", encoding="utf-8") as input_file:
+        with open(file_path, "w", encoding="utf-8") as output_file:
+            for line in input_file:
+                line = re.sub(
+                    r"this\.IsNotIdentifierAssign\(\)",
+                    _IS_NOT_IDENTIFIER_ASSIGN,
+                    line,
+                )
+                output_file.write(line)
+
+
+if __name__ == "__main__" and needs_transform():
+    for file in glob("./*.g4"):
+        transform_grammar(file)


### PR DESCRIPTION
## Summary

- detect sibling `Rust/transformGrammar.py` bundles and identify them by repository, revision, path, and content fingerprint
- require explicit trust through a styled interactive prompt or an exact non-interactive `--trust-rust-support` fingerprint
- persist trust-on-revision and trust-on-repository decisions in the platform configuration directory
- fingerprint the staged bytes that will execute, then run the approved transform in a bundled RustPython child with bounded output and a configurable deadline
- automatically enable embedded actions, strict semantics, generated-only parser coverage, and transformed `superClass` acknowledgement
- relocate shipped Rust support modules behind a generated aggregator, expose helpers through a stable `rust_support` re-export, and emit transformed grammars plus `rust-support.json`

## Why

Issue #265 identified two grammars-v4 Rust support folders whose transforms target the older antlr4rust generated API. The compatibility surfaces from #267 and committed action timing from #266 are now available, so codegen can consume those bundles without modifying the source checkout or requiring users to run Python, copy files, add flags, or declare support modules manually.

The execution contract is deliberately trusted-source-first. Staging protects the checkout and makes outputs auditable, but it is not presented as a host security sandbox.

## Scope

- automatic execution is currently an `antlr4-rust-gen` CLI feature; `Builder` and TestRig do not execute sibling scripts
- Python compatibility is tested only against the imports and filesystem behavior used by the current `c/Rust` and `java/java/Rust` transforms
- strict support policy is scoped to transformed sources when support and ordinary grammar roots share one invocation
- this does not change the generated-source/runtime API revision

## Validation

- `cargo test --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo package --locked -p antlr-rust-codegen --allow-dirty`
- `ANTLR_RUST_RELEASE_ALLOW_DIRTY=1 tools/release/verify-package-contents.sh antlr-rust-codegen`
- full ANTLR runtime testsuite: 357 passed, 0 failed, 0 skipped
- generated and compiled the exact upstream C and Java Rust folders from grammars-v4 `42b1ea521705c126d84331186b221c9819db1058`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery and support for selected grammars-v4 C and Java Rust transformation scripts.
  * Transformations run on disposable grammar copies using an isolated Python runtime, preserving the original checkout.
  * Generated output now includes transformed grammars, Rust support modules, and an audit manifest.
  * Added configurable transformation timeouts and trust options for interactive and non-interactive use.
* **Documentation**
  * Documented trust decisions, fingerprints, configuration, generated artifacts, and supported Python behavior.
* **Bug Fixes**
  * Improved diagnostics and source-path handling for transformed grammar errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->