### PR TITLE
perf(prediction): specialize default ATN configs

### DIFF
--- a/crates/antlr-rust-runtime/src/atn/lexer.rs
+++ b/crates/antlr-rust-runtime/src/atn/lexer.rs
@@ -3,6 +3,7 @@
 use std::cell::RefCell;
 use std::collections::{HashMap, HashSet};
 use std::hash::BuildHasherDefault;
+use std::num::NonZeroU32;
 
 use crate::atn::lexer_dfa::{
     CompiledLexerAccept, CompiledLexerContext, CompiledLexerContinuation, CompiledLexerDfa,
@@ -12,10 +13,10 @@ use crate::atn::{AtnStateKind, LexerAction, LexerAtn, LexerTransition};
 use crate::char_stream::{CharStream, TextInterval};
 use crate::int_stream::EOF;
 use crate::lexer::{
-    BaseLexer, EMPTY_LEXER_CONTEXT, Lexer, LexerContextArena, LexerContextId, LexerContextNode,
-    LexerCustomAction, LexerDfaActionKey, LexerDfaCachedAccept, LexerDfaCachedState,
-    LexerDfaCachedTransition, LexerDfaConfigKey, LexerDfaKey, LexerLifecycleCtx, LexerPredicate,
-    LexerSemCtx,
+    BaseLexer, EMPTY_LEXER_CONTEXT, Lexer, LexerActionTrace, LexerActionTraceList,
+    LexerContextArena, LexerContextId, LexerContextNode, LexerCustomAction, LexerDfaActionKey,
+    LexerDfaCachedAccept, LexerDfaCachedState, LexerDfaCachedTransition, LexerDfaConfigKey,
+    LexerDfaKey, LexerLifecycleCtx, LexerPredicate, LexerSemCtx,
 };
 use crate::parser::{SemanticHooks, UnknownSemanticPolicy};
 use crate::prediction::{PredictionFxHasher, PredictionWorkspace};
@@ -34,21 +35,56 @@ const MAX_CHAR_VALUE: i32 = 0x0010_FFFF;
 pub(super) struct LexerConfig {
     pub(super) state: usize,
     pub(super) position: usize,
-    pub(super) consumed_eof: bool,
-    pub(super) alt_rule_index: Option<usize>,
-    pub(super) passed_non_greedy: bool,
     pub(super) context: LexerContextId,
-    pub(super) actions: Vec<LexerActionTrace>,
+    pub(super) actions: LexerActionTraceList,
+    alt_rule_index: Option<NonZeroU32>,
+    pub(super) consumed_eof: bool,
+    pub(super) passed_non_greedy: bool,
+}
+
+impl LexerConfig {
+    pub(super) fn new(state: usize, position: usize, context: LexerContextId) -> Self {
+        Self {
+            state,
+            position,
+            context,
+            actions: LexerActionTraceList::default(),
+            alt_rule_index: None,
+            consumed_eof: false,
+            passed_non_greedy: false,
+        }
+    }
+
+    pub(super) fn with_alt_rule_index(mut self, rule_index: usize) -> Self {
+        self.set_alt_rule_index(Some(rule_index));
+        self
+    }
+
+    pub(super) fn alt_rule_index(&self) -> Option<usize> {
+        self.alt_rule_index.map(|rule_index| {
+            usize::try_from(rule_index.get() - 1).expect("u32 lexer rule index fits usize")
+        })
+    }
+
+    pub(super) fn set_alt_rule_index(&mut self, rule_index: Option<usize>) {
+        self.alt_rule_index = rule_index.map(|rule_index| {
+            u32::try_from(rule_index)
+                .ok()
+                .and_then(|rule_index| rule_index.checked_add(1))
+                .and_then(NonZeroU32::new)
+                .expect("lexer rule index must fit below the u32 sentinel")
+        });
+    }
 }
 
 #[derive(Clone, Debug, Eq, Hash, PartialEq)]
 struct LexerConfigKey {
     state: usize,
     position: usize,
+    actions: LexerActionTraceList,
+    alt_rule_index: Option<NonZeroU32>,
     consumed_eof: bool,
-    alt_rule_index: Option<usize>,
     passed_non_greedy: bool,
-    actions: Vec<LexerActionTrace>,
 }
 
 impl From<&LexerConfig> for LexerConfigKey {
@@ -56,10 +92,10 @@ impl From<&LexerConfig> for LexerConfigKey {
         Self {
             state: config.state,
             position: config.position,
-            consumed_eof: config.consumed_eof,
-            alt_rule_index: config.alt_rule_index,
-            passed_non_greedy: config.passed_non_greedy,
             actions: config.actions.clone(),
+            alt_rule_index: config.alt_rule_index,
+            consumed_eof: config.consumed_eof,
+            passed_non_greedy: config.passed_non_greedy,
         }
     }
 }
@@ -158,17 +194,6 @@ impl LexerConfigSet {
     fn into_configs(self) -> Vec<LexerConfig> {
         self.configs
     }
-}
-
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub(super) struct LexerActionTrace {
-    pub(super) action_index: usize,
-    pub(super) position: usize,
-    /// Lexer rule that the action transition belonged to. ANTLR suppresses
-    /// commands of nested non-fragment rule references, so the dispatcher
-    /// must compare this against the accepted rule before applying side
-    /// effects like `pushMode` / `popMode`.
-    pub(super) rule_index: usize,
 }
 
 #[derive(Clone, Debug)]
@@ -1005,15 +1030,7 @@ where
     let start_closure = epsilon_closure_with_lexer(
         lexer,
         atn,
-        [LexerConfig {
-            state: start_state,
-            position: start,
-            consumed_eof: false,
-            alt_rule_index: None,
-            passed_non_greedy: false,
-            context: EMPTY_LEXER_CONTEXT,
-            actions: Vec::new(),
-        }],
+        [LexerConfig::new(start_state, start, EMPTY_LEXER_CONTEXT)],
         semantic_predicate,
     );
     let active = prune_after_accepts(atn, start_closure.configs);
@@ -1582,14 +1599,8 @@ where
         continuation
             .configs
             .iter()
-            .map(|config| LexerConfig {
-                state: config.state,
-                position,
-                consumed_eof: config.consumed_eof,
-                alt_rule_index: config.alt_rule_index,
-                passed_non_greedy: config.passed_non_greedy,
-                context: contexts[config.context as usize],
-                actions: config
+            .map(|config| {
+                let traces = config
                     .actions
                     .iter()
                     .map(|action| LexerActionTrace {
@@ -1597,7 +1608,14 @@ where
                         position: position.saturating_sub(action.behind),
                         rule_index: action.rule_index,
                     })
-                    .collect(),
+                    .collect::<Vec<_>>();
+                let mut restored =
+                    LexerConfig::new(config.state, position, contexts[config.context as usize]);
+                restored.consumed_eof = config.consumed_eof;
+                restored.passed_non_greedy = config.passed_non_greedy;
+                restored.set_alt_rule_index(config.alt_rule_index);
+                restored.actions = LexerActionTraceList::from_vec(traces);
+                restored
             })
             .collect::<Vec<_>>()
     };
@@ -1724,15 +1742,7 @@ where
     let start_closure = epsilon_closure_with_lexer(
         lexer,
         atn,
-        [LexerConfig {
-            state: start_state,
-            position: start,
-            consumed_eof: false,
-            alt_rule_index: None,
-            passed_non_greedy: false,
-            context: EMPTY_LEXER_CONTEXT,
-            actions: Vec::new(),
-        }],
+        [LexerConfig::new(start_state, start, EMPTY_LEXER_CONTEXT)],
         semantic_predicate,
     );
     let active = prune_after_accepts(atn, start_closure.configs);
@@ -1765,35 +1775,31 @@ fn cache_dfa_state<I>(
 where
     I: CharStream,
 {
-    let state = lexer.lexer_dfa_state(
-        lexer_dfa_key(active, token_start),
-        accept_prediction(atn, active),
-    );
-    if !has_semantic_context {
-        lexer.cache_lexer_dfa_state(
-            state,
-            LexerDfaCachedState {
-                has_semantic_context,
-                configs: active
-                    .iter()
-                    .map(|config| normalized_config_key(config, token_start))
-                    .collect(),
-                accept: best_accept(atn, active).map(|accept| LexerDfaCachedAccept {
-                    position_delta: accept.position.saturating_sub(position),
-                    rule_index: accept.rule_index,
-                    consumed_eof: accept.consumed_eof,
-                    actions: accept
-                        .actions
-                        .iter()
-                        .map(|action| LexerDfaActionKey {
-                            action_index: action.action_index,
-                            position_delta: action.position.saturating_sub(token_start),
-                            rule_index: action.rule_index,
-                        })
-                        .collect(),
-                }),
-            },
-        );
+    let key = lexer_dfa_key(active, token_start);
+    let cached_state = (!has_semantic_context).then(|| LexerDfaCachedState {
+        has_semantic_context,
+        configs: active
+            .iter()
+            .map(|config| normalized_config_key(config, token_start))
+            .collect(),
+        accept: best_accept(atn, active).map(|accept| LexerDfaCachedAccept {
+            position_delta: accept.position.saturating_sub(position),
+            rule_index: accept.rule_index,
+            consumed_eof: accept.consumed_eof,
+            actions: accept
+                .actions
+                .iter()
+                .map(|action| LexerDfaActionKey {
+                    action_index: action.action_index,
+                    position_delta: action.position.saturating_sub(token_start),
+                    rule_index: action.rule_index,
+                })
+                .collect(),
+        }),
+    });
+    let state = lexer.lexer_dfa_state(key, accept_prediction(atn, active));
+    if let Some(cached_state) = cached_state {
+        lexer.cache_lexer_dfa_state(state, cached_state);
     }
     state
 }
@@ -2012,7 +2018,7 @@ fn close_config<C, P>(
                         position: config.position,
                         rule_index: *rule_index,
                     };
-                    let keep = next.alt_rule_index.is_none_or(|accept_rule| {
+                    let keep = next.alt_rule_index().is_none_or(|accept_rule| {
                         lexer_action_belongs_to_accept(atn, accept_rule, *rule_index)
                     });
                     if keep {
@@ -2042,7 +2048,7 @@ fn close_config<C, P>(
 /// result cannot be observed before this one overwrites it.
 fn append_lexer_action_trace(
     atn: &LexerAtn,
-    actions: &mut Vec<LexerActionTrace>,
+    actions: &mut LexerActionTraceList,
     trace: LexerActionTrace,
 ) {
     #[derive(Clone, Copy, Eq, PartialEq)]
@@ -2061,6 +2067,7 @@ fn append_lexer_action_trace(
         }
     }
 
+    let actions = actions.make_mut();
     let Some(action) = atn.lexer_actions().get(trace.action_index) else {
         actions.push(trace);
         return;
@@ -2098,7 +2105,7 @@ pub(super) fn prune_after_accepts(atn: &LexerAtn, configs: Vec<LexerConfig>) -> 
     let mut accepted_rules = Vec::new();
     let mut pruned = Vec::with_capacity(configs.len());
     for config in configs {
-        let Some(rule_index) = config.alt_rule_index else {
+        let Some(rule_index) = config.alt_rule_index() else {
             pruned.push(config);
             continue;
         };
@@ -2122,6 +2129,19 @@ pub(super) fn prune_after_accepts(atn: &LexerAtn, configs: Vec<LexerConfig>) -> 
 /// `match_token` handles longest-match selection across input positions. Within
 /// one closure, an EOF-consuming accept wins before rule order is considered.
 pub(super) fn best_accept(atn: &LexerAtn, configs: &[LexerConfig]) -> Option<AcceptState> {
+    let (config, rule_index) = best_accept_config(atn, configs)?;
+    Some(AcceptState {
+        position: config.position,
+        rule_index,
+        consumed_eof: config.consumed_eof,
+        actions: config.actions.to_vec(),
+    })
+}
+
+fn best_accept_config<'a>(
+    atn: &LexerAtn,
+    configs: &'a [LexerConfig],
+) -> Option<(&'a LexerConfig, usize)> {
     configs
         .iter()
         .filter_map(|config| {
@@ -2129,20 +2149,15 @@ pub(super) fn best_accept(atn: &LexerAtn, configs: &[LexerConfig]) -> Option<Acc
             if !state.is_rule_stop() || config.context != EMPTY_LEXER_CONTEXT {
                 return None;
             }
-            Some(AcceptState {
-                position: config.position,
-                rule_index: config.alt_rule_index.or(state.rule_index)?,
-                consumed_eof: config.consumed_eof,
-                actions: config.actions.clone(),
-            })
+            Some((config, config.alt_rule_index().or(state.rule_index)?))
         })
-        .min_by_key(|accept| (!accept.consumed_eof, accept.rule_index))
+        .min_by_key(|(config, rule_index)| (!config.consumed_eof, *rule_index))
 }
 
 /// Returns the token type predicted by an accepting lexer config set, if any.
 fn accept_prediction(atn: &LexerAtn, configs: &[LexerConfig]) -> Option<i32> {
-    best_accept(atn, configs)
-        .and_then(|accept| atn.rule_to_token_type().get(accept.rule_index).copied())
+    best_accept_config(atn, configs)
+        .and_then(|(_, rule_index)| atn.rule_to_token_type().get(rule_index).copied())
 }
 
 /// Builds a stable DFA state identity from a lexer closure while ignoring the
@@ -2162,12 +2177,13 @@ fn lexer_dfa_key(configs: &[LexerConfig], token_start: usize) -> LexerDfaKey {
 fn normalized_config_key(config: &LexerConfig, token_start: usize) -> LexerDfaConfigKey {
     LexerDfaConfigKey::new(
         config.state,
-        config.alt_rule_index,
+        config.alt_rule_index(),
         config.consumed_eof,
         config.passed_non_greedy,
         config.context,
         config
             .actions
+            .as_slice()
             .iter()
             .map(|action| {
                 debug_assert!(
@@ -2199,14 +2215,8 @@ fn cached_configs_to_configs(
 ) -> Vec<LexerConfig> {
     configs
         .iter()
-        .map(|config| LexerConfig {
-            state: config.state,
-            position,
-            consumed_eof: config.consumed_eof,
-            alt_rule_index: config.alt_rule_index,
-            passed_non_greedy: config.passed_non_greedy,
-            context: config.context,
-            actions: config
+        .map(|config| {
+            let traces = config
                 .actions
                 .iter()
                 .map(|action| LexerActionTrace {
@@ -2214,7 +2224,15 @@ fn cached_configs_to_configs(
                     position: token_start + action.position_delta,
                     rule_index: action.rule_index,
                 })
-                .collect(),
+                .collect::<Vec<_>>();
+            let mut restored = LexerConfig::new(config.state, position, config.context);
+            if let Some(rule_index) = config.alt_rule_index {
+                restored = restored.with_alt_rule_index(rule_index);
+            }
+            restored.consumed_eof = config.consumed_eof;
+            restored.passed_non_greedy = config.passed_non_greedy;
+            restored.actions = LexerActionTraceList::from_vec(traces);
+            restored
         })
         .collect()
 }
@@ -2223,8 +2241,8 @@ fn cached_configs_to_configs(
 /// once the config leaves a mode start state.
 pub(super) fn set_config_state(atn: &LexerAtn, config: &mut LexerConfig, state_number: usize) {
     config.state = state_number;
-    if config.alt_rule_index.is_none() {
-        config.alt_rule_index = atn.state(state_number).and_then(|state| state.rule_index);
+    if config.alt_rule_index().is_none() {
+        config.set_alt_rule_index(atn.state(state_number).and_then(|state| state.rule_index));
     }
 }
 
@@ -2280,6 +2298,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::mem::size_of;
     use std::sync::{Arc, Mutex};
 
     use super::*;
@@ -2290,6 +2309,7 @@ mod tests {
     use crate::atn::{LexerAtnState, LexerTransition};
     use crate::char_stream::InputStream;
     use crate::errors::{ErrorListener, SyntaxErrorEvent};
+    use crate::lexer::LexerDfaStats;
     use crate::recognizer::{Recognizer, RecognizerData};
     use crate::token::{DEFAULT_CHANNEL, HIDDEN_CHANNEL, TOKEN_EOF, Token, TokenStore, TokenView};
     use crate::vocabulary::Vocabulary;
@@ -2307,6 +2327,15 @@ mod tests {
             "T",
             Vocabulary::new([None, Some("T")], [None, Some("T")], [None::<&str>, None]),
         )
+    }
+
+    #[cfg(target_pointer_width = "64")]
+    #[test]
+    fn lexer_config_hot_path_layout_stays_compact() {
+        // Inline Vec action storage made both action-free layouts 64 bytes.
+        assert_eq!(size_of::<LexerConfig>(), 40);
+        assert_eq!(size_of::<LexerConfigKey>(), 32);
+        assert_eq!(size_of::<LexerActionTraceList>(), 8);
     }
 
     #[derive(Clone, Debug)]
@@ -2383,6 +2412,58 @@ mod tests {
         atn
     }
 
+    fn action_before_predicate_atn() -> LexerAtn {
+        let mut atn = LexerAtn::new(1);
+        for (state_number, kind, rule_index) in [
+            (0, AtnStateKind::TokenStart, None),
+            (1, AtnStateKind::RuleStart, Some(0)),
+            (2, AtnStateKind::Basic, Some(0)),
+            (3, AtnStateKind::Basic, Some(0)),
+            (4, AtnStateKind::RuleStop, Some(0)),
+        ] {
+            let mut state = LexerAtnState::new(state_number, kind);
+            if let Some(rule_index) = rule_index {
+                state = state.with_rule_index(rule_index);
+            }
+            atn.add_state(state);
+        }
+        atn.state_mut(0)
+            .expect("token start")
+            .add_transition(LexerTransition::Epsilon { target: 1 });
+        atn.state_mut(1)
+            .expect("rule start")
+            .add_transition(LexerTransition::Atom {
+                target: 2,
+                label: 'a' as i32,
+            });
+        atn.state_mut(2)
+            .expect("action source")
+            .add_transition(LexerTransition::Action {
+                target: 3,
+                rule_index: 0,
+                action_index: Some(0),
+                context_dependent: false,
+            });
+        atn.state_mut(3)
+            .expect("predicate source")
+            .add_transition(LexerTransition::Predicate {
+                target: 4,
+                rule_index: 0,
+                pred_index: 0,
+                context_dependent: false,
+            });
+        atn.set_rule_to_start_state(vec![1]);
+        atn.set_rule_to_stop_state(vec![4]);
+        atn.set_rule_to_token_type(vec![1]);
+        atn.add_mode_start_state(0);
+        atn.add_decision_state(0);
+        atn.set_lexer_actions(vec![LexerAction::Custom {
+            rule_index: 0,
+            action_index: 0,
+        }]);
+        atn
+    }
+
     fn tail_call_atn() -> LexerAtn {
         let mut atn = LexerAtn::new(1);
         for (state_number, kind, rule_index) in [
@@ -2421,15 +2502,7 @@ mod tests {
         let parent = contexts.singleton(EMPTY_LEXER_CONTEXT, 99);
         let before = contexts.len();
 
-        let config = LexerConfig {
-            state: 0,
-            position: 0,
-            consumed_eof: false,
-            alt_rule_index: Some(0),
-            passed_non_greedy: false,
-            context: parent,
-            actions: Vec::new(),
-        };
+        let config = LexerConfig::new(0, 0, parent).with_alt_rule_index(0);
         let _ = epsilon_closure(&atn, [config], &mut contexts, &mut workspace, &mut |_| true);
         assert_eq!(
             contexts.len(),
@@ -2437,15 +2510,7 @@ mod tests {
             "tail call with no empty lexer path must reuse its caller context"
         );
 
-        let local = LexerConfig {
-            state: 0,
-            position: 0,
-            consumed_eof: false,
-            alt_rule_index: Some(0),
-            passed_non_greedy: false,
-            context: EMPTY_LEXER_CONTEXT,
-            actions: Vec::new(),
-        };
+        let local = LexerConfig::new(0, 0, EMPTY_LEXER_CONTEXT).with_alt_rule_index(0);
         let _ = epsilon_closure(&atn, [local], &mut contexts, &mut workspace, &mut |_| true);
         assert!(
             contexts.len() > before,
@@ -3558,6 +3623,67 @@ mod tests {
     }
 
     #[test]
+    fn nested_shared_lexer_prediction_preserves_outer_action_payload() {
+        let atn: &'static LexerAtn = Box::leak(Box::new(action_before_predicate_atn()));
+        let data = || {
+            RecognizerData::new(
+                "T",
+                Vocabulary::new([None, Some("T")], [None, Some("T")], [None::<&str>, None]),
+            )
+        };
+        let mut outer = BaseLexer::new(InputStream::new("a"), data()).with_shared_dfa(atn);
+        let mut nested = BaseLexer::new(InputStream::new("xa"), data()).with_shared_dfa(atn);
+        let mut outer_store = TokenStore::new(outer.source_text(), outer.source_name());
+        let mut outer_sink = TokenSink::new(&mut outer_store);
+        let mut nested_store = TokenStore::new(nested.source_text(), nested.source_name());
+        let mut nested_sink = TokenSink::new(&mut nested_store);
+        let mut outer_action_positions = Vec::new();
+        let mut nested_action_positions = Vec::new();
+        let mut nested_ran = false;
+
+        let outer_id = next_token_with_cache(
+            &mut outer,
+            &mut outer_sink,
+            atn,
+            |_, action| outer_action_positions.push(action.position()),
+            |_, _| {
+                if !nested_ran {
+                    nested_ran = true;
+                    let nested_id = next_token_with_hooks(
+                        &mut nested,
+                        &mut nested_sink,
+                        atn,
+                        |_, action| nested_action_positions.push(action.position()),
+                        |_, _| true,
+                        |_, _, _| {},
+                    )
+                    .expect("nested token should fit");
+                    assert_eq!(
+                        nested_sink
+                            .view(nested_id)
+                            .expect("nested token should exist")
+                            .text(),
+                        Some("a")
+                    );
+                }
+                true
+            },
+            |_, _, _| {},
+        )
+        .expect("outer token should fit");
+
+        assert_eq!(
+            outer_sink
+                .view(outer_id)
+                .expect("outer token should exist")
+                .text(),
+            Some("a")
+        );
+        assert_eq!(nested_action_positions, [2]);
+        assert_eq!(outer_action_positions, [1]);
+    }
+
+    #[test]
     fn lexer_action_hook_context_can_change_mode() {
         // A custom-action hook receives a mutable lexer borrow, so it can push /
         // pop / set the lexer mode (matching the closure `custom_action` API). A
@@ -3782,6 +3908,7 @@ mod tests {
             let mut sink = TokenSink::new(&mut store);
             let mut token_count = 0;
             let mut contexts_after_warmup = 0;
+            let mut action_stats_after_warmup = LexerDfaStats::default();
             loop {
                 let token = match strategy {
                     TestMatchStrategy::Interpreted => next_token_with_hooks(
@@ -3805,6 +3932,7 @@ mod tests {
                     assert_eq!(token.channel(), HIDDEN_CHANNEL, "{strategy:?}");
                 } else if token_count == 3 {
                     contexts_after_warmup = lexer.lexer_dfa_cache_shape().3;
+                    action_stats_after_warmup = lexer.lexer_dfa_stats();
                 }
                 token_count += 1;
                 if token.token_type() == TOKEN_EOF {
@@ -3815,8 +3943,29 @@ mod tests {
 
             let (cached_states, cached_transitions, max_configs, contexts) =
                 lexer.lexer_dfa_cache_shape();
+            let stats = lexer.lexer_dfa_stats();
             assert!(max_configs <= 16, "{strategy:?}: {max_configs} configs");
             assert!(contexts <= 1024, "{strategy:?}: {contexts} contexts");
+            assert!(
+                stats.action_trace_sequences
+                    <= action_stats_after_warmup.action_trace_sequences + 16,
+                "{strategy:?}: action sequences grew from {} to {}",
+                action_stats_after_warmup.action_trace_sequences,
+                stats.action_trace_sequences,
+            );
+            assert!(
+                stats.action_traces <= action_stats_after_warmup.action_traces + 64,
+                "{strategy:?}: action traces grew from {} to {}",
+                action_stats_after_warmup.action_traces,
+                stats.action_traces,
+            );
+            assert!(
+                stats.action_trace_bytes
+                    <= action_stats_after_warmup.action_trace_bytes + 64 * 1024,
+                "{strategy:?}: retained action bytes grew from {} to {}",
+                action_stats_after_warmup.action_trace_bytes,
+                stats.action_trace_bytes,
+            );
             assert!(
                 contexts <= contexts_after_warmup + 16,
                 "{strategy:?}: contexts grew from {contexts_after_warmup} to {contexts}"

--- a/crates/antlr-rust-runtime/src/atn/lexer_dfa.rs
+++ b/crates/antlr-rust-runtime/src/atn/lexer_dfa.rs
@@ -1047,7 +1047,7 @@ impl ModeBuild {
             .map(|config| CompiledLexerConfig {
                 state: config.state,
                 consumed_eof: config.consumed_eof,
-                alt_rule_index: config.alt_rule_index,
+                alt_rule_index: config.alt_rule_index(),
                 passed_non_greedy: config.passed_non_greedy,
                 context: compile_context(
                     &self.contexts,
@@ -1057,6 +1057,7 @@ impl ModeBuild {
                 ),
                 actions: config
                     .actions
+                    .as_slice()
                     .iter()
                     .map(|action| CompiledLexerActionTrace {
                         action_index: action.action_index,
@@ -1084,12 +1085,13 @@ impl ModeBuild {
 fn relative_config_key(config: &LexerConfig, step: usize) -> LexerDfaConfigKey {
     LexerDfaConfigKey::new(
         config.state,
-        config.alt_rule_index,
+        config.alt_rule_index(),
         config.consumed_eof,
         config.passed_non_greedy,
         config.context,
         config
             .actions
+            .as_slice()
             .iter()
             .map(|action| LexerDfaActionKey {
                 action_index: action.action_index,
@@ -1140,15 +1142,7 @@ fn build_mode(
     let start_configs = closed_configs(
         atn,
         &mut build,
-        vec![LexerConfig {
-            state: start_state,
-            position: 0,
-            consumed_eof: false,
-            alt_rule_index: None,
-            passed_non_greedy: false,
-            context: EMPTY_LEXER_CONTEXT,
-            actions: Vec::new(),
-        }],
+        vec![LexerConfig::new(start_state, 0, EMPTY_LEXER_CONTEXT)],
     )?;
     let start_id = build.intern(atn, start_configs, 0);
     if start_id == ESCAPE_STATE {
@@ -1211,7 +1205,7 @@ fn closed_configs(
 /// DFA-state identity would mint a fresh state per input offset — rules that
 /// loop over comment/whitespace references would never determinize.
 fn prune_dead_action_traces(atn: &LexerAtn, config: &mut LexerConfig) {
-    let Some(accept_rule) = config.alt_rule_index else {
+    let Some(accept_rule) = config.alt_rule_index() else {
         return;
     };
     config
@@ -1986,15 +1980,7 @@ mod tests {
         for return_state in 0..MAX_CONTEXT_DEPTH {
             bounded = contexts.singleton(bounded, return_state);
         }
-        let config = |context| LexerConfig {
-            state: 0,
-            position: 0,
-            consumed_eof: false,
-            alt_rule_index: Some(0),
-            passed_non_greedy: false,
-            context,
-            actions: Vec::new(),
-        };
+        let config = |context| LexerConfig::new(0, 0, context).with_alt_rule_index(0);
 
         assert!(!has_recursive_context(&config(bounded), &contexts));
 
@@ -2016,15 +2002,7 @@ mod tests {
             context = contexts.merge(context, branch, &mut workspace);
         }
         let expected_contexts = contexts.len() - 1;
-        let config = LexerConfig {
-            state: 0,
-            position: 0,
-            consumed_eof: false,
-            alt_rule_index: Some(0),
-            passed_non_greedy: false,
-            context,
-            actions: Vec::new(),
-        };
+        let config = LexerConfig::new(0, 0, context).with_alt_rule_index(0);
 
         std::thread::Builder::new()
             .stack_size(64 * 1024)

--- a/crates/antlr-rust-runtime/src/atn/parser.rs
+++ b/crates/antlr-rust-runtime/src/atn/parser.rs
@@ -14,8 +14,9 @@ use crate::prediction::{
     AtnConfig, AtnConfigSet, ContextArena, ContextId, EMPTY_CONTEXT, EMPTY_RETURN_STATE,
     PredictionContextStats, PredictionFxHasher, PredictionPredicateCall,
     PredictionSemanticProvenanceArena, PredictionSemanticProvenanceId, PredictionWorkspace,
-    SemanticContext, SllConflict, all_subsets_conflict, all_subsets_equal, conflicting_alt_subsets,
-    exact_context_sll_conflict, has_sll_conflict_terminating_prediction, single_viable_alt,
+    SemanticContext, SemanticContextArena, SemanticContextId, SllConflict, all_subsets_conflict,
+    all_subsets_equal, conflicting_alt_subsets, exact_context_sll_conflict,
+    has_sll_conflict_terminating_prediction, single_viable_alt,
 };
 use crate::token::TOKEN_EOF;
 use std::cell::RefCell;
@@ -161,6 +162,7 @@ fn atn_has_predicate_transition(atn: &Atn) -> bool {
 #[derive(Debug, Default)]
 struct PredictionStore {
     contexts: ContextArena,
+    semantic_contexts: SemanticContextArena,
     decision_to_dfa: Vec<ParserDfa>,
 }
 
@@ -168,6 +170,7 @@ impl PredictionStore {
     fn new(atn: &Atn) -> Self {
         Self {
             contexts: ContextArena::new(),
+            semantic_contexts: SemanticContextArena::new(),
             decision_to_dfa: initial_decision_dfas(atn),
         }
     }
@@ -323,6 +326,7 @@ enum FullContextResolution {
 fn full_context_prediction(
     alt: usize,
     configs: &AtnConfigSet,
+    semantic_contexts: &SemanticContextArena,
     stop_index: usize,
     resolution: FullContextResolution,
 ) -> FullContextPrediction {
@@ -335,11 +339,14 @@ fn full_context_prediction(
         },
         stop_index,
         resolution,
-        semantic_candidates: semantic_prediction_candidates(configs),
+        semantic_candidates: semantic_prediction_candidates(configs, semantic_contexts),
     }
 }
 
-fn semantic_prediction_candidates(configs: &AtnConfigSet) -> Vec<CompactParserSemanticCandidate> {
+fn semantic_prediction_candidates(
+    configs: &AtnConfigSet,
+    semantic_contexts: &SemanticContextArena,
+) -> Vec<CompactParserSemanticCandidate> {
     if !configs.has_semantic_context() {
         return Vec::new();
     }
@@ -348,7 +355,7 @@ fn semantic_prediction_candidates(configs: &AtnConfigSet) -> Vec<CompactParserSe
         .iter()
         .map(|config| CompactParserSemanticCandidate {
             alt: config.alt,
-            context: config.semantic_context.clone(),
+            context: config.semantic_context(semantic_contexts).clone(),
             semantic_provenance: config.semantic_provenance_id(),
         })
         .collect::<Vec<_>>();
@@ -361,7 +368,7 @@ fn semantic_prediction_candidates(configs: &AtnConfigSet) -> Vec<CompactParserSe
 struct ClosureConfigKey {
     state: usize,
     alt: usize,
-    semantic_context: SemanticContext,
+    semantic_context: SemanticContextId,
     context_and_provenance: u64,
 }
 
@@ -370,7 +377,7 @@ impl From<&AtnConfig> for ClosureConfigKey {
         Self {
             state: config.state,
             alt: config.alt,
-            semantic_context: config.semantic_context.clone(),
+            semantic_context: config.semantic_context_id(),
             context_and_provenance: u64::from(config.context.compact())
                 | (u64::from(config.semantic_provenance_and_flags()) << 32),
         }
@@ -488,9 +495,17 @@ fn union_prediction_stores(
     mut local: PredictionStore,
     workspace: &mut PredictionWorkspace,
 ) {
-    let remap = shared.contexts.import_all(&local.contexts, workspace);
+    let context_remap = shared.contexts.import_all(&local.contexts, workspace);
+    let semantic_context_remap = shared
+        .semantic_contexts
+        .import_all(&local.semantic_contexts);
     for dfa in &mut local.decision_to_dfa {
-        dfa.remap_contexts(&remap, &shared.contexts);
+        dfa.remap_store_ids(
+            &context_remap,
+            &semantic_context_remap,
+            &shared.contexts,
+            &shared.semantic_contexts,
+        );
     }
     union_decision_dfas(&mut shared.decision_to_dfa, local.decision_to_dfa);
 }
@@ -887,6 +902,16 @@ impl<'a> ParserAtnSimulator<'a> {
         for dfa in &self.store.decision_to_dfa {
             stats.add_assign(dfa.stats());
         }
+        stats.semantic_contexts = self.store.semantic_contexts.len();
+        stats.semantic_context_bytes = self.store.semantic_contexts.retained_bytes();
+        if let Some(provenance) = self.semantic_provenance.as_deref() {
+            stats.semantic_provenance_records = provenance.len();
+            stats.semantic_provenance_bytes = provenance.retained_bytes();
+        }
+        stats.cold_bytes = stats
+            .cold_bytes
+            .saturating_add(stats.semantic_context_bytes)
+            .saturating_add(stats.semantic_provenance_bytes);
         stats
     }
 
@@ -1259,7 +1284,8 @@ impl<'a> ParserAtnSimulator<'a> {
                     .map(|dfa| dfa.configs(state_number).clone())
                     && let Some(alt) = self.alt_that_finished_decision_entry_rule(&configs)
                 {
-                    self.prediction_semantic_candidates = semantic_prediction_candidates(&configs);
+                    self.prediction_semantic_candidates =
+                        semantic_prediction_candidates(&configs, &self.store.semantic_contexts);
                     return Ok(ParserAtnPrediction {
                         alt,
                         requires_full_context: false,
@@ -1315,7 +1341,12 @@ impl<'a> ParserAtnSimulator<'a> {
             .store
             .decision_to_dfa
             .get(decision)
-            .map(|dfa| semantic_prediction_candidates(dfa.configs(state_number)))
+            .map(|dfa| {
+                semantic_prediction_candidates(
+                    dfa.configs(state_number),
+                    &self.store.semantic_contexts,
+                )
+            })
             .unwrap_or_default();
         self.prediction_semantic_candidates = semantic_candidates;
         // SLL-probe stage: the caller only needs to know that this conflict
@@ -1440,7 +1471,12 @@ impl<'a> ParserAtnSimulator<'a> {
             .store
             .decision_to_dfa
             .get(decision)
-            .map(|dfa| semantic_prediction_candidates(dfa.configs(state_number)))
+            .map(|dfa| {
+                semantic_prediction_candidates(
+                    dfa.configs(state_number),
+                    &self.store.semantic_contexts,
+                )
+            })
             .unwrap_or_default();
     }
 
@@ -1708,6 +1744,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 return Ok(full_context_prediction(
                     alt,
                     &configs,
+                    &self.store.semantic_contexts,
                     input.index(),
                     FullContextResolution::Unique,
                 ));
@@ -1725,6 +1762,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 return Ok(full_context_prediction(
                     alt,
                     &configs,
+                    &self.store.semantic_contexts,
                     input.index(),
                     FullContextResolution::Unique,
                 ));
@@ -1743,6 +1781,7 @@ impl<'a> ParserAtnSimulator<'a> {
                         return Ok(full_context_prediction(
                             alt,
                             &configs,
+                            &self.store.semantic_contexts,
                             input.index(),
                             FullContextResolution::Ambiguous { exact: true, alts },
                         ));
@@ -1752,6 +1791,7 @@ impl<'a> ParserAtnSimulator<'a> {
                     return Ok(full_context_prediction(
                         alt,
                         &configs,
+                        &self.store.semantic_contexts,
                         input.index(),
                         FullContextResolution::Ambiguous { exact: false, alts },
                     ));
@@ -1777,6 +1817,7 @@ impl<'a> ParserAtnSimulator<'a> {
                 return Ok(full_context_prediction(
                     alt,
                     &configs,
+                    &self.store.semantic_contexts,
                     input.index(),
                     resolution,
                 ));
@@ -2225,14 +2266,16 @@ impl<'a> ParserAtnSimulator<'a> {
         full_context: bool,
     ) -> Option<AtnConfig> {
         let semantic_context = match transition_kind {
-            ParserTransitionKind::Predicate if collect_predicates => SemanticContext::and(
-                config.semantic_context.clone(),
-                SemanticContext::Predicate {
-                    rule_index: transition.arg0() as usize,
-                    pred_index: transition.arg1() as usize,
-                    context_dependent: transition.arg2() != 0,
-                },
-            ),
+            ParserTransitionKind::Predicate if collect_predicates => {
+                self.store.semantic_contexts.and(
+                    config.semantic_context_id(),
+                    SemanticContext::Predicate {
+                        rule_index: transition.arg0() as usize,
+                        pred_index: transition.arg1() as usize,
+                        context_dependent: transition.arg2() != 0,
+                    },
+                )
+            }
             ParserTransitionKind::Precedence
                 if collect_predicates
                     && i32::from_le_bytes(transition.arg0().to_le_bytes()) < precedence =>
@@ -2240,14 +2283,14 @@ impl<'a> ParserAtnSimulator<'a> {
                 return None;
             }
             ParserTransitionKind::Precedence if collect_predicates && !full_context => {
-                SemanticContext::and(
-                    config.semantic_context.clone(),
+                self.store.semantic_contexts.and(
+                    config.semantic_context_id(),
                     SemanticContext::Precedence {
                         precedence: i32::from_le_bytes(transition.arg0().to_le_bytes()),
                     },
                 )
             }
-            _ => config.semantic_context.clone(),
+            _ => config.semantic_context_id(),
         };
         let context_has_empty_path = self.store.contexts.has_empty_path(config.context);
         let elide_tail_call = transition_kind == ParserTransitionKind::Rule
@@ -2267,7 +2310,7 @@ impl<'a> ParserAtnSimulator<'a> {
             config.context
         };
         let mut target = config.moved_to(transition.target(), context, &self.store.contexts);
-        target.semantic_context = semantic_context;
+        target.set_semantic_context(semantic_context, &self.store.semantic_contexts);
         if self.track_prediction_rule_calls {
             match transition_kind {
                 ParserTransitionKind::Rule => {
@@ -2421,7 +2464,7 @@ fn configs_have_semantic_context_for_alt(configs: &AtnConfigSet, alt: usize) -> 
     configs
         .configs()
         .iter()
-        .any(|config| config.alt == alt && !config.semantic_context.is_none())
+        .any(|config| config.alt == alt && config.has_semantic_context())
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2704,6 +2747,35 @@ mod tests {
     }
 
     #[test]
+    fn parser_dfa_stats_account_for_optional_config_payload_arenas() {
+        let atn = two_token_decision_atn();
+        let mut simulator = ParserAtnSimulator::new(&atn);
+        simulator
+            .store
+            .semantic_contexts
+            .intern(SemanticContext::Predicate {
+                rule_index: 1,
+                pred_index: 2,
+                context_dependent: false,
+            });
+        let mut provenance = PredictionSemanticProvenanceArena::default();
+        provenance.enter_rule(PredictionSemanticProvenanceId::default(), 3, 4);
+        simulator.semantic_provenance = Some(Box::new(provenance));
+
+        let stats = simulator.parser_dfa_stats();
+        assert_eq!(stats.semantic_contexts, 2);
+        assert_eq!(stats.semantic_provenance_records, 1);
+        assert!(stats.semantic_context_bytes > 0);
+        assert!(stats.semantic_provenance_bytes > 0);
+        assert!(
+            stats.cold_bytes
+                >= stats
+                    .semantic_context_bytes
+                    .saturating_add(stats.semantic_provenance_bytes)
+        );
+    }
+
+    #[test]
     fn union_decision_dfa_preserves_disjoint_coverage() {
         fn configs(
             atn_state: usize,
@@ -2759,7 +2831,7 @@ mod tests {
     }
 
     #[test]
-    fn union_prediction_stores_remaps_context_ids_before_dfa_union() {
+    fn union_prediction_stores_remaps_config_store_ids_before_dfa_union() {
         let atn = two_token_decision_atn();
         let mut shared = PredictionStore::new(&atn);
         let mut local = PredictionStore::new(&atn);
@@ -2768,13 +2840,23 @@ mod tests {
         let distracting = shared.contexts.singleton(EMPTY_CONTEXT, 99);
         let local_context = local.contexts.singleton(EMPTY_CONTEXT, 7);
         assert_eq!(distracting, local_context, "both stores allocate ID 1");
+        let distracting_semantic = shared
+            .semantic_contexts
+            .intern(SemanticContext::Precedence { precedence: 99 });
+        let local_semantic = local.semantic_contexts.intern(SemanticContext::Predicate {
+            rule_index: 2,
+            pred_index: 3,
+            context_dependent: true,
+        });
+        assert_eq!(
+            distracting_semantic, local_semantic,
+            "both semantic stores allocate ID 1"
+        );
 
         let mut configs = AtnConfigSet::new();
-        configs.add(
-            AtnConfig::new(42, 1, local_context, &local.contexts),
-            &mut local.contexts,
-            &mut workspace,
-        );
+        let mut config = AtnConfig::new(42, 1, local_context, &local.contexts);
+        config.set_semantic_context(local_semantic, &local.semantic_contexts);
+        configs.add(config, &mut local.contexts, &mut workspace);
         local.decision_to_dfa[0].add_state(DfaStateBuilder::new(configs));
 
         union_prediction_stores(&mut shared, local, &mut workspace);
@@ -2786,6 +2868,14 @@ mod tests {
             .expect("local DFA config imported");
         assert_ne!(imported.context, local_context);
         assert_eq!(shared.contexts.return_state(imported.context, 0), Some(7));
+        assert_eq!(
+            imported.semantic_context(&shared.semantic_contexts),
+            &SemanticContext::Predicate {
+                rule_index: 2,
+                pred_index: 3,
+                context_dependent: true,
+            }
+        );
         imported.assert_store(&shared.contexts);
     }
 
@@ -3662,6 +3752,7 @@ mod tests {
                     pred_index: 0,
                     context_dependent: false,
                 },
+                &mut simulator.store.semantic_contexts,
             ),
             &mut simulator.store.contexts,
             &mut workspace,
@@ -3827,19 +3918,27 @@ mod tests {
             .epsilon_target_config(&config, transition, transition.kind(), 1, true, false)
             .expect("sll start transition");
         assert!(matches!(
-            sll_start.semantic_context,
+            sll_start.semantic_context(&simulator.store.semantic_contexts),
             SemanticContext::Precedence { precedence: 2 }
         ));
 
         let full_context_start = simulator
             .epsilon_target_config(&config, transition, transition.kind(), 1, true, true)
             .expect("full-context start transition");
-        assert!(full_context_start.semantic_context.is_none());
+        assert!(
+            full_context_start
+                .semantic_context(&simulator.store.semantic_contexts)
+                .is_none()
+        );
 
         let reach = simulator
             .epsilon_target_config(&config, transition, transition.kind(), 3, false, false)
             .expect("reach transition");
-        assert!(reach.semantic_context.is_none());
+        assert!(
+            reach
+                .semantic_context(&simulator.store.semantic_contexts)
+                .is_none()
+        );
 
         assert!(
             simulator
@@ -3920,7 +4019,9 @@ mod tests {
             .find(|config| config.state == 2)
             .expect("config at state 2");
         assert!(
-            at_two.semantic_context.is_none(),
+            at_two
+                .semantic_context(&simulator.store.semantic_contexts)
+                .is_none(),
             "predicate after an action edge must not be collected during prediction"
         );
 
@@ -3945,7 +4046,7 @@ mod tests {
             )
             .expect("predicate transition");
         assert!(matches!(
-            direct.semantic_context,
+            direct.semantic_context(&simulator.store.semantic_contexts),
             SemanticContext::Predicate { pred_index: 0, .. }
         ));
     }
@@ -3990,6 +4091,7 @@ mod tests {
     #[test]
     fn semantic_context_flag_is_scoped_to_predicted_alt() {
         let mut arena = ContextArena::new();
+        let mut semantic_contexts = SemanticContextArena::new();
         let mut workspace = PredictionWorkspace::default();
         let mut configs = AtnConfigSet::new();
         configs.add(
@@ -4004,6 +4106,7 @@ mod tests {
                     pred_index: 0,
                     context_dependent: false,
                 },
+                &mut semantic_contexts,
             ),
             &mut arena,
             &mut workspace,

--- a/crates/antlr-rust-runtime/src/dfa.rs
+++ b/crates/antlr-rust-runtime/src/dfa.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 // Copyright (c) 2026 Konstantin Vyatkin
-use crate::prediction::{AtnConfigSet, ContextArena, ContextId, PredictionFxHasher};
+use crate::prediction::{
+    AtnConfigSet, ContextArena, ContextId, PredictionFxHasher, SemanticContextArena,
+    SemanticContextId,
+};
 use std::collections::HashMap;
 use std::hash::BuildHasherDefault;
 use std::mem::size_of;
@@ -77,6 +80,15 @@ pub struct ParserDfaStats {
     pub edge_density_histogram: [usize; 6],
     pub hot_bytes: usize,
     pub cold_bytes: usize,
+    /// Store-wide semantic-context records. Populated by
+    /// `ParserAtnSimulator::parser_dfa_stats`; zero for one standalone DFA.
+    pub semantic_contexts: usize,
+    /// Retained element storage for the store-wide semantic-context arena.
+    pub semantic_context_bytes: usize,
+    /// Store-wide semantic-provenance records used by parameterized predicates.
+    pub semantic_provenance_records: usize,
+    /// Retained element storage for the optional semantic-provenance arena.
+    pub semantic_provenance_bytes: usize,
     pub states_created: usize,
     pub states_deduplicated: usize,
     pub fingerprint_candidates: usize,
@@ -116,6 +128,18 @@ impl ParserDfaStats {
         }
         self.hot_bytes = self.hot_bytes.saturating_add(other.hot_bytes);
         self.cold_bytes = self.cold_bytes.saturating_add(other.cold_bytes);
+        self.semantic_contexts = self
+            .semantic_contexts
+            .saturating_add(other.semantic_contexts);
+        self.semantic_context_bytes = self
+            .semantic_context_bytes
+            .saturating_add(other.semantic_context_bytes);
+        self.semantic_provenance_records = self
+            .semantic_provenance_records
+            .saturating_add(other.semantic_provenance_records);
+        self.semantic_provenance_bytes = self
+            .semantic_provenance_bytes
+            .saturating_add(other.semantic_provenance_bytes);
         self.states_created = self.states_created.saturating_add(other.states_created);
         self.states_deduplicated = self
             .states_deduplicated
@@ -285,6 +309,10 @@ impl ParserDfa {
                 + self.interner.retained_bytes()
                 + self.precedence_start_states.capacity() * size_of::<DfaStateId>(),
             cold_bytes: self.cold.retained_bytes(),
+            semantic_contexts: 0,
+            semantic_context_bytes: 0,
+            semantic_provenance_records: 0,
+            semantic_provenance_bytes: 0,
             states_created: self.learning.states_created,
             states_deduplicated: self.learning.states_deduplicated,
             fingerprint_candidates: self.learning.fingerprint_candidates,
@@ -411,9 +439,20 @@ impl ParserDfa {
         }
     }
 
-    pub(crate) fn remap_contexts(&mut self, remap: &[ContextId], arena: &ContextArena) {
+    pub(crate) fn remap_store_ids(
+        &mut self,
+        context_remap: &[ContextId],
+        semantic_context_remap: &[SemanticContextId],
+        contexts: &ContextArena,
+        semantic_contexts: &SemanticContextArena,
+    ) {
         for configs in &mut self.cold.configs {
-            configs.remap_contexts(remap, arena);
+            configs.remap_store_ids(
+                context_remap,
+                semantic_context_remap,
+                contexts,
+                semantic_contexts,
+            );
         }
         self.interner.rebuild(&self.cold.configs);
     }

--- a/crates/antlr-rust-runtime/src/generated.rs
+++ b/crates/antlr-rust-runtime/src/generated.rs
@@ -849,6 +849,12 @@ macro_rules! __antlr4_rust_lexer_facade {
             pub fn clear_dfa(&self) {
                 self.$base.clear_dfa();
             }
+
+            /// Returns learned lexer-DFA shape and optional action-payload storage.
+            #[must_use]
+            pub fn lexer_dfa_stats(&self) -> $crate::lexer::LexerDfaStats {
+                self.$base.lexer_dfa_stats()
+            }
         }
 
         impl<$input, $hooks> $crate::generated::GeneratedLexer for $lexer<$input, $hooks>

--- a/crates/antlr-rust-runtime/src/lexer.rs
+++ b/crates/antlr-rust-runtime/src/lexer.rs
@@ -3,8 +3,10 @@
 use std::cell::{RefCell, RefMut};
 use std::collections::{BTreeSet, HashMap, VecDeque};
 use std::hash::BuildHasherDefault;
+use std::mem::size_of;
 use std::ops::Range;
 use std::rc::Rc;
+use std::sync::Arc;
 
 use crate::atn::LexerAtn;
 use crate::char_stream::{CharStream, TextInterval};
@@ -894,12 +896,77 @@ struct LexerDfaCache {
     mode_starts: FxHashMap<i32, usize>,
 }
 
+/// Storage measurements for one learned lexer DFA cache.
+#[non_exhaustive]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct LexerDfaStats {
+    pub states: usize,
+    pub cached_states: usize,
+    pub transitions: usize,
+    pub max_configs_per_state: usize,
+    pub contexts: usize,
+    pub action_trace_sequences: usize,
+    pub action_traces: usize,
+    /// Retained element storage for action payloads in learned cache entries.
+    pub action_trace_bytes: usize,
+}
+
 /// Canonical caller contexts paired with the learned lexer DFA that stores
 /// their IDs.
 #[derive(Debug, Default)]
 pub(crate) struct LexerPredictionStore {
     pub(crate) contexts: LexerContextArena,
     pub(crate) workspace: PredictionWorkspace,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct LexerActionTrace {
+    pub(crate) action_index: usize,
+    pub(crate) position: usize,
+    /// Owning lexer rule, used to suppress actions from nested token-rule calls.
+    pub(crate) rule_index: usize,
+}
+
+/// Thin clone-on-write handle; `Arc<[T]>` would widen every action-free config
+/// and cannot append in place when the payload is uniquely owned.
+#[allow(clippy::rc_buffer)]
+#[derive(Clone, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct LexerActionTraceList(Option<Arc<Vec<LexerActionTrace>>>);
+
+impl LexerActionTraceList {
+    pub(crate) fn from_vec(traces: Vec<LexerActionTrace>) -> Self {
+        if traces.is_empty() {
+            Self::default()
+        } else {
+            Self(Some(Arc::new(traces)))
+        }
+    }
+
+    pub(crate) fn as_slice(&self) -> &[LexerActionTrace] {
+        self.0.as_deref().map_or(&[], Vec::as_slice)
+    }
+
+    pub(crate) fn to_vec(&self) -> Vec<LexerActionTrace> {
+        self.as_slice().to_vec()
+    }
+
+    pub(crate) fn make_mut(&mut self) -> &mut Vec<LexerActionTrace> {
+        Arc::make_mut(self.0.get_or_insert_with(|| Arc::new(Vec::new())))
+    }
+
+    pub(crate) fn retain(&mut self, mut keep: impl FnMut(&LexerActionTrace) -> bool) {
+        let Some(traces) = self.0.as_mut() else {
+            return;
+        };
+        Arc::make_mut(traces).retain(|trace| keep(trace));
+        if traces.is_empty() {
+            self.0 = None;
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.as_slice().len()
+    }
 }
 
 /// Store-local identity for one ordered lexer caller-context node.
@@ -1006,7 +1073,6 @@ impl LexerContextArena {
         self.path_sets.has_empty_path(self.record(context).path_set)
     }
 
-    #[cfg(test)]
     pub(crate) const fn len(&self) -> usize {
         self.records.len()
     }
@@ -1827,11 +1893,11 @@ where
         self.dfa_cache.borrow_mut().prediction.workspace.reset();
     }
 
-    #[cfg(test)]
-    pub(crate) fn lexer_dfa_cache_shape(&self) -> (usize, usize, usize, usize) {
+    /// Returns learned lexer-DFA shape and optional action-payload storage.
+    pub fn lexer_dfa_stats(&self) -> LexerDfaStats {
         let cache = self.dfa_cache.borrow();
         let cached_states = cache.cached_states.iter().flatten().count();
-        let cached_transitions = cache
+        let transitions = cache
             .dense_edges
             .iter()
             .flatten()
@@ -1842,15 +1908,58 @@ where
             })
             .sum::<usize>()
             + cache.sparse_edges.len();
-        let max_configs = cache
+        let max_configs_per_state = cache
             .cached_states
             .iter()
             .flatten()
             .map(|state| state.configs.len())
             .max()
             .unwrap_or(0);
-        let contexts = cache.prediction.contexts.len();
-        (cached_states, cached_transitions, max_configs, contexts)
+        let mut action_trace_sequences = 0;
+        let mut action_traces = 0;
+        let mut action_trace_bytes = 0;
+        let mut account_actions = |actions: &Vec<LexerDfaActionKey>| {
+            if actions.is_empty() {
+                return;
+            }
+            action_trace_sequences += 1;
+            action_traces += actions.len();
+            action_trace_bytes += actions.capacity() * size_of::<LexerDfaActionKey>();
+        };
+        for key in cache.state_numbers.keys() {
+            for config in &key.configs {
+                account_actions(&config.actions);
+            }
+        }
+        for state in cache.cached_states.iter().flatten() {
+            for config in &state.configs {
+                account_actions(&config.actions);
+            }
+            if let Some(accept) = state.accept.as_ref() {
+                account_actions(&accept.actions);
+            }
+        }
+        LexerDfaStats {
+            states: cache.state_numbers.len(),
+            cached_states,
+            transitions,
+            max_configs_per_state,
+            contexts: cache.prediction.contexts.len(),
+            action_trace_sequences,
+            action_traces,
+            action_trace_bytes,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn lexer_dfa_cache_shape(&self) -> (usize, usize, usize, usize) {
+        let stats = self.lexer_dfa_stats();
+        (
+            stats.cached_states,
+            stats.transitions,
+            stats.max_configs_per_state,
+            stats.contexts,
+        )
     }
 
     /// Returns the stable state number for a normalized lexer DFA config set,
@@ -1991,6 +2100,51 @@ mod tests {
     use crate::recognizer::RecognizerData;
     use crate::token::{DEFAULT_CHANNEL, Token, TokenStore};
     use crate::vocabulary::Vocabulary;
+
+    #[test]
+    fn action_trace_lists_clone_on_write_without_aliasing() {
+        let first = LexerActionTrace {
+            action_index: 1,
+            position: 2,
+            rule_index: 3,
+        };
+        let second = LexerActionTrace {
+            action_index: 4,
+            position: 5,
+            rule_index: 6,
+        };
+        let mut original = LexerActionTraceList::default();
+        original.make_mut().push(first);
+        let mut fork = original.clone();
+        fork.make_mut().push(second);
+
+        assert_eq!(original.as_slice(), [first]);
+        assert_eq!(fork.as_slice(), [first, second]);
+        fork.retain(|_| false);
+        assert!(fork.as_slice().is_empty());
+
+        fn assert_send<T: Send>() {}
+        assert_send::<LexerActionTraceList>();
+    }
+
+    #[test]
+    fn action_trace_lists_do_not_retain_growing_prefixes() {
+        let mut actions = LexerActionTraceList::default();
+        for position in 0..1024 {
+            let source = actions.clone();
+            actions.make_mut().push(LexerActionTrace {
+                action_index: 0,
+                position,
+                rule_index: 0,
+            });
+            drop(source);
+            assert_eq!(
+                Arc::strong_count(actions.0.as_ref().expect("non-empty action list")),
+                1
+            );
+        }
+        assert_eq!(actions.len(), 1024);
+    }
 
     #[derive(Clone, Debug)]
     struct UnsharedInput {

--- a/crates/antlr-rust-runtime/src/lib.rs
+++ b/crates/antlr-rust-runtime/src/lib.rs
@@ -58,8 +58,9 @@ pub use errors::{AntlrError, ConsoleErrorListener, ErrorListener, SyntaxErrorEve
 pub use generated::{GeneratedLexer, GeneratedParseOutput, GeneratedParser, GrammarMetadata};
 pub use int_stream::{EOF, IntStream, UNKNOWN_SOURCE_NAME};
 pub use lexer::{
-    BaseLexer, Lexer, LexerCustomAction, LexerLifecycleCtx, LexerMode, LexerPredicate, LexerSemCtx,
-    LexerSemIrCtx, LexerSemanticAction, LexerSemanticPredicate, LexerSemantics,
+    BaseLexer, Lexer, LexerCustomAction, LexerDfaStats, LexerLifecycleCtx, LexerMode,
+    LexerPredicate, LexerSemCtx, LexerSemIrCtx, LexerSemanticAction, LexerSemanticPredicate,
+    LexerSemantics,
 };
 pub use parser::{
     BailErrorStrategy, BaseParser, EnterRuleEvent, ExpectedTokenSet, NoSemanticHooks,

--- a/crates/antlr-rust-runtime/src/prediction.rs
+++ b/crates/antlr-rust-runtime/src/prediction.rs
@@ -824,6 +824,136 @@ impl SemanticContext {
     }
 }
 
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub(crate) struct SemanticContextId(u32);
+
+#[derive(Debug)]
+pub(crate) struct SemanticContextArena {
+    records: Vec<SemanticContext>,
+    interner_heads: FxHashMap<u64, SemanticContextId>,
+    interner_next: Vec<Option<SemanticContextId>>,
+}
+
+impl SemanticContextArena {
+    pub(crate) fn new() -> Self {
+        let semantic_context = SemanticContext::None;
+        let cached_hash = semantic_context_hash(&semantic_context);
+        let mut interner_heads = FxHashMap::default();
+        interner_heads.insert(cached_hash, SemanticContextId::default());
+        Self {
+            records: vec![semantic_context],
+            interner_heads,
+            interner_next: vec![None],
+        }
+    }
+
+    pub(crate) fn intern(&mut self, semantic_context: SemanticContext) -> SemanticContextId {
+        if semantic_context.is_none() {
+            return SemanticContextId::default();
+        }
+        let cached_hash = semantic_context_hash(&semantic_context);
+        if let Some(id) = self.find_interned(cached_hash, &semantic_context) {
+            return id;
+        }
+        let id = SemanticContextId(
+            u32::try_from(self.records.len()).expect("semantic-context arena exhausted"),
+        );
+        let previous = self.interner_heads.insert(cached_hash, id);
+        self.records.push(semantic_context);
+        self.interner_next.push(previous);
+        id
+    }
+
+    pub(crate) fn and(
+        &mut self,
+        left: SemanticContextId,
+        right: SemanticContext,
+    ) -> SemanticContextId {
+        let combined = SemanticContext::and(self.get(left).clone(), right);
+        self.intern(combined)
+    }
+
+    pub(crate) fn get(&self, id: SemanticContextId) -> &SemanticContext {
+        self.assert_valid(id);
+        &self.records[usize::try_from(id.0).expect("u32 semantic-context ID fits usize")]
+    }
+
+    pub(crate) fn import_all(&mut self, source: &Self) -> Vec<SemanticContextId> {
+        source
+            .records
+            .iter()
+            .cloned()
+            .map(|semantic_context| self.intern(semantic_context))
+            .collect()
+    }
+
+    pub(crate) const fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.records.capacity() * size_of::<SemanticContext>()
+            + self
+                .records
+                .iter()
+                .map(semantic_context_heap_retained_bytes)
+                .sum::<usize>()
+            + self.interner_heads.capacity() * size_of::<(u64, SemanticContextId)>()
+            + self.interner_next.capacity() * size_of::<Option<SemanticContextId>>()
+    }
+
+    fn find_interned(
+        &self,
+        cached_hash: u64,
+        semantic_context: &SemanticContext,
+    ) -> Option<SemanticContextId> {
+        let mut candidate = self.interner_heads.get(&cached_hash).copied();
+        while let Some(id) = candidate {
+            let index = usize::try_from(id.0).ok()?;
+            if self.records.get(index) == Some(semantic_context) {
+                return Some(id);
+            }
+            candidate = self.interner_next.get(index).copied().flatten();
+        }
+        None
+    }
+
+    fn assert_valid(&self, id: SemanticContextId) {
+        assert!(
+            usize::try_from(id.0).is_ok_and(|index| index < self.records.len()),
+            "semantic-context ID does not belong to this store"
+        );
+    }
+}
+
+impl Default for SemanticContextArena {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn semantic_context_hash(semantic_context: &SemanticContext) -> u64 {
+    let mut hasher = PredictionFxHasher::default();
+    semantic_context.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn semantic_context_heap_retained_bytes(semantic_context: &SemanticContext) -> usize {
+    match semantic_context {
+        SemanticContext::And(children) | SemanticContext::Or(children) => {
+            children.capacity() * size_of::<SemanticContext>()
+                + children
+                    .iter()
+                    .map(semantic_context_heap_retained_bytes)
+                    .sum::<usize>()
+        }
+        SemanticContext::None
+        | SemanticContext::Predicate { .. }
+        | SemanticContext::Precedence { .. } => 0,
+    }
+}
+
 fn combine_semantic_context(
     left: SemanticContext,
     right: SemanticContext,
@@ -938,6 +1068,32 @@ impl PredictionSemanticProvenanceArena {
             .map_or(&[], |provenance| provenance.predicate_calls.as_slice())
     }
 
+    pub(crate) const fn len(&self) -> usize {
+        self.records.len()
+    }
+
+    pub(crate) fn retained_bytes(&self) -> usize {
+        self.records.capacity() * size_of::<PredictionSemanticProvenance>()
+            + self
+                .records
+                .iter()
+                .map(|provenance| {
+                    provenance.active_rule_calls.capacity() * size_of::<PredictionRuleCall>()
+                        + provenance.predicate_calls.capacity()
+                            * size_of::<PredictionPredicateCall>()
+                        + provenance
+                            .predicate_calls
+                            .iter()
+                            .map(|call| {
+                                call.rule_calls.capacity() * size_of::<PredictionRuleCall>()
+                            })
+                            .sum::<usize>()
+                })
+                .sum::<usize>()
+            + self.interner_heads.capacity() * size_of::<(u64, PredictionSemanticProvenanceId)>()
+            + self.interner_next.capacity() * size_of::<Option<PredictionSemanticProvenanceId>>()
+    }
+
     fn get(&self, id: PredictionSemanticProvenanceId) -> Option<&PredictionSemanticProvenance> {
         let index = id.0.checked_sub(1)?;
         self.records.get(usize::try_from(index).ok()?)
@@ -995,7 +1151,7 @@ pub(crate) struct AtnConfig {
     pub(crate) state: usize,
     pub(crate) alt: usize,
     pub(crate) context: ContextId,
-    pub(crate) semantic_context: SemanticContext,
+    semantic_context: SemanticContextId,
     pub(crate) reaches_into_outer_context: usize,
     semantic_provenance_and_flags: u32,
     #[cfg(debug_assertions)]
@@ -1009,7 +1165,7 @@ impl AtnConfig {
             state,
             alt,
             context,
-            semantic_context: SemanticContext::None,
+            semantic_context: SemanticContextId::default(),
             reaches_into_outer_context: 0,
             semantic_provenance_and_flags: 0,
             #[cfg(debug_assertions)]
@@ -1019,9 +1175,37 @@ impl AtnConfig {
 
     #[must_use]
     #[cfg(test)]
-    pub(crate) fn with_semantic_context(mut self, semantic_context: SemanticContext) -> Self {
-        self.semantic_context = semantic_context;
+    pub(crate) fn with_semantic_context(
+        mut self,
+        semantic_context: SemanticContext,
+        arena: &mut SemanticContextArena,
+    ) -> Self {
+        self.semantic_context = arena.intern(semantic_context);
         self
+    }
+
+    pub(crate) const fn semantic_context_id(&self) -> SemanticContextId {
+        self.semantic_context
+    }
+
+    pub(crate) fn semantic_context<'a>(
+        &self,
+        arena: &'a SemanticContextArena,
+    ) -> &'a SemanticContext {
+        arena.get(self.semantic_context)
+    }
+
+    pub(crate) const fn has_semantic_context(&self) -> bool {
+        self.semantic_context.0 != 0
+    }
+
+    pub(crate) fn set_semantic_context(
+        &mut self,
+        semantic_context: SemanticContextId,
+        arena: &SemanticContextArena,
+    ) {
+        arena.assert_valid(semantic_context);
+        self.semantic_context = semantic_context;
     }
 
     pub(crate) fn set_context(&mut self, context: ContextId, arena: &ContextArena) {
@@ -1035,7 +1219,7 @@ impl AtnConfig {
 
     pub(crate) fn moved_to(&self, state: usize, context: ContextId, arena: &ContextArena) -> Self {
         let mut moved = Self::new(state, self.alt, context, arena);
-        moved.semantic_context = self.semantic_context.clone();
+        moved.semantic_context = self.semantic_context;
         moved.reaches_into_outer_context = self.reaches_into_outer_context;
         moved.semantic_provenance_and_flags = self.semantic_provenance_and_flags;
         moved
@@ -1148,7 +1332,7 @@ impl AtnConfigSet {
         config.assert_store(arena);
         #[cfg(feature = "perf-counters")]
         crate::perf::record_config_add_call();
-        if !config.semantic_context.is_none() {
+        if config.has_semantic_context() {
             self.has_semantic_context = true;
         }
         if config.reaches_into_outer_context > 0 {
@@ -1243,14 +1427,28 @@ impl AtnConfigSet {
         self.conflicting_alts.clone()
     }
 
-    pub(crate) fn remap_contexts(&mut self, remap: &[ContextId], arena: &ContextArena) {
+    pub(crate) fn remap_store_ids(
+        &mut self,
+        context_remap: &[ContextId],
+        semantic_context_remap: &[SemanticContextId],
+        contexts: &ContextArena,
+        semantic_contexts: &SemanticContextArena,
+    ) {
         for config in &mut self.configs {
             let index = usize::try_from(config.context.0).expect("u32 context ID fits usize");
             config.set_context(
-                *remap
+                *context_remap
                     .get(index)
                     .expect("every imported context ID has a remap"),
-                arena,
+                contexts,
+            );
+            let semantic_index = usize::try_from(config.semantic_context_id().0)
+                .expect("u32 semantic-context ID fits usize");
+            config.set_semantic_context(
+                *semantic_context_remap
+                    .get(semantic_index)
+                    .expect("every imported semantic-context ID has a remap"),
+                semantic_contexts,
             );
         }
         self.config_index.clear();
@@ -1310,7 +1508,7 @@ impl PartialOrd for AtnConfigSet {
 struct AtnConfigKey {
     state: usize,
     alt: usize,
-    semantic_context: SemanticContext,
+    semantic_context: SemanticContextId,
     semantic_provenance: PredictionSemanticProvenanceId,
 }
 
@@ -1319,7 +1517,7 @@ impl From<&AtnConfig> for AtnConfigKey {
         Self {
             state: config.state,
             alt: config.alt,
-            semantic_context: config.semantic_context.clone(),
+            semantic_context: config.semantic_context_id(),
             semantic_provenance: config.semantic_provenance_id(),
         }
     }
@@ -1596,6 +1794,46 @@ mod tests {
     }
 
     #[test]
+    fn semantic_context_arena_interns_imports_and_accounts_for_payloads() {
+        let predicate = SemanticContext::Predicate {
+            rule_index: 2,
+            pred_index: 3,
+            context_dependent: true,
+        };
+        let mut source = SemanticContextArena::new();
+        let predicate_id = source.intern(predicate.clone());
+        assert_eq!(source.intern(predicate), predicate_id);
+
+        let combined_id = source.and(predicate_id, SemanticContext::Precedence { precedence: 4 });
+        assert_ne!(combined_id, predicate_id);
+        assert_eq!(source.len(), 3);
+        assert!(source.retained_bytes() >= source.len() * size_of::<SemanticContext>());
+
+        let mut destination = SemanticContextArena::new();
+        let distracting_id = destination.intern(SemanticContext::Precedence { precedence: 99 });
+        assert_eq!(distracting_id, predicate_id, "both arenas allocate ID 1");
+        let remap = destination.import_all(&source);
+        let imported = remap[usize::try_from(combined_id.0).expect("semantic ID fits usize")];
+        assert_eq!(destination.get(imported), source.get(combined_id));
+        assert_ne!(imported, combined_id);
+    }
+
+    #[test]
+    fn semantic_context_arena_verifies_hash_collisions() {
+        let mut arena = SemanticContextArena::new();
+        let first = SemanticContext::Precedence { precedence: 1 };
+        let first_id = arena.intern(first);
+        let second = SemanticContext::Precedence { precedence: 2 };
+        arena
+            .interner_heads
+            .insert(semantic_context_hash(&second), first_id);
+
+        let second_id = arena.intern(second.clone());
+        assert_ne!(second_id, first_id);
+        assert_eq!(arena.intern(second), second_id);
+    }
+
+    #[test]
     fn config_set_merges_context_ids() {
         let mut arena = ContextArena::new();
         let mut workspace = PredictionWorkspace::default();
@@ -1648,6 +1886,7 @@ mod tests {
     #[test]
     fn exact_context_conflict_joins_semantically_distinct_configs() {
         let mut arena = ContextArena::new();
+        let mut semantic_contexts = SemanticContextArena::new();
         let mut workspace = PredictionWorkspace::default();
         let first = arena.singleton(EMPTY_CONTEXT, 10);
         let second = arena.singleton(EMPTY_CONTEXT, 20);
@@ -1659,12 +1898,14 @@ mod tests {
         };
         let mut configs = AtnConfigSet::new();
         configs.add(
-            AtnConfig::new(7, 1, first, &arena).with_semantic_context(predicate(0)),
+            AtnConfig::new(7, 1, first, &arena)
+                .with_semantic_context(predicate(0), &mut semantic_contexts),
             &mut arena,
             &mut workspace,
         );
         configs.add(
-            AtnConfig::new(7, 1, second, &arena).with_semantic_context(predicate(1)),
+            AtnConfig::new(7, 1, second, &arena)
+                .with_semantic_context(predicate(1), &mut semantic_contexts),
             &mut arena,
             &mut workspace,
         );
@@ -1825,6 +2066,7 @@ mod tests {
     #[test]
     fn config_set_keeps_distinct_prediction_provenance() {
         let mut arena = ContextArena::new();
+        let semantic_contexts = SemanticContextArena::new();
         let mut provenance = PredictionSemanticProvenanceArena::default();
         let mut workspace = PredictionWorkspace::default();
         let mut first = AtnConfig::new(1, 1, EMPTY_CONTEXT, &arena);
@@ -1839,20 +2081,27 @@ mod tests {
         assert_eq!(set.len(), 2);
         assert_eq!(set.config_index.len(), set.len());
 
-        set.remap_contexts(&[EMPTY_CONTEXT], &arena);
+        set.remap_store_ids(
+            &[EMPTY_CONTEXT],
+            &[SemanticContextId::default()],
+            &arena,
+            &semantic_contexts,
+        );
         assert_eq!(set.config_index.len(), set.len());
     }
 
     #[cfg(target_pointer_width = "64")]
     #[test]
     fn parser_config_hot_path_layout_stays_compact() {
+        // Inline SemanticContext storage was 64 bytes in release / 72 in debug;
+        // cloning it into AtnConfigKey made each key 56 bytes.
         let debug_generation = if cfg!(debug_assertions) {
             size_of::<u64>()
         } else {
             0
         };
-        assert!(size_of::<AtnConfig>() <= 64 + debug_generation);
-        assert!(size_of::<AtnConfigKey>() <= 56);
+        assert_eq!(size_of::<AtnConfig>(), 40 + debug_generation);
+        assert_eq!(size_of::<AtnConfigKey>(), 24);
     }
 
     #[test]


### PR DESCRIPTION
Closes #337.

## Summary

- intern parser semantic contexts behind compact store-local IDs and remap them alongside prediction contexts when shared DFA stores are unioned
- replace inline per-lexer-config action vectors with thin clone-on-write shared payloads, while compacting optional lexer rule indices
- preserve semantic/provenance/action equality and cache identity through collision-checked interning and content materialization at DFA, continuation, and accept boundaries
- account for parser semantic/provenance arenas and lexer action traces in the public DFA statistics surfaces

## Layout

| Type (64-bit) | Before | After |
| --- | ---: | ---: |
| `AtnConfig` release | 64 B | 40 B |
| `AtnConfig` debug | 72 B | 48 B |
| `AtnConfigKey` | 56 B | 24 B |
| `LexerConfig` | 64 B | 40 B |
| `LexerConfigKey` | 64 B | 32 B |

Non-empty lexer payloads detach only when a path appends or prunes an action. Old growing prefixes are reclaimed when their configs leave scope, and nested lexing through the same shared DFA cannot invalidate an outer config's payload.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked --workspace --all-targets --all-features -- -D warnings`
- `cargo test --locked --workspace --all-features`
- `cargo test --release -p antlr-rust-runtime hot_path_layout_stays_compact -- --test-threads=1`
- `cargo run --release --quiet -p antlr-rust-runtime-testsuite --bin antlr4-runtime-testsuite`
  - `357 passed, 0 failed, 0 skipped`
