### PR TITLE
chore(deps): remove reintroduced sha2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,7 +119,6 @@ dependencies = [
  "rustpython-pylib",
  "rustpython-vm",
  "serde",
- "sha2",
  "tempfile",
  "thiserror",
  "toml",
@@ -251,15 +250,6 @@ dependencies = [
  "num-traits",
  "radium",
  "ref-cast",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -424,15 +414,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,16 +426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
-name = "crypto-common"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
 name = "derive-where"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,16 +434,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
-]
-
-[[package]]
-name = "digest"
-version = "0.10.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
-dependencies = [
- "block-buffer",
- "crypto-common",
 ]
 
 [[package]]
@@ -589,16 +550,6 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -2076,17 +2027,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest",
-]
-
-[[package]]
 name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2359,12 +2299,6 @@ name = "twox-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8464ec13c3691491391d9fce00f6416c9a48e46972f72d7865688be2080192c9"
-
-[[package]]
-name = "typenum"
-version = "1.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uname"

--- a/crates/antlr-rust-codegen/Cargo.toml
+++ b/crates/antlr-rust-codegen/Cargo.toml
@@ -43,6 +43,7 @@ clap = { version = "4.6.5", default-features = false, features = [
     "suggestions",
     "usage",
 ] }
+hmac-sha256 = "1"
 icu_casemap = "2.2.0"
 icu_properties.workspace = true
 intl = { version = "0.6.0", default-features = false, features = ["full", "normalization"] }
@@ -57,13 +58,11 @@ rustpython-vm = { version = "0.5.0", default-features = false, features = [
     "stdio",
 ] }
 serde = { version = "1", features = ["derive"] }
-sha2 = "0.10"
 tempfile = "3"
 thiserror.workspace = true
 toml = "0.9"
 
 [dev-dependencies]
-hmac-sha256      = "1"
 insta.workspace  = true
 memchr.workspace = true
 

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -358,10 +358,12 @@ fn default_trust_store_path() -> Option<PathBuf> {
 }
 
 #[cfg(test)]
+#[allow(clippy::disallowed_methods)] // insta assertion macros unwrap internal I/O.
 mod tests {
+    use std::fs;
     use std::sync::{Arc, Barrier};
 
-    use super::{BundleIdentity, TrustStore, normalize_repository};
+    use super::{BundleIdentity, TrustStore, fingerprint_directory, normalize_repository};
 
     #[test]
     fn repository_identity_strips_remote_credentials() {
@@ -464,5 +466,28 @@ mod tests {
         };
 
         assert_ne!(first.artifact_id(), second.artifact_id());
+    }
+
+    #[test]
+    fn identity_hashes_match_legacy_sha2_values() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let nested = temporary.path().join("nested");
+        fs::create_dir(&nested).expect("nested support directory");
+        fs::write(temporary.path().join("Grammar.g4"), "grammar Example;\n")
+            .expect("root support file");
+        fs::write(nested.join("support.rs"), "pub struct Support;\n").expect("nested support file");
+
+        let identity = BundleIdentity {
+            repository: "https://example.test/grammars".to_owned(),
+            revision: Some("0123456789abcdef".to_owned()),
+            bundle_path: "example/Rust".to_owned(),
+            fingerprint: fingerprint_directory(temporary.path())
+                .expect("support directory fingerprint"),
+        };
+
+        insta::assert_debug_snapshot!(
+            "legacy_sha2_identity_values",
+            (&identity.fingerprint, identity.artifact_id())
+        );
     }
 }

--- a/crates/antlr-rust-codegen/src/rust_support/identity.rs
+++ b/crates/antlr-rust-codegen/src/rust_support/identity.rs
@@ -5,8 +5,8 @@ use std::io::{self, Write as _};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use hmac_sha256::Hash;
 use serde::{Deserialize, Serialize};
-use sha2::{Digest as _, Sha256};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) struct BundleIdentity {
@@ -39,7 +39,7 @@ impl BundleIdentity {
             .fingerprint
             .strip_prefix("sha256:")
             .expect("fingerprints are normalized");
-        let mut digest = Sha256::new();
+        let mut digest = Hash::new();
         digest.update(self.repository.as_bytes());
         digest.update(b"\0");
         digest.update(self.revision.as_deref().unwrap_or("unversioned").as_bytes());
@@ -89,7 +89,7 @@ pub(crate) fn fingerprint_directory(directory: &Path) -> io::Result<String> {
     collect_files(directory, directory, &mut files)?;
     files.sort_by(|left, right| left.0.cmp(&right.0));
 
-    let mut digest = Sha256::new();
+    let mut digest = Hash::new();
     digest.update(b"antlr-rust-support-v1\0");
     for (relative, path) in files {
         let contents = fs::read(path)?;

--- a/crates/antlr-rust-codegen/src/rust_support/snapshots/antlr_rust_codegen__rust_support__identity__tests__legacy_sha2_identity_values.snap
+++ b/crates/antlr-rust-codegen/src/rust_support/snapshots/antlr_rust_codegen__rust_support__identity__tests__legacy_sha2_identity_values.snap
@@ -1,0 +1,8 @@
+---
+source: crates/antlr-rust-codegen/src/rust_support/identity.rs
+expression: "(&identity.fingerprint, identity.artifact_id())"
+---
+(
+    "sha256:4598f85710c4e40754704f4c2e70120c3763e70c2911a3c5f0c57d068d911013",
+    "4598f85710c4-772b681a",
+)


### PR DESCRIPTION
## Summary

- replace `sha2` in trusted Rust support identity hashing with the existing
  `hmac-sha256` streaming `Hash` API
- promote `hmac-sha256` from a codegen dev-dependency to a normal dependency
- remove `sha2` and its otherwise-unused RustCrypto support crates from the
  lockfile
- pin representative directory-fingerprint and artifact-ID values from the
  legacy `sha2` implementation

## Why

PR #304 reintroduced `sha2` for support-bundle fingerprints and artifact IDs
after PR #173 had removed it from the project. Renovate PR #306 exposed the
regression by proposing another `sha2` minor-version update.

`hmac-sha256` was already present for the codegen Unicode oracle and its `Hash`
type provides the same incremental raw SHA-256 operation needed by bundle
identity generation. Reusing it preserves the identity bytes while avoiding a
second hashing implementation and the recurring `sha2` 0.x dependency churn.

## Compatibility

This does not change generated output or the generated-code API revision.
Existing support fingerprints and artifact IDs remain byte-for-byte SHA-256.
The pinned trusted-support fingerprint snapshot and Java `MessageDigest`
Unicode oracle both pass unchanged.

Supersedes #306.

## Validation

- `cargo test --locked -p antlr-rust-codegen --lib`
- `cargo test --locked -p antlr-rust-codegen --lib rust_support::identity::tests`
- `cargo test --locked -p antlr-rust-codegen --test antlr4_rust_gen_cli rust_support`
- `cargo test --locked --workspace --all-targets --all-features`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo tree --locked -p antlr-rust-codegen --depth 1`
