### PR TITLE
fix(codegen): dedupe generated constant names whose upper-snake mangling collides

### DIFF
--- a/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__channel_and_mode_constants_dedupe_lossy_name_collisions.snap
+++ b/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__channel_and_mode_constants_dedupe_lossy_name_collisions.snap
@@ -1,10 +1,10 @@
 ---
 source: crates/antlr-rust-codegen/src/generator/tests.rs
-expression: render_lexer_state_constants(&data)
+expression: "render_lexer_state_constants(&data, &mut BTreeSet::new())"
 ---
 pub const CHANNEL_DEFAULT_TOKEN_CHANNEL: i32 = 0;
-pub const CHANNEL_FOO_BAR: i32 = 3;
-pub const CHANNEL_FOO_BAR_2: i32 = 2;
+pub const CHANNEL_FOO_BAR_2: i32 = 3;
+pub const CHANNEL_FOO_BAR: i32 = 2;
 pub const MODE_DEFAULT_MODE: i32 = 0;
-pub const MODE_FOO_BAR: i32 = 2;
-pub const MODE_FOO_BAR_2: i32 = 1;
+pub const MODE_FOO_BAR_2: i32 = 2;
+pub const MODE_FOO_BAR: i32 = 1;

--- a/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__channel_and_mode_constants_dedupe_lossy_name_collisions.snap
+++ b/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__channel_and_mode_constants_dedupe_lossy_name_collisions.snap
@@ -1,0 +1,10 @@
+---
+source: crates/antlr-rust-codegen/src/generator/tests.rs
+expression: render_lexer_state_constants(&data)
+---
+pub const CHANNEL_DEFAULT_TOKEN_CHANNEL: i32 = 0;
+pub const CHANNEL_FOO_BAR: i32 = 3;
+pub const CHANNEL_FOO_BAR_2: i32 = 2;
+pub const MODE_DEFAULT_MODE: i32 = 0;
+pub const MODE_FOO_BAR: i32 = 2;
+pub const MODE_FOO_BAR_2: i32 = 1;

--- a/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__lexer_token_and_state_constants_share_the_module_namespace.snap
+++ b/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__lexer_token_and_state_constants_share_the_module_namespace.snap
@@ -1,0 +1,9 @@
+---
+source: crates/antlr-rust-codegen/src/generator/tests.rs
+expression: rendered
+---
+pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;
+pub const CHANNEL_FOO: i32 = 1;
+pub const MODE_BAR: i32 = 2;
+pub const CHANNEL_FOO_2: i32 = 2;
+pub const MODE_BAR_2: i32 = 1;

--- a/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__parser_token_and_rule_constants_share_the_module_namespace.snap
+++ b/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__parser_token_and_rule_constants_share_the_module_namespace.snap
@@ -1,0 +1,7 @@
+---
+source: crates/antlr-rust-codegen/src/generator/tests.rs
+expression: rendered
+---
+pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;
+pub const RULE_FOO: i32 = 1;
+pub const RULE_FOO_2: usize = 0;

--- a/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__rule_constants_dedupe_lossy_name_collisions.snap
+++ b/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__rule_constants_dedupe_lossy_name_collisions.snap
@@ -1,0 +1,8 @@
+---
+source: crates/antlr-rust-codegen/src/generator/tests.rs
+expression: render_rule_constants(&data)
+---
+pub const RULE_COMPILATION_UNIT: usize = 0;
+pub const RULE_STATEMENT: usize = 1;
+pub const RULE_COMPILATION_UNIT_2: usize = 2;
+pub const RULE_COMPILATION_UNIT_3: usize = 3;

--- a/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__token_constants_dedupe_lossy_name_collisions.snap
+++ b/crates/antlr-rust-codegen/src/generator/snapshots/antlr_rust_codegen__generator__tests__token_constants_dedupe_lossy_name_collisions.snap
@@ -1,0 +1,8 @@
+---
+source: crates/antlr-rust-codegen/src/generator/tests.rs
+expression: rendered
+---
+pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;
+pub const FOO_BAR: i32 = 1;
+pub const FOO_BAR_2: i32 = 2;
+pub const EOF_2: i32 = 3;

--- a/crates/antlr-rust-codegen/src/generator/tests.rs
+++ b/crates/antlr-rust-codegen/src/generator/tests.rs
@@ -143,6 +143,112 @@ fn renders_structural_channel_and_mode_constants() {
 }
 
 #[test]
+fn rule_constants_dedupe_lossy_name_collisions() {
+    let data = RecognizerCodegenData {
+        rule_names: vec![
+            "compilationUnit".to_owned(),
+            "statement".to_owned(),
+            "compilation_unit".to_owned(),
+            "COMPILATION_UNIT".to_owned(),
+        ],
+        ..RecognizerCodegenData::default()
+    };
+
+    insta::assert_snapshot!(
+        "rule_constants_dedupe_lossy_name_collisions",
+        render_rule_constants(&data)
+    );
+}
+
+#[test]
+fn token_constants_dedupe_lossy_name_collisions() {
+    let common = RecognizerCodegenData {
+        symbolic_names: vec![
+            None,
+            Some("FooBar".to_owned()),
+            Some("FOO_BAR".to_owned()),
+            Some("Eof".to_owned()),
+        ],
+        ..RecognizerCodegenData::default()
+    };
+
+    let rendered = render_token_constants(&common);
+
+    insta::assert_snapshot!("token_constants_dedupe_lossy_name_collisions", rendered);
+
+    let lexer_data = LexerCodegenData {
+        common,
+        channel_names: Vec::new(),
+        channel_numbers: BTreeMap::new(),
+        mode_names: Vec::new(),
+        mode_numbers: BTreeMap::new(),
+        lexer_atn_words: Vec::new(),
+        lexer_atn: LexerAtn::new(0),
+        lexer_dfa_words: Vec::new(),
+    };
+    assert_eq!(
+        render_lexer_token_constants(&lexer_data),
+        rendered,
+        "lexer and parser token-constant rendering must stay in lockstep"
+    );
+}
+
+#[test]
+fn token_const_allocation_skips_same_type_and_suffixes_collisions() {
+    let mut seen = BTreeMap::from([("EOF".to_owned(), TOKEN_EOF)]);
+
+    assert_eq!(
+        allocate_token_const_name("FooBar", 1, &mut seen),
+        Some("FOO_BAR".to_owned())
+    );
+    assert_eq!(
+        allocate_token_const_name("FooBar", 1, &mut seen),
+        None,
+        "re-emitting the same token type must not duplicate its constant"
+    );
+    assert_eq!(
+        allocate_token_const_name("FOO_BAR", 2, &mut seen),
+        Some("FOO_BAR_2".to_owned())
+    );
+    assert_eq!(
+        allocate_token_const_name("Foo_Bar", 3, &mut seen),
+        Some("FOO_BAR_3".to_owned())
+    );
+    assert_eq!(
+        allocate_token_const_name("Eof", 4, &mut seen),
+        Some("EOF_2".to_owned()),
+        "a token mangling to the predefined EOF constant must keep a constant"
+    );
+}
+
+#[test]
+fn channel_and_mode_constants_dedupe_lossy_name_collisions() {
+    let data = LexerCodegenData {
+        common: RecognizerCodegenData::default(),
+        channel_names: Vec::new(),
+        channel_numbers: BTreeMap::from([
+            ("DEFAULT_TOKEN_CHANNEL".to_owned(), 0),
+            ("FOO_BAR".to_owned(), 3),
+            ("FooBar".to_owned(), 2),
+        ]),
+        mode_names: Vec::new(),
+        mode_numbers: BTreeMap::from([
+            ("DEFAULT_MODE".to_owned(), 0),
+            ("FOO_BAR".to_owned(), 2),
+            ("FooBar".to_owned(), 1),
+        ]),
+        lexer_atn_words: Vec::new(),
+        lexer_atn: LexerAtn::new(0),
+        lexer_dfa_words: Vec::new(),
+    };
+
+    insta::assert_snapshot!(
+        "channel_and_mode_constants_dedupe_lossy_name_collisions",
+        render_lexer_state_constants(&data)
+    );
+}
+
+#[test]
 fn renders_parser_rustdoc_with_entry_rule_methods() {
     let data = RecognizerCodegenData {
         rule_names: vec![

--- a/crates/antlr-rust-codegen/src/generator/tests.rs
+++ b/crates/antlr-rust-codegen/src/generator/tests.rs
@@ -138,7 +138,7 @@ fn renders_structural_channel_and_mode_constants() {
 
     insta::assert_snapshot!(
         "structural_channel_and_mode_constants",
-        render_lexer_state_constants(&data)
+        render_lexer_state_constants(&data, &mut BTreeSet::new())
     );
 }
 
@@ -156,13 +156,13 @@ fn rule_constants_dedupe_lossy_name_collisions() {
 
     insta::assert_snapshot!(
         "rule_constants_dedupe_lossy_name_collisions",
-        render_rule_constants(&data)
+        render_rule_constants(&data, &mut BTreeSet::new())
     );
 }
 
 #[test]
 fn token_constants_dedupe_lossy_name_collisions() {
-    let common = RecognizerCodegenData {
+    let data = RecognizerCodegenData {
         symbolic_names: vec![
             None,
             Some("FooBar".to_owned()),
@@ -172,57 +172,75 @@ fn token_constants_dedupe_lossy_name_collisions() {
         ..RecognizerCodegenData::default()
     };
 
-    let rendered = render_token_constants(&common);
-
-    insta::assert_snapshot!("token_constants_dedupe_lossy_name_collisions", rendered);
-
-    let lexer_data = LexerCodegenData {
-        common,
-        channel_names: Vec::new(),
-        channel_numbers: BTreeMap::new(),
-        mode_names: Vec::new(),
-        mode_numbers: BTreeMap::new(),
-        lexer_atn_words: Vec::new(),
-        lexer_atn: LexerAtn::new(0),
-        lexer_dfa_words: Vec::new(),
-    };
-    assert_eq!(
-        render_lexer_token_constants(&lexer_data),
-        rendered,
-        "lexer and parser token-constant rendering must stay in lockstep"
+    insta::assert_snapshot!(
+        "token_constants_dedupe_lossy_name_collisions",
+        render_recognizer_token_constants(&data, &mut BTreeSet::new())
     );
 }
 
 #[test]
-fn token_const_allocation_skips_same_type_and_suffixes_collisions() {
-    let mut seen = BTreeMap::from([("EOF".to_owned(), TOKEN_EOF)]);
+fn parser_token_and_rule_constants_share_the_module_namespace() {
+    // Token `RuleFoo` and rule `foo` both mangle to `RULE_FOO`; the shared
+    // used-set must suffix the later (rule) emission.
+    let data = RecognizerCodegenData {
+        symbolic_names: vec![None, Some("RuleFoo".to_owned())],
+        rule_names: vec!["foo".to_owned()],
+        ..RecognizerCodegenData::default()
+    };
 
-    assert_eq!(
-        allocate_token_const_name("FooBar", 1, &mut seen),
-        Some("FOO_BAR".to_owned())
+    let mut const_names = BTreeSet::new();
+    let rendered = format!(
+        "{}{}",
+        render_recognizer_token_constants(&data, &mut const_names),
+        render_rule_constants(&data, &mut const_names)
     );
-    assert_eq!(
-        allocate_token_const_name("FooBar", 1, &mut seen),
-        None,
-        "re-emitting the same token type must not duplicate its constant"
+
+    insta::assert_snapshot!(
+        "parser_token_and_rule_constants_share_the_module_namespace",
+        rendered
     );
-    assert_eq!(
-        allocate_token_const_name("FOO_BAR", 2, &mut seen),
-        Some("FOO_BAR_2".to_owned())
+}
+
+#[test]
+fn lexer_token_and_state_constants_share_the_module_namespace() {
+    // Tokens `ChannelFoo` / `ModeBar` mangle to the same identifiers as
+    // channel `foo` / mode `bar`; the shared used-set must suffix the later
+    // (state-constant) emissions.
+    let data = LexerCodegenData {
+        common: RecognizerCodegenData {
+            symbolic_names: vec![
+                None,
+                Some("ChannelFoo".to_owned()),
+                Some("ModeBar".to_owned()),
+            ],
+            ..RecognizerCodegenData::default()
+        },
+        channel_names: Vec::new(),
+        channel_numbers: BTreeMap::from([("foo".to_owned(), 2)]),
+        mode_names: Vec::new(),
+        mode_numbers: BTreeMap::from([("bar".to_owned(), 1)]),
+        lexer_atn_words: Vec::new(),
+        lexer_atn: LexerAtn::new(0),
+        lexer_dfa_words: Vec::new(),
+    };
+
+    let mut const_names = BTreeSet::new();
+    let rendered = format!(
+        "{}{}",
+        render_recognizer_token_constants(&data, &mut const_names),
+        render_lexer_state_constants(&data, &mut const_names)
     );
-    assert_eq!(
-        allocate_token_const_name("Foo_Bar", 3, &mut seen),
-        Some("FOO_BAR_3".to_owned())
-    );
-    assert_eq!(
-        allocate_token_const_name("Eof", 4, &mut seen),
-        Some("EOF_2".to_owned()),
-        "a token mangling to the predefined EOF constant must keep a constant"
+
+    insta::assert_snapshot!(
+        "lexer_token_and_state_constants_share_the_module_namespace",
+        rendered
     );
 }
 
 #[test]
 fn channel_and_mode_constants_dedupe_lossy_name_collisions() {
+    // `FooBar` is declared first (lower channel/mode number), so it keeps
+    // the canonical identifier even though `FOO_BAR` sorts first by name.
     let data = LexerCodegenData {
         common: RecognizerCodegenData::default(),
         channel_names: Vec::new(),
@@ -244,7 +262,7 @@ fn channel_and_mode_constants_dedupe_lossy_name_collisions() {
 
     insta::assert_snapshot!(
         "channel_and_mode_constants_dedupe_lossy_name_collisions",
-        render_lexer_state_constants(&data)
+        render_lexer_state_constants(&data, &mut BTreeSet::new())
     );
 }
 

--- a/crates/antlr-rust-codegen/src/lexer/render.rs
+++ b/crates/antlr-rust-codegen/src/lexer/render.rs
@@ -35,8 +35,11 @@ pub(crate) fn render_lexer_model(model: &LexerRenderModel<'_>) -> io::Result<Str
     let type_name = rust_type_name(grammar_name);
     let metadata = render_lexer_metadata(grammar_name, data);
     let lex_convenience = render_lexer_lex_convenience(&type_name);
-    let token_constants = render_lexer_token_constants(data);
-    let lexer_state_constants = render_lexer_state_constants(data);
+    // Every constant in the generated module shares one Rust value
+    // namespace; allocation order matches emission order (tokens first).
+    let mut const_names = BTreeSet::new();
+    let token_constants = render_recognizer_token_constants(data, &mut const_names);
+    let lexer_state_constants = render_lexer_state_constants(data, &mut const_names);
     // Embedded mode: lexer action/predicate bodies are verbatim Rust from the
     // rendered grammar; translate the recognizer surface textually and skip
     // the template machinery entirely.

--- a/crates/antlr-rust-codegen/src/lexer/render_model.rs
+++ b/crates/antlr-rust-codegen/src/lexer/render_model.rs
@@ -103,59 +103,46 @@ pub(crate) fn render_lexer_metadata(grammar_name: &str, data: &LexerCodegenData<
     )
 }
 
-/// Renders lexer token constants without coupling lexer emission to parser
-/// surface rendering. Re-emissions of the same token type are skipped, and
-/// distinct token types whose names mangle to one identifier are
-/// deduplicated with a numbered suffix.
-pub(crate) fn render_lexer_token_constants(data: &LexerCodegenData<'_>) -> String {
-    let mut out = String::from("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\n");
-    let mut seen = BTreeMap::from([("EOF".to_owned(), TOKEN_EOF)]);
-    if let Some(semantic) = data.semantic {
-        let vocabulary = &semantic.recognizer.vocabulary;
-        for name in vocabulary
-            .name_order
-            .iter()
-            .filter(|name| name.starts_with("T__"))
-        {
-            let ident = sanitize_identifier(name);
-            let token_type = vocabulary.by_name[name];
-            let _ = seen.insert(ident.clone(), token_type);
-            writeln!(out, "pub const {ident}: i32 = {token_type};")
-                .expect("writing to a string cannot fail");
-        }
-    }
-    for (index, name) in data.symbolic_names.iter().enumerate() {
-        let Some(name) = name else { continue };
-        let token_type = i32::try_from(index).expect("token type exceeds i32");
-        let Some(ident) = allocate_token_const_name(name, token_type, &mut seen) else {
-            continue;
-        };
-        writeln!(out, "pub const {ident}: i32 = {token_type};")
+/// Renders `CHANNEL_*` / `MODE_*` constants for one prefix.
+///
+/// Identifiers are allocated in declaration order (channel/mode number), so
+/// the first-declared name keeps the canonical identifier and a `_2` suffix
+/// never reads like a channel or mode number, while emission keeps the
+/// name-ordered layout so non-colliding grammars render byte-identically.
+fn render_lexer_prefixed_constants<N: Copy + Ord + std::fmt::Display>(
+    prefix: &str,
+    numbers: &BTreeMap<String, N>,
+    used: &mut BTreeSet<String>,
+) -> String {
+    let mut declaration_order: Vec<(&String, N)> =
+        numbers.iter().map(|(name, number)| (name, *number)).collect();
+    declaration_order.sort_by_key(|&(_, number)| number);
+    let idents: BTreeMap<&String, String> = declaration_order
+        .into_iter()
+        .map(|(name, _)| (name, allocate_const_name(prefix, name, used)))
+        .collect();
+    let mut out = String::new();
+    for (name, number) in numbers {
+        writeln!(out, "pub const {}: i32 = {number};", idents[name])
             .expect("writing to a string cannot fail");
     }
     out
 }
 
-pub(crate) fn render_lexer_state_constants(data: &LexerCodegenData<'_>) -> String {
-    let mut out = String::new();
-    let mut used_channels = BTreeSet::new();
-    for (name, number) in &data.channel_numbers {
-        writeln!(
-            out,
-            "pub const CHANNEL_{}: i32 = {number};",
-            allocate_rust_const_name(name, &mut used_channels)
-        )
-        .expect("writing to a string cannot fail");
-    }
-    let mut used_modes = BTreeSet::new();
-    for (name, number) in &data.mode_numbers {
-        writeln!(
-            out,
-            "pub const MODE_{}: i32 = {number};",
-            allocate_rust_const_name(name, &mut used_modes)
-        )
-        .expect("writing to a string cannot fail");
-    }
+/// Renders lexer channel and mode constants. Both prefixes share the
+/// generated module's `used` identifier set with the token constants, since
+/// a token named `ChannelFoo` or `ModeBar` would otherwise collide with a
+/// channel `foo` or mode `bar`.
+pub(crate) fn render_lexer_state_constants(
+    data: &LexerCodegenData<'_>,
+    used: &mut BTreeSet<String>,
+) -> String {
+    let mut out = render_lexer_prefixed_constants("CHANNEL_", &data.channel_numbers, used);
+    out.push_str(&render_lexer_prefixed_constants(
+        "MODE_",
+        &data.mode_numbers,
+        used,
+    ));
     out
 }
 

--- a/crates/antlr-rust-codegen/src/lexer/render_model.rs
+++ b/crates/antlr-rust-codegen/src/lexer/render_model.rs
@@ -104,10 +104,12 @@ pub(crate) fn render_lexer_metadata(grammar_name: &str, data: &LexerCodegenData<
 }
 
 /// Renders lexer token constants without coupling lexer emission to parser
-/// surface rendering.
+/// surface rendering. Re-emissions of the same token type are skipped, and
+/// distinct token types whose names mangle to one identifier are
+/// deduplicated with a numbered suffix.
 pub(crate) fn render_lexer_token_constants(data: &LexerCodegenData<'_>) -> String {
     let mut out = String::from("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\n");
-    let mut seen = BTreeSet::new();
+    let mut seen = BTreeMap::from([("EOF".to_owned(), TOKEN_EOF)]);
     if let Some(semantic) = data.semantic {
         let vocabulary = &semantic.recognizer.vocabulary;
         for name in vocabulary
@@ -116,19 +118,19 @@ pub(crate) fn render_lexer_token_constants(data: &LexerCodegenData<'_>) -> Strin
             .filter(|name| name.starts_with("T__"))
         {
             let ident = sanitize_identifier(name);
-            let _ = seen.insert(ident.clone());
             let token_type = vocabulary.by_name[name];
+            let _ = seen.insert(ident.clone(), token_type);
             writeln!(out, "pub const {ident}: i32 = {token_type};")
                 .expect("writing to a string cannot fail");
         }
     }
     for (index, name) in data.symbolic_names.iter().enumerate() {
         let Some(name) = name else { continue };
-        let ident = rust_const_name(name);
-        if ident == "EOF" || !seen.insert(ident.clone()) {
+        let token_type = i32::try_from(index).expect("token type exceeds i32");
+        let Some(ident) = allocate_token_const_name(name, token_type, &mut seen) else {
             continue;
-        }
-        writeln!(out, "pub const {ident}: i32 = {index};")
+        };
+        writeln!(out, "pub const {ident}: i32 = {token_type};")
             .expect("writing to a string cannot fail");
     }
     out
@@ -136,19 +138,21 @@ pub(crate) fn render_lexer_token_constants(data: &LexerCodegenData<'_>) -> Strin
 
 pub(crate) fn render_lexer_state_constants(data: &LexerCodegenData<'_>) -> String {
     let mut out = String::new();
+    let mut used_channels = BTreeSet::new();
     for (name, number) in &data.channel_numbers {
         writeln!(
             out,
             "pub const CHANNEL_{}: i32 = {number};",
-            rust_const_name(name)
+            allocate_rust_const_name(name, &mut used_channels)
         )
         .expect("writing to a string cannot fail");
     }
+    let mut used_modes = BTreeSet::new();
     for (name, number) in &data.mode_numbers {
         writeln!(
             out,
             "pub const MODE_{}: i32 = {number};",
-            rust_const_name(name)
+            allocate_rust_const_name(name, &mut used_modes)
         )
         .expect("writing to a string cannot fail");
     }

--- a/crates/antlr-rust-codegen/src/parser/render/mod.rs
+++ b/crates/antlr-rust-codegen/src/parser/render/mod.rs
@@ -24,8 +24,11 @@ pub(crate) fn render_parser_with_decision_report(
     let metadata = render_parser_metadata(grammar_name, data);
     let parser_atn = data.parser_atn();
     let parser_atn_data = render_u32_slice(parser_atn.packed_words());
-    let token_constants = render_token_constants(data);
-    let rule_constants = render_rule_constants(data);
+    // Every constant in the generated module shares one Rust value
+    // namespace; allocation order matches emission order (tokens first).
+    let mut const_names = BTreeSet::new();
+    let token_constants = render_recognizer_token_constants(data, &mut const_names);
+    let rule_constants = render_rule_constants(data, &mut const_names);
     // Decision routing: embedded mode always follows the tool
     // classification (Java parity); `--fixed-lookahead` additionally
     // compiles static dispatch for provable decisions in either mode. The

--- a/crates/antlr-rust-codegen/src/parser/surface/support_abi.rs
+++ b/crates/antlr-rust-codegen/src/parser/surface/support_abi.rs
@@ -677,39 +677,6 @@ fn render_metadata_with_atn(
     )
 }
 
-/// Renders token constants from symbolic token names while avoiding duplicate
-/// Rust identifiers after sanitization: re-emissions of the same token type
-/// are skipped, and distinct token types whose names mangle to one identifier
-/// are deduplicated with a numbered suffix.
-pub(crate) fn render_token_constants(data: &RecognizerCodegenData<'_>) -> String {
-    let mut out = String::from("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\n");
-    let mut seen = BTreeMap::from([("EOF".to_owned(), TOKEN_EOF)]);
-    if let Some(semantic) = data.semantic {
-        let vocabulary = &semantic.recognizer.vocabulary;
-        for name in vocabulary
-            .name_order
-            .iter()
-            .filter(|name| name.starts_with("T__"))
-        {
-            let ident = sanitize_identifier(name);
-            let token_type = vocabulary.by_name[name];
-            let _ = seen.insert(ident.clone(), token_type);
-            writeln!(out, "pub const {ident}: i32 = {token_type};")
-                .expect("writing to a string cannot fail");
-        }
-    }
-    for (index, name) in data.symbolic_names.iter().enumerate() {
-        let Some(name) = name else { continue };
-        let token_type = i32::try_from(index).expect("token type exceeds i32");
-        let Some(ident) = allocate_token_const_name(name, token_type, &mut seen) else {
-            continue;
-        };
-        writeln!(out, "pub const {ident}: i32 = {token_type};")
-            .expect("writing to a string cannot fail");
-    }
-    out
-}
-
 /// Metadata-derived `<GeneratedParserType>_<TOKEN>` aliases used by
 /// antlr4rust embedded bodies.
 fn antlr4rust_token_alias_name(type_name: &str, token_name: &str) -> String {
@@ -902,16 +869,20 @@ fn render_antlr4rust_token_aliases(
 }
 
 /// Renders rule-index constants from grammar rule names. Rule names are
-/// unique in the grammar, but their upper-snake mangling is lossy, so
-/// colliding constants are deduplicated with a numbered suffix.
-pub(crate) fn render_rule_constants(data: &RecognizerCodegenData<'_>) -> String {
+/// unique in the grammar, but their upper-snake mangling is lossy and the
+/// literal `RULE_` prefix can itself collide with a token constant (token
+/// `RuleFoo` vs rule `foo`), so allocation shares the generated module's
+/// `used` identifier set and colliders get a numbered suffix.
+pub(crate) fn render_rule_constants(
+    data: &RecognizerCodegenData<'_>,
+    used: &mut BTreeSet<String>,
+) -> String {
     let mut out = String::new();
-    let mut used = BTreeSet::new();
     for (index, name) in data.rule_names.iter().enumerate() {
         writeln!(
             out,
-            "pub const RULE_{}: usize = {index};",
-            allocate_rust_const_name(name, &mut used)
+            "pub const {}: usize = {index};",
+            allocate_const_name("RULE_", name, used)
         )
         .expect("writing to a string cannot fail");
     }

--- a/crates/antlr-rust-codegen/src/parser/surface/support_abi.rs
+++ b/crates/antlr-rust-codegen/src/parser/surface/support_abi.rs
@@ -678,10 +678,12 @@ fn render_metadata_with_atn(
 }
 
 /// Renders token constants from symbolic token names while avoiding duplicate
-/// Rust identifiers after sanitization.
+/// Rust identifiers after sanitization: re-emissions of the same token type
+/// are skipped, and distinct token types whose names mangle to one identifier
+/// are deduplicated with a numbered suffix.
 pub(crate) fn render_token_constants(data: &RecognizerCodegenData<'_>) -> String {
     let mut out = String::from("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\n");
-    let mut seen = BTreeSet::new();
+    let mut seen = BTreeMap::from([("EOF".to_owned(), TOKEN_EOF)]);
     if let Some(semantic) = data.semantic {
         let vocabulary = &semantic.recognizer.vocabulary;
         for name in vocabulary
@@ -690,19 +692,19 @@ pub(crate) fn render_token_constants(data: &RecognizerCodegenData<'_>) -> String
             .filter(|name| name.starts_with("T__"))
         {
             let ident = sanitize_identifier(name);
-            let _ = seen.insert(ident.clone());
             let token_type = vocabulary.by_name[name];
+            let _ = seen.insert(ident.clone(), token_type);
             writeln!(out, "pub const {ident}: i32 = {token_type};")
                 .expect("writing to a string cannot fail");
         }
     }
     for (index, name) in data.symbolic_names.iter().enumerate() {
         let Some(name) = name else { continue };
-        let ident = rust_const_name(name);
-        if ident == "EOF" || !seen.insert(ident.clone()) {
+        let token_type = i32::try_from(index).expect("token type exceeds i32");
+        let Some(ident) = allocate_token_const_name(name, token_type, &mut seen) else {
             continue;
-        }
-        writeln!(out, "pub const {ident}: i32 = {index};")
+        };
+        writeln!(out, "pub const {ident}: i32 = {token_type};")
             .expect("writing to a string cannot fail");
     }
     out
@@ -899,14 +901,17 @@ fn render_antlr4rust_token_aliases(
     out
 }
 
-/// Renders rule-index constants from grammar rule names.
+/// Renders rule-index constants from grammar rule names. Rule names are
+/// unique in the grammar, but their upper-snake mangling is lossy, so
+/// colliding constants are deduplicated with a numbered suffix.
 pub(crate) fn render_rule_constants(data: &RecognizerCodegenData<'_>) -> String {
     let mut out = String::new();
+    let mut used = BTreeSet::new();
     for (index, name) in data.rule_names.iter().enumerate() {
         writeln!(
             out,
             "pub const RULE_{}: usize = {index};",
-            rust_const_name(name)
+            allocate_rust_const_name(name, &mut used)
         )
         .expect("writing to a string cannot fail");
     }

--- a/crates/antlr-rust-codegen/src/pipeline.rs
+++ b/crates/antlr-rust-codegen/src/pipeline.rs
@@ -1,7 +1,7 @@
 pub(crate) mod prelude {
     pub(crate) use super::{
         GENERATED_MODULE_FOOTER, LexerCodegenData, ParserCodegenData, RecognizerCodegenData,
-        allocate_rust_const_name, allocate_token_const_name, generated_module_header, max_len,
+        allocate_const_name, generated_module_header, max_len, render_recognizer_token_constants,
         token_type_for_name,
     };
     pub(crate) use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
@@ -210,15 +210,19 @@ pub(crate) fn rust_const_name(name: &str) -> String {
     sanitize_identifier(&ident)
 }
 
-/// Allocates a collision-free [`rust_const_name`] for `name`.
+/// Allocates a collision-free generated-constant identifier: `prefix`
+/// followed by the upper-snake [`rust_const_name`] mangling of `name`.
 ///
-/// The conversion is lossy — `compilationUnit` and `compilation_unit` both
-/// mangle to `COMPILATION_UNIT` — so the first source name keeps the
-/// canonical identifier and later colliding names receive a deterministic
-/// `_2`, `_3`, ... suffix, mirroring the numbered dedup used for generated
-/// rule methods and context types.
-pub(crate) fn allocate_rust_const_name(name: &str, used: &mut BTreeSet<String>) -> String {
-    let canonical = rust_const_name(name);
+/// The mangling is lossy — `compilationUnit` and `compilation_unit` both
+/// yield `COMPILATION_UNIT` — and every constant a generated recognizer
+/// module emits (token, `RULE_*`, `CHANNEL_*`, `MODE_*`) shares one Rust
+/// value namespace, so callers thread a single `used` set per generated
+/// module through every constant renderer (tokens first, matching emission
+/// order). The first emission keeps the canonical identifier and later
+/// colliders receive a deterministic `_2`, `_3`, ... suffix, mirroring the
+/// numbered dedup used for generated rule methods and context types.
+pub(crate) fn allocate_const_name(prefix: &str, name: &str, used: &mut BTreeSet<String>) -> String {
+    let canonical = format!("{prefix}{}", rust_const_name(name));
     if used.insert(canonical.clone()) {
         return canonical;
     }
@@ -232,35 +236,41 @@ pub(crate) fn allocate_rust_const_name(name: &str, used: &mut BTreeSet<String>) 
     }
 }
 
-/// Allocates a token-constant identifier for a symbolic token name, or `None`
-/// when the identifier is already bound to the same token type (implicit
-/// `T__n` vocabulary tokens are rendered ahead of symbolic names, and `EOF`
-/// is always predefined).
+/// Renders token constants from the vocabulary's implicit `T__n` tokens and
+/// the symbolic token names, shared verbatim by lexer and parser emission.
 ///
-/// Distinct token types whose names mangle to one identifier receive a
-/// deterministic `_2`, `_3`, ... suffix instead of silently losing their
-/// constant.
-pub(crate) fn allocate_token_const_name(
-    name: &str,
-    token_type: i32,
-    seen: &mut BTreeMap<String, i32>,
-) -> Option<String> {
-    let canonical = rust_const_name(name);
-    let mut candidate = canonical.clone();
-    let mut suffix = 2_usize;
-    loop {
-        match seen.entry(candidate) {
-            Entry::Vacant(entry) => {
-                let allocated = entry.key().clone();
-                entry.insert(token_type);
-                return Some(allocated);
-            }
-            Entry::Occupied(entry) if *entry.get() == token_type => return None,
-            Entry::Occupied(_) => {}
+/// Distinct token types whose names mangle to one identifier are
+/// deduplicated with a numbered suffix instead of silently losing their
+/// constant (a token mangling to the predefined `EOF` becomes `EOF_2`).
+/// Every allocated identifier is recorded in `used` so the module's other
+/// constant renderers cannot collide with a token constant.
+pub(crate) fn render_recognizer_token_constants(
+    data: &RecognizerCodegenData<'_>,
+    used: &mut BTreeSet<String>,
+) -> String {
+    let mut out = String::from("pub const EOF: i32 = antlr4_runtime::TOKEN_EOF;\n");
+    let _ = used.insert("EOF".to_owned());
+    if let Some(semantic) = data.semantic {
+        let vocabulary = &semantic.recognizer.vocabulary;
+        for name in vocabulary
+            .name_order
+            .iter()
+            .filter(|name| name.starts_with("T__"))
+        {
+            let ident = sanitize_identifier(name);
+            let token_type = vocabulary.by_name[name];
+            let _ = used.insert(ident.clone());
+            writeln!(out, "pub const {ident}: i32 = {token_type};")
+                .expect("writing to a string cannot fail");
         }
-        candidate = format!("{canonical}_{suffix}");
-        suffix += 1;
     }
+    for (index, name) in data.symbolic_names.iter().enumerate() {
+        let Some(name) = name else { continue };
+        let ident = allocate_const_name("", name, used);
+        writeln!(out, "pub const {ident}: i32 = {index};")
+            .expect("writing to a string cannot fail");
+    }
+    out
 }
 
 /// Converts ASCII letters to upper case without using allocation-hiding string

--- a/crates/antlr-rust-codegen/src/pipeline.rs
+++ b/crates/antlr-rust-codegen/src/pipeline.rs
@@ -1,7 +1,8 @@
 pub(crate) mod prelude {
     pub(crate) use super::{
         GENERATED_MODULE_FOOTER, LexerCodegenData, ParserCodegenData, RecognizerCodegenData,
-        generated_module_header, max_len, rust_const_name, token_type_for_name,
+        allocate_rust_const_name, allocate_token_const_name, generated_module_header, max_len,
+        token_type_for_name,
     };
     pub(crate) use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
     pub(crate) use std::env;
@@ -207,6 +208,59 @@ pub(crate) fn rust_const_name(name: &str) -> String {
         ascii_uppercase(&words.join("_"))
     };
     sanitize_identifier(&ident)
+}
+
+/// Allocates a collision-free [`rust_const_name`] for `name`.
+///
+/// The conversion is lossy — `compilationUnit` and `compilation_unit` both
+/// mangle to `COMPILATION_UNIT` — so the first source name keeps the
+/// canonical identifier and later colliding names receive a deterministic
+/// `_2`, `_3`, ... suffix, mirroring the numbered dedup used for generated
+/// rule methods and context types.
+pub(crate) fn allocate_rust_const_name(name: &str, used: &mut BTreeSet<String>) -> String {
+    let canonical = rust_const_name(name);
+    if used.insert(canonical.clone()) {
+        return canonical;
+    }
+    let mut suffix = 2_usize;
+    loop {
+        let candidate = format!("{canonical}_{suffix}");
+        if used.insert(candidate.clone()) {
+            return candidate;
+        }
+        suffix += 1;
+    }
+}
+
+/// Allocates a token-constant identifier for a symbolic token name, or `None`
+/// when the identifier is already bound to the same token type (implicit
+/// `T__n` vocabulary tokens are rendered ahead of symbolic names, and `EOF`
+/// is always predefined).
+///
+/// Distinct token types whose names mangle to one identifier receive a
+/// deterministic `_2`, `_3`, ... suffix instead of silently losing their
+/// constant.
+pub(crate) fn allocate_token_const_name(
+    name: &str,
+    token_type: i32,
+    seen: &mut BTreeMap<String, i32>,
+) -> Option<String> {
+    let canonical = rust_const_name(name);
+    let mut candidate = canonical.clone();
+    let mut suffix = 2_usize;
+    loop {
+        match seen.entry(candidate) {
+            Entry::Vacant(entry) => {
+                let allocated = entry.key().clone();
+                entry.insert(token_type);
+                return Some(allocated);
+            }
+            Entry::Occupied(entry) if *entry.get() == token_type => return None,
+            Entry::Occupied(_) => {}
+        }
+        candidate = format!("{canonical}_{suffix}");
+        suffix += 1;
+    }
 }
 
 /// Converts ASCII letters to upper case without using allocation-hiding string


### PR DESCRIPTION
## Summary

Fixes the generated-code compile failure reported in #253 (comment): grammars containing two rule names whose upper-snake mangling collides (e.g. `compilationUnit` and `compilation_unit` in the grammars-v4 `java8` grammar with an added snake_case entry rule) emitted two `pub const RULE_COMPILATION_UNIT` definitions and failed to compile with E0428.

The mangled-constant renderers were the only generated naming surfaces without collision handling — context types, listener methods, and public entry methods already dedupe with used-sets. Because every constant a generated recognizer module emits (token, `RULE_*`, `CHANNEL_*`, `MODE_*`) lives in one Rust value namespace, the fix threads a **single used-set of final prefixed identifiers per generated module** through every constant renderer, in emission order (tokens first):

- **Rule constants** and **channel/mode constants**: the first emission keeps the canonical identifier, later colliders get a deterministic `_2`, `_3`, ... suffix — the same numbering scheme the public rule-method dedup already uses, so the java8 repro pairs `compilation_unit_2()` with `RULE_COMPILATION_UNIT_2`. This also covers cross-family collisions (a token named `RuleFoo` vs rule `foo`, token `ChannelFoo` vs channel `foo`), which were the same E0428 failure mode.
- **Token constants**: previously colliding names were *silently skipped*, so the second token type lost its constant entirely; now they get a suffixed constant (a token mangling to the predefined `EOF`, e.g. `Eof`, becomes `EOF_2`). The parser and lexer token renderers were character-for-character identical and are merged into one shared `render_recognizer_token_constants`.
- **Channel/mode allocation order**: identifiers are allocated in declaration order (channel/mode number), so the first-declared name keeps the canonical identifier and a `_2` suffix never reads like a channel number; emission keeps the name-ordered layout.

Resolution is fully automatic — no new flags, no diagnostics to act on.

## Compatibility

Generated output is **byte-identical** for grammars without collisions, verified two ways:

- diffed pre-fix-binary vs post-fix-binary generator output on the pristine grammars-v4 `java8` grammar — identical;
- `tools/toml-syntax/update-generated.sh --check` — checked-in TOML recognizer is current.

No generated-source API revision bump is needed (no runtime contract change), and the runtime crate is untouched, so parse performance is unaffected. Generator wall-time on java8 is unchanged (~0.76 s before and after).

## Testing

| Check | Result |
|---|---|
| kaby76's java8 repro (`compilationUnit` + `compilation_unit`) | generates `RULE_COMPILATION_UNIT = 31` / `RULE_COMPILATION_UNIT_2 = 236`; smoke crate depending on the runtime compiles |
| Cross-namespace repro (`grammar Cross2; foo : RuleFoo ; RuleFoo : 'a' ; ...`) | token keeps `RULE_FOO`, rule gets `RULE_FOO_2`; compiles |
| New tests | 6 tests, 6 insta snapshots (rule, token, channel/mode, parser cross-namespace, lexer cross-namespace collisions) |
| Workspace tests | 1444 passed, 0 failed |
| Upstream conformance sweep | 357/357 pass |
| `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings` | clean |
| `cargo fmt --all --check` | clean |

Fixes #253.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented naming conflicts among generated rule, token, channel, and mode constants.
  - Added deterministic numeric suffixes when distinct names normalize to the same identifier.
  - Suppressed duplicate token constants for identical token types while preserving predefined constants such as `EOF`.
  - Ensured lexer and parser constants share consistent collision handling.
  - Improved reliability for grammars with overlapping or similarly named declarations.
  - Validated symbolic token indices before generating constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->